### PR TITLE
Fix suggestions deserialization

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -197,9 +197,11 @@ def read_suggestions(labels_path: str, videos: list[Video]) -> list[SuggestionFr
     Returns:
         A list of `SuggestionFrame` objects.
     """
-    suggestions = [
-        json.loads(x) for x in read_hdf5_dataset(labels_path, "suggestions_json")
-    ]
+    try:
+        suggestions = read_hdf5_dataset(labels_path, "suggestions_json")
+    except KeyError:
+        return []
+    suggestions = [json.loads(x) for x in suggestions]
     suggestions_objects = []
     for suggestion in suggestions:
         suggestions_objects.append(

--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -2,4 +2,4 @@
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -12,6 +12,7 @@ from sleap_io import (
     PredictedPoint,
     PredictedInstance,
     Labels,
+    SuggestionFrame,
 )
 from sleap_io.io.slp import (
     read_videos,
@@ -29,6 +30,8 @@ from sleap_io.io.slp import (
     write_lfs,
     read_labels,
     write_labels,
+    read_suggestions,
+    write_suggestions,
 )
 from sleap_io.io.utils import read_hdf5_dataset
 import numpy as np
@@ -237,3 +240,20 @@ def test_slp_imgvideo(tmpdir, slp_imgvideo):
     assert type(videos[0].backend) == ImageVideo
     assert len(videos[0].filename) == 2
     assert videos[0].shape is None
+
+
+def test_suggestions(tmpdir):
+    labels = Labels()
+    labels.videos.append(Video.from_filename("fake.mp4"))
+    labels.suggestions.append(SuggestionFrame(video=labels.video, frame_idx=0))
+
+    write_suggestions(tmpdir / "test.slp", labels.suggestions, labels.videos)
+    loaded_suggestions = read_suggestions(tmpdir / "test.slp", labels.videos)
+    assert len(loaded_suggestions) == 1
+    assert loaded_suggestions[0].video.filename == "fake.mp4"
+    assert loaded_suggestions[0].frame_idx == 0
+
+    # Handle missing suggestions dataset
+    write_videos(tmpdir / "test2.slp", labels.videos)
+    loaded_suggestions = read_suggestions(tmpdir / "test2.slp", labels.videos)
+    assert len(loaded_suggestions) == 0


### PR DESCRIPTION
This fixes an issue where we fail to load SLP files if they don't contain suggestions data. This was the case for SLP files produced with `sleap-io<0.1.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when reading suggestions from datasets. Now returns an empty list if the dataset is not found, enhancing stability and user experience.

- **Chores**
  - Updated package version from "0.1.1" to "0.1.2".

- **Tests**
  - Added new tests to ensure the correct functionality of reading and writing suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->