### PR TITLE
Add write utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,22 @@ on:
       - "setup.cfg"
 
 jobs:
+  # Lint with black
+  lint:
+    name: Lint
+    runs-on: "ubuntu-22.04"
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+      - name: Install Dependencies
+        run: |
+          pip install black
+      - name: Run Black
+        run: |
+          black --check sleap_io tests
   # Tests with pytest
   tests:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - "environment.yml"
       - "setup.cfg"
   push:
+    branches:
+      - main
     paths:
       - "sleap_io/**"
       - "tests/**"
@@ -21,7 +23,6 @@ on:
 jobs:
   # Tests with pytest
   tests:
-
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +33,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-
       - name: Checkout repo
         uses: actions/checkout@v3.0.2
 

--- a/sleap_io/io/utils.py
+++ b/sleap_io/io/utils.py
@@ -21,6 +21,35 @@ def read_hdf5_dataset(filename: str, dataset: str) -> np.ndarray:
     return data
 
 
+def _overwrite_hdf5_dataset(
+    f: Union[h5py.File, h5py.Group], dataset: str, data: np.ndarray
+):
+    """Overwrite dataset in HDF5 file.
+
+    Args:
+        filename: Path to an HDF5 file.
+        dataset: Path to a dataset.
+        data: Data to write to dataset.
+    """
+    try:
+        del f[dataset]
+    except KeyError:
+        pass
+    f.create_dataset(dataset, data=data)
+
+
+def write_hdf5_dataset(filename: str, dataset: str, data: np.ndarray):
+    """Write data from an HDF5 file.
+
+    Args:
+        filename: Path to an HDF5 file.
+        dataset: Path to a dataset.
+        data: Data to write to dataset.
+    """
+    with h5py.File(filename, "r+") as f:
+        _overwrite_hdf5_dataset(f, dataset, data)
+
+
 def read_hdf5_group(filename: str, group: str = "/") -> dict[str, np.ndarray]:
     """Read an entire group from an HDF5 file.
 
@@ -45,6 +74,50 @@ def read_hdf5_group(filename: str, group: str = "/") -> dict[str, np.ndarray]:
     return data
 
 
+def write_hdf5_group(filename: str, data: dict[str, np.ndarray]):
+    """Write an entire group to an HDF5 file.
+
+    Args:
+        filename: Path an HDF5 file.
+        data: A dictionary with keys corresponding to dataset/group paths and values
+            corresponding to either sub group paths or the datasets as arrays.
+    """
+
+    def overwrite_hdf5_group(
+        file_or_group: Union[h5py.File, h5py.Group], group_name: str
+    ) -> h5py.Group:
+        """Overwrite group in HDF5 file.
+
+        Args:
+            file_or_group: Path to an HDF5 file or parent group.
+            group_name: Path to a group.
+
+        Return:
+            group: (Sub-)group under specified file or parent group.
+        """
+        try:
+            del file_or_group[group_name]
+        except KeyError:
+            pass
+        group = file_or_group.create_group(group_name)
+        return group
+
+    def write_group(parent_group, data_to_write):
+        for name, dataset_or_group in data_to_write.items():
+            if isinstance(dataset_or_group, dict):
+                # Create (sub-)group under parent group (top level being the file)
+                group = overwrite_hdf5_group(parent_group, name)
+                write_group(group, dataset_or_group)  # Recall with new parent
+            else:
+                # Create dataset if dataset_or_group is a dataset
+                _overwrite_hdf5_dataset(
+                    f=parent_group, dataset=name, data=dataset_or_group
+                )
+
+    with h5py.File(filename, "r+") as f:
+        write_group(f, data)
+
+
 def read_hdf5_attrs(
     filename, dataset: str = "/", attribute: Optional[str] = None
 ) -> Union[Any, dict[str, Any]]:
@@ -57,7 +130,7 @@ def read_hdf5_attrs(
             all attributes for the dataset will be returned.
 
     Returns:
-        The attributes in a dictionary, or the attribute field is `attribute` was
+        The attributes in a dictionary, or the attribute field if `attribute` was
         provided.
     """
     with h5py.File(filename, "r") as f:
@@ -67,3 +140,34 @@ def read_hdf5_attrs(
         else:
             data = ds.attrs[attribute]
     return data
+
+
+def write_hdf5_attrs(filename: str, dataset: str, attributes: dict[str, Any]):
+    """Write attributes to an HDF5 dataset.
+
+    Args:
+        filename: Path to an HDF5 file.
+        dataset: Path to a dataset or group to which attributes will be written.
+        attributes: The attributes in a dictionary with the keys as the attribute names.
+    """
+
+    def _overwrite_hdf5_attr(
+        group_or_dataset: Union[h5py.Group, h5py.Dataset], attr_name: str, data: Any
+    ):
+        """Overwrite attribute for group or dataset in HDF5 file.
+
+        Args:
+            group_or_dataset: Path to group or dataset in HDF5 file.
+            attr_name: Name of attribute.
+            data: Data to write to attribute.
+        """
+        try:
+            del group_or_dataset.attrs[attr_name]
+        except KeyError:
+            pass
+        group_or_dataset.attrs.create(attr_name, data)
+
+    with h5py.File(filename, "r+") as f:
+        ds = f[dataset]
+        for attr_name, attr_value in attributes.items():
+            _overwrite_hdf5_attr(ds, attr_name, attr_value)

--- a/tests/io/test_utils.py
+++ b/tests/io/test_utils.py
@@ -2,7 +2,14 @@
 import pytest
 import h5py
 import numpy as np
-from sleap_io.io.utils import read_hdf5_attrs, read_hdf5_dataset, read_hdf5_group
+from sleap_io.io.utils import (
+    read_hdf5_attrs,
+    read_hdf5_dataset,
+    read_hdf5_group,
+    write_hdf5_dataset,
+    write_hdf5_group,
+    write_hdf5_attrs,
+)
 
 
 @pytest.fixture
@@ -17,17 +24,25 @@ def hdf5_file(tmp_path):
     return path
 
 
-def test_read_hdf5_attrs(hdf5_file):
-    """Test `read_hdf5_attrs` can read hdf5 attributes."""
-    assert read_hdf5_attrs(hdf5_file, dataset="/", attribute="attr1") == 0
-    assert read_hdf5_attrs(hdf5_file, dataset="/", attribute="attr2") == 1
-    attrs = read_hdf5_attrs(hdf5_file, dataset="/")
-    assert attrs == {"attr1": 0, "attr2": 1}
-
-
 def test_read_hdf5_dataset(hdf5_file):
     """Test `read_hdf5_dataset` can read hdf5 datasets."""
     np.testing.assert_array_equal(read_hdf5_dataset(hdf5_file, "ds1"), [0, 1, 2])
+
+
+def test_write_hdf5_dataset(hdf5_file):
+    """Test `write_hdf5_dataset` can write hdf5 datasets."""
+
+    def write_read_assert_dataset(file, dataset, data):
+        write_hdf5_dataset(file, dataset, data)
+        np.testing.assert_array_equal(read_hdf5_dataset(file, dataset), data)
+
+    # Overwrite existing dataset
+    write_read_assert_dataset(hdf5_file, dataset="ds1", data=np.array([1, 2]))
+    write_read_assert_dataset(hdf5_file, dataset="grp/ds2", data=np.array([4, 5]))
+
+    # Write new dataset
+    write_read_assert_dataset(hdf5_file, dataset="ds3", data=np.array([1, 2]))
+    write_read_assert_dataset(hdf5_file, dataset="grp/ds4", data=np.array([4, 5]))
 
 
 def test_read_hdf5_group(hdf5_file):
@@ -36,3 +51,89 @@ def test_read_hdf5_group(hdf5_file):
     np.testing.assert_array_equal(data["/ds1"], [0, 1, 2])
     np.testing.assert_array_equal(data["/grp/ds2"], [3, 4, 5])
     assert len(data.keys()) == 2
+
+
+def test_write_hdf5_group(hdf5_file):
+    """Test `write_hdf5_group` can write hdf5 groups."""
+
+    def write_read_assert_group(file, data, group, values):
+        write_hdf5_group(file, data)
+        read = read_hdf5_group if isinstance(data.values(), dict) else read_hdf5_dataset
+        np.testing.assert_array_equal(read(file, group), values)
+
+    # Overwrite existing group
+    write_read_assert_group(
+        hdf5_file, data={"ds1": np.array([1, 2])}, group="ds1", values=np.array([1, 2])
+    )  # Expect dataset to be overwritten
+    write_read_assert_group(
+        hdf5_file,
+        data={"grp/ds2": np.array([4, 5])},
+        group="grp/ds2",
+        values=np.array([4, 5]),
+    )  # Expect group to be overwritten
+    write_read_assert_group(
+        hdf5_file,
+        data={"grp": {"ds2": np.array([6, 7])}},
+        group="grp/ds2",
+        values=np.array([6, 7]),
+    )  # Test different way of writing group
+
+    # Write new group
+    write_read_assert_group(
+        hdf5_file, data={"ds3": np.array([1, 2])}, group="ds3", values=np.array([1, 2])
+    )  # Expect just a dataset
+    write_read_assert_group(
+        hdf5_file,
+        data={"grp/ds4": np.array([4, 5])},
+        group="grp/ds4",
+        values=np.array([4, 5]),
+    )  # Expect a group and a dataset
+    write_read_assert_group(
+        hdf5_file,
+        data={"grp": {"ds5": np.array([6, 7])}},
+        group="grp/ds5",
+        values=np.array([6, 7]),
+    )  # Test different way of writing group with existing group, but new dataset
+    write_read_assert_group(
+        hdf5_file,
+        data={"grp2": {"ds6": np.array([0, 3])}},
+        group="grp2/ds6",
+        values=np.array([0, 3]),
+    )  # Test different way of writing group with new group
+
+    # Ensure entire group is overwritten
+    with pytest.raises(KeyError):
+        np.testing.assert_array_equal(
+            read_hdf5_group(hdf5_file, group="grp/ds4"), np.array([4, 5])
+        )
+
+
+def test_read_hdf5_attrs(hdf5_file):
+    """Test `read_hdf5_attrs` can read hdf5 attributes."""
+    assert read_hdf5_attrs(hdf5_file, dataset="/", attribute="attr1") == 0
+    assert read_hdf5_attrs(hdf5_file, dataset="/", attribute="attr2") == 1
+    attrs = read_hdf5_attrs(hdf5_file, dataset="/")
+    assert attrs == {"attr1": 0, "attr2": 1}
+
+
+def test_write_hdf5_attrs(hdf5_file):
+    """Test `write_hdf5_attrs` can write hdf5 attributes."""
+
+    def write_read_assert_attrs(file, dataset, attributes):
+        existing_attrs = read_hdf5_attrs(file, dataset)
+        write_hdf5_attrs(file, dataset, attributes)
+        assert read_hdf5_attrs(hdf5_file, dataset) == {**existing_attrs, **attributes}
+
+    # Add new attributes
+    write_read_assert_attrs(
+        hdf5_file, dataset="ds1", attributes={"attr3": 2}
+    )  # Add attributes to dataset
+    write_read_assert_attrs(
+        hdf5_file, dataset="grp", attributes={"attr4": 3}
+    )  # Add attributes to group
+    write_read_assert_attrs(
+        hdf5_file, dataset="grp/ds2", attributes={"attr5": 4, "attr6": 5}
+    )  # Add multiple attributes to dataset inside group
+
+    # Append attributes
+    write_read_assert_attrs(hdf5_file, dataset="/", attributes={"attr7": 6})


### PR DESCRIPTION
### Description
Add utilities to write to pre-existing hdf5 files. Adds utilities that (over)write datasets, groups, and attributes.

---

Other minor updates:
- [Fix ci.yml to run either on PR or Push](https://github.com/talmolab/sleap-io/pull/11/commits/1c800957699ff5e4690f1d23d22098c6f422f7d9)

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [x] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
No.