### PR TITLE
Added dunder `__repr__` to labels object

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -248,9 +248,9 @@ def read_labels(labels_path: str) -> Labels:
     )
 
     frames = read_hdf5_dataset(labels_path, "frames")
-    lfs = []
-    for frame_id, video_id, frame_idx, instance_id_start, instance_id_end in frames:
-        lfs.append(
+    labeled_frames = []
+    for _, video_id, frame_idx, instance_id_start, instance_id_end in frames:
+        labeled_frames.append(
             LabeledFrame(
                 video=videos[video_id],
                 frame_idx=frame_idx,
@@ -258,6 +258,8 @@ def read_labels(labels_path: str) -> Labels:
             )
         )
 
-    labels = Labels(lfs)
+    labels = Labels(
+        labeled_frames=labeled_frames, videos=videos, skeletons=skeletons, tracks=tracks
+    )
 
     return labels

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -59,6 +59,7 @@ class Labels:
                 if inst.track is not None and inst.track not in self.tracks:
                     self.tracks.append(inst.track)
 
+
     def __getitem__(self, key: int) -> Union[list[LabeledFrame], LabeledFrame]:
         """Return one or more labeled frames based on indexing criteria."""
         if type(key) == int:
@@ -73,3 +74,18 @@ class Labels:
     def __len__(self) -> int:
         """Return number of labeled frames."""
         return len(self.labeled_frames)
+
+    def __repr__(self) -> str:
+        """Return a readable representation of the labels."""
+        return (
+            "Labels("
+            f"labeled_frames={len(self.labeled_frames)}, "
+            f"videos={len(self.videos)}, "
+            f"skeletons={len(self.skeletons)}, "
+            f"tracks={len(self.tracks)}"
+            ")"
+        )
+
+    def __str__(self) -> str:
+        """Return a readable representation of the labels."""
+        return self.__repr__()


### PR DESCRIPTION
Hi, when I was exploring the library I realize that the labels object does not have the `__repr__` method that it has on the main sleap repository. I think that is useful so I added on my fork and I was wondering if it would be useful in general. Also, as the function `read_labels` is used in `main.py` to form a labels objects I propagated all the other read attributes to it so they are accessible at the top level and not only nested in the labeled frames.

Let me know if this is a a good idea, if I am missing something and also if you would like tests of some kind.