### PR TITLE
Fallback on import newer numpy.testing module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9"
 ]
 dependencies = [
-    "numpy>=1.19.5",
+    "numpy>=1.19.2",
     "attrs>=21.2.0",
     "h5py>=3.1.0",
     "pynwb",

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -2,7 +2,7 @@
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 
 from sleap_io.model.skeleton import Node, Edge, Skeleton, Symmetry
 from sleap_io.model.video import Video

--- a/sleap_io/io/nwb.py
+++ b/sleap_io/io/nwb.py
@@ -8,7 +8,11 @@ import re
 
 import pandas as pd  # type: ignore[import]
 import numpy as np
-from numpy.typing import ArrayLike
+
+try:
+    from numpy.typing import ArrayLike
+except ImportError:
+    ArrayLike = np.ndarray
 from pynwb import NWBFile, NWBHDF5IO, ProcessingModule  # type: ignore[import]
 from ndx_pose import PoseEstimationSeries, PoseEstimation  # type: ignore[import]
 


### PR DESCRIPTION
This PR adds a workaround for running sleap-io in older environments with numpy <1.20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Compatibility: Improved support for different versions of `numpy` by handling the import of `ArrayLike` from `numpy.typing`. This change ensures that the code can function correctly even if `ArrayLike` is not available in the installed version of `numpy`.
- Chore: Updated the package version from "0.0.9" to "0.0.10". No changes were made to the functionality, interfaces, or exported elements of the package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->