### PR TITLE
Add Labels.find and Labels.video

### DIFF
--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -2,7 +2,7 @@
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 from sleap_io.model.skeleton import Node, Edge, Skeleton, Symmetry
 from sleap_io.model.video import Video


### PR DESCRIPTION
This PR adds `Labels.find()` and `Labels.video` following the core SLEAP implementations.

Note: Since we don't have a labels cache, the `Labels.find()` implementation will be highly inefficient for many query types or datasets.