### PR TITLE
Fix split calculation and allow for not embedding

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1112,7 +1112,7 @@ def write_labels(
     """
     if Path(labels_path).exists():
         Path(labels_path).unlink()
-    if embed is not None:
+    if embed:
         embed_videos(labels_path, labels, embed)
     write_videos(labels_path, labels.videos, restore_source=(embed == "source"))
     write_tracks(labels_path, labels.tracks)

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -537,7 +537,7 @@ def test_split(slp_real_data, tmp_path):
     )
 
 
-def test_make_training_splits(slp_real_data, tmp_path):
+def test_make_training_splits(slp_real_data):
     labels = load_slp(slp_real_data)
     assert len(labels.user_labeled_frames) == 5
 
@@ -568,6 +568,11 @@ def test_make_training_splits(slp_real_data, tmp_path):
     assert len(val) == 1
     assert len(test) == 1
 
+    train, val, test = labels.make_training_splits(n_train=0.4, n_val=0.4, n_test=0.2)
+    assert len(train) == 2
+    assert len(val) == 2
+    assert len(test) == 1
+
 
 def test_make_training_splits_save(slp_real_data, tmp_path):
     labels = load_slp(slp_real_data)
@@ -587,3 +592,38 @@ def test_make_training_splits_save(slp_real_data, tmp_path):
     assert train_.provenance["source_labels"] == slp_real_data
     assert val_.provenance["source_labels"] == slp_real_data
     assert test_.provenance["source_labels"] == slp_real_data
+
+
+@pytest.mark.parametrize("embed", [True, False])
+def test_make_training_splits_save(slp_real_data, tmp_path, embed):
+    labels = load_slp(slp_real_data)
+
+    train, val, test = labels.make_training_splits(
+        0.6, 0.2, 0.2, save_dir=tmp_path, embed=embed
+    )
+
+    if embed:
+        train_, val_, test_ = (
+            load_slp(tmp_path / "train.pkg.slp"),
+            load_slp(tmp_path / "val.pkg.slp"),
+            load_slp(tmp_path / "test.pkg.slp"),
+        )
+    else:
+        train_, val_, test_ = (
+            load_slp(tmp_path / "train.slp"),
+            load_slp(tmp_path / "val.slp"),
+            load_slp(tmp_path / "test.slp"),
+        )
+
+    assert len(train_) == len(train)
+    assert len(val_) == len(val)
+    assert len(test_) == len(test)
+
+    if embed:
+        assert train_.provenance["source_labels"] == slp_real_data
+        assert val_.provenance["source_labels"] == slp_real_data
+        assert test_.provenance["source_labels"] == slp_real_data
+    else:
+        assert train_.video.filename == labels.video.filename
+        assert val_.video.filename == labels.video.filename
+        assert test_.video.filename == labels.video.filename


### PR DESCRIPTION
This pull request fixes the split calculation in the `make_training_splits` function and adds the option to not embed user-labeled frame images in the saved files.


- Fix: The function now correctly splits the labels into training, validation, and test sets based on the specified proportions (fixes #117).
- Enhancement: `Labels.make_training_splits(..., embed=False)`
    Previously, the function would always embed the images, which could be slow for large projects. With this change, the `embed` parameter is introduced, allowing the user to choose whether to embed the images or save the labels with references to the source video files.