### PR TITLE
Metadata not correctly propagated to nwb bug

### DIFF
--- a/sleap_io/io/nwb.py
+++ b/sleap_io/io/nwb.py
@@ -1,5 +1,6 @@
 """Functions to write and read from the neurodata without borders (NWB) format. 
 """
+from copy import deepcopy
 from typing import List, Optional, Generator
 from pathlib import Path
 import datetime
@@ -168,7 +169,7 @@ def append_labels_data_to_nwb(
         or the sampling rate with key`video_sample_rate`.
 
         e.g. pose_estimation_metadata["video_timestamps"] = np.array(timestamps)
-        or   pose_estimation_metadata["video_sample_rate] = 15  # In Hz
+        or   pose_estimation_metadata["video_sample_rate"] = 15  # In Hz
 
         2) The other use of this dictionary is to ovewrite sleap-io default
         arguments for the PoseEstimation container.
@@ -270,6 +271,8 @@ def build_pose_estimation_container_for_track(
         of all the node trajectories in the track are stored. One time series per
         node.
     """
+    # Copy metadata for local use and modification
+    pose_estimation_metadata_copy = deepcopy(pose_estimation_metadata)
     video_path = Path(video.filename)
 
     all_track_skeletons = (
@@ -291,8 +294,8 @@ def build_pose_estimation_container_for_track(
     ]
 
     # Combine each node's PoseEstimationSeries to create a PoseEstimation container
-    timestamps = pose_estimation_metadata.pop("video_timestamps", None)
-    sample_rate = pose_estimation_metadata.pop("video_sample_rate", 1.0)
+    timestamps = pose_estimation_metadata_copy.pop("video_timestamps", None)
+    sample_rate = pose_estimation_metadata_copy.pop("video_sample_rate", 1.0)
     if timestamps is None:
         # Keeps backward compatbility.
         timestamps = np.arange(track_data_df.shape[0]) * sample_rate
@@ -312,7 +315,7 @@ def build_pose_estimation_container_for_track(
         # dimensions=np.array([[video.backend.height, video.backend.width]]),
     )
 
-    pose_estimation_container_kwargs.update(**pose_estimation_metadata)
+    pose_estimation_container_kwargs.update(**pose_estimation_metadata_copy)
     pose_estimation_container = PoseEstimation(**pose_estimation_container_kwargs)
 
     return pose_estimation_container

--- a/tests/io/test_nwb.py
+++ b/tests/io/test_nwb.py
@@ -105,7 +105,11 @@ def test_provenance_writing(nwbfile, slp_predictions_with_provenance):
 
 def test_default_metadata_overwriting(nwbfile, slp_predictions_with_provenance):
     labels = load_slp(slp_predictions_with_provenance)
-    pose_estimation_metadata = {"scorer": "overwritten_value"}
+    expected_sampling_rate = 10.0
+    pose_estimation_metadata = {
+        "scorer": "overwritten_value",
+        "video_sample_rate": expected_sampling_rate,
+    }
     nwbfile = append_labels_data_to_nwb(labels, nwbfile, pose_estimation_metadata)
 
     # Extract processing module
@@ -118,6 +122,11 @@ def test_default_metadata_overwriting(nwbfile, slp_predictions_with_provenance):
     # Test that the value of scorer was overwritten
     for pose_estimation_container in processing_module.data_interfaces.values():
         assert pose_estimation_container.scorer == "overwritten_value"
+        all_nodes = pose_estimation_container.nodes
+        for node in all_nodes:
+            pose_estimation_series = pose_estimation_container[node]
+            if pose_estimation_series.rate:
+                assert pose_estimation_series.rate == expected_sampling_rate
 
 
 def test_complex_case_append(nwbfile, slp_predictions):


### PR DESCRIPTION
### Description
I realized that there is a bug when writing more than one track and propagating metadata. In the code, the metadata dictionary drops the timestamps and the rate for each track. Because of python copying mechanism this means that those fields are not available for the second track metadata once they are droped. The solution is to create a local copy of the metadata before any modification. This PR fixes the bug and introduces a test for correctly propagating the rate.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap-io/blob/main/CONTRIBUTING.md) to this repository
- [x] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP-IO!
:heart:
