### PR TITLE
Make skeleton nodes mutable

### DIFF
--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -92,8 +92,8 @@ def test_read_skeleton(centered_pair):
     assert len(skeleton.nodes) == 24
     assert len(skeleton.edges) == 23
     assert len(skeleton.symmetries) == 20
-    assert Node("wingR") in skeleton.symmetries[0].nodes
-    assert Node("wingL") in skeleton.symmetries[0].nodes
+    assert "wingR" in skeleton.symmetry_names[0]
+    assert "wingL" in skeleton.symmetry_names[0]
 
 
 def test_read_videos_pkg(slp_minimal_pkg):
@@ -157,7 +157,10 @@ def test_write_metadata(centered_pair, tmp_path):
     assert saved_skeletons[0].name == labels.skeletons[0].name
     assert saved_skeletons[0].node_names == labels.skeletons[0].node_names
     assert saved_skeletons[0].edge_inds == labels.skeletons[0].edge_inds
-    assert saved_skeletons[0].flipped_node_inds == labels.skeletons[0].flipped_node_inds
+    assert (
+        saved_skeletons[0].get_flipped_node_inds()
+        == labels.skeletons[0].get_flipped_node_inds()
+    )
 
 
 def test_write_lfs(centered_pair, slp_real_data, tmp_path):
@@ -224,8 +227,8 @@ def test_load_multi_skeleton(tmpdir):
     assert loaded_skels[1].node_names == ["n3", "n4"]
     assert loaded_skels[0].edge_inds == [(0, 1)]
     assert loaded_skels[1].edge_inds == [(0, 1)]
-    assert loaded_skels[0].flipped_node_inds == [1, 0]
-    assert loaded_skels[1].flipped_node_inds == [1, 0]
+    assert loaded_skels[0].get_flipped_node_inds() == [1, 0]
+    assert loaded_skels[1].get_flipped_node_inds() == [1, 0]
 
 
 def test_slp_imgvideo(tmpdir, slp_imgvideo):

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -20,14 +20,15 @@ from pathlib import Path
 
 def test_labels():
     """Test methods in the `Labels` data structure."""
+    skel = Skeleton(["A", "B"])
     labels = Labels(
         [
             LabeledFrame(
                 video=Video(filename="test"),
                 frame_idx=0,
                 instances=[
-                    Instance([[0, 1], [2, 3]], skeleton=Skeleton(["A", "B"])),
-                    PredictedInstance([[4, 5], [6, 7]], skeleton=Skeleton(["A", "B"])),
+                    Instance([[0, 1], [2, 3]], skeleton=skel),
+                    PredictedInstance([[4, 5], [6, 7]], skeleton=skel),
                 ],
             )
         ]

--- a/tests/model/test_skeleton.py
+++ b/tests/model/test_skeleton.py
@@ -75,18 +75,16 @@ def test_skeleton_node_map():
     assert skel.index("B") == 0
 
 
-def test_flipped_node_inds():
+def test_get_flipped_node_inds():
     skel = Skeleton(["A", "BL", "BR", "C", "DL", "DR"])
-    assert skel.flipped_node_inds == [0, 1, 2, 3, 4, 5]
+    assert skel.get_flipped_node_inds() == [0, 1, 2, 3, 4, 5]
 
-    skel.symmetries = [
-        Symmetry([Node("BL"), Node("BR")]),
-        Symmetry([Node("DL"), Node("DR")]),
-    ]
-    assert skel.flipped_node_inds == [0, 2, 1, 3, 5, 4]
+    skel.add_symmetry("BL", "BR")
+    skel.add_symmetry("DL", "DR")
+    assert skel.get_flipped_node_inds() == [0, 2, 1, 3, 5, 4]
 
-    assert skel.symmetries[0][0] in (Node("BL"), Node("BR"))
-    assert skel.symmetries[0][1] in (Node("BL"), Node("BR"))
+    assert skel.symmetries[0][0].name in ("BL", "BR")
+    assert skel.symmetries[0][1].name in ("BL", "BR")
     syms = list(skel.symmetries[0])
     assert syms[0] != syms[1]
 
@@ -113,8 +111,9 @@ def test_add_node():
     skel.add_node("C")
     assert skel.node_names == ["A", "B", "C"]
 
-    skel.add_node("B")
-    assert skel.node_names == ["A", "B", "C"]
+    with pytest.raises(ValueError):
+        skel.add_node("B")
+        assert skel.node_names == ["A", "B", "C"]
 
 
 def test_add_edge():
@@ -135,31 +134,22 @@ def test_add_edge():
     skel.add_edge("D", "A")
     assert skel.edge_inds == [(0, 1), (1, 0), (0, 2), (3, 0)]
 
-    skel = Skeleton(["A", "B"])
-    skel.add_edge(Edge(Node("A"), Node("B")))
-    assert skel.edge_inds == [(0, 1)]
-
-    skel.add_edge(Edge(Node("C"), Node("D")))
-    assert skel.edge_inds == [(0, 1), (2, 3)]
-
 
 def test_add_symmetry():
     skel = Skeleton(["A", "B"])
     skel.add_symmetry("A", "B")
-    assert skel.symmetries == [Symmetry([Node("A"), Node("B")])]
+    assert skel.symmetry_inds == [(0, 1)]
+    assert skel.symmetry_names == [("A", "B")]
 
+    # Don't duplicate reversed symmetries
     skel.add_symmetry("B", "A")
-    assert skel.symmetries == [Symmetry([Node("A"), Node("B")])]
+    assert skel.symmetry_inds == [(0, 1)]
+    assert skel.symmetry_names == [("A", "B")]
 
+    # Add new symmetry with new node objects
     skel.add_symmetry(Symmetry([Node("C"), Node("D")]))
-    assert skel.symmetries == [
-        Symmetry([Node("A"), Node("B")]),
-        Symmetry([Node("C"), Node("D")]),
-    ]
+    assert skel.symmetry_inds == [(0, 1), (2, 3)]
 
+    # Add new symmetry with node names
     skel.add_symmetry("E", "F")
-    assert skel.symmetries == [
-        Symmetry([Node("A"), Node("B")]),
-        Symmetry([Node("C"), Node("D")]),
-        Symmetry([Node("E"), Node("F")]),
-    ]
+    assert skel.symmetry_inds == [(0, 1), (2, 3), (4, 5)]


### PR DESCRIPTION
This PR introduces an overhaul to how we define equality for skeleton objects to enable skeleton mutability.

Previously, we tested for equality between instances of classes like `Skeleton` and `Node` by value. This was convenient so that we could do `Node("a") == Node("a")` and get `True`.

We didn't use that pattern often, but we _do_ use `Node` objects as keys (e.g., in `Instance` objects), meaning that they have to be hashable. If two objects are equal, then they must have the same hash. This also means that they have to be immutable ([see this explanation](https://www.attrs.org/en/stable/hashing.html)).

This PR makes `Node` objects mutable at the cost of making them hashable by ID, e.g.:

```py
# These are two different objects, even though they have the same contents in their attributes
assert Node("a") != Node("a")
assert Node("a").name == Node("a").name

# Mutating the node attribute doesn't change its identity
node = Node("a")
node_id = hash(node)
node.name = "b"
assert hash(node) == node_id
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of skeleton symmetries with new properties for symmetry indices and names.
	- Introduced a method for retrieving flipped node indices to aid in data augmentation.
	- Improved error handling to prevent duplicate node additions.

- **Bug Fixes**
	- Updated assertions in tests to reflect changes in symmetry handling and node management.

- **Tests**
	- Refined test cases for the `Skeleton` class to improve clarity and robustness, focusing on symmetry and edge management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->