### PR TITLE
Fix serialization for negative anchors metadata field in SLP files

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -367,7 +367,7 @@ def write_metadata(labels_path: str, labels: Labels):
         "videos": [],
         "tracks": [],
         "suggestions": [],  # TODO: Handle suggestions metadata.
-        "negative_anchors": [],
+        "negative_anchors": {},
         "provenance": labels.provenance,
     }
     with h5py.File(labels_path, "a") as f:


### PR DESCRIPTION
The `"negative_anchors"` key in the metadata for SLP files needed to be a dictionary to be unstructured appropriately in core SLEAP.