### PR TITLE
Grayscale property passthrough

### DIFF
--- a/sleap_io/io/video.py
+++ b/sleap_io/io/video.py
@@ -161,6 +161,8 @@ class VideoBackend:
     def img_shape(self) -> Tuple[int, int, int]:
         """Shape of a single frame in the video."""
         height, width, channels = self.read_test_frame().shape
+        if self.grayscale is None:
+            self.detect_grayscale()
         if self.grayscale is False:
             channels = 3
         elif self.grayscale is True:

--- a/sleap_io/io/video.py
+++ b/sleap_io/io/video.py
@@ -160,7 +160,11 @@ class VideoBackend:
     @property
     def img_shape(self) -> Tuple[int, int, int]:
         """Shape of a single frame in the video."""
-        height, width, channels = self.get_frame(0).shape
+        height, width, channels = self.read_test_frame().shape
+        if self.grayscale is False:
+            channels = 3
+        elif self.grayscale is True:
+            channels = 1
         return int(height), int(width), int(channels)
 
     @property
@@ -578,7 +582,7 @@ class HDF5Video(VideoBackend):
             frame_idx = list(self.frame_map.keys())[0]
         else:
             frame_idx = 0
-        return self.read_frame(frame_idx)
+        return self._read_frame(frame_idx)
 
     @property
     def has_embedded_images(self) -> bool:
@@ -699,7 +703,7 @@ class ImageVideo(VideoBackend):
     This backend supports reading videos stored as a list of images.
 
     Attributes:
-        filename: Path to video files.
+        filename: Path to image files.
         grayscale: Whether to force grayscale. If None, autodetect on first frame load.
     """
 

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -120,7 +120,7 @@ class Video:
                 return self.backend_metadata["shape"]
             return None
 
-    @property.getter
+    @property
     def grayscale(self) -> bool | None:
         """Return whether the video is grayscale.
 
@@ -131,17 +131,16 @@ class Video:
         if shape is not None:
             return shape[-1] == 1
         else:
-            if "grayscale" in self.backend_metadata:
-                return self.backend_metadata["grayscale"]
-            return None
+            return self.backend_metadata.get("grayscale", None)
 
-    @property.setter
+    @grayscale.setter
     def grayscale(self, value: bool):
         """Set the grayscale value and adjust the backend."""
-        self.backend.grayscale = value
-        self.backend._cached_shape = None
-        if "grayscale" in self.backend_metadata:
-            self.backend_metadata["grayscale"] = value
+        if self.backend is not None:
+            self.backend.grayscale = value
+            self.backend._cached_shape = None
+
+        self.backend_metadata["grayscale"] = value
 
     def __len__(self) -> int:
         """Return the length of the video as the number of frames."""

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -120,7 +120,7 @@ class Video:
                 return self.backend_metadata["shape"]
             return None
 
-    @property
+    @property.getter
     def grayscale(self) -> bool | None:
         """Return whether the video is grayscale.
 
@@ -134,6 +134,14 @@ class Video:
             if "grayscale" in self.backend_metadata:
                 return self.backend_metadata["grayscale"]
             return None
+
+    @property.setter
+    def grayscale(self, value: bool):
+        """Set the grayscale value and adjust the backend."""
+        self.backend.grayscale = value
+        self.backend._cached_shape = None
+        if "grayscale" in self.backend_metadata:
+            self.backend_metadata["grayscale"] = value
 
     def __len__(self) -> int:
         """Return the length of the video as the number of frames."""

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -122,3 +122,12 @@ def test_video_replace_filename(
     video.replace_filename(centered_pair_frame_paths)
     assert type(video.backend) == ImageVideo
     assert video.exists(check_all=True) is True
+
+
+def test_grayscale(centered_pair_low_quality_path):
+    video = Video.from_filename(centered_pair_low_quality_path)
+    assert video.grayscale == True
+    assert video.shape[-1] == 1
+
+    video.grayscale = False
+    assert video.shape[-1] == 3

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -131,3 +131,14 @@ def test_grayscale(centered_pair_low_quality_path):
 
     video.grayscale = False
     assert video.shape[-1] == 3
+
+    video.close()
+    video.open()
+    assert video.grayscale == False
+    assert video.shape[-1] == 3
+
+    video.grayscale = True
+    video.close()
+    video.open()
+    assert video.grayscale == True
+    assert video.shape[-1] == 1


### PR DESCRIPTION
This PR addresses #97 by implementing the behavior of setting the `video.grayscale` property so that it gets passed through to the backend appropriately and is used when computing `video.shape`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for handling grayscale videos and channel assignment in the video functionality.

- **Tests**
  - Included new tests for verifying grayscale conversion and properties in video objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->