### PR TITLE
Change equality semantics for Points and Instances

### DIFF
--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -55,7 +55,7 @@ class Point:
             precision error for `x` and `y` attributes).
         """
         # check that other is a Point
-        if not isinstance(other, Point):
+        if type(other) is not type(self):
             return False
 
         # we know that we have some kind of point at this point

--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -15,19 +15,6 @@ import numpy as np
 import math
 
 
-def _safe_float_comparison(a, b) -> bool:
-    """Compare `a` and `b` for equality, but allowing for some wiggle room due to float errors
-
-    Args:
-        a, b: scalar or array types to compare
-
-    Returns:
-        True if `a` and `b` are sufficently close. If `a` and `b` are arrays, all elements must pass equality.
-    """
-
-    return bool(np.all(np.isclose(a, b, equal_nan=True)))
-
-
 @define
 class Point:
     """A 2D spatial landmark and metadata associated with annotation.
@@ -46,8 +33,8 @@ class Point:
     eq_atol: ClassVar[float] = 1e-08
     eq_rtol: ClassVar[float] = 0
 
-    x: float = field(eq=cmp_using(eq=_safe_float_comparison))  # type: ignore
-    y: float = field(eq=cmp_using(eq=_safe_float_comparison))  # type: ignore
+    x: float
+    y: float
     visible: bool = True
     complete: bool = False
 

--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -44,6 +44,42 @@ class Point:
     visible: bool = True
     complete: bool = False
 
+    def __eq__(self, other: Point, allow_precision_error=False):
+        """Compare `self` and `other` for equality, optionally allowing precision error.
+
+        Args:
+            self, other: instances of `Point` to compare
+
+        Returns:
+            True if all attributes of `self` and `other` are the identical (allowing
+            precision error for `x` and `y` attributes if `allow_precision_error` is 
+            True).
+        """
+        if isinstance(other, list):
+            allow_precision_error = other[1]
+            other = other[0]
+
+        if allow_precision_error:
+            atol = 1e-8
+            rtol = 1e-5
+        else:
+            atol = 0
+            rtol = 0
+
+        return bool(
+            np.all(
+                np.isclose(
+                    [self.x, self.y],
+                    [other.x, other.y],
+                    rtol=rtol,
+                    atol=atol,
+                    equal_nan=True,
+                )
+            )
+            and (self.visible == other.visible)
+            and (self.complete == other.complete)
+        )
+
     def numpy(self) -> np.ndarray:
         """Return the coordinates as a numpy array of shape `(2,)`."""
         return np.array([self.x, self.y]) if self.visible else np.full((2,), np.nan)

--- a/tests/model/test_instance.py
+++ b/tests/model/test_instance.py
@@ -44,7 +44,6 @@ def test_close_points():
     assert not pt1 == pt2
 
 
-
 def test_predicted_point():
     """Test `PredictedPoint` is initialized as expected."""
     pt = PredictedPoint(x=1.2, y=3.4, visible=True, complete=False, score=0.9)

--- a/tests/model/test_instance.py
+++ b/tests/model/test_instance.py
@@ -18,8 +18,25 @@ def test_point():
     pt = Point(x=1.2, y=3.4, visible=True, complete=True)
     assert_equal(pt.numpy(), np.array([1.2, 3.4]))
 
+    pt2 = Point(x=1.2, y=3.4, visible=True, complete=True)
+    assert pt == pt2
+
     pt.visible = False
     assert_equal(pt.numpy(), np.array([np.nan, np.nan]))
+
+
+def test_close_points():
+    """Test equality of two `Point` objects which have a floating point error."""
+
+    # test floating point error
+    pt1 = Point(x=135.82268970698718, y=213.22842752594835)
+    pt2 = Point(x=135.82268970698718, y=213.2284275259484)
+    assert pt1 == pt2
+
+    # test points with NAN for coordinates
+    pt1 = Point(x=np.nan, y=np.nan, visible=False, complete=False)
+    pt2 = Point(x=np.nan, y=np.nan, visible=False, complete=False)
+    assert pt1 == pt2
 
 
 def test_predicted_point():
@@ -75,6 +92,19 @@ def test_instance():
 
     with pytest.raises(IndexError):
         inst[None]
+
+
+def test_instance_comparison():
+    """Test some properties of `Instance` equality semantics"""
+    # test that instances with different skeletons are not considered equal
+    inst1 = Instance({"A": [0, 1], "B": [2, 3]}, skeleton=Skeleton(["A", "B"]))
+    inst2 = Instance({"A": [0, 1], "C": [2, 3]}, skeleton=Skeleton(["A", "C"]))
+    assert not inst1 == inst2
+
+    # test that instances with the same skeleton but different point coordinates are not considered equal
+    inst1 = Instance({"A": [0, 1], "B": [2, 3]}, skeleton=Skeleton(["A", "B"]))
+    inst2 = Instance({"A": [2, 3], "B": [0, 1]}, skeleton=Skeleton(["A", "B"]))
+    assert not inst1 == inst2
 
 
 def test_predicted_instance():

--- a/tests/model/test_instance.py
+++ b/tests/model/test_instance.py
@@ -28,15 +28,21 @@ def test_point():
 def test_close_points():
     """Test equality of two `Point` objects which have a floating point error."""
 
+    # test points with NAN for coordinates
+    pt1 = Point(x=np.nan, y=np.nan, visible=False, complete=False)
+    pt2 = Point(x=np.nan, y=np.nan, visible=False, complete=False)
+    assert pt1 == pt2
+
     # test floating point error
     pt1 = Point(x=135.82268970698718, y=213.22842752594835)
     pt2 = Point(x=135.82268970698718, y=213.2284275259484)
     assert pt1 == pt2
 
-    # test points with NAN for coordinates
-    pt1 = Point(x=np.nan, y=np.nan, visible=False, complete=False)
-    pt2 = Point(x=np.nan, y=np.nan, visible=False, complete=False)
-    assert pt1 == pt2
+    # change allowed tolerance, and check we fail comparison
+    Point.eq_atol = 0
+    Point.eq_rtol = 0
+    assert not pt1 == pt2
+
 
 
 def test_predicted_point():

--- a/tests/model/test_instance.py
+++ b/tests/model/test_instance.py
@@ -43,12 +43,39 @@ def test_close_points():
     Point.eq_rtol = 0
     assert not pt1 == pt2
 
+    # reset tolerance
+    Point.eq_atol = 1e-08
+    Point.eq_rtol = 0
+
+    # test points with NAN for coordinates
+    pt1 = PredictedPoint(x=np.nan, y=np.nan, visible=False, complete=False)
+    pt2 = PredictedPoint(x=np.nan, y=np.nan, visible=False, complete=False)
+    assert pt1 == pt2
+
+    # test floating point error
+    pt1 = PredictedPoint(x=135.82268970698718, y=213.22842752594835)
+    pt2 = PredictedPoint(x=135.82268970698718, y=213.2284275259484)
+    assert pt1 == pt2
+
+    # change allowed tolerance, and check we fail comparison
+    Point.eq_atol = 0
+    Point.eq_rtol = 0
+    assert not pt1 == pt2
+
 
 def test_predicted_point():
     """Test `PredictedPoint` is initialized as expected."""
-    pt = PredictedPoint(x=1.2, y=3.4, visible=True, complete=False, score=0.9)
-    assert pt.score == 0.9
-    assert_equal(pt.numpy(), np.array([1.2, 3.4, 0.9]))
+    ppt1 = PredictedPoint(x=1.2, y=3.4, visible=True, complete=False, score=0.9)
+    assert ppt1.score == 0.9
+    assert_equal(ppt1.numpy(), np.array([1.2, 3.4, 0.9]))
+
+    ppt2 = PredictedPoint(x=1.2, y=3.4, visible=True, complete=False, score=0.9)
+    assert ppt1 == ppt2
+
+    # Test equivelance of Point and PredictedPoint
+    pt3 = Point(x=1.2, y=3.4, visible=True, complete=False)
+    assert not ppt1 == pt3  # PredictedPoint is not equivelant to Point
+    assert not pt3 == ppt1  # Point is not equivelant to PredictedPoint
 
 
 def test_track():


### PR DESCRIPTION
### Description
Changes to data model to enable sensible equality semantics for `Point`s and `Instance`s.

- Fix equality of `Points`. `X` and `Y` coordinates were previously compared using normal float equality semantics. Here we change to utilize the `numpy.isclose()` method for comparison, where two floats are compared for equality within some tolerance (we use just the default tolerances). Additionally, we will consider that two `NaN` values are equal, which is normally not true.
- Allow `Instance` objects to be compared for equality. The `Instance.points` collections compared with the rule that both collections of points must contain the same set of nodes, and for each node the point must be equal according to the semantics described above for `Point`s.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap-io/blob/main/CONTRIBUTING.md) to this repository
- [x] Add tests that prove your fix is effective or that your feature works
- [x] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP-IO!
:heart:
