### PR TITLE
Path sanitization hotfix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,17 +5,17 @@ channels:
 
 dependencies:
   - python
-  - ffmpeg<6.1.0
+  - ffmpeg
   - imageio
-  - imageio-ffmpeg
+  - imageio-ffmpeg >=0.5.0
   - av
   - attrs
   - pandas
   - simplejson
-  - h5py>=3.8.0
+  - h5py >=3.8.0
   - hdmf
-  - numpy
-  - opencv<4.9.0
+  - numpy <2.0.0
+  - opencv
   - pynwb
   - ndx-pose
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pandas",
     "simplejson",
     "imageio",
-    "imageio-ffmpeg",
+    "imageio-ffmpeg>=0.5.0",
     "av"]
 dynamic = ["version", "readme"]
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -65,8 +65,7 @@ def make_video(
         is_embedded = True
 
     # Basic path resolution.
-    video_path = video_path.replace("\\", "/")
-    video_path = Path(video_path)
+    video_path = Path(Path(video_path).as_posix().replace("\\", "/"))
 
     try:
         if not video_path.exists():

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -65,16 +65,21 @@ def make_video(
         is_embedded = True
 
     # Basic path resolution.
+    video_path = video_path.replace("\\", "/")
     video_path = Path(video_path)
-    if not video_path.exists():
-        # Check for the same filename in the same directory as the labels file.
-        video_path_ = Path(labels_path).parent / video_path.name
-        if video_path_.exists():
-            video_path = video_path_
-        else:
-            # TODO (TP): Expand capabilities of path resolution to support more
-            # complex path finding strategies.
-            pass
+
+    try:
+        if not video_path.exists():
+            # Check for the same filename in the same directory as the labels file.
+            video_path_ = Path(labels_path).parent / video_path.name
+            if video_path_.exists():
+                video_path = video_path_
+            else:
+                # TODO (TP): Expand capabilities of path resolution to support more
+                # complex path finding strategies.
+                pass
+    except OSError:
+        pass
 
     # Convert video path to string.
     video_path = video_path.as_posix()

--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -2,4 +2,4 @@
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/tests/io/test_nwb.py
+++ b/tests/io/test_nwb.py
@@ -131,6 +131,7 @@ def test_default_metadata_overwriting(nwbfile, slp_predictions_with_provenance):
 
 def test_complex_case_append(nwbfile, centered_pair):
     labels = load_slp(centered_pair)
+    labels.clean(tracks=True)
     nwbfile = append_nwb_data(labels, nwbfile)
 
     # Test matching number of processing modules
@@ -169,6 +170,7 @@ def test_complex_case_append(nwbfile, centered_pair):
 
 def test_complex_case_append_with_timestamps_metadata(nwbfile, centered_pair):
     labels = load_slp(centered_pair)
+    labels.clean(tracks=True)
 
     number_of_frames = 1100  # extracted using ffmpeg probe
     video_sample_rate = 15.0  # 15 Hz extracted using ffmpeg probe for the video stream
@@ -238,6 +240,7 @@ def test_typical_case_write(slp_typical, tmp_path):
 
 def test_get_timestamps(nwbfile, centered_pair):
     labels = load_slp(centered_pair)
+    labels.clean(tracks=True)
     nwbfile = append_nwb_data(labels, nwbfile)
     processing = nwbfile.processing["SLEAP_VIDEO_000_centered_pair_low_quality"]
     assert True


### PR DESCRIPTION
Fixes root issue in #106: we need to manually replace `\\` with `/` when on Linux, but Windows paths are stored, and running on a platform that doesn't support it (e.g., our networked NetApp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in the video creation process to prevent crashes from invalid paths.
	- Standardized video path format for better compatibility across different operating systems.

- **Chores**
	- Updated package version from 0.1.6 to 0.1.7, indicating new improvements and updates.
	- Enhanced dependency management by updating version constraints for critical libraries to ensure compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->