### PR TITLE
Fix edge unpacking

### DIFF
--- a/sleap_io/model/skeleton.py
+++ b/sleap_io/model/skeleton.py
@@ -40,14 +40,14 @@ class Edge:
     source: Node
     destination: Node
 
-    def __getitem__(self, idx):
+    def __getitem__(self, idx) -> Node:
         """Return the source `Node` (`idx` is 0) or destination `Node` (`idx` is 1)."""
         if idx == 0:
             return self.source
         elif idx == 1:
             return self.destination
         else:
-            raise ValueError("Edge only has 2 nodes (source and destination).")
+            raise IndexError("Edge only has 2 nodes (source and destination).")
 
 
 @define

--- a/tests/model/test_skeleton.py
+++ b/tests/model/test_skeleton.py
@@ -86,3 +86,14 @@ def test_flipped_node_inds():
     assert skel.symmetries[0][1] in (Node("BL"), Node("BR"))
     syms = list(skel.symmetries[0])
     assert syms[0] != syms[1]
+
+
+def test_edge_unpack():
+    skel = Skeleton(["A", "B", "C"], edges=[("A", "B"), ("B", "C")])
+    edge = skel.edges[0]
+    assert edge[0].name == "A"
+    assert edge[1].name == "B"
+
+    src, dst = skel.edges[0]
+    assert src.name == "A"
+    assert dst.name == "B"

--- a/tests/model/test_skeleton.py
+++ b/tests/model/test_skeleton.py
@@ -8,7 +8,7 @@ def test_edge():
     edge = Edge(Node("A"), Node("B"))
     assert edge[0].name == "A"
     assert edge[1].name == "B"
-    with pytest.raises(ValueError):
+    with pytest.raises(IndexError):
         edge[2]
 
 


### PR DESCRIPTION
This PR fixes #58 to allow for the `src, dst = skeleton.edges[0]` API.

The issue was that we needed to raise a `IndexError` rather than `ValueError` to comply with the [object subclassing API](https://docs.python.org/3/reference/datamodel.html#object.__getitem__) for `__getitem__`.