### PR TITLE
Add better support for exporting and loading RGB videos from .pkg.slp files

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -209,7 +209,7 @@ def video_to_dict(video: Video) -> dict:
                 "input_format": video.backend.input_format,
                 "convert_range": False,
                 "has_embedded_images": video.backend.has_embedded_images,
-                "greyscale": video.grayscale,
+                "grayscale": video.grayscale,
             },
         }
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -125,10 +125,15 @@ def make_video(
             video_path = [Path(sanitize_filename(p)) for p in video_path]
 
         try:
+            grayscale = None
+            if "grayscale" in backend_metadata:
+                grayscale = backend_metadata["grayscale"]
+            elif "shape" in backend_metadata:
+                grayscale = backend_metadata["shape"][-1] == 1
             backend = VideoBackend.from_filename(
                 video_path,
                 dataset=backend_metadata.get("dataset", None),
-                grayscale=backend_metadata.get("grayscale", None),
+                grayscale=grayscale,
                 input_format=backend_metadata.get("input_format", None),
             )
         except Exception:
@@ -204,6 +209,7 @@ def video_to_dict(video: Video) -> dict:
                 "input_format": video.backend.input_format,
                 "convert_range": False,
                 "has_embedded_images": video.backend.has_embedded_images,
+                "greyscale": video.grayscale,
             },
         }
 
@@ -264,10 +270,10 @@ def embed_video(
                     cv2.imencode("." + image_format, frame)[1]
                 ).astype("int8")
             else:
+                if frame.shape[-1] == 1:
+                    frame = frame.squeeze(axis=-1)
                 img_data = np.frombuffer(
-                    iio.imwrite(
-                        "<bytes>", frame.squeeze(axis=-1), extension="." + image_format
-                    ),
+                    iio.imwrite("<bytes>", frame, extension="." + image_format),
                     dtype="int8",
                 )
 
@@ -440,7 +446,6 @@ def write_videos(labels_path: str, videos: list[Video], restore_source: bool = F
     """
     video_jsons = []
     for video_ind, video in enumerate(videos):
-
         if type(video.backend) == HDF5Video and video.backend.has_embedded_images:
             if restore_source:
                 video = video.source_video

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -146,8 +146,6 @@ class Video:
             grayscale = None
             if "grayscale" in self.backend_metadata:
                 grayscale = self.backend_metadata["grayscale"]
-            elif "shape" in self.backend_metadata:
-                grayscale = self.backend_metadata["shape"][-1] == 1
             return grayscale
 
     @grayscale.setter

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -143,7 +143,12 @@ class Video:
         if shape is not None:
             return shape[-1] == 1
         else:
-            return self.backend_metadata.get("grayscale", None)
+            grayscale = None
+            if "grayscale" in self.backend_metadata:
+                grayscale = self.backend_metadata["grayscale"]
+            elif "shape" in self.backend_metadata:
+                grayscale = self.backend_metadata["shape"][-1] == 1
+            return grayscale
 
     @grayscale.setter
     def grayscale(self, value: bool):
@@ -271,8 +276,11 @@ class Video:
         else:
             if dataset is None and "dataset" in self.backend_metadata:
                 dataset = self.backend_metadata["dataset"]
-            if grayscale is None and "grayscale" in self.backend_metadata:
-                grayscale = self.backend_metadata["grayscale"]
+            if grayscale is None:
+                if "grayscale" in self.backend_metadata:
+                    grayscale = self.backend_metadata["grayscale"]
+                elif "shape" in self.backend_metadata:
+                    grayscale = self.backend_metadata["shape"][-1] == 1
 
         # Close previous backend if open.
         self.close()

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -367,6 +367,31 @@ def test_embed_rgb(tmpdir, slp_real_data):
     labels = read_labels(labels_path)
     assert labels.video[0].shape == (384, 384, 3)
 
+    # Fallback to imageio
+    cv2_mod = sys.modules.pop("cv2")
+
+    labels_path = str(tmpdir / "labels_imageio.pkg.slp")
+    write_labels(labels_path, base_labels, embed="user")
+    labels = read_labels(labels_path)
+    assert labels.video[0].shape == (384, 384, 3)
+
+    sys.modules["cv2"] = cv2_mod
+
+
+def test_embed_grayscale(tmpdir, slp_real_data):
+    base_labels = read_labels(slp_real_data)
+    assert base_labels.video[0].shape == (384, 384, 1)
+
+    # Fallback to imageio
+    cv2_mod = sys.modules.pop("cv2")
+
+    labels_path = str(tmpdir / "labels_imageio_gray.pkg.slp")
+    write_labels(labels_path, base_labels, embed="user")
+    labels = read_labels(labels_path)
+    assert labels.video[0].shape == (384, 384, 1)
+
+    sys.modules["cv2"] = cv2_mod
+
 
 def test_lazy_video_read(slp_real_data):
     labels = read_labels(slp_real_data)

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -105,7 +105,6 @@ def test_read_videos_pkg(slp_minimal_pkg):
 
 
 def test_write_videos(slp_minimal_pkg, centered_pair, tmp_path):
-
     def compare_videos(videos_ref, videos_test):
         assert len(videos_ref) == len(videos_test)
         for video_ref, video_test in zip(videos_ref, videos_test):
@@ -355,6 +354,18 @@ def test_embed_two_rounds(tmpdir, slp_real_data):
         == "tests/data/videos/centered_pair_low_quality.mp4"
     )
     assert type(labels3.video.backend) == MediaVideo
+
+
+def test_embed_rgb(tmpdir, slp_real_data):
+    base_labels = read_labels(slp_real_data)
+    base_labels.video.grayscale = False
+    assert base_labels.video.shape == (1100, 384, 384, 3)
+    assert base_labels.video[0].shape == (384, 384, 3)
+
+    labels_path = str(tmpdir / "labels.pkg.slp")
+    write_labels(labels_path, base_labels, embed="user")
+    labels = read_labels(labels_path)
+    assert labels.video[0].shape == (384, 384, 3)
 
 
 def test_lazy_video_read(slp_real_data):

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -151,8 +151,11 @@ def test_grayscale(centered_pair_low_quality_path):
     assert "grayscale" in video.backend_metadata
     assert video.grayscale == True
 
-    video.backend_metadata = {"shape": (1100, 384, 384, 1)}
-    assert video.grayscale == True
+    video.backend_metadata = {"shape": (1100, 384, 384, 3)}
+    assert video.grayscale == False
+
+    video.open()
+    assert video.grayscale == False
 
 
 def test_open_backend_preference(centered_pair_low_quality_path):

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -147,6 +147,13 @@ def test_grayscale(centered_pair_low_quality_path):
     assert video.grayscale == True
     assert video.shape[-1] == 1
 
+    video.close()
+    assert "grayscale" in video.backend_metadata
+    assert video.grayscale == True
+
+    video.backend_metadata = {"shape": (1100, 384, 384, 1)}
+    assert video.grayscale == True
+
 
 def test_open_backend_preference(centered_pair_low_quality_path):
     video = Video(centered_pair_low_quality_path)


### PR DESCRIPTION
- `greyscale` attribute is now stored in the backend metadata
- Video backend creation now uses the greyscale setting in the backend metadata if available
- Better handling of grayscale serialization in the imageio backend during export

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced video handling with improved grayscale detection and metadata serialization.
	- Robust frame processing for embedding videos.

- **Bug Fixes**
	- Adjusted error handling in video creation to prevent unhandled states.

- **Tests**
	- Added new tests for verifying RGB and grayscale video data handling.
	- Improved code readability through indentation corrections in existing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->