### PR TITLE
Fix build by including readme correctly in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ dependencies = [
     "imageio-ffmpeg",
     "av"
 ]
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 
 [tool.setuptools.dynamic]
 version = {attr = "sleap_io.__version__"}
-readme = {file = ["README.md"]}
+readme = {file = ["README.md"], content-type="text/markdown"}
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Fix the build process which was failing when uploading to PyPI after #32. This was happening since we switched to `pyproject.toml` and failing to set the `readme` attribute as dynamic so that it would pull in the `README.md` appropriately to fill the `long_description` field of the package metadata.