### PR TITLE
Add NWB support II

### DIFF
--- a/sleap_io/io/nwb.py
+++ b/sleap_io/io/nwb.py
@@ -132,7 +132,7 @@ def write_labels_to_nwb(
         io.write(nwbfile)
 
 
-def append_labels_data_to_nwb(labels: Labels, nwbfile: NWBFile) -> NWBFile:
+def append_labels_data_to_nwb(labels: Labels, nwbfile: NWBFile, pose_estimation_metadata: dict) -> NWBFile:
     """Append data from a Labels object to an in-memory nwb file.
 
     Args:
@@ -163,7 +163,7 @@ def append_labels_data_to_nwb(labels: Labels, nwbfile: NWBFile) -> NWBFile:
         # For every track in that video create a PoseEstimation container
         for track_index, track_name in enumerate(name_of_tracks_in_video):
             pose_estimation_container = build_pose_estimation_container_for_track(
-                labels_data_df, labels, track_name, video
+                labels_data_df, labels, track_name, video, pose_estimation_metadata,
             )
             nwb_processing_module.add(pose_estimation_container)
 
@@ -196,7 +196,7 @@ def get_processing_module_for_video(
 
 
 def build_pose_estimation_container_for_track(
-    labels_data_df: pd.DataFrame, labels: Labels, track_name: str, video: Video
+    labels_data_df: pd.DataFrame, labels: Labels, track_name: str, video: Video, pose_estimation_metadata: dict
 ) -> PoseEstimation:
     """Creates a PoseEstimation container for a track.
 
@@ -238,6 +238,9 @@ def build_pose_estimation_container_for_track(
         f"Estimated positions of {skeleton.name} in video {video_path.name} "
         f"using SLEAP."
     )
+    
+    pose_estimation_container_kwargs = dict(name=f"track={track_name}", description=container_description)
+    
     pose_estimation_container = PoseEstimation(
         name=f"track={track_name}",
         pose_estimation_series=pose_estimation_series_list,

--- a/tests/io/test_nwb.py
+++ b/tests/io/test_nwb.py
@@ -2,6 +2,7 @@ import pytest
 from pathlib import Path
 import datetime
 
+import numpy as np
 from pynwb import NWBFile, NWBHDF5IO, ProcessingModule
 
 from sleap_io import load_slp
@@ -54,6 +55,47 @@ def test_typical_case_append(nwbfile, slp_typical):
     for node_name in pose_estimation_container.nodes:
         assert node_name in pose_estimation_container.pose_estimation_series
 
+
+def test_typical_case_append_with_metadata_sampling_rate(nwbfile, slp_typical):
+    labels = load_slp(slp_typical)
+
+    number_of_frames = 1100 # extracted using ffmpeg probe
+    video_sampling_rate = 15.0 # 15 Hz extracted using ffmpeg probe for the video stream
+    video_timestamps = np.ones(number_of_frames) / video_sampling_rate
+
+    pose_estimation_metadata = {
+        "video_timestamps": video_timestamps,
+        "source_software": "1.2.3",  # Sleap-version, I chosen a random one for the test
+        "dimensions": [384, 384]  # The dimensions of the video frame extracted using ffmpeg probe
+    }
+    
+    nwbfile = append_labels_data_to_nwb(labels, nwbfile, pose_estimation_metadata)
+
+    # Test processing module naming
+    video_index = 0
+    video = labels.videos[video_index]
+    video_path = Path(video.filename)
+    processing_module_name = f"SLEAP_VIDEO_{video_index:03}_{video_path.stem}"
+
+    processing_module = nwbfile.processing[processing_module_name]
+    pose_estimation_container = processing_module.data_interfaces["track=untracked"]
+    
+    # Test pose estimation metadata propagation
+    extracted_source_software = pose_estimation_container.source_software
+    expected_source_software = pose_estimation_metadata["source_software"]
+    assert extracted_source_software == expected_source_software
+    
+    extracted_dimensions = pose_estimation_container.dimensions
+    expected_dimensions = pose_estimation_metadata["dimensions"]
+    assert extracted_dimensions == expected_dimensions
+
+    # Test sampling rate propagation. In this case the timestamps are uniform so
+    # The sampling rate should be stored instead of them
+    expected_sampling_rate = video_sampling_rate 
+    for node_name in pose_estimation_container.nodes:
+        pose_estimation_series = pose_estimation_container.pose_estimation_series[node_name]
+        extracted_sampling_rate = pose_estimation_series.rate
+        assert extracted_sampling_rate == expected_sampling_rate
 
 def test_complex_case_append(nwbfile, slp_predictions):
     labels = load_slp(slp_predictions)


### PR DESCRIPTION
### Description
When writing to an nwb file it is important for provenance and reproducibility to store as much as data as possible. This PR enables propagation of further metadata to the `PoseEstimation` container so if this data is not available in provenance it can be propagated to the file by other means (for example, if it was generated with an older version of sleap).

 Of particular important is that it adds the possibility of propagating timestamps as the video (from which the timestamps can be extracted in principle) is not available and either the timestamps or the rate is a required argument of `PoseEstimationSeries` (right now here and in sleap you are creating dummy values for this). 

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap-io/blob/main/CONTRIBUTING.md) to this repository
- [x] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP-IO!
:heart:
