### PR TITLE
Add skeleton manipulation utilities

### DIFF
--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -308,6 +308,39 @@ class Instance:
                 pts[self.skeleton.index(node)] = point.numpy()
         return pts
 
+    def update_skeleton(self):
+        """Update the points dictionary to match the skeleton.
+
+        Points associated with nodes that are no longer in the skeleton will be removed.
+
+        Additionally, the keys of the points dictionary will be ordered to match the
+        order of the nodes in the skeleton.
+
+        Notes:
+            This method is useful when the skeleton has been updated (e.g., nodes
+            removed or reordered).
+
+            However, it is recommended to use `Labels`-level methods (e.g.,
+            `Labels.remove_nodes()`) when manipulating the skeleton as these will
+            automatically call this method on every instance.
+
+            It is NOT necessary to call this method after renaming nodes.
+        """
+        # Create a new dictionary to hold the updated points
+        new_points = {}
+
+        # Iterate over the nodes in the skeleton
+        for node in self.skeleton.nodes:
+            # Get the point associated with the node
+            point = self.points.get(node, None)
+
+            # If the point is not None, add it to the new dictionary
+            if point is not None:
+                new_points[node] = point
+
+        # Update the points dictionary
+        self.points = new_points
+
 
 @define
 class PredictedInstance(Instance):

--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from attrs import define, validators, field, cmp_using
 from typing import ClassVar, Optional, Union, cast
 from sleap_io import Skeleton, Node
+from sleap_io.model.skeleton import NodeOrIndex
 import numpy as np
 import math
 
@@ -323,8 +324,6 @@ class Instance:
             However, it is recommended to use `Labels`-level methods (e.g.,
             `Labels.remove_nodes()`) when manipulating the skeleton as these will
             automatically call this method on every instance.
-
-            It is NOT necessary to call this method after renaming nodes.
         """
         # Create a new dictionary to hold the updated points
         new_points = {}
@@ -339,6 +338,59 @@ class Instance:
                 new_points[node] = point
 
         # Update the points dictionary
+        self.points = new_points
+
+    def replace_skeleton(
+        self,
+        new_skeleton: Skeleton,
+        node_map: dict[NodeOrIndex, NodeOrIndex] | None = None,
+        rev_node_map: dict[NodeOrIndex, NodeOrIndex] | None = None,
+    ):
+        """Replace the skeleton associated with the instance.
+
+        The points dictionary will be updated to match the new skeleton.
+
+        Args:
+            new_skeleton: The new `Skeleton` to associate with the instance.
+            node_map: Dictionary mapping nodes in the old skeleton to nodes in the new
+                skeleton. Keys and values can be specified as `Node` objects, integer
+                indices, or string names. If not provided, only nodes with identical
+                names will be mapped. Points associated with unmapped nodes will be
+                removed.
+            rev_node_map: Dictionary mapping nodes in the new skeleton to nodes in the
+                old skeleton. This is used internally when calling from
+                `Labels.replace_skeleton()` as it is more efficient to compute this
+                mapping once and pass it to all instances. No validation is done on this
+                mapping, so nodes are expected to be `Node` objects.
+        """
+        if rev_node_map is None:
+            if node_map is None:
+                node_map = {}
+                for old_node in self.skeleton.nodes:
+                    for new_node in new_skeleton.nodes:
+                        if old_node.name == new_node.name:
+                            node_map[old_node] = new_node
+                            break
+            else:
+                node_map = {
+                    self.skeleton.require_node(
+                        old, add_missing=False
+                    ): new_skeleton.require_node(new, add_missing=False)
+                    for old, new in node_map.items()
+                }
+
+            # Make new -> old mapping for nodes
+            rev_node_map = {new: old for old, new in node_map.items()}
+
+        # Build new points list with mapped nodes
+        new_points = {}
+        for new_node in new_skeleton.nodes:
+            old_node = rev_node_map.get(new_node, None)
+            if old_node is not None and old_node in self.points:
+                new_points[new_node] = self.points[old_node]
+
+        # Update the skeleton and points
+        self.skeleton = new_skeleton
         self.points = new_points
 
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -510,10 +510,6 @@ class Labels:
 
         skeleton.rename_nodes(name_map)
 
-        for inst in self.instances:
-            if inst.skeleton == skeleton:
-                inst.update_skeleton()
-
     def remove_nodes(self, nodes: list[NodeOrIndex], skeleton: Skeleton | None = None):
         """Remove nodes from the skeleton.
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -21,7 +21,7 @@ from sleap_io import (
     SuggestionFrame,
 )
 from attrs import define, field
-from typing import Union, Optional, Any
+from typing import Iterator, Union, Optional, Any
 import numpy as np
 from pathlib import Path
 from sleap_io.model.skeleton import Skeleton
@@ -458,6 +458,11 @@ class Labels:
     def user_labeled_frames(self) -> list[LabeledFrame]:
         """Return all labeled frames with user (non-predicted) instances."""
         return [lf for lf in self.labeled_frames if lf.has_user_instances]
+
+    @property
+    def instances(self) -> Iterator[Instance]:
+        """Return an iterator over all instances within all labeled frames."""
+        return (instance for lf in self.labeled_frames for instance in lf.instances)
 
     def replace_videos(
         self,

--- a/sleap_io/model/skeleton.py
+++ b/sleap_io/model/skeleton.py
@@ -74,7 +74,7 @@ class Symmetry:
 NodeOrIndex: TypeAlias = Node | str | int
 
 
-@define
+@define(eq=False)
 class Skeleton:
     """A description of a set of landmark types and connections between them.
 
@@ -420,6 +420,10 @@ class Skeleton:
                 If a list of strings is provided of the same length as the current
                 nodes, the nodes will be renamed to the names in the list in order.
 
+        Raises:
+            ValueError: If the new node names exist in the skeleton or if the old node
+                names are not found in the skeleton.
+
         Notes:
             This method should always be used when renaming nodes in the skeleton as it
             handles updating the lookup caches necessary for indexing nodes by name.
@@ -436,10 +440,6 @@ class Skeleton:
             >>> skel.rename_nodes(["a", "b", "c"])
             >>> skel.node_names
             ["a", "b", "c"]
-
-        Raises:
-            ValueError: If the new node names exist in the skeleton or if the old node
-                names are not found in the skeleton.
         """
         if type(name_map) == list:
             if len(name_map) != len(self.nodes):
@@ -482,8 +482,8 @@ class Skeleton:
             nodes: A list of node names, indices, or `Node` objects to remove.
 
         Notes:
-            This method should always be used when removing nodes from the skeleton as
-            it handles updating the lookup caches necessary for indexing nodes by name.
+            This method handles updating the lookup caches necessary for indexing nodes
+            by name.
 
             Any edges and symmetries that are connected to the removed nodes will also
             be removed.
@@ -531,8 +531,8 @@ class Skeleton:
                 or `Node` object.
 
         Notes:
-            This method should always be used when removing nodes from the skeleton as
-            it handles updating the lookup caches necessary for indexing nodes by name.
+            This method handles updating the lookup caches necessary for indexing nodes
+            by name.
 
             Any edges and symmetries that are connected to the removed node will also be
             removed.
@@ -561,8 +561,8 @@ class Skeleton:
                 nodes.
 
         Notes:
-            This method should always be used when reordering nodes in the skeleton as
-            it handles updating the lookup caches necessary for indexing nodes by name.
+            This method handles updating the lookup caches necessary for indexing nodes
+            by name.
 
         Warning:
             After reordering, instances using this skeleton do not need to be updated as

--- a/sleap_io/model/skeleton.py
+++ b/sleap_io/model/skeleton.py
@@ -372,8 +372,8 @@ class Skeleton:
         for old_name, new_name in name_map.items():
             if type(old_name) == Node:
                 old_name = old_name.name
-            if type(new_name) == int:
-                new_name = self.nodes[new_name].name
+            if type(old_name) == int:
+                old_name = self.nodes[old_name].name
 
             if old_name not in self._node_name_map:
                 raise ValueError(f"Node '{old_name}' not found in the skeleton.")
@@ -384,3 +384,13 @@ class Skeleton:
             node.name = new_name
             self._node_name_map[new_name] = node
             del self._node_name_map[old_name]
+
+    def rename_node(self, old_name: str | int | Node, new_name: str):
+        """Rename a single node in the skeleton.
+
+        Args:
+            old_name: The name of the node to rename. Can also be specified as an
+                integer index or `Node` object.
+            new_name: The new name for the node.
+        """
+        self.rename_nodes({old_name: new_name})

--- a/sleap_io/model/skeleton.py
+++ b/sleap_io/model/skeleton.py
@@ -542,10 +542,10 @@ class Skeleton:
             changes.
 
             It is recommended to use the `Labels.remove_nodes()` method which will
-            update all contained to reflect the changes made to the skeleton.
+            update all contained instances to reflect the changes made to the skeleton.
 
             To manually update instances after this method is called, call
-            `instance.update_skeleton()` on each instance that uses this skeleton.
+            `Instance.update_skeleton()` on each instance that uses this skeleton.
         """
         self.remove_nodes([node])
 
@@ -556,16 +556,29 @@ class Skeleton:
             new_order: A list of node names, indices, or `Node` objects specifying the
                 new order of the nodes.
 
+        Raises:
+            ValueError: If the new order of nodes is not the same length as the current
+                nodes.
+
         Notes:
             This method should always be used when reordering nodes in the skeleton as
             it handles updating the lookup caches necessary for indexing nodes by name.
 
-            After reordering, instances using this skeleton do NOT need to be updated as
+        Warning:
+            After reordering, instances using this skeleton do not need to be updated as
             the nodes are stored by reference in the skeleton.
 
-        Raises:
-            ValueError: If the new order of nodes is not the same length as the current
-                nodes.
+            However, the order that points are stored in the instances will not be
+            updated to match the new order of the nodes in the skeleton. This should not
+            matter unless the ordering of the keys in the `Instance.points` dictionary
+            is used instead of relying on the skeleton node order.
+
+            To make sure these are aligned, it is recommended to use the
+            `Labels.reorder_nodes()` method which will update all contained instances to
+            reflect the changes made to the skeleton.
+
+            To manually update instances after this method is called, call
+            `Instance.update_skeleton()` on each instance that uses this skeleton.
         """
         if len(new_order) != len(self.nodes):
             raise ValueError(

--- a/sleap_io/model/skeleton.py
+++ b/sleap_io/model/skeleton.py
@@ -7,7 +7,7 @@ differently depending on the underlying pose model.
 
 from __future__ import annotations
 from attrs import define, field
-from typing import TypeAlias
+import typing
 import numpy as np
 
 
@@ -71,7 +71,9 @@ class Symmetry:
                 return node
 
 
-NodeOrIndex: TypeAlias = Node | str | int
+NodeOrIndex = Node | str | int  # type: typing.TypeAlias
+# NodeOrIndex: TypeAlias = Node | str | int  # py >= 3.10
+# type NodeOrIndex = Node | str | int  # py >= 3.12
 
 
 @define(eq=False)

--- a/sleap_io/model/skeleton.py
+++ b/sleap_io/model/skeleton.py
@@ -71,7 +71,7 @@ class Symmetry:
                 return node
 
 
-NodeOrIndex = Node | str | int  # type: typing.TypeAlias
+NodeOrIndex = typing.Union[Node, str, int]
 # NodeOrIndex: TypeAlias = Node | str | int  # py >= 3.10
 # type NodeOrIndex = Node | str | int  # py >= 3.12
 

--- a/sleap_io/model/skeleton.py
+++ b/sleap_io/model/skeleton.py
@@ -76,6 +76,20 @@ NodeOrIndex = typing.Union[Node, str, int]
 # type NodeOrIndex = Node | str | int  # py >= 3.12
 
 
+def is_node_or_index(obj: typing.Any) -> bool:
+    """Check if an object is a `Node`, string name or integer index.
+
+    Args:
+        obj: The object to check.
+
+    Notes:
+        This is mainly for backwards compatibility with Python versions < 3.10 where
+        generics can't be used with `isinstance`. In newer Python, this is equivalent
+        to `isinstance(obj, NodeOrIndex)`.
+    """
+    return isinstance(obj, (Node, str, int))
+
+
 @define(eq=False)
 class Skeleton:
     """A description of a set of landmark types and connections between them.
@@ -364,8 +378,8 @@ class Skeleton:
         if type(src) == tuple:
             src, dst = src
 
-        if isinstance(src, NodeOrIndex):
-            if not isinstance(dst, NodeOrIndex):
+        if is_node_or_index(src):
+            if not is_node_or_index(dst):
                 raise ValueError("Destination node must be specified.")
 
             src = self.require_node(src)

--- a/tests/model/test_instance.py
+++ b/tests/model/test_instance.py
@@ -164,3 +164,36 @@ def test_predicted_instance():
         str(inst) == "PredictedInstance(points=[[0.0, 1.0], [2.0, 3.0]], track=None, "
         "score=0.60, tracking_score=None)"
     )
+
+
+def test_instance_update_skeleton():
+    skel = Skeleton(["A", "B", "C"])
+    inst = Instance.from_numpy([[0, 0], [1, 1], [2, 2]], skeleton=skel)
+
+    # No need to update on rename
+    skel.rename_nodes({"A": "X", "B": "Y", "C": "Z"})
+    assert inst["X"].x == 0
+    assert inst["Y"].x == 1
+    assert inst["Z"].x == 2
+    assert_equal(inst.numpy(), [[0, 0], [1, 1], [2, 2]])
+
+    # Remove a node from the skeleton
+    Y = skel["Y"]
+    skel.remove_node("Y")
+    assert Y not in skel
+
+    with pytest.raises(KeyError):
+        inst.numpy()  # .numpy() breaks without update
+    assert Y in inst.points  # and the points dict still has the old key
+    inst.update_skeleton()
+    assert Y not in inst.points  # after update, the old key is gone
+    assert_equal(inst.numpy(), [[0, 0], [2, 2]])
+
+    # Reorder nodes
+    skel.reorder_nodes(["Z", "X"])
+    assert_equal(inst.numpy(), [[2, 2], [0, 0]])  # .numpy() works without update
+    assert (
+        list(inst.points.keys()) != skel.nodes
+    )  # but the points dict still has the old order
+    inst.update_skeleton()
+    assert list(inst.points.keys()) == skel.nodes  # after update, the order is correct

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -633,3 +633,35 @@ def test_make_training_splits_save(slp_real_data, tmp_path, embed):
         for labels_ in [train_, val_, test_]:
             for lf in labels_:
                 assert lf.image.shape == (384, 384, 1)
+
+
+def test_labels_instances():
+    labels = Labels()
+    labels.append(
+        LabeledFrame(
+            video=Video("test.mp4"),
+            frame_idx=0,
+            instances=[
+                Instance.from_numpy(
+                    np.array([[0, 1], [2, 3]]), skeleton=Skeleton(["A", "B"])
+                )
+            ],
+        )
+    )
+    assert len(list(labels.instances)) == 1
+
+    labels.append(
+        LabeledFrame(
+            video=labels.video,
+            frame_idx=1,
+            instances=[
+                Instance.from_numpy(
+                    np.array([[0, 1], [2, 3]]), skeleton=labels.skeleton
+                ),
+                Instance.from_numpy(
+                    np.array([[0, 1], [2, 3]]), skeleton=labels.skeleton
+                ),
+            ],
+        )
+    )
+    assert len(list(labels.instances)) == 3

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -716,3 +716,34 @@ def test_labels_reorder_nodes(slp_real_data):
     labels.skeletons.append(Skeleton())
     with pytest.raises(ValueError):
         labels.reorder_nodes(["head", "abdomen"])
+
+
+def test_labels_replace_skeleton(slp_real_data):
+    labels = load_slp(slp_real_data)
+    assert labels.skeleton.node_names == ["head", "abdomen"]
+    inst = labels[0][0]
+    assert_allclose(inst.numpy(), [[91.886988, 204.018843], [151.536969, 159.825034]])
+
+    # Replace with full mapping
+    new_skel = Skeleton(["ABDOMEN", "HEAD"])
+    labels.replace_skeleton(new_skel, node_map={"abdomen": "ABDOMEN", "head": "HEAD"})
+    assert labels.skeleton == new_skel
+    inst = labels[0][0]
+    assert inst.skeleton == new_skel
+    assert_allclose(inst.numpy(), [[151.536969, 159.825034], [91.886988, 204.018843]])
+
+    # Replace with partial (inferred) mapping
+    new_skel = Skeleton(["x", "ABDOMEN"])
+    labels.replace_skeleton(new_skel)
+    assert labels.skeleton == new_skel
+    inst = labels[0][0]
+    assert inst.skeleton == new_skel
+    assert_allclose(inst.numpy(), [[np.nan, np.nan], [151.536969, 159.825034]])
+
+    # Replace with no mapping
+    new_skel = Skeleton(["front", "back"])
+    labels.replace_skeleton(new_skel)
+    assert labels.skeleton == new_skel
+    inst = labels[0][0]
+    assert inst.skeleton == new_skel
+    assert_allclose(inst.numpy(), [[np.nan, np.nan], [np.nan, np.nan]])

--- a/tests/model/test_skeleton.py
+++ b/tests/model/test_skeleton.py
@@ -104,16 +104,24 @@ def test_add_node():
     skel = Skeleton()
     skel.add_node("A")
     assert skel.node_names == ["A"]
+    assert "A" in skel
+    assert skel.index("A") == 0
 
-    skel.add_node(Node("B"))
+    B = Node("B")
+    skel.add_node(B)
     assert skel.node_names == ["A", "B"]
+    assert B in skel
+    assert "B" in skel
+    assert skel.index("B") == 1
 
     skel.add_node("C")
     assert skel.node_names == ["A", "B", "C"]
 
     with pytest.raises(ValueError):
         skel.add_node("B")
-        assert skel.node_names == ["A", "B", "C"]
+
+    skel.add_nodes(["D", "E"])
+    assert skel.node_names == ["A", "B", "C", "D", "E"]
 
 
 def test_add_edge():

--- a/tests/model/test_skeleton.py
+++ b/tests/model/test_skeleton.py
@@ -165,7 +165,29 @@ def test_rename_nodes():
     assert skel.node_names == ["a", "b", "c"]
 
     with pytest.raises(ValueError):
+        skel.rename_nodes(["a1", "b1"])
+
+    with pytest.raises(ValueError):
         skel.rename_nodes({"a": "b"})
 
     with pytest.raises(ValueError):
         skel.rename_nodes({"d": "e"})
+
+
+def test_rename_node():
+    """Test renaming a single node in the skeleton."""
+    skel = Skeleton(["A", "B", "C"])
+    skel.rename_node("A", "X")
+    assert skel.node_names == ["X", "B", "C"]
+
+    skel.rename_node(1, "Y")
+    assert skel.node_names == ["X", "Y", "C"]
+
+    skel.rename_node(skel.nodes[2], "Z")
+    assert skel.node_names == ["X", "Y", "Z"]
+
+    with pytest.raises(ValueError):
+        skel.rename_node("X", "Y")
+
+    with pytest.raises(ValueError):
+        skel.rename_node("D", "E")

--- a/tests/model/test_skeleton.py
+++ b/tests/model/test_skeleton.py
@@ -153,3 +153,19 @@ def test_add_symmetry():
     # Add new symmetry with node names
     skel.add_symmetry("E", "F")
     assert skel.symmetry_inds == [(0, 1), (2, 3), (4, 5)]
+
+
+def test_rename_nodes():
+    """Test renaming nodes in the skeleton."""
+    skel = Skeleton(["A", "B", "C"])
+    skel.rename_nodes({"A": "X", "B": "Y", "C": "Z"})
+    assert skel.node_names == ["X", "Y", "Z"]
+
+    skel.rename_nodes(["a", "b", "c"])
+    assert skel.node_names == ["a", "b", "c"]
+
+    with pytest.raises(ValueError):
+        skel.rename_nodes({"a": "b"})
+
+    with pytest.raises(ValueError):
+        skel.rename_nodes({"d": "e"})

--- a/tests/model/test_skeleton.py
+++ b/tests/model/test_skeleton.py
@@ -142,6 +142,9 @@ def test_add_edge():
     skel.add_edge("D", "A")
     assert skel.edge_inds == [(0, 1), (1, 0), (0, 2), (3, 0)]
 
+    skel.add_edges([("D", "E"), ("E", "A")])
+    assert skel.edge_inds == [(0, 1), (1, 0), (0, 2), (3, 0), (3, 4), (4, 0)]
+
 
 def test_add_symmetry():
     skel = Skeleton(["A", "B"])


### PR DESCRIPTION
This PR builds on #135 to add a number of methods for `Skeleton` manipulation, addressing #123 and more.

API changes:

### `Skeleton`
- `__contains__(node: NodeOrIndex)`: Returns `True` if a node exists in the skeleton.
- `rebuild_cache()`: Method allowing explicit regeneration of the caching attributes from the nodes.
- Caching attributes are now named `_name_to_node_cache` and `_node_to_ind_cache`, better reflecting the mapping directionality.
- `require_node(node: NodeOrIndex, add_missing: bool = True)`: Returns a `Node` given a `Node`, `int` or `str`. If `add_missing` is `True`, the node is added or created, otherwise an `IndexError` is raised. This is helpful for flexibly converting between node representations with convenient existence handling.
- `add_nodes(list[Node | str])`: Convenience method to add a list of nodes.
- `add_edges(edges: list[Edge | tuple[NodeOrIndex, NodeOrIndex]])`: Convenience method to add a list of edges.
- `rename_nodes(name_map: dict[NodeOrIndex, str] | list[str])`: Method to rename nodes either by specifying a potentially partial mapping from node(s) to new name(s), or a list of new names. Handles updating both the `Node.name` attributes and the cache.
- `rename_node(old_name: NodeOrIndex, new_name: str)`: Shorter syntax for renaming a single node.
- `remove_nodes(nodes: list[NodeOrIndex])`: Method for removing nodes from the skeleton and updating caches. **Does NOT update corresponding instances.**
- `remove_node(node: NodeOrIndex)`: Shorter syntax for removing a single node.
- `reorder_nodes(new_order: list[NodeOrIndex])`: Method for setting the order of the nodes within the skeleton with cache updating. **Does NOT update corresponding instances.**

### `Instance`/`PredictedInstance`
- `update_skeleton()`: Updates the `points` attribute on the instance to reflect changes in the associated skeleton (removed nodes and reordering). This is called internally after updating the skeleton from the `Labels` level, but also exposed for more complex data manipulation workflows.
- `replace_skeleton(new_skeleton: Skeleton, node_map: dict[NodeOrIndex, NodeOrIndex] | None = None, rev_node_map: dict[NodeOrIndex, NodeOrIndex] | None = None)`: Method to replace the skeleton on the instance with optional capability to specify a node mapping so that data stored in the `points` attribute is retained and associated with the right nodes in the new skeleton. Mapping is specified in `node_map` from old to new nodes and defaults to mapping between node objects with the same name. `rev_node_map` maps new nodes to old nodes and is used internally when calling from the `Labels` level as it bypasses validation.

### `Labels`
- `instances`: Convenience property that returns a generator that loops over all labeled frames and returns all instances. This can be lazily iterated over without having to construct a huge list of all the instances.
- `rename_nodes(name_map: dict[NodeOrIndex, str] | list[str], skeleton: Skeleton | None = None)`: Method to rename nodes in a specified skeleton within the labels.
- `remove_nodes(nodes: list[NodeOrIndex], skeleton: Skeleton | None = None)`: Method to remove nodes in a specified skeleton within the labels. This also updates all instances associated with the skeleton, removing point data for the removed nodes.
- `reorder_nodes(new_order: list[NodeOrIndex], skeleton: Skeleton | None = None)`: Method to reorder nodes in a specified skeleton within the labels. This also updates all instances associated with the skeleton, reordering point data for the nodes.
- `replace_skeleton(new_skeleton: Skeleton, old_skeleton: Skeleton | None = None, node_map: dict[NodeOrIndex, NodeOrIndex] | None = None)`: Method to replace a skeleton entirely within the labels, updating all instances associated with the old skeleton to use the new skeleton, optionally with node remapping to retain previous point data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new methods for renaming, removing, and reordering nodes in both the `Skeleton` and `Labels` classes.
	- Added an `instances` property in the `Labels` class for easier access to instance data.
	- Enhanced the `Instance` class with methods to update and replace skeletons.

- **Bug Fixes**
	- Improved error handling for various operations involving nodes, ensuring robustness.

- **Tests**
	- Expanded test coverage for the `Skeleton`, `Labels`, and `Instance` classes, validating new functionalities and error conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->