### PR TITLE
Add support for embedding images in .pkg.slp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+lcov.info
 
 # Translations
 *.mo

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,15 @@ We check for coverage by parsing the outputs from `pytest` and uploading to [Cod
 
 All changes should aim to increase or maintain test coverage.
 
+### Live coverage
+
+*The following steps are based on [this guide](https://jasonstitt.com/perfect-python-live-test-coverage).*
+
+1. If you already have an environment installed, `pip install -e ."[dev]"` to make sure you have the latest dev tools (namely `pytest-watch`).
+2. Install the [Coverage Gutters extension](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) in VS Code.
+3. Open a terminal, `conda activate sleap-io` and then run `ptw` to automatically run tests. This will generate a new `lcov.info` file when it's done.
+4. Enable the coverage gutters by using **Ctrl/Cmd**+**Shift**+**P**, then **Coverage Gutters: Display Coverage**.
+
 
 ### Code style
 To standardize formatting conventions, we use [`black`](https://black.readthedocs.io/en/stable/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ name = "sleap-io"
 authors = [
     {name = "Liezl Maree", email = "lmaree@salk.edu"},
     {name = "David Samy", email = "davidasamy@gmail.com"},
-    {name = "Talmo Pereira", email = "talmo@salk.edu"}
-]
+    {name = "Talmo Pereira", email = "talmo@salk.edu"}]
 description="Standalone utilities for working with pose data from SLEAP and other tools."
 requires-python = ">=3.7"
 keywords = ["sleap", "pose tracking", "pose estimation", "behavior"]
@@ -19,8 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
-]
+    "Programming Language :: Python :: 3.12"]
 dependencies = [
     "numpy",
     "attrs",
@@ -31,8 +29,7 @@ dependencies = [
     "simplejson",
     "imageio",
     "imageio-ffmpeg",
-    "av"
-]
+    "av"]
 dynamic = ["version", "readme"]
 
 [tool.setuptools.dynamic]
@@ -43,6 +40,7 @@ readme = {file = ["README.md"], content-type="text/markdown"}
 dev = [
     "pytest",
     "pytest-cov",
+    "pytest-watch",
     "black",
     "pydocstyle",
     "toml",
@@ -52,12 +50,14 @@ dev = [
     "mkdocs-jupyter",
     "mkdocstrings[python]>=0.18",
     "mkdocs-gen-files",
-    "mkdocs-literate-nav"
-]
+    "mkdocs-literate-nav"]
 
 [project.urls]
-Homepage = "https://sleap.ai"
+Homepage = "https://io.sleap.ai"
 Repository = "https://github.com/talmolab/sleap-io"
+
+[tool.setuptools.packages.find]
+exclude = ["site"]
 
 [tool.black]
 line-length = 88
@@ -65,3 +65,9 @@ line-length = 88
 [pydocstyle]
 convention = "google"
 match-dir = "sleap_io"
+
+[tool.coverage.run]
+source = ["livecov"]
+
+[tool.pytest.ini_options]
+addopts = "--cov sleap_io --cov-report=lcov:lcov.info --cov-report=term"

--- a/sleap_io/io/jabs.py
+++ b/sleap_io/io/jabs.py
@@ -86,6 +86,7 @@ def read_labels(
     frames: List[LabeledFrame] = []
     # Video name is the pose file minus the suffix
     video_name = re.sub(r"(_pose_est_v[2-6])?\.h5", ".avi", labels_path)
+    video = Video.from_filename(video_name)
     if not skeleton:
         skeleton = JABS_DEFAULT_SKELETON
     tracks = {}
@@ -166,7 +167,7 @@ def read_labels(
                     )
                     if new_instance:
                         instances.append(new_instance)
-            frame_label = LabeledFrame(Video(video_name), frame_idx, instances)
+            frame_label = LabeledFrame(video, frame_idx, instances)
             frames.append(frame_label)
     return Labels(frames)
 

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -19,14 +19,20 @@ def load_slp(filename: str) -> Labels:
     return slp.read_labels(filename)
 
 
-def save_slp(labels: Labels, filename: str):
+def save_slp(
+    labels: Labels, filename: str, embed: str | list[tuple[Video, int]] | None = None
+):
     """Save a SLEAP dataset to a `.slp` file.
 
     Args:
         labels: A SLEAP `Labels` object (see `load_slp`).
         filename: Path to save labels to ending with `.slp`.
+        embed: One of `"user"`, `"suggestions"`, `"user+suggestions"`, `"source"` or
+            list of tuples of `(video, frame_idx)` specifying the frames to embed. If
+            `"source"` is specified, no images will be embedded and the source video
+            will be restored if available.
     """
-    return slp.write_labels(filename, labels)
+    return slp.write_labels(filename, labels, embed=embed)
 
 
 def load_nwb(filename: str) -> Labels:

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -360,7 +360,6 @@ def embed_videos(
             `"source"` is specified, no images will be embedded and the source video
             will be restored if available.
     """
-
     if embed == "user":
         embed = [(lf.video, lf.frame_idx) for lf in labels.user_labeled_frames]
     elif embed == "suggestions":

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -300,7 +300,7 @@ def embed_video(
             video_to_dict(source_video), separators=(",", ":")
         )
 
-        return embedded_video
+    return embedded_video
 
 
 def embed_frames(
@@ -362,8 +362,10 @@ def write_videos(labels_path: str, videos: list[Video]):
         if type(video.backend) == HDF5Video and video.backend.has_embedded_images:
             # If the video has embedded images, embed them images again if we haven't
             # already.
-            with h5py.File(labels_path, "r") as f:
-                already_embedded = f"video{video_ind}/video" in f
+            already_embedded = False
+            if Path(labels_path).exists():
+                with h5py.File(labels_path, "r") as f:
+                    already_embedded = f"video{video_ind}/video" in f
 
             if not already_embedded:
                 video = embed_video(

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -136,7 +136,7 @@ def video_to_dict(video: Video) -> dict:
         A dictionary containing the video metadata.
     """
     if video.backend is None:
-        return {"filename": video.filename, "backend": None}
+        return {"filename": video.filename, "backend": video.backend_metadata}
 
     if type(video.backend) == MediaVideo:
         return {
@@ -176,9 +176,9 @@ def video_to_dict(video: Video) -> dict:
                 "shape": video.shape,
                 "filename": video.backend.filename[0],
                 "filenames": video.backend.filename,
-                "dataset": getattr(video.backend, "dataset", None),
-                "grayscale": getattr(video.backend, "grayscale", None),
-                "input_format": getattr(video.backend, "input_format", None),
+                "dataset": video.backend_metadata.get("dataset", None),
+                "grayscale": video.grayscale,
+                "input_format": video.backend_metadata.get("input_format", None),
             },
         }
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -282,6 +282,7 @@ def embed_video(
             # If this is already an embedded dataset, retain the previous source video.
             source_video = video.source_video
             embedded_video = video
+            video.replace_filename(labels_path, open=False)
         else:
             source_video = video
             embedded_video = Video(
@@ -348,6 +349,11 @@ def embed_frames(
         if lf.video in replaced_videos:
             lf.video = replaced_videos[lf.video]
 
+    # Update suggestions with the new videos.
+    for sf in labels.suggestions:
+        if sf.video in replaced_videos:
+            sf.video = replaced_videos[sf.video]
+
 
 def embed_videos(
     labels_path: str, labels: Labels, to_embed: str | list[tuple[Video, int]]
@@ -362,11 +368,11 @@ def embed_videos(
     """
 
     if to_embed == "user":
-        to_embed = [(lf.video, lf.frame_idx) for lf in labels]
+        to_embed = [(lf.video, lf.frame_idx) for lf in labels.user_labeled_frames]
     elif to_embed == "suggestions":
         to_embed = [(sf.video, sf.frame_idx) for sf in labels.suggestions]
     elif to_embed == "user+suggestions":
-        to_embed = [(lf.video, lf.frame_idx) for lf in labels]
+        to_embed = [(lf.video, lf.frame_idx) for lf in labels.user_labeled_frames]
         to_embed += [(sf.video, sf.frame_idx) for sf in labels.suggestions]
     elif isinstance(to_embed, list):
         to_embed = to_embed

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -25,9 +25,15 @@ from sleap_io.io.utils import (
     read_hdf5_attrs,
     read_hdf5_dataset,
 )
-import imageio.v3 as iio
 from enum import IntEnum
 from pathlib import Path
+import imageio.v3 as iio
+import sys
+
+try:
+    import cv2
+except ImportError:
+    pass
 
 
 class InstanceType(IntEnum):
@@ -214,9 +220,17 @@ def embed_video(
         if image_format == "hdf5":
             img_data = frame
         else:
-            img_data = iio.imwrite(
-                "<bytes>", frame, extension="." + image_format
-            ).astype("int8")
+            if "cv2" in sys.modules:
+                img_data = np.squeeze(
+                    cv2.imencode("." + image_format, frame)[1]
+                ).astype("int8")
+            else:
+                img_data = np.frombuffer(
+                    iio.imwrite(
+                        "<bytes>", frame.squeeze(axis=-1), extension="." + image_format
+                    ),
+                    dtype="int8",
+                )
 
         imgs_data.append(img_data)
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -202,10 +202,10 @@ def embed_video(
     Args:
         labels_path: A string path to the SLEAP labels file.
         video: A `Video` object to embed in the labels file.
-        frame_inds: A list of frame indices to embed.
         group: The name of the group to store the embedded video in. Image data will be
             stored in a dataset named `{group}/video`. Frame indices will be stored
             in a data set named `{group}/frame_numbers`.
+        frame_inds: A list of frame indices to embed.
         image_format: The image format to use for embedding. Valid formats are "png"
             (the default), "jpg" or "hdf5".
         fixed_length: If `True` (the default), the embedded images will be padded to the

--- a/sleap_io/io/video.py
+++ b/sleap_io/io/video.py
@@ -160,7 +160,8 @@ class VideoBackend:
     @property
     def img_shape(self) -> Tuple[int, int, int]:
         """Shape of a single frame in the video."""
-        return self.get_frame(0).shape
+        height, width, channels = self.get_frame(0).shape
+        return int(height), int(width), int(channels)
 
     @property
     def shape(self) -> Tuple[int, int, int, int]:
@@ -434,20 +435,6 @@ class MediaVideo(VideoBackend):
                     )
         return imgs
 
-    def to_json(self) -> dict:
-        """Return JSON-serializable dictionary of the video backend."""
-        return {
-            "type": "MediaVideo",
-            "shape": self.shape,
-            "backend": {
-                "filename": self.filename,
-                "grayscale": self.grayscale,
-                "bgr": True,
-                "dataset": "",
-                "input_format": "",
-            },
-        }
-
 
 @attrs.define
 class HDF5Video(VideoBackend):
@@ -577,7 +564,7 @@ class HDF5Video(VideoBackend):
                 img_shape = ds.shape[1:]
         if self.input_format == "channels_first":
             img_shape = img_shape[::-1]
-        return img_shape
+        return int(img_shape[0]), int(img_shape[1]), int(img_shape[2])
 
     def read_test_frame(self) -> np.ndarray:
         """Read a single frame from the video to test for grayscale."""
@@ -696,20 +683,6 @@ class HDF5Video(VideoBackend):
 
         return imgs
 
-    def to_json(self) -> dict:
-        """Return JSON-serializable dictionary of the video backend."""
-        return {
-            "type": "HDF5Video",
-            "shape": self.shape,
-            "backend": {
-                "filename": ("." if self.has_embedded_images else self.filename),
-                "dataset": self.dataset,
-                "input_format": self.input_format,
-                "convert_range": False,
-                "has_embedded_images": self.has_embedded_images,
-            },
-        }
-
 
 @attrs.define
 class ImageVideo(VideoBackend):
@@ -754,25 +727,3 @@ class ImageVideo(VideoBackend):
         if img.ndim == 2:
             img = np.expand_dims(img, axis=-1)
         return img
-
-    def to_json(self) -> dict:
-        """Return JSON-serializable dictionary of the video backend."""
-
-        shape = self.shape
-        if shape is None:
-            height, width, channels = 0, 0, 1
-        else:
-            height, width, channels = shape[1:]
-
-        return {
-            "type": "ImageVideo",
-            "shape": self.shape,
-            "backend": {
-                "filename": self.filename[0],
-                "filenames": self.filename,
-                "height_": height,
-                "width_": width,
-                "channels_": channels,
-                "grayscale": self.grayscale,
-            },
-        }

--- a/sleap_io/io/video.py
+++ b/sleap_io/io/video.py
@@ -674,7 +674,7 @@ class HDF5Video(VideoBackend):
 
         if "format" in ds.attrs:
             imgs = np.stack(
-                [self.decode_embedded(img, ds.attrs["format"]) for img in imgs],
+                [self.decode_embedded(img) for img in imgs],
                 axis=0,
             )
 

--- a/sleap_io/io/video.py
+++ b/sleap_io/io/video.py
@@ -585,6 +585,11 @@ class HDF5Video(VideoBackend):
         """Return True if the dataset contains embedded images."""
         return self.image_format is not None and self.image_format != "hdf5"
 
+    @property
+    def embedded_frame_inds(self) -> list[int]:
+        """Return the frame indices of the embedded images."""
+        return list(self.frame_map.keys())
+
     def decode_embedded(self, img_string: np.ndarray) -> np.ndarray:
         """Decode an embedded image string into a numpy array.
 

--- a/sleap_io/io/video.py
+++ b/sleap_io/io/video.py
@@ -585,13 +585,12 @@ class HDF5Video(VideoBackend):
         """Return True if the dataset contains embedded images."""
         return self.image_format is not None and self.image_format != "hdf5"
 
-    def decode_embedded(self, img_string: np.ndarray, format: str) -> np.ndarray:
+    def decode_embedded(self, img_string: np.ndarray) -> np.ndarray:
         """Decode an embedded image string into a numpy array.
 
         Args:
             img_string: Binary string of the image as a `int8` numpy vector with the
                 bytes as values corresponding to the format-encoded image.
-            format: Image format (e.g., "png" or "jpg").
 
         Returns:
             The decoded image as a numpy array of shape `(height, width, channels)`. If
@@ -604,7 +603,7 @@ class HDF5Video(VideoBackend):
         if "cv2" in sys.modules:
             img = cv2.imdecode(img_string, cv2.IMREAD_UNCHANGED)
         else:
-            img = iio.imread(BytesIO(img_string), extension=f".{format}")
+            img = iio.imread(BytesIO(img_string), extension=f".{self.image_format}")
 
         if img.ndim == 2:
             img = np.expand_dims(img, axis=-1)

--- a/sleap_io/io/video.py
+++ b/sleap_io/io/video.py
@@ -434,6 +434,20 @@ class MediaVideo(VideoBackend):
                     )
         return imgs
 
+    def to_json(self) -> dict:
+        """Return JSON-serializable dictionary of the video backend."""
+        return {
+            "type": "MediaVideo",
+            "shape": self.shape,
+            "backend": {
+                "filename": self.filename,
+                "grayscale": self.grayscale,
+                "bgr": True,
+                "dataset": "",
+                "input_format": "",
+            },
+        }
+
 
 @attrs.define
 class HDF5Video(VideoBackend):
@@ -682,6 +696,20 @@ class HDF5Video(VideoBackend):
 
         return imgs
 
+    def to_json(self) -> dict:
+        """Return JSON-serializable dictionary of the video backend."""
+        return {
+            "type": "HDF5Video",
+            "shape": self.shape,
+            "backend": {
+                "filename": ("." if self.has_embedded_images else self.filename),
+                "dataset": self.dataset,
+                "input_format": self.input_format,
+                "convert_range": False,
+                "has_embedded_images": self.has_embedded_images,
+            },
+        }
+
 
 @attrs.define
 class ImageVideo(VideoBackend):
@@ -726,3 +754,25 @@ class ImageVideo(VideoBackend):
         if img.ndim == 2:
             img = np.expand_dims(img, axis=-1)
         return img
+
+    def to_json(self) -> dict:
+        """Return JSON-serializable dictionary of the video backend."""
+
+        shape = self.shape
+        if shape is None:
+            height, width, channels = 0, 0, 1
+        else:
+            height, width, channels = shape[1:]
+
+        return {
+            "type": "ImageVideo",
+            "shape": self.shape,
+            "backend": {
+                "filename": self.filename[0],
+                "filenames": self.filename,
+                "height_": height,
+                "width_": width,
+                "channels_": channels,
+                "grayscale": self.grayscale,
+            },
+        }

--- a/sleap_io/model/labeled_frame.py
+++ b/sleap_io/model/labeled_frame.py
@@ -11,14 +11,19 @@ from typing import Union
 import numpy as np
 
 
-@define(auto_attribs=True)
+@define(eq=False)
 class LabeledFrame:
     """Labeled data for a single frame of a video.
 
     Attributes:
-        video: The :class:`Video` associated with this `LabeledFrame`.
+        video: The `Video` associated with this `LabeledFrame`.
         frame_idx: The index of the `LabeledFrame` in the `Video`.
         instances: List of `Instance` objects associated with this `LabeledFrame`.
+
+    Notes:
+        Instances of this class are hashed by identity, not by value. This means that
+        two `LabeledFrame` instances with the same attributes will NOT be considered
+        equal in a set or dict.
     """
 
     video: Video
@@ -43,9 +48,25 @@ class LabeledFrame:
         return [inst for inst in self.instances if type(inst) == Instance]
 
     @property
+    def has_user_instances(self) -> bool:
+        """Return True if the frame has any user-labeled instances."""
+        for inst in self.instances:
+            if type(inst) == Instance:
+                return True
+        return False
+
+    @property
     def predicted_instances(self) -> list[Instance]:
         """Frame instances that are predicted by a model (`PredictedInstance` objects)."""
         return [inst for inst in self.instances if type(inst) == PredictedInstance]
+
+    @property
+    def has_predicted_instances(self) -> bool:
+        """Return True if the frame has any predicted instances."""
+        for inst in self.instances:
+            if type(inst) == PredictedInstance:
+                return True
+        return False
 
     def numpy(self) -> np.ndarray:
         """Return all instances in the frame as a numpy array.

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -279,7 +279,13 @@ class Labels:
 
         return results
 
-    def save(self, filename: str, format: Optional[str] = None, **kwargs):
+    def save(
+        self,
+        filename: str,
+        format: Optional[str] = None,
+        embed: str | list[tuple[Video, int]] | None = None,
+        **kwargs,
+    ):
         """Save labels to file in specified format.
 
         Args:
@@ -287,10 +293,15 @@ class Labels:
             format: The format to save the labels in. If `None`, the format will be
                 inferred from the file extension. Available formats are "slp", "nwb",
                 "labelstudio", and "jabs".
+            embed: One of `"user"`, `"suggestions"`, `"user+suggestions"`, `"source"` or
+                list of tuples of `(video, frame_idx)` specifying the frames to embed.
+                If `"source"` is specified, no images will be embedded and the source
+                video will be restored if available. This argument is only valid for the
+                SLP backend.
         """
         from sleap_io import save_file
 
-        save_file(self, filename, format=format, **kwargs)
+        save_file(self, filename, format=format, embed=embed, **kwargs)
 
     def clean(
         self,

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -374,3 +374,8 @@ class Labels:
                 tracks=True,
                 videos=False,
             )
+
+    @property
+    def user_labeled_frames(self) -> list[LabeledFrame]:
+        """Return all labeled frames with user (non-predicted) instances."""
+        return [lf for lf in self.labeled_frames if lf.has_user_instances]

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -390,3 +390,30 @@ class Labels:
     def user_labeled_frames(self) -> list[LabeledFrame]:
         """Return all labeled frames with user (non-predicted) instances."""
         return [lf for lf in self.labeled_frames if lf.has_user_instances]
+
+    def replace_videos(
+        self,
+        old_videos: list[Video] | None = None,
+        new_videos: list[Video] | None = None,
+        video_map: dict[Video, Video] | None = None,
+    ):
+        """Replace videos and update all references.
+
+        Args:
+            old_videos: List of videos to be replaced.
+            new_videos: List of videos to replace with.
+            video_map: Alternative input of dictionary where keys are the old videos and
+                values are the new videos.
+        """
+        if video_map is None:
+            video_map = {o: n for o, n in zip(old_videos, new_videos)}
+
+        # Update the labeled frames with the new videos.
+        for lf in self.labeled_frames:
+            if lf.video in video_map:
+                lf.video = video_map[lf.video]
+
+        # Update suggestions with the new videos.
+        for sf in self.suggestions:
+            if sf.video in video_map:
+                sf.video = video_map[sf.video]

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -47,6 +47,11 @@ class Video:
 
     EXTS = MediaVideo.EXTS + HDF5Video.EXTS
 
+    def __attrs_post_init__(self):
+        """Post init syntactic sugar."""
+        if self.backend is None and self.exists():
+            self.open()
+
     @classmethod
     def from_filename(
         cls,

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -5,14 +5,14 @@ a video and its components used in SLEAP.
 """
 
 from __future__ import annotations
-from attrs import define
+import attrs
 from typing import Tuple, Optional, Optional
 import numpy as np
 from sleap_io.io.video import VideoBackend, MediaVideo, HDF5Video
 from pathlib import Path
 
 
-@define
+@attrs.define
 class Video:
     """`Video` class used by sleap to represent videos and data associated with them.
 
@@ -37,7 +37,7 @@ class Video:
 
     filename: str | list[str]
     backend: Optional[VideoBackend] = None
-    backend_metadata: dict[str, any] = {}
+    backend_metadata: dict[str, any] = attrs.field(factory=dict)
     source_video: Optional[Video] = None
 
     EXTS = MediaVideo.EXTS + HDF5Video.EXTS

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -12,7 +12,7 @@ from sleap_io.io.video import VideoBackend, MediaVideo, HDF5Video
 from pathlib import Path
 
 
-@attrs.define
+@attrs.define(eq=False)
 class Video:
     """`Video` class used by sleap to represent videos and data associated with them.
 
@@ -31,6 +31,11 @@ class Video:
             information) without having access to the video file itself.
         source_video: The source video object if this is a proxy video. This is present
             when the video contains an embedded subset of frames from another video.
+
+    Notes:
+        Instances of this class are hashed by identity, not by value. This means that
+        two `Video` instances with the same attributes will NOT be considered equal in a
+        set or dict.
 
     See also: VideoBackend
     """

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -231,3 +231,10 @@ class Video:
                 self.open()
             else:
                 self.close()
+
+    def to_json(self) -> dict:
+        """Return a dictionary representation of the video."""
+        if self.backend is not None:
+            return self.backend.to_json()
+        else:
+            return {"filename": self.filename, "backend": None}

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -55,6 +55,7 @@ def test_jabs(tmp_path, jabs_real_data_v2, jabs_real_data_v5):
     labels_single_written = load_jabs(str(tmp_path / jabs_real_data_v2))
     # Confidence field is not preserved, so just check number of labels
     assert len(labels_single) == len(labels_single_written)
+    assert len(labels_single.videos) == len(labels_single_written.videos)
     assert type(load_file(jabs_real_data_v2)) == Labels
 
     labels_multi = load_jabs(jabs_real_data_v5)
@@ -66,6 +67,7 @@ def test_jabs(tmp_path, jabs_real_data_v2, jabs_real_data_v5):
     # v5 contains all v4 and v3 data, so only need to check v5
     # Confidence field and ordering of identities is not preserved, so just check number of labels
     assert len(labels_v5_written) == len(labels_multi)
+    assert len(labels_v5_written.videos) == len(labels_multi.videos)
 
 
 def test_load_video(centered_pair_low_quality_path):

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -279,7 +279,7 @@ def test_pkg_roundtrip(tmpdir, slp_minimal_pkg):
     assert labels.video.backend.embedded_frame_inds == [0]
     assert (
         Path(labels.video.filename).as_posix()
-        == (tmpdir / "roundtrip.pkg.slp").as_posix()
+        == Path(tmpdir / "roundtrip.pkg.slp").as_posix()
     )
 
 

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -277,7 +277,10 @@ def test_pkg_roundtrip(tmpdir, slp_minimal_pkg):
     assert type(labels.video.backend) == HDF5Video
     assert labels.video.shape == (1, 384, 384, 1)
     assert labels.video.backend.embedded_frame_inds == [0]
-    assert labels.video.filename == str(tmpdir / "roundtrip.pkg.slp")
+    assert (
+        Path(labels.video.filename).as_posix()
+        == (tmpdir / "roundtrip.pkg.slp").as_posix()
+    )
 
 
 @pytest.mark.parametrize("to_embed", ["user", "suggestions", "user+suggestions"])
@@ -293,12 +296,12 @@ def test_embed(tmpdir, slp_real_data, to_embed):
     assert len(base_labels.suggestions) == 10
     assert len(base_labels.user_labeled_frames) == 5
 
-    labels_path = str(tmpdir / "labels.pkg.slp")
+    labels_path = Path(tmpdir / "labels.pkg.slp").as_posix()
     write_labels(labels_path, base_labels, embed=to_embed)
     labels = read_labels(labels_path)
     assert len(labels) == 10
     assert type(labels.video.backend) == HDF5Video
-    assert labels.video.filename == labels_path
+    assert Path(labels.video.filename).as_posix() == labels_path
     assert (
         Path(labels.video.source_video.filename).as_posix()
         == "tests/data/videos/centered_pair_low_quality.mp4"

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -101,32 +101,26 @@ def test_read_videos_pkg(slp_minimal_pkg):
 
 def test_write_videos(slp_minimal_pkg, centered_pair, tmp_path):
 
-    def load_jsons(h5_path, dataset):
-        return [json.loads(x) for x in read_hdf5_dataset(h5_path, dataset)]
+    def compare_videos(videos_ref, videos_test):
+        assert len(videos_ref) == len(videos_test)
+        for video_ref, video_test in zip(videos_ref, videos_test):
+            assert video_ref.shape == video_test.shape
+            assert (video_ref[0] == video_test[0]).all()
 
-    def compare_jsons(jsons_ref, jsons_test):
-        for jsons_ref, jsons_test in zip(jsons_ref, jsons_test):
-            for k in jsons_ref["backend"]:
-                assert jsons_ref["backend"][k] == jsons_test["backend"][k]
+    videos_ref = read_videos(slp_minimal_pkg)
+    write_videos(tmp_path / "test_minimal_pkg.slp", videos_ref)
+    videos_test = read_videos(tmp_path / "test_minimal_pkg.slp")
+    compare_videos(videos_ref, videos_test)
 
-    videos = read_videos(slp_minimal_pkg)
-    write_videos(tmp_path / "test_minimal_pkg.slp", videos)
-    json_fixture = load_jsons(slp_minimal_pkg, "videos_json")
-    json_test = load_jsons(tmp_path / "test_minimal_pkg.slp", "videos_json")
-    compare_jsons(json_fixture, json_test)
-
-    videos = read_videos(centered_pair)
-    write_videos(tmp_path / "test_centered_pair.slp", videos)
-    json_fixture = load_jsons(centered_pair, "videos_json")
-    json_test = load_jsons(tmp_path / "test_centered_pair.slp", "videos_json")
-    compare_jsons(json_fixture, json_test)
+    videos_ref = read_videos(centered_pair)
+    write_videos(tmp_path / "test_centered_pair.slp", videos_ref)
+    videos_test = read_videos(tmp_path / "test_centered_pair.slp")
+    compare_videos(videos_ref, videos_test)
 
     videos = read_videos(centered_pair) * 2
     write_videos(tmp_path / "test_centered_pair_2vids.slp", videos)
-    json_test = read_hdf5_dataset(
-        tmp_path / "test_centered_pair_2vids.slp", "videos_json"
-    )
-    assert len(json_test) == 2
+    videos_test = read_videos(tmp_path / "test_centered_pair_2vids.slp")
+    compare_videos(videos, videos_test)
 
 
 def test_write_tracks(centered_pair, tmp_path):

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -288,3 +288,27 @@ def test_embed(tmpdir, slp_real_data, to_embed):
         assert len(labels.video.backend.embedded_frame_inds) == 10
     elif to_embed == "suggestions+user":
         assert len(labels.video.backend.embedded_frame_inds) == 10
+
+
+def test_embed_two_rounds(tmpdir, slp_real_data):
+    base_labels = read_labels(slp_real_data)
+    labels_path = str(tmpdir / "labels.pkg.slp")
+    write_labels(labels_path, base_labels, embed="user")
+    labels = read_labels(labels_path)
+
+    assert labels.video.backend.embedded_frame_inds == [0, 990, 440, 220, 770]
+
+    labels2_path = str(tmpdir / "labels2.pkg.slp")
+    write_labels(labels2_path, labels)
+    labels2 = read_labels(labels2_path)
+    assert (
+        labels2.video.source_video.filename
+        == "tests/data/videos/centered_pair_low_quality.mp4"
+    )
+    assert labels2.video.backend.embedded_frame_inds == [0, 990, 440, 220, 770]
+
+    labels3_path = str(tmpdir / "labels3.slp")
+    write_labels(labels3_path, labels, embed="source")
+    labels3 = read_labels(labels3_path)
+    assert labels3.video.filename == "tests/data/videos/centered_pair_low_quality.mp4"
+    assert type(labels3.video.backend) == MediaVideo

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -32,6 +32,8 @@ from sleap_io.io.slp import (
 )
 from sleap_io.io.utils import read_hdf5_dataset
 import numpy as np
+import simplejson as json
+
 
 from sleap_io.io.video import ImageVideo
 
@@ -98,17 +100,26 @@ def test_read_videos_pkg(slp_minimal_pkg):
 
 
 def test_write_videos(slp_minimal_pkg, centered_pair, tmp_path):
+
+    def load_jsons(h5_path, dataset):
+        return [json.loads(x) for x in read_hdf5_dataset(h5_path, dataset)]
+
+    def compare_jsons(jsons_ref, jsons_test):
+        for jsons_ref, jsons_test in zip(jsons_ref, jsons_test):
+            for k in jsons_ref["backend"]:
+                assert jsons_ref["backend"][k] == jsons_test["backend"][k]
+
     videos = read_videos(slp_minimal_pkg)
     write_videos(tmp_path / "test_minimal_pkg.slp", videos)
-    json_fixture = read_hdf5_dataset(slp_minimal_pkg, "videos_json")
-    json_test = read_hdf5_dataset(tmp_path / "test_minimal_pkg.slp", "videos_json")
-    assert json_fixture == json_test
+    json_fixture = load_jsons(slp_minimal_pkg, "videos_json")
+    json_test = load_jsons(tmp_path / "test_minimal_pkg.slp", "videos_json")
+    compare_jsons(json_fixture, json_test)
 
     videos = read_videos(centered_pair)
     write_videos(tmp_path / "test_centered_pair.slp", videos)
-    json_fixture = read_hdf5_dataset(centered_pair, "videos_json")
-    json_test = read_hdf5_dataset(tmp_path / "test_centered_pair.slp", "videos_json")
-    assert json_fixture == json_test
+    json_fixture = load_jsons(centered_pair, "videos_json")
+    json_test = load_jsons(tmp_path / "test_centered_pair.slp", "videos_json")
+    compare_jsons(json_fixture, json_test)
 
     videos = read_videos(centered_pair) * 2
     write_videos(tmp_path / "test_centered_pair_2vids.slp", videos)

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -37,7 +37,7 @@ from sleap_io.io.utils import read_hdf5_dataset
 import numpy as np
 import simplejson as json
 import pytest
-
+from pathlib import Path
 
 from sleap_io.io.video import ImageVideo, HDF5Video, MediaVideo
 
@@ -285,7 +285,8 @@ def test_embed(tmpdir, slp_real_data, to_embed):
     base_labels = read_labels(slp_real_data)
     assert type(base_labels.video.backend) == MediaVideo
     assert (
-        base_labels.video.filename == "tests/data/videos/centered_pair_low_quality.mp4"
+        Path(base_labels.video.filename).as_posix()
+        == "tests/data/videos/centered_pair_low_quality.mp4"
     )
     assert base_labels.video.shape == (1100, 384, 384, 1)
     assert len(base_labels) == 10
@@ -299,7 +300,7 @@ def test_embed(tmpdir, slp_real_data, to_embed):
     assert type(labels.video.backend) == HDF5Video
     assert labels.video.filename == labels_path
     assert (
-        labels.video.source_video.filename
+        Path(labels.video.source_video.filename).as_posix()
         == "tests/data/videos/centered_pair_low_quality.mp4"
     )
     if to_embed == "user":
@@ -322,7 +323,7 @@ def test_embed_two_rounds(tmpdir, slp_real_data):
     write_labels(labels2_path, labels)
     labels2 = read_labels(labels2_path)
     assert (
-        labels2.video.source_video.filename
+        Path(labels2.video.source_video.filename).as_posix()
         == "tests/data/videos/centered_pair_low_quality.mp4"
     )
     assert labels2.video.backend.embedded_frame_inds == [0, 990, 440, 220, 770]
@@ -330,5 +331,8 @@ def test_embed_two_rounds(tmpdir, slp_real_data):
     labels3_path = str(tmpdir / "labels3.slp")
     write_labels(labels3_path, labels, embed="source")
     labels3 = read_labels(labels3_path)
-    assert labels3.video.filename == "tests/data/videos/centered_pair_low_quality.mp4"
+    assert (
+        Path(labels3.video.filename).as_posix()
+        == "tests/data/videos/centered_pair_low_quality.mp4"
+    )
     assert type(labels3.video.backend) == MediaVideo

--- a/tests/model/test_labeled_frame.py
+++ b/tests/model/test_labeled_frame.py
@@ -1,7 +1,7 @@
 """Tests for methods in sleap_io.model.labeled_frame file."""
 
 from numpy.testing import assert_equal
-from sleap_io import Video, Skeleton, Instance, PredictedInstance
+from sleap_io import Video, Skeleton, Instance, PredictedInstance, Track
 from sleap_io.model.labeled_frame import LabeledFrame
 import numpy as np
 
@@ -28,6 +28,9 @@ def test_labeled_frame():
     # Test LabeledFrame.__getitem__ method
     assert lf[0] == inst
 
+    assert lf.has_predicted_instances
+    assert lf.has_user_instances
+
 
 def test_remove_predictions():
     """Test removing predictions from `LabeledFrame`."""
@@ -43,6 +46,8 @@ def test_remove_predictions():
 
     assert len(lf) == 2
     assert len(lf.predicted_instances) == 1
+    assert lf.has_predicted_instances
+    assert lf.has_user_instances
 
     # Remove predictions
     lf.remove_predictions()
@@ -51,6 +56,8 @@ def test_remove_predictions():
     assert len(lf.predicted_instances) == 0
     assert type(lf[0]) == Instance
     assert_equal(lf.numpy(), [[[0, 1], [2, 3]]])
+    assert not lf.has_predicted_instances
+    assert lf.has_user_instances
 
 
 def test_remove_empty_instances():
@@ -75,3 +82,44 @@ def test_remove_empty_instances():
     assert len(lf) == 1
     assert type(lf[0]) == Instance
     assert_equal(lf.numpy(), [[[0, 1], [2, 3]]])
+
+
+def test_labeled_frame_image(centered_pair_low_quality_path):
+    video = Video.from_filename(centered_pair_low_quality_path)
+    lf = LabeledFrame(video=video, frame_idx=0)
+    assert_equal(lf.image, video[0])
+
+
+def test_labeled_frame_unused_predictions():
+    video = Video("test.mp4")
+    skel = Skeleton(["A", "B"])
+    track = Track("trk")
+
+    lf1 = LabeledFrame(video=video, frame_idx=0)
+    lf1.instances.append(
+        Instance.from_numpy([[0, 0], [0, 0]], skeleton=skel, track=track)
+    )
+    lf1.instances.append(
+        PredictedInstance.from_numpy(
+            [[0, 0], [0, 0]], [1, 1], 1, skeleton=skel, track=track
+        )
+    )
+    lf1.instances.append(
+        PredictedInstance.from_numpy([[1, 1], [1, 1]], [1, 1], 1, skeleton=skel)
+    )
+
+    assert len(lf1.unused_predictions) == 1
+    assert (lf1.unused_predictions[0].numpy() == 1).all()
+
+    lf2 = LabeledFrame(video=video, frame_idx=1)
+    lf2.instances.append(
+        PredictedInstance.from_numpy([[0, 0], [0, 0]], [1, 1], 1, skeleton=skel)
+    )
+    lf2.instances.append(Instance.from_numpy([[0, 0], [0, 0]], skeleton=skel))
+    lf2.instances[-1].from_predicted = lf2.instances[-2]
+    lf2.instances.append(
+        PredictedInstance.from_numpy([[1, 1], [1, 1]], [1, 1], 1, skeleton=skel)
+    )
+
+    assert len(lf2.unused_predictions) == 1
+    assert (lf2.unused_predictions[0].numpy() == 1).all()

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -258,3 +258,17 @@ def test_labels_remove_predictions(slp_real_data):
     labels.remove_predictions(clean=True)
     assert len(labels) == 5
     assert sum([len(lf.predicted_instances) for lf in labels]) == 0
+
+
+def test_replace_videos(slp_real_data):
+    labels = load_slp(slp_real_data)
+    assert labels.video.filename == "tests/data/videos/centered_pair_low_quality.mp4"
+    labels.replace_videos(
+        old_videos=[labels.video], new_videos=[Video.from_filename("fake.mp4")]
+    )
+
+    for lf in labels:
+        assert lf.video.filename == "fake.mp4"
+
+    for sf in labels.suggestions:
+        assert sf.video.filename == "fake.mp4"

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -20,6 +20,7 @@ def test_video_from_filename(centered_pair_low_quality_path):
     test_video = Video.from_filename(centered_pair_low_quality_path)
     assert test_video.filename == centered_pair_low_quality_path
     assert test_video.shape == (1100, 384, 384, 1)
+    assert len(test_video) == 1100
     assert type(test_video.backend) == MediaVideo
 
 

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -57,8 +57,8 @@ def test_video_exists(centered_pair_low_quality_video, centered_pair_frame_paths
 
 def test_video_open_close(centered_pair_low_quality_path):
     video = Video(centered_pair_low_quality_path)
-    assert video.is_open is False
-    assert video.backend is None
+    assert video.is_open
+    assert type(video.backend) == MediaVideo
 
     img = video[0]
     assert img.shape == (384, 384, 1)


### PR DESCRIPTION
## Highlights
- Saving SLP files with embedded images will re-save the embedded images.
- Embed images into SLP files with: `labels.save("labels.pkg.slp", embed="user")`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functions for video manipulation and embedding in SLEAP labels files.
  - Added properties to `LabeledFrame` for checking specific instance types.
  - Enabled embedding frames in saved files with the `save_slp` function.

- **Enhancements**
  - Updated `Video` class with new attributes and methods for better metadata handling.
  - Improved image shape handling in `HDF5Video` class.
  - Added `user_labeled_frames` property to return frames with user instances.

- **Bug Fixes**
  - Fixed issues with video object creation and frame embedding.

- **Documentation**
  - Enhanced `CONTRIBUTING.md` with live coverage setup steps.

- **Chores**
  - Updated `.gitignore` to include `lcov.info`.
  - Adjusted `pyproject.toml` for dependencies and testing configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->