### PR TITLE
Allow CI to be triggered manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize]
     paths:


### PR DESCRIPTION
### Description
This change allows the CI action to be run manually via the Github UI.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [x] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
N/A

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap-io/blob/main/CONTRIBUTING.md) to this repository
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP-IO!
:heart:
