### PR TITLE
`Labels.split` and `Labels.make_training_splits`

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,10 +37,11 @@ import sleap_io as sio
 labels = sio.load_file("predictions.slp")
 
 # Save to NWB file.
-sio.save_file(labels, "predictions.nwb")
-# Or:
-# labels.save("predictions.nwb")
+labels.save("predictions.nwb")
 ```
+
+**See also:** [`Labels.save`](model.md#sleap_io.Labels.save) and [Formats](formats.md)
+
 
 ### Convert labels to raw arrays
 
@@ -60,6 +61,9 @@ n_frames, n_tracks, n_nodes, xy_score = trx.shape
 assert xy_score == 3
 ```
 
+**See also:** [`Labels.numpy`](model.md#sleap_io.Labels.numpy)
+
+
 ### Read video data
 
 ```py
@@ -71,6 +75,10 @@ n_frames, height, width, channels = video.shape
 frame = video[0]
 height, width, channels = frame.shape
 ```
+
+**See also:** [`sio.load_video`](formats.md#sleap_io.load_video) and [`Video`](model.md#sleap_io.Video)
+
+
 
 ### Create labels from raw data
 
@@ -106,6 +114,67 @@ labels = sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=[lf])
 # Save.
 labels.save("labels.slp")
 ```
+
+**See also:** [Model](model.md), [`Labels`](model.md#sleap_io.Labels),
+[`LabeledFrame`](model.md#sleap_io.LabeledFrame),
+[`Instance`](model.md#sleap_io.Instance),
+[`PredictedInstance`](model.md#sleap_io.PredictedInstance),
+[`Skeleton`](model.md#sleap_io.Skeleton), [`Video`](model.md#sleap_io.Video), [`Track`](model.md#sleap_io.Track), [`SuggestionFrame`](model.md#sleap_io.SuggestionFrame)
+
+
+### Fix video paths
+
+```py
+import sleap_io as sio
+
+labels = sio.load_file("labels.v001.slp")
+
+# Fix paths using prefixes.
+labels.replace_filenames(prefix_map={
+    "D:/data/sleap_projects": "/home/user/sleap_projects",
+    "C:/Users/sleaper/Desktop/test": "/home/user/sleap_projects",
+})
+
+labels.save("labels.v002.slp")
+```
+
+**See also:** [`Labels.replace_filenames`](model.md#sleap_io.Labels.replace_filenames)
+
+
+### Save labels with embedded images
+
+```py
+import sleap_io as sio
+
+# Load source labels.
+labels = sio.load_file("labels.v001.slp")
+
+# Save with embedded images for frames with user labeled data and suggested frames.
+labels.save("labels.v001.pkg.slp", embed="user+suggestions")
+```
+
+**See also:** [`Labels.save`](model.md#sleap_io.Labels.save)
+
+
+### Make training/validation/test splits
+
+```py
+import sleap_io as sio
+
+# Load source labels.
+labels = sio.load_file("labels.v001.slp")
+
+# Make splits and export with embedded images.
+labels.make_training_splits(n_train=0.8, n_val=0.1, n_test=0.1, save_dir="split1", seed=42)
+
+# Splits will be saved as self-contained SLP package files with images and labels.
+labels_train = sio.load_file("split1/train.pkg.slp")
+labels_val = sio.load_file("split1/val.pkg.slp")
+labels_test = sio.load_file("split1/test.pkg.slp")
+```
+
+**See also:** [`Labels.make_training_splits`](model.md#sleap_io.Labels.make_training_splits)
+
 
 ## Support
 For technical inquiries specific to this package, please [open an Issue](https://github.com/talmolab/sleap-io/issues)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,13 +144,13 @@ extra_css:
   - css/mkdocstrings.css
 
 copyright: >
-  Copyright &copy; 2024 - 2024 Talmo Lab –
+  Copyright &copy; 2022 - 2024 Talmo Lab –
   <a href="#__consent">Change cookie settings</a>
 
 nav:
   - Overview: index.md
   - Changelog: https://github.com/talmolab/sleap-io/releases
   - Core API:
-    - Data model: model.md
-    - Data formats: formats.md
+    - Model: model.md
+    - Formats: formats.md
   - Full API: reference/

--- a/sleap_io/io/jabs.py
+++ b/sleap_io/io/jabs.py
@@ -169,7 +169,9 @@ def read_labels(
                         instances.append(new_instance)
             frame_label = LabeledFrame(video, frame_idx, instances)
             frames.append(frame_label)
-    return Labels(frames)
+    labels = Labels(frames)
+    labels.provenance["filename"] = labels_path
+    return labels
 
 
 def make_simple_skeleton(name: str, num_points: int) -> Skeleton:

--- a/sleap_io/io/labelstudio.py
+++ b/sleap_io/io/labelstudio.py
@@ -43,7 +43,9 @@ def read_labels(
     else:
         assert isinstance(skeleton, Skeleton)
 
-    return parse_tasks(tasks, skeleton)
+    labels = parse_tasks(tasks, skeleton)
+    labels.provenance["filename"] = labels_path
+    return labels
 
 
 def infer_nodes(tasks: List[Dict]) -> Skeleton:

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -161,7 +161,7 @@ def load_file(
         A `Labels` or `Video` object.
     """
     if isinstance(filename, Path):
-        filename = str(filename)
+        filename = filename.as_posix()
 
     if format is None:
         if filename.endswith(".slp"):

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -20,17 +20,29 @@ def load_slp(filename: str) -> Labels:
 
 
 def save_slp(
-    labels: Labels, filename: str, embed: str | list[tuple[Video, int]] | None = None
+    labels: Labels,
+    filename: str,
+    embed: bool | str | list[tuple[Video, int]] | None = None,
 ):
     """Save a SLEAP dataset to a `.slp` file.
 
     Args:
         labels: A SLEAP `Labels` object (see `load_slp`).
         filename: Path to save labels to ending with `.slp`.
-        embed: One of `"user"`, `"suggestions"`, `"user+suggestions"`, `"source"` or
-            list of tuples of `(video, frame_idx)` specifying the frames to embed. If
-            `"source"` is specified, no images will be embedded and the source video
+        embed: Frames to embed in the saved labels file. One of `None`, `True`,
+            `"all"`, `"user"`, `"suggestions"`, `"user+suggestions"`, `"source"` or list
+            of tuples of `(video, frame_idx)`.
+
+            If `None` is specified (the default) and the labels contains embedded
+            frames, those embedded frames will be re-saved to the new file.
+
+            If `True` or `"all"`, all labeled frames and suggested frames will be
+            embedded.
+
+            If `"source"` is specified, no images will be embedded and the source video
             will be restored if available.
+
+            This argument is only valid for the SLP backend.
     """
     return slp.write_labels(filename, labels, embed=embed)
 

--- a/sleap_io/io/nwb.py
+++ b/sleap_io/io/nwb.py
@@ -140,6 +140,7 @@ def read_nwb(path: str) -> Labels:
                     LabeledFrame(video=video, frame_idx=frame_idx, instances=insts)
                 )
     labels = Labels(lfs)
+    labels.provenance["filename"] = path
     return labels
 
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -373,7 +373,7 @@ def embed_videos(
 
             This argument is only valid for the SLP backend.
     """
-    if embed == True:
+    if embed is True:
         embed = "all"
     if embed == "user":
         embed = [(lf.video, lf.frame_idx) for lf in labels.user_labeled_frames]

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -967,12 +967,9 @@ def write_lfs(labels_path: str, labels: Labels):
 
     # Link instances based on from_predicted field.
     for instance_id, from_predicted in to_link:
-        if id(from_predicted) in inst_to_id:
-            instances[instance_id][5] = inst_to_id[id(from_predicted)]
-        else:
-            # Source instance may be missing if predictions were removed from the
-            # labels, in which case, remove the link.
-            instances[instance_id][5] = -1
+        # Source instance may be missing if predictions were removed from the labels, in
+        # which case, remove the link.
+        instances[instance_id][5] = inst_to_id.get(id(from_predicted), -1)
 
     # Create structured arrays.
     points = np.array([tuple(x) for x in points], dtype=point_dtype)

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1031,6 +1031,7 @@ def read_labels(labels_path: str) -> Labels:
         suggestions=suggestions,
         provenance=provenance,
     )
+    labels.provenance["filename"] = labels_path
 
     return labels
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -967,7 +967,12 @@ def write_lfs(labels_path: str, labels: Labels):
 
     # Link instances based on from_predicted field.
     for instance_id, from_predicted in to_link:
-        instances[instance_id][5] = inst_to_id[id(from_predicted)]
+        if id(from_predicted) in inst_to_id:
+            instances[instance_id][5] = inst_to_id[id(from_predicted)]
+        else:
+            # Source instance may be missing if predictions were removed from the
+            # labels, in which case, remove the link.
+            instances[instance_id][5] = -1
 
     # Create structured arrays.
     points = np.array([tuple(x) for x in points], dtype=point_dtype)

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -729,6 +729,13 @@ def write_metadata(labels_path: str, labels: Labels):
         "negative_anchors": {},
         "provenance": labels.provenance,
     }
+
+    # Custom encoding.
+    for k in md["provenance"]:
+        if isinstance(md["provenance"][k], Path):
+            # Path -> str
+            md["provenance"][k] = md["provenance"][k].as_posix()
+
     with h5py.File(labels_path, "a") as f:
         grp = f.require_group("metadata")
         grp.attrs["format_id"] = 1.2

--- a/sleap_io/io/video.py
+++ b/sleap_io/io/video.py
@@ -538,7 +538,7 @@ class HDF5Video(VideoBackend):
                 self.image_format = ds.attrs["format"]
 
             if "frame_numbers" in ds.parent:
-                frame_numbers = ds.parent["frame_numbers"][:]
+                frame_numbers = ds.parent["frame_numbers"][:].astype(int)
                 self.frame_map = {frame: idx for idx, frame in enumerate(frame_numbers)}
                 self.source_inds = frame_numbers
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -608,4 +608,9 @@ class Labels:
         split1, split2 = deepcopy(split1), deepcopy(split2)
         split1, split2 = Labels(split1), Labels(split2)
 
+        split1.provenance = self.provenance
+        split2.provenance = self.provenance
+        split1.provenance["source_labels"] = self.provenance.get("filename", None)
+        split2.provenance["source_labels"] = self.provenance.get("filename", None)
+
         return split1, split2

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -341,7 +341,7 @@ class Labels:
         self,
         filename: str,
         format: Optional[str] = None,
-        embed: str | list[tuple[Video, int]] | None = None,
+        embed: bool | str | list[tuple[Video, int]] | None = None,
         **kwargs,
     ):
         """Save labels to file in specified format.
@@ -349,13 +349,22 @@ class Labels:
         Args:
             filename: Path to save labels to.
             format: The format to save the labels in. If `None`, the format will be
-                inferred from the file extension. Available formats are "slp", "nwb",
-                "labelstudio", and "jabs".
-            embed: One of `"user"`, `"suggestions"`, `"user+suggestions"`, `"source"` or
-                list of tuples of `(video, frame_idx)` specifying the frames to embed.
+                inferred from the file extension. Available formats are `"slp"`,
+                `"nwb"`, `"labelstudio"`, and `"jabs"`.
+            embed: Frames to embed in the saved labels file. One of `None`, `True`,
+                `"all"`, `"user"`, `"suggestions"`, `"user+suggestions"`, `"source"` or
+                list of tuples of `(video, frame_idx)`.
+
+                If `None` is specified (the default) and the labels contains embedded
+                frames, those embedded frames will be re-saved to the new file.
+
+                If `True` or `"all"`, all labeled frames and suggested frames will be
+                embedded.
+
                 If `"source"` is specified, no images will be embedded and the source
-                video will be restored if available. This argument is only valid for the
-                SLP backend.
+                video will be restored if available.
+
+                This argument is only valid for the SLP backend.
         """
         from sleap_io import save_file
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -647,9 +647,10 @@ class Labels:
             Frames with user labeled data will be embedded in the resulting files.
 
             If `save_dir` is specified, this will save the randomly sampled splits to:
-                - `{save_dir}/train.pkg.slp`
-                - `{save_dir}/val.pkg.slp`
-                - `{save_dir}/test.pkg.slp` (if `n_test` is specified)
+
+            - `{save_dir}/train.pkg.slp`
+            - `{save_dir}/val.pkg.slp`
+            - `{save_dir}/test.pkg.slp` (if `n_test` is specified)
 
         See also: `Labels.split`
         """

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -55,11 +55,6 @@ class Video:
         if self.backend is None and self.exists():
             self.open()
 
-    def __attrs_post_init__(self):
-        """Post init syntactic sugar."""
-        if self.backend is None and self.exists():
-            self.open()
-
     @classmethod
     def from_filename(
         cls,
@@ -273,7 +268,7 @@ class Video:
                 the new filename does not exist, no error is raised.
         """
         if isinstance(new_filename, Path):
-            new_filename = str(new_filename)
+            new_filename = new_filename.as_posix()
 
         if isinstance(new_filename, list):
             new_filename = [

--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -2,4 +2,4 @@
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -283,7 +283,9 @@ def test_pkg_roundtrip(tmpdir, slp_minimal_pkg):
     )
 
 
-@pytest.mark.parametrize("to_embed", ["user", "suggestions", "user+suggestions"])
+@pytest.mark.parametrize(
+    "to_embed", [True, "all", "user", "suggestions", "user+suggestions"]
+)
 def test_embed(tmpdir, slp_real_data, to_embed):
     base_labels = read_labels(slp_real_data)
     assert type(base_labels.video.backend) == MediaVideo
@@ -306,8 +308,21 @@ def test_embed(tmpdir, slp_real_data, to_embed):
         Path(labels.video.source_video.filename).as_posix()
         == "tests/data/videos/centered_pair_low_quality.mp4"
     )
-    if to_embed == "user":
-        assert labels.video.backend.embedded_frame_inds == [0, 990, 440, 220, 770]
+    if to_embed == "all" or to_embed is True:
+        assert labels.video.backend.embedded_frame_inds == [
+            0,
+            110,
+            220,
+            330,
+            440,
+            550,
+            660,
+            770,
+            880,
+            990,
+        ]
+    elif to_embed == "user":
+        assert labels.video.backend.embedded_frame_inds == [0, 220, 440, 770, 990]
     elif to_embed == "suggestions":
         assert len(labels.video.backend.embedded_frame_inds) == 10
     elif to_embed == "suggestions+user":
@@ -320,7 +335,7 @@ def test_embed_two_rounds(tmpdir, slp_real_data):
     write_labels(labels_path, base_labels, embed="user")
     labels = read_labels(labels_path)
 
-    assert labels.video.backend.embedded_frame_inds == [0, 990, 440, 220, 770]
+    assert labels.video.backend.embedded_frame_inds == [0, 220, 440, 770, 990]
 
     labels2_path = str(tmpdir / "labels2.pkg.slp")
     write_labels(labels2_path, labels)
@@ -329,7 +344,7 @@ def test_embed_two_rounds(tmpdir, slp_real_data):
         Path(labels2.video.source_video.filename).as_posix()
         == "tests/data/videos/centered_pair_low_quality.mp4"
     )
-    assert labels2.video.backend.embedded_frame_inds == [0, 990, 440, 220, 770]
+    assert labels2.video.backend.embedded_frame_inds == [0, 220, 440, 770, 990]
 
     labels3_path = str(tmpdir / "labels3.slp")
     write_labels(labels3_path, labels, embed="source")

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -498,8 +498,14 @@ def test_split(slp_real_data, tmp_path):
     split1.save(tmp_path / "split1.pkg.slp", embed=True)
     split2.save(tmp_path / "split2.pkg.slp", embed=True)
     assert pkg.video.filename == (tmp_path / "test.pkg.slp").as_posix()
-    assert split1.video.filename == (tmp_path / "split1.pkg.slp").as_posix()
-    assert split2.video.filename == (tmp_path / "split2.pkg.slp").as_posix()
+    assert (
+        Path(split1.video.filename).as_posix()
+        == (tmp_path / "split1.pkg.slp").as_posix()
+    )
+    assert (
+        Path(split2.video.filename).as_posix()
+        == (tmp_path / "split2.pkg.slp").as_posix()
+    )
     assert (
         split1.video.source_video.filename
         == "tests/data/videos/centered_pair_low_quality.mp4"
@@ -513,8 +519,14 @@ def test_split(slp_real_data, tmp_path):
     split2_ = load_slp(tmp_path / "split2.pkg.slp")
     assert len(split1_) == 8
     assert len(split2_) == 2
-    assert split1_.video.filename == (tmp_path / "split1.pkg.slp").as_posix()
-    assert split2_.video.filename == (tmp_path / "split2.pkg.slp").as_posix()
+    assert (
+        Path(split1_.video.filename).as_posix()
+        == (tmp_path / "split1.pkg.slp").as_posix()
+    )
+    assert (
+        Path(split2_.video.filename).as_posix()
+        == (tmp_path / "split2.pkg.slp").as_posix()
+    )
     assert (
         split1_.video.source_video.filename
         == "tests/data/videos/centered_pair_low_quality.mp4"

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -523,3 +523,55 @@ def test_split(slp_real_data, tmp_path):
         split2_.video.source_video.filename
         == "tests/data/videos/centered_pair_low_quality.mp4"
     )
+
+
+def test_make_training_splits(slp_real_data, tmp_path):
+    labels = load_slp(slp_real_data)
+    assert len(labels.user_labeled_frames) == 5
+
+    train, val = labels.make_training_splits(0.8)
+    assert len(train) == 4
+    assert len(val) == 1
+
+    train, val = labels.make_training_splits(3)
+    assert len(train) == 3
+    assert len(val) == 2
+
+    train, val = labels.make_training_splits(0.8, 0.2)
+    assert len(train) == 4
+    assert len(val) == 1
+
+    train, val, test = labels.make_training_splits(0.8, 0.1, 0.1)
+    assert len(train) == 4
+    assert len(val) == 1
+    assert len(test) == 1
+
+    train, val, test = labels.make_training_splits(n_train=0.6, n_test=1)
+    assert len(train) == 3
+    assert len(val) == 1
+    assert len(test) == 1
+
+    train, val, test = labels.make_training_splits(n_train=1, n_val=1, n_test=1)
+    assert len(train) == 1
+    assert len(val) == 1
+    assert len(test) == 1
+
+
+def test_make_training_splits_save(slp_real_data, tmp_path):
+    labels = load_slp(slp_real_data)
+
+    train, val, test = labels.make_training_splits(0.6, 0.2, 0.2, save_dir=tmp_path)
+
+    train_, val_, test_ = (
+        load_slp(tmp_path / "train.pkg.slp"),
+        load_slp(tmp_path / "val.pkg.slp"),
+        load_slp(tmp_path / "test.pkg.slp"),
+    )
+
+    assert len(train_) == len(train)
+    assert len(val_) == len(val)
+    assert len(test_) == len(test)
+
+    assert train_.provenance["source_labels"] == slp_real_data
+    assert val_.provenance["source_labels"] == slp_real_data
+    assert test_.provenance["source_labels"] == slp_real_data


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced functionalities for fixing video paths, saving labels with embedded images, and creating training/validation/test splits.
  - Added new options for embedding frames when saving SLEAP datasets.

- **Updates**
  - Updated navigation labels in documentation.
  - Updated the package version to 0.1.5.

- **Bug Fixes**
  - Ensured unique frame indices for each video and improved metadata encoding.
  - Improved error handling in linking instances based on predictions.

- **Documentation**
  - Added references to related functions and modules.
  - Updated method calls and documentation for new functionalities and embedding options.

- **Tests**
  - Introduced new tests for data splitting, creating training splits, and embedding options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->