### PR TITLE
Fix importing in Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ on:
       - "tests/**"
       - ".github/workflows/ci.yml"
       - "environment.yml"
-      - "setup.cfg"
 
 jobs:
   # Lint with black and docstring check with pydocstyle
@@ -99,6 +98,7 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9 }}
         shell: bash -l {0}
         run: |
+          apt-get update && apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx  # https://github.com/conda-forge/opencv-feedstock/issues/401
           pytest --cov=sleap_io --cov-report=xml tests/
 
       - name: Upload coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,13 @@ jobs:
           micromamba list
           pip freeze
 
+      - name: Install graphics dependencies on Ubuntu
+        # https://github.com/conda-forge/opencv-feedstock/issues/401
+        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        shell: bash -l {0}
+        run: |
+          sudo apt-get update && sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
+
       - name: Test with pytest
         if: ${{ !(startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9) }}
         shell: bash -l {0}
@@ -98,7 +105,6 @@ jobs:
         if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9 }}
         shell: bash -l {0}
         run: |
-          apt-get update && apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx  # https://github.com/conda-forge/opencv-feedstock/issues/401
           pytest --cov=sleap_io --cov-report=xml tests/
 
       - name: Upload coverage

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -2,7 +2,7 @@
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.0.13"
+__version__ = "0.0.14"
 
 from sleap_io.model.skeleton import Node, Edge, Skeleton, Symmetry
 from sleap_io.model.video import Video

--- a/sleap_io/io/jabs.py
+++ b/sleap_io/io/jabs.py
@@ -1,5 +1,7 @@
 """This module handles direct I/O operations for working with JABS files."""
 
+from __future__ import annotations
+
 import h5py
 import re
 import os


### PR DESCRIPTION
Added a `from __future__ import annotations` in a module using newer type hinting syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated package version to 0.0.14.
	- Modified CI workflow to address OpenCV issue.
- **Refactor**
	- Improved compatibility with future Python annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->