### PR TITLE
Update labels videos list on replace

### DIFF
--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -473,6 +473,13 @@ class Labels:
             video_map: Alternative input of dictionary where keys are the old videos and
                 values are the new videos.
         """
+        if (
+            old_videos is None
+            and new_videos is not None
+            and len(new_videos) == len(self.videos)
+        ):
+            old_videos = self.videos
+
         if video_map is None:
             video_map = {o: n for o, n in zip(old_videos, new_videos)}
 
@@ -485,6 +492,9 @@ class Labels:
         for sf in self.suggestions:
             if sf.video in video_map:
                 sf.video = video_map[sf.video]
+
+        # Update the list of videos.
+        self.videos = [video_map.get(video, video) for video in self.videos]
 
     def replace_filenames(
         self,

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -356,15 +356,15 @@ def test_labels_remove_predictions(slp_real_data):
 def test_replace_videos(slp_real_data):
     labels = load_slp(slp_real_data)
     assert labels.video.filename == "tests/data/videos/centered_pair_low_quality.mp4"
-    labels.replace_videos(
-        old_videos=[labels.video], new_videos=[Video.from_filename("fake.mp4")]
-    )
+    labels.replace_videos(new_videos=[Video.from_filename("fake.mp4")])
 
     for lf in labels:
         assert lf.video.filename == "fake.mp4"
 
     for sf in labels.suggestions:
         assert sf.video.filename == "fake.mp4"
+
+    assert labels.video.filename == "fake.mp4"
 
 
 def test_replace_filenames():


### PR DESCRIPTION
Fix: `Labels.replace_videos` now correctly updates the `Labels.videos` list in addition to frame and suggestion references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced video and filename replacement methods for improved flexibility and error handling in the Labels class.
	- Introduced new test cases to validate the functionality of the Labels class, including splitting and training data creation.

- **Bug Fixes**
	- Improved error handling for edge cases in video and filename replacement methods.

- **Tests**
	- Expanded and refined test cases for existing methods to ensure robustness and correct behavior under various conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->