### PR TITLE
Dependency management

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - numpy
   - opencv
   - pynwb
-  - ndx-pose
+  - ndx-pose<0.2.0
   - pytest
   - pytest-cov
   - black

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - ffmpeg
   - imageio
   - imageio-ffmpeg >=0.5.0
-  - av
   - attrs
   - pandas
   - simplejson

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,3 @@ line-length = 88
 [pydocstyle]
 convention = "google"
 match-dir = "sleap_io"
-
-[tool.coverage.run]
-source = ["livecov"]
-
-[tool.pytest.ini_options]
-addopts = "--cov sleap_io --cov-report=lcov:lcov.info --cov-report=term"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ dependencies = [
     "pandas",
     "simplejson",
     "imageio",
-    "imageio-ffmpeg>=0.5.0",
-    "av"]
+    "imageio-ffmpeg>=0.5.0"]
 dynamic = ["version", "readme"]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "attrs",
     "h5py>=3.8.0",
     "pynwb",
-    "ndx-pose",
+    "ndx-pose<0.2.0",
     "pandas",
     "simplejson",
     "imageio",

--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -2,4 +2,4 @@
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/tests/io/test_video_backends.py
+++ b/tests/io/test_video_backends.py
@@ -59,6 +59,7 @@ def test_get_frame(centered_pair_low_quality_path):
 
 @pytest.mark.parametrize("keep_open", [False, True])
 def test_mediavideo(centered_pair_low_quality_path, keep_open):
+    # Test with FFMPEG backend
     backend = VideoBackend.from_filename(
         centered_pair_low_quality_path, plugin="FFMPEG", keep_open=keep_open
     )
@@ -74,21 +75,28 @@ def test_mediavideo(centered_pair_low_quality_path, keep_open):
     else:
         assert backend._open_reader is None
 
-    backend = VideoBackend.from_filename(
-        centered_pair_low_quality_path, plugin="pyav", keep_open=keep_open
-    )
-    assert type(backend) == MediaVideo
-    assert backend.filename == centered_pair_low_quality_path
-    assert backend.shape == (1100, 384, 384, 1)
-    assert backend[0].shape == (384, 384, 1)
-    assert backend[:3].shape == (3, 384, 384, 1)
-    if keep_open:
-        assert backend._open_reader is not None
-        assert backend[0].shape == (384, 384, 1)
-        assert type(backend._open_reader).__name__ == "PyAVPlugin"
-    else:
-        assert backend._open_reader is None
+    # Test with pyav backend (if installed)
+    try:
+        import av
 
+        backend = VideoBackend.from_filename(
+            centered_pair_low_quality_path, plugin="pyav", keep_open=keep_open
+        )
+        assert type(backend) == MediaVideo
+        assert backend.filename == centered_pair_low_quality_path
+        assert backend.shape == (1100, 384, 384, 1)
+        assert backend[0].shape == (384, 384, 1)
+        assert backend[:3].shape == (3, 384, 384, 1)
+        if keep_open:
+            assert backend._open_reader is not None
+            assert backend[0].shape == (384, 384, 1)
+            assert type(backend._open_reader).__name__ == "PyAVPlugin"
+        else:
+            assert backend._open_reader is None
+    except ImportError:
+        pass
+
+    # Test with opencv backend
     backend = VideoBackend.from_filename(
         centered_pair_low_quality_path, plugin="opencv", keep_open=keep_open
     )


### PR DESCRIPTION
- Drop `av` as a dependency since it's still a little buggy and doesn't have broad enough platform compatibility.
- Pin `ndx-pose` < 0.2.0 until #104 is merged in.
- Remove livecov dev tool as it was interfering with VSCode debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Removed the `"av"` dependency from the project configuration, streamlining the dependency list.
	- Updated the `"ndx-pose"` dependency to specify a version constraint of `<0.2.0`, ensuring compatibility.
	- Updated the package version from `0.1.8` to `0.1.9`, indicating a new release.

- **Tests**
	- Introduced a new test case for the `test_mediavideo` function, enhancing coverage for the FFMPEG backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->