### PR TITLE
Update backend filename when backend isn't created on replace

### DIFF
--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -316,6 +316,7 @@ class Video:
             ]
 
         self.filename = new_filename
+        self.backend_metadata["filename"] = new_filename
 
         if open:
             if self.exists():

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -115,6 +115,7 @@ def test_video_replace_filename(
     video.replace_filename("test.mp4")
     assert video.exists() is False
     assert video.is_open is False
+    assert video.backend_metadata["filename"] == "test.mp4"
 
     video.replace_filename(centered_pair_low_quality_path, open=False)
     assert video.exists() is True


### PR DESCRIPTION
When using `Video.replace_filename` or `Labels.replace_filenames` (which calls it), replacing the filename with one that doesn't exist will not create the backend.

When the backend doesn't exist, saving to SLP defaults to using the `Video.backend_metadata` dictionary, which was previously not being overwritten with the backend data if the backend wasn't initialized.

This PR updates the `"filename"` key in the backend whenever it's replaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced filename tracking in backend metadata when filenames are replaced.
  
- **Bug Fixes**
	- Improved verification of filename replacement in tests to ensure metadata accuracy. 

- **Refactor**
	- Corrected indentation in the `replace_filename` method for better code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->