### PR TITLE
Fix video indexing when embedding from labels that already have embedded data

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1069,7 +1069,7 @@ def read_labels(labels_path: str, open_videos: bool = True) -> Labels:
         labeled_frames.append(
             LabeledFrame(
                 video=videos[video_id],
-                frame_idx=frame_idx,
+                frame_idx=int(frame_idx),
                 instances=instances[instance_id_start:instance_id_end],
             )
         )

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -627,3 +627,8 @@ def test_make_training_splits_save(slp_real_data, tmp_path, embed):
         assert train_.video.filename == labels.video.filename
         assert val_.video.filename == labels.video.filename
         assert test_.video.filename == labels.video.filename
+
+    if embed:
+        for labels_ in [train_, val_, test_]:
+            for lf in labels_:
+                assert lf.image.shape == (384, 384, 1)


### PR DESCRIPTION
When embedding videos and the source video is itself an embedded video, we were previously reusing the video object rather than creating a new one. This had the effect of retaining metadata pointing to the original dataset rather than the dataset in the newly saved file, resulting in indexing errors.

We now recreate the video object regardless of the source, refreshing the metadata before saving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of video shapes in the embedding process for better dataset creation.
	- Enhanced type safety in reading labeled frames with consistent integer indexing.

- **Tests**
	- Added new test cases to validate image shapes in training, validation, and test splits.
	- Updated existing tests to include additional assertions for image processing and data formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->