### PR TITLE
Fix detection of embedded images when loading SLP files

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -44,9 +44,14 @@ def read_videos(labels_path: str) -> list[Video]:
     video_objects = []
     for video in videos:
         backend = video["backend"]
+        video_path = backend["filename"]
+
+        # Marker for embedded videos.
+        if video_path == ".":
+            video_path = labels_path
 
         # Basic path resolution.
-        video_path = Path(backend["filename"])
+        video_path = Path(video_path)
         if not video_path.exists():
             # Check for the same filename in the same directory as the labels file.
             video_path_ = Path(labels_path).parent / video_path.name

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -65,3 +65,11 @@ def test_read_instances_from_predicted(slp_real_data):
     assert lf.instances[2].from_predicted == lf.instances[1]
     assert lf.instances[3].from_predicted == lf.instances[0]
     assert len(lf.unused_predictions) == 0
+
+
+def test_read_videos_pkg(slp_minimal_pkg):
+    videos = read_videos(slp_minimal_pkg)
+    assert len(videos) == 1
+    video = videos[0]
+    assert video.shape == (1, 384, 384, 1)
+    assert video.backend.dataset == "video0/video"


### PR DESCRIPTION
This PR fixes automatic instantiation of video backend when loading SLP files since they use `"."` as the marker for embedded labels.