### PR TITLE
Add propagation of start time when writing nwbfile

### DIFF
--- a/sleap_io/io/nwb.py
+++ b/sleap_io/io/nwb.py
@@ -380,7 +380,7 @@ def build_track_pose_estimation_list(
         if rate:
             # Video sample rates are ints but nwb expect floats
             rate = float(int(rate))
-            pose_estimation_kwargs.update(rate=rate)
+            pose_estimation_kwargs.update(rate=rate, starting_time=timestamps_for_data[0])
         else:
             pose_estimation_kwargs.update(timestamps=timestamps_for_data)
 

--- a/sleap_io/io/nwb.py
+++ b/sleap_io/io/nwb.py
@@ -299,6 +299,8 @@ def build_pose_estimation_container_for_track(
     if timestamps is None:
         # Keeps backward compatbility.
         timestamps = np.arange(track_data_df.shape[0]) * sample_rate
+    else:
+        timestamps = np.array(timestamps)
 
     pose_estimation_series_list = build_track_pose_estimation_list(
         track_data_df, timestamps

--- a/sleap_io/io/nwb.py
+++ b/sleap_io/io/nwb.py
@@ -380,7 +380,9 @@ def build_track_pose_estimation_list(
         if rate:
             # Video sample rates are ints but nwb expect floats
             rate = float(int(rate))
-            pose_estimation_kwargs.update(rate=rate, starting_time=timestamps_for_data[0])
+            pose_estimation_kwargs.update(
+                rate=rate, starting_time=timestamps_for_data[0]
+            )
         else:
             pose_estimation_kwargs.update(timestamps=timestamps_for_data)
 

--- a/sleap_io/io/nwb.py
+++ b/sleap_io/io/nwb.py
@@ -300,7 +300,7 @@ def build_pose_estimation_container_for_track(
         # Keeps backward compatbility.
         timestamps = np.arange(track_data_df.shape[0]) * sample_rate
     else:
-        timestamps = np.array(timestamps)
+        timestamps = np.asarray(timestamps)
 
     pose_estimation_series_list = build_track_pose_estimation_list(
         track_data_df, timestamps

--- a/tests/io/test_nwb.py
+++ b/tests/io/test_nwb.py
@@ -203,6 +203,8 @@ def test_complex_case_append_with_timestamps_metadata(nwbfile, slp_predictions):
         if pose_estimation_series.rate:
             extracted_rate = pose_estimation_series.rate
             assert extracted_rate == expected_rate, f"{node_name}"
+            extracted_starting_time = pose_estimation_series.starting_time
+            assert extracted_starting_time == 0
 
         # Other store timestamps and the timestmaps should be a subset of the videotimestamps
         else:


### PR DESCRIPTION
### Description
When passing the timestamps for an nwb file `build_track_pose_estimation_list`  determines whther the timestamps for that specific node have a uniform sampling rate of not. If it does, then PoseEstimationSeries is written with a rate instead of a with timestamps* (to save space in the final nwbfile).  

However, an edge case can occur when the timestamps corresponding to a node have uniform sampling rate but their first frame included that has a prediction is not the first one in the video. In that case is necessary to write both the sampling rate and the starting time in the nwbfile for correct provenance. This PR addresses this and modifies the corresponding testing to account for this case.

*This is usually not the case as not all frames might contain predictions for that node leading to PoseEstimationSeries / nodes with non-uniform sampling rates (non-uniform in their timestamps, that is). 

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap-io/blob/main/CONTRIBUTING.md) to this repository
- [x] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP-IO!
:heart:
