### PR TITLE
Update CI and versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 0
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.10
 
     - name: Install dependencies
       run: |
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-14"]
-        python: [3.7, 3.11]
+        python: [3.7, 3.10]
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}
@@ -74,6 +74,7 @@ jobs:
           conda-solver: "libmamba"
           environment-file: environment.yml
           activate-environment: sleap-io
+          python-version: ${{ matrix.python }}
 
       - name: Print environment info
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Test with pytest (with coverage)
         shell: bash -l {0}
         run: |
-          pytest --cov=sleap_io --cov-report=xml tests/
+          pytest --cov=sleap_io --cov-report=xml --durations=-1 tests/
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.12"
 
     - name: Install dependencies
       run: |
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-14"]
-        python: ["3.8", "3.11"]
+        python: ["3.8", "3.12"]
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,12 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install dependencies
       run: |
@@ -57,8 +57,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python: [3.7, 3.9]
+        os: ["ubuntu-latest", "windows-latest", "macos-14"]
+        python: [3.7, 3.11]
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}
@@ -67,18 +67,13 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup Micromamba
-        # https://github.com/mamba-org/setup-micromamba
-        # Note: Set channel-priority in .condarc if needed
-        uses: mamba-org/setup-micromamba@v1
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          miniforge-version: latest
+          conda-solver: "libmamba"
           environment-file: environment.yml
-          cache-environment: true
-          cache-environment-key: environment-${{ hashFiles('environment.yml') }}-${{ hashFiles('pyproject.toml') }}
-          init-shell: >-
-            bash
-            powershell
-          post-cleanup: all
+          activate-environment: sleap-io
 
       - name: Print environment info
         shell: bash -l {0}
@@ -95,21 +90,13 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
 
-      - name: Test with pytest
-        if: ${{ !(startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9) }}
-        shell: bash -l {0}
-        run: |
-          pytest
-
       - name: Test with pytest (with coverage)
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9 }}
         shell: bash -l {0}
         run: |
           pytest --cov=sleap_io --cov-report=xml tests/
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.python == 3.9 }}
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           verbose: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,10 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-14"]
-        python: ["3.7", "3.10"]
+        python: ["3.8", "3.10"]
         exclude:
           - os: "macos-14"
-            python: "3.7"
+            python: "3.8"
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-14"]
         python: ["3.8", "3.11"]
-        exclude:
-          - os: "macos-14"
-            python: "3.8"
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,12 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-14"]
         python: ["3.7", "3.10"]
+        exclude:
+          - os: "macos-14"
+            python: "3.7"
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: Install dependencies
       run: |
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-14"]
-        python: ["3.8", "3.10"]
+        python: ["3.8", "3.11"]
         exclude:
           - os: "macos-14"
             python: "3.8"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     # Note: This uses Google-style docstring convention
     # Ref: https://google.github.io/styleguide/pyguide.html
     name: Lint
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-latest"
     steps:
 
     - name: Checkout repo
@@ -79,8 +79,8 @@ jobs:
         shell: bash -l {0}
         run: |
           which python
-          micromamba info
-          micromamba list
+          conda info
+          conda list
           pip freeze
 
       - name: Install graphics dependencies on Ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-14"]
-        python: [3.7, 3.10]
+        python: ["3.7", "3.10"]
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: sleap-io
 
 channels:
   - conda-forge
-  - defaults
 
 dependencies:
   - python
@@ -14,7 +13,7 @@ dependencies:
   - h5py>=3.7.0
   - hdmf
   - numpy
-  - conda-forge::opencv
+  - opencv<4.9.0
   - pynwb
   - ndx-pose
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -8,8 +8,10 @@ dependencies:
   - ffmpeg>=6.1.0
   - imageio
   - imageio-ffmpeg
+  - av
   - attrs
   - pandas
+  - simplejson
   - h5py>=3.7.0
   - hdmf
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -6,12 +6,13 @@ channels:
 
 dependencies:
   - python
-  - ffmpeg
+  - ffmpeg>=6.1.0
   - imageio
   - imageio-ffmpeg
   - attrs
   - pandas
-  - h5py
+  - h5py>=3.8
+  - hdmf
   - numpy
   - conda-forge::opencv
   - pynwb

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - attrs
   - pandas
   - simplejson
-  - h5py>=3.7.0
+  - h5py>=3.8.0
   - hdmf
   - numpy
   - opencv<4.9.0

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - python
-  - ffmpeg>=6.1.0
+  - ffmpeg
   - imageio
   - imageio-ffmpeg
   - av

--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,10 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.11
+  - python=3.10
   - ffmpeg
   - imageio
+  - imageio-ffmpeg
   - attrs
   - pandas
   - h5py

--- a/environment.yml
+++ b/environment.yml
@@ -5,13 +5,16 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.9
+  - python=3.11
   - ffmpeg
   - imageio
   - attrs
+  - pandas
   - h5py
   - numpy
   - conda-forge::opencv
+  - pynwb
+  - ndx-pose
   - pip
   - pip:
     - "--editable=.[dev]"

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - imageio-ffmpeg
   - attrs
   - pandas
-  - h5py>=3.8
+  - h5py>=3.7.0
   - hdmf
   - numpy
   - conda-forge::opencv

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   - python
-  - ffmpeg
+  - ffmpeg<6.1.0
   - imageio
   - imageio-ffmpeg
   - av
@@ -18,6 +18,13 @@ dependencies:
   - opencv<4.9.0
   - pynwb
   - ndx-pose
+  - pytest
+  - pytest-cov
+  - black
+  - pydocstyle
+  - toml
+  - twine
+  - build
   - pip
   - pip:
     - "--editable=.[dev]"

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.10
+  - python
   - ffmpeg
   - imageio
   - imageio-ffmpeg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "numpy>=1.19.2",
     "attrs>=21.2.0",
-    "h5py>=3.1.0",
+    "h5py>=3.8.0",
     "pynwb",
     "ndx-pose",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.10"
 ]
 dependencies = [
     "numpy>=1.19.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,17 +16,18 @@ license = {text = "BSD-3-Clause"}
 classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10"
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
 ]
 dependencies = [
-    "numpy>=1.19.2",
-    "attrs>=21.2.0",
+    "numpy",
+    "attrs",
     "h5py>=3.8.0",
     "pynwb",
     "ndx-pose",
     "pandas",
     "simplejson",
-    "imageio>=2.26.0",
+    "imageio",
     "imageio-ffmpeg",
     "av"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,10 @@ authors = [
     {name = "Talmo Pereira", email = "talmo@salk.edu"}
 ]
 description="Standalone utilities for working with pose data from SLEAP and other tools."
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = ["sleap", "pose tracking", "pose estimation", "behavior"]
 license = {text = "BSD-3-Clause"}
 classifiers = [
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,9 @@ license = {text = "BSD-3-Clause"}
 classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9"
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
 ]
 dependencies = [
     "numpy>=1.19.2",


### PR DESCRIPTION
- Update dependency ranges (see below)
- Update action workflow versions
- Enable M1 mac runners
- Expand python version range to 3.7-3.12
    - Note: Python 3.7 is no longer tested in CI due to lack of conda-forge compatability.
- Enable pure conda-forge dependency setup

## Notes on dependency pins
- `ffmpeg < 6.1` due to https://github.com/imageio/imageio-ffmpeg/issues/99
- `h5py >= 3.8.0` due to https://github.com/h5py/h5py/issues/2118
- `python >= 3.8` due to `h5py >= 3.8.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
    - Updated GitHub Actions workflows and Python environment setup.
    - Enhanced continuous integration with macOS support and updated dependencies.

- **New Features**
    - Expanded Python environment to support versions 3.10, 3.11.
    - Updated environment.yml with additional dependencies and removed Python version specification.
    - Added new packages while maintaining existing dependencies.

- **Documentation**
    - Updated project documentation to reflect new dependencies and supported Python versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->