### PR TITLE
Bump to v0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,11 @@ authors = [
     {name = "Talmo Pereira", email = "talmo@salk.edu"}
 ]
 description="Standalone utilities for working with pose data from SLEAP and other tools."
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 keywords = ["sleap", "pose tracking", "pose estimation", "behavior"]
 license = {text = "BSD-3-Clause"}
 classifiers = [
+    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -2,7 +2,7 @@
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.0.14"
+__version__ = "0.1.0"
 
 from sleap_io.model.skeleton import Node, Edge, Skeleton, Symmetry
 from sleap_io.model.video import Video


### PR DESCRIPTION
- Bump package to v0.1.0
- Expand `pyproject.toml` version range to include Python 3.7, which is technically compatible via pip-only install