### PR TITLE
Support NumPy > 2.0 and Python 3.12

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - simplejson
   - h5py >=3.8.0
   - hdmf
-  - numpy <2.0.0
+  - numpy
   - opencv
   - pynwb
   - ndx-pose
@@ -24,7 +24,7 @@ dependencies:
   - pydocstyle
   - toml
   - twine
-  - build
+  - python-build
   - pip
   - pip:
     - "--editable=.[dev]"

--- a/sleap_io/io/labelstudio.py
+++ b/sleap_io/io/labelstudio.py
@@ -193,10 +193,10 @@ def convert_labels(labels: Labels) -> List[dict]:
                         "result": frame_annots,
                         "was_cancelled": False,
                         "ground_truth": False,
-                        "created_at": datetime.datetime.utcnow().strftime(
+                        "created_at": datetime.datetime.now(datetime.timezone.utc).strftime(
                             "%Y-%m-%dT%H:%M:%S.%fZ"
                         ),
-                        "updated_at": datetime.datetime.utcnow().strftime(
+                        "updated_at": datetime.datetime.now(datetime.timezone.utc).strftime(
                             "%Y-%m-%dT%H:%M:%S.%fZ"
                         ),
                         "lead_time": 0,

--- a/sleap_io/io/labelstudio.py
+++ b/sleap_io/io/labelstudio.py
@@ -9,13 +9,14 @@ Some important nomenclature:
 """
 
 import datetime
-import simplejson as json
 import math
 import uuid
-from typing import Dict, Iterable, List, Tuple, Optional, Union
 import warnings
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
-from sleap_io import Instance, LabeledFrame, Labels, Node, Point, Video, Skeleton
+import simplejson as json
+
+from sleap_io import Instance, LabeledFrame, Labels, Node, Point, Skeleton, Video
 
 
 def read_labels(
@@ -193,12 +194,12 @@ def convert_labels(labels: Labels) -> List[dict]:
                         "result": frame_annots,
                         "was_cancelled": False,
                         "ground_truth": False,
-                        "created_at": datetime.datetime.now(datetime.timezone.utc).strftime(
-                            "%Y-%m-%dT%H:%M:%S.%fZ"
-                        ),
-                        "updated_at": datetime.datetime.now(datetime.timezone.utc).strftime(
-                            "%Y-%m-%dT%H:%M:%S.%fZ"
-                        ),
+                        "created_at": datetime.datetime.now(
+                            datetime.timezone.utc
+                        ).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                        "updated_at": datetime.datetime.now(
+                            datetime.timezone.utc
+                        ).strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                         "lead_time": 0,
                         "result_count": 1,
                         # "completed_by": user['id']

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -434,7 +434,7 @@ def write_videos(labels_path: str, videos: list[Video], restore_source: bool = F
 
         video_json = video_to_dict(video)
 
-        video_jsons.append(np.string_(json.dumps(video_json, separators=(",", ":"))))
+        video_jsons.append(np.bytes_(json.dumps(video_json, separators=(",", ":"))))
 
     with h5py.File(labels_path, "a") as f:
         f.create_dataset("videos_json", data=video_jsons, maxshape=(None,))
@@ -466,7 +466,7 @@ def write_tracks(labels_path: str, tracks: list[Track]):
     # TODO: Add support for track metadata like spawned on frame.
     SPAWNED_ON = 0
     tracks_json = [
-        np.string_(json.dumps([SPAWNED_ON, track.name], separators=(",", ":")))
+        np.bytes_(json.dumps([SPAWNED_ON, track.name], separators=(",", ":")))
         for track in tracks
     ]
     with h5py.File(labels_path, "a") as f:
@@ -517,7 +517,7 @@ def write_suggestions(
             "frame_idx": suggestion.frame_idx,
             "group": GROUP,
         }
-        suggestion_json = np.string_(json.dumps(suggestion_dict, separators=(",", ":")))
+        suggestion_json = np.bytes_(json.dumps(suggestion_dict, separators=(",", ":")))
         suggestions_json.append(suggestion_json)
 
     with h5py.File(labels_path, "a") as f:
@@ -743,7 +743,7 @@ def write_metadata(labels_path: str, labels: Labels):
     with h5py.File(labels_path, "a") as f:
         grp = f.require_group("metadata")
         grp.attrs["format_id"] = 1.2
-        grp.attrs["json"] = np.string_(json.dumps(md, separators=(",", ":")))
+        grp.attrs["json"] = np.bytes_(json.dumps(md, separators=(",", ":")))
 
 
 def read_points(labels_path: str) -> list[Point]:

--- a/sleap_io/io/video.py
+++ b/sleap_io/io/video.py
@@ -148,7 +148,7 @@ class VideoBackend:
         """
         if test_img is None:
             test_img = self.read_test_frame()
-        is_grayscale = bool(np.all(test_img[..., 0] == test_img[..., -1]))
+        is_grayscale = np.array_equal(test_img[..., 0], test_img[..., -1])
         self.grayscale = is_grayscale
         return is_grayscale
 

--- a/tests/io/test_nwb.py
+++ b/tests/io/test_nwb.py
@@ -211,7 +211,7 @@ def test_complex_case_append_with_timestamps_metadata(nwbfile, centered_pair):
         # Other store timestamps and the timestmaps should be a subset of the videotimestamps
         else:
             extracted_timestamps = pose_estimation_series.timestamps
-            assert np.in1d(
+            assert np.isin(
                 extracted_timestamps, video_timestamps, assume_unique=True
             ).all()
 


### PR DESCRIPTION
Closes #114 

This PR addresses the failing tests reported in #114 (due to deprecations in NumPy 2.0) by:
- replacing the deprecated `np.string_` with `np.bytes_`
- replacing `bool(np.all(...))` with `np.array_equal` in grayscale detection
- replacing `np.in1d` with `np.isin`

In addition, `datetime.utcnow()` is also deprecated since Python 3.12. So this has been replaced with `datetime.datetime.now(datetime.timezone.utc)`. The alternative would be `datetime.datetime.now(datetime.UTC)` but this alias has only been added in version 3.11.

Despite the above changes, the tests continued to fail on CI. It turns out that on [conda-forge the `build` package is called `python-build`](https://github.com/pypa/build?tab=readme-ov-file#conda-forge). So I've updated this in the `environment.yml` as well. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated environment configuration to allow any version of `numpy`, enhancing compatibility with newer features.
	- Improved timestamp generation with explicit UTC timezone for better consistency across applications.

- **Bug Fixes**
	- Enhanced grayscale detection logic for improved reliability in image processing.

- **Tests**
	- Replaced `np.in1d` with `np.isin` in test cases for better clarity and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->