### PR TITLE
Safer video loading from SLP

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -134,14 +134,16 @@ labels.save("labels.slp")
 ```py
 import sleap_io as sio
 
-labels = sio.load_file("labels.v001.slp")
+# Load labels without trying to open the video files.
+labels = sio.load_file("labels.v001.slp", open_videos=False)
 
-# Fix paths using prefixes.
+# Fix paths using prefix replacement.
 labels.replace_filenames(prefix_map={
     "D:/data/sleap_projects": "/home/user/sleap_projects",
     "C:/Users/sleaper/Desktop/test": "/home/user/sleap_projects",
 })
 
+# Save labels with updated paths.
 labels.save("labels.v002.slp")
 ```
 

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -7,16 +7,19 @@ from typing import Optional, Union
 from pathlib import Path
 
 
-def load_slp(filename: str) -> Labels:
+def load_slp(filename: str, open_videos: bool = True) -> Labels:
     """Load a SLEAP dataset.
 
     Args:
         filename: Path to a SLEAP labels file (`.slp`).
+        open_videos: If `True` (the default), attempt to open the video backend for
+            I/O. If `False`, the backend will not be opened (useful for reading metadata
+            when the video files are not available).
 
     Returns:
         The dataset as a `Labels` object.
     """
-    return slp.read_labels(filename)
+    return slp.read_labels(filename, open_videos=open_videos)
 
 
 def save_slp(

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -21,10 +21,7 @@ from sleap_io import (
     Labels,
 )
 from sleap_io.io.video import VideoBackend, ImageVideo, MediaVideo, HDF5Video
-from sleap_io.io.utils import (
-    read_hdf5_attrs,
-    read_hdf5_dataset,
-)
+from sleap_io.io.utils import read_hdf5_attrs, read_hdf5_dataset, is_file_accessible
 from enum import IntEnum
 from pathlib import Path
 import imageio.v3 as iio
@@ -107,11 +104,11 @@ def make_video(
     backend = None
     if open_backend:
         try:
-            if not video_path.exists():
+            if not is_file_accessible(video_path):
                 # Check for the same filename in the same directory as the labels file.
-                video_path_ = Path(labels_path).parent / video_path.name
-                if video_path_.exists() and video_path.stat():
-                    video_path = video_path_
+                candidate_video_path = Path(labels_path).parent / video_path.name
+                if is_file_accessible(candidate_video_path):
+                    video_path = candidate_video_path
                 else:
                     # TODO (TP): Expand capabilities of path resolution to support more
                     # complex path finding strategies.

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -109,6 +109,9 @@ def make_video(
             # This is an ImageVideo.
             # TODO: Path resolution.
             video_path = backend_metadata["filenames"]
+            video_path = [
+                Path(Path(p).as_posix().replace("\\", "/")) for p in video_path
+            ]
 
         try:
             backend = VideoBackend.from_filename(
@@ -117,7 +120,7 @@ def make_video(
                 grayscale=backend_metadata.get("grayscale", None),
                 input_format=backend_metadata.get("input_format", None),
             )
-        except:
+        except Exception:
             backend = None
 
     return Video(
@@ -125,10 +128,11 @@ def make_video(
         backend=backend,
         backend_metadata=backend_metadata,
         source_video=source_video,
+        open_backend=open_backend,
     )
 
 
-def read_videos(labels_path: str, open_backend: bool = False) -> list[Video]:
+def read_videos(labels_path: str, open_backend: bool = True) -> list[Video]:
     """Read `Video` dataset in a SLEAP labels file.
 
     Args:

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -660,13 +660,19 @@ class Labels:
         labels.suggestions = []
         labels.clean()
 
-        # Make splits.
+        # Make train split.
         labels_train, labels_rest = labels.split(n_train, seed=seed)
+
+        # Make test split.
         if n_test is not None:
             if n_test < 1:
                 n_test = (n_test * len(labels)) / len(labels_rest)
             labels_test, labels_rest = labels_rest.split(n=n_test, seed=seed)
-        if n_val is not None:
+        else:
+            labels_test = labels_rest
+
+        # Make val split.
+        if n_val is not None or (isinstance(n_val, float) and n_val == 1.0):
             if n_val < 1:
                 n_val = (n_val * len(labels)) / len(labels_rest)
             labels_val, _ = labels_rest.split(n=n_val, seed=seed)

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -660,19 +660,13 @@ class Labels:
         labels.suggestions = []
         labels.clean()
 
-        # Make train split.
+        # Make splits.
         labels_train, labels_rest = labels.split(n_train, seed=seed)
-
-        # Make test split.
         if n_test is not None:
             if n_test < 1:
                 n_test = (n_test * len(labels)) / len(labels_rest)
             labels_test, labels_rest = labels_rest.split(n=n_test, seed=seed)
-        else:
-            labels_test = labels_rest
-
-        # Make val split.
-        if n_val is not None or (isinstance(n_val, float) and n_val == 1.0):
+        if n_val is not None:
             if n_val < 1:
                 n_val = (n_val * len(labels)) / len(labels_rest)
             labels_val, _ = labels_rest.split(n=n_val, seed=seed)

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -9,6 +9,7 @@ import attrs
 from typing import Tuple, Optional, Optional
 import numpy as np
 from sleap_io.io.video import VideoBackend, MediaVideo, HDF5Video, ImageVideo
+from sleap_io.io.utils import is_file_accessible
 from pathlib import Path
 
 
@@ -197,21 +198,24 @@ class Video:
         return self.backend[inds]
 
     def exists(self, check_all: bool = False) -> bool:
-        """Check if the video file exists.
+        """Check if the video file exists and is accessible.
 
         Args:
             check_all: If `True`, check that all filenames in a list exist. If `False`
                 (the default), check that the first filename exists.
+
+        Returns:
+            `True` if the file exists and is accessible, `False` otherwise.
         """
         if isinstance(self.filename, list):
             if check_all:
                 for f in self.filename:
-                    if not Path(f).exists():
+                    if not is_file_accessible(f):
                         return False
                 return True
             else:
-                return Path(self.filename[0]).exists()
-        return Path(self.filename).exists()
+                return is_file_accessible(self.filename[0])
+        return is_file_accessible(self.filename)
 
     @property
     def is_open(self) -> bool:

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -246,7 +246,7 @@ class Video:
             Values for the HDF5 dataset and grayscale will be remembered if not
             specified.
         """
-        if self.filename:
+        if filename is not None:
             self.replace_filename(filename, open=False)
 
         if not self.exists():

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -354,3 +354,12 @@ def test_embed_two_rounds(tmpdir, slp_real_data):
         == "tests/data/videos/centered_pair_low_quality.mp4"
     )
     assert type(labels3.video.backend) == MediaVideo
+
+
+def test_lazy_video_read(slp_real_data):
+    labels = read_labels(slp_real_data)
+    assert type(labels.video.backend) == MediaVideo
+    assert labels.video.exists()
+
+    labels = read_labels(slp_real_data, open_videos=False)
+    assert labels.video.backend is None

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -38,7 +38,7 @@ import numpy as np
 import simplejson as json
 import pytest
 from pathlib import Path
-
+import shutil
 from sleap_io.io.video import ImageVideo, HDF5Video, MediaVideo
 
 
@@ -363,3 +363,37 @@ def test_lazy_video_read(slp_real_data):
 
     labels = read_labels(slp_real_data, open_videos=False)
     assert labels.video.backend is None
+
+
+def test_video_path_resolution(slp_real_data, tmp_path):
+    labels = read_labels(slp_real_data)
+    assert (
+        Path(labels.video.filename).as_posix()
+        == "tests/data/videos/centered_pair_low_quality.mp4"
+    )
+    shutil.copyfile(labels.video.filename, tmp_path / "centered_pair_low_quality.mp4")
+    labels.video.replace_filename(
+        "fake/path/to/centered_pair_low_quality.mp4", open=False
+    )
+    labels.save(tmp_path / "labels.slp")
+
+    # Resolve when the same video filename is found in the labels directory.
+    labels = read_labels(tmp_path / "labels.slp")
+    assert (
+        Path(labels.video.filename).as_posix()
+        == (tmp_path / "centered_pair_low_quality.mp4").as_posix()
+    )
+    assert labels.video.exists()
+
+    # Make the video file inaccessible.
+    labels.video.replace_filename("new_fake/path/to/inaccessible.mp4", open=False)
+    labels.save(tmp_path / "labels2.slp")
+    shutil.copyfile(
+        tmp_path / "centered_pair_low_quality.mp4", tmp_path / "inaccessible.mp4"
+    )
+    Path(tmp_path / "inaccessible.mp4").chmod(0o000)
+
+    # Fail to resolve when the video file is inaccessible.
+    labels = read_labels(tmp_path / "labels2.slp")
+    assert not labels.video.exists()
+    assert Path(labels.video.filename).as_posix() == "new_fake/path/to/inaccessible.mp4"

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -56,7 +56,7 @@ def test_video_exists(centered_pair_low_quality_video, centered_pair_frame_paths
     assert video.exists(check_all=True) is False
 
 
-def test_video_open_close(centered_pair_low_quality_path):
+def test_video_open_close(centered_pair_low_quality_path, centered_pair_frame_paths):
     video = Video(centered_pair_low_quality_path)
     assert video.is_open
     assert type(video.backend) == MediaVideo
@@ -90,6 +90,10 @@ def test_video_open_close(centered_pair_low_quality_path):
     assert video.shape == (1100, 384, 384, 3)
     video.open(grayscale=True)
     assert video.shape == (1100, 384, 384, 1)
+
+    video.open(centered_pair_frame_paths)
+    assert video.shape == (3, 384, 384, 1)
+    assert type(video.backend) == ImageVideo
 
 
 def test_video_replace_filename(
@@ -142,3 +146,20 @@ def test_grayscale(centered_pair_low_quality_path):
     video.open()
     assert video.grayscale == True
     assert video.shape[-1] == 1
+
+
+def test_open_backend_preference(centered_pair_low_quality_path):
+    video = Video(centered_pair_low_quality_path)
+    assert video.is_open
+    assert type(video.backend) == MediaVideo
+
+    video = Video(centered_pair_low_quality_path, open_backend=False)
+    assert video.is_open is False
+    assert video.backend is None
+    with pytest.raises(ValueError):
+        video[0]
+
+    video.open_backend = True
+    img = video[0]
+    assert video.is_open
+    assert type(video.backend) == MediaVideo


### PR DESCRIPTION
This PR adds more flexibility and a safer path for loading SLP files in cases where the video files might not be accessible.

- Catches more I/O errors when checking if the video is accessible (addresses #116).
- Explicit control over whether video files should be opened when loading labels with:`sio.load_slp(..., open_videos=False)`
- Explicit control over whether backend is auto-initialized when creating or using `Video` objects with `Video(..., open_backend=False)`.
- More sanitization of filenames to posix/forward-slash safe forms when reading and writing SLP files.
- Added `sio.io.utils.is_file_accessible` to check for readability by actually reading a byte. This catches permission and other esoteric filesystem errors.