### PR TITLE
Pin imageio version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "ndx-pose",
     "pandas",
     "simplejson",
-    "imageio",
+    "imageio>=2.26.0",
     "imageio-ffmpeg",
     "av"
 ]


### PR DESCRIPTION
This pins imageio to a newer version to address #38 in which the v3 imageio API was not available in older versions of the package.