### PR TITLE
Fix `HDF5Video` edge cases

### DIFF
--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -580,16 +580,31 @@ class HDF5Video(VideoBackend):
         """Shape of a single frame in the video as `(height, width, channels)`."""
         with h5py.File(self.filename, "r") as f:
             ds = f[self.dataset]
+
+            img_shape = None
             if "height" in ds.attrs:
+                # Try to get shape from the attributes.
                 img_shape = (
                     ds.attrs["height"],
                     ds.attrs["width"],
                     ds.attrs["channels"],
                 )
-            else:
+
+                if img_shape[0] == 0 or img_shape[1] == 0:
+                    # Invalidate the shape if the attributes are zero.
+                    img_shape = None
+
+            if img_shape is None and self.image_format == "hdf5" and ds.ndim == 4:
+                # Use the dataset shape if just stored as a rank-4 array.
                 img_shape = ds.shape[1:]
-        if self.input_format == "channels_first":
-            img_shape = img_shape[::-1]
+
+                if self.input_format == "channels_first":
+                    img_shape = img_shape[::-1]
+
+        if img_shape is None:
+            # Fall back to reading a test frame.
+            return super().img_shape
+
         return int(img_shape[0]), int(img_shape[1]), int(img_shape[2])
 
     def read_test_frame(self) -> np.ndarray:

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -238,6 +238,8 @@ class Video:
             with h5py.File(self.filename, "r") as f:
                 return dataset in f
 
+        return True
+
     @property
     def is_open(self) -> bool:
         """Check if the video backend is open."""

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -11,6 +11,7 @@ import numpy as np
 from sleap_io.io.video_reading import VideoBackend, MediaVideo, HDF5Video, ImageVideo
 from sleap_io.io.utils import is_file_accessible
 from pathlib import Path
+import h5py
 
 
 @attrs.define(eq=False)
@@ -205,12 +206,14 @@ class Video:
                 )
         return self.backend[inds]
 
-    def exists(self, check_all: bool = False) -> bool:
+    def exists(self, check_all: bool = False, dataset: str | None = None) -> bool:
         """Check if the video file exists and is accessible.
 
         Args:
             check_all: If `True`, check that all filenames in a list exist. If `False`
                 (the default), check that the first filename exists.
+            dataset: Name of dataset in HDF5 file. If specified, this will function will
+                return `False` if the dataset does not exist.
 
         Returns:
             `True` if the file exists and is accessible, `False` otherwise.
@@ -223,7 +226,17 @@ class Video:
                 return True
             else:
                 return is_file_accessible(self.filename[0])
-        return is_file_accessible(self.filename)
+
+        file_is_accessible = is_file_accessible(self.filename)
+        if not file_is_accessible:
+            return False
+
+        if dataset is None:
+            dataset = self.backend_metadata.get("dataset", None)
+
+        if dataset is not None:
+            with h5py.File(self.filename, "r") as f:
+                return dataset in f
 
     @property
     def is_open(self) -> bool:
@@ -261,9 +274,6 @@ class Video:
         if filename is not None:
             self.replace_filename(filename, open=False)
 
-        if not self.exists():
-            raise FileNotFoundError(f"Video file not found: {self.filename}")
-
         # Try to remember values from previous backend if available and not specified.
         if self.backend is not None:
             if dataset is None:
@@ -279,6 +289,12 @@ class Video:
                     grayscale = self.backend_metadata["grayscale"]
                 elif "shape" in self.backend_metadata:
                     grayscale = self.backend_metadata["shape"][-1] == 1
+
+        if not self.exists(dataset=dataset):
+            msg = f"Video does not exist or is inaccessible: {self.filename}"
+            if dataset is not None:
+                msg += f" (dataset: {dataset})"
+            raise FileNotFoundError(msg)
 
         # Close previous backend if open.
         self.close()

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -231,12 +231,21 @@ class Video:
         if not file_is_accessible:
             return False
 
-        if dataset is None:
+        if dataset is None or dataset == "":
             dataset = self.backend_metadata.get("dataset", None)
 
-        if dataset is not None:
-            with h5py.File(self.filename, "r") as f:
-                return dataset in f
+        if dataset is not None and dataset != "":
+            has_dataset = False
+            if (
+                self.backend is not None
+                and type(self.backend) == HDF5Video
+                and self.backend._open_reader is not None
+            ):
+                has_dataset = dataset in self.backend._open_reader
+            else:
+                with h5py.File(self.filename, "r") as f:
+                    has_dataset = dataset in f
+            return has_dataset
 
         return True
 


### PR DESCRIPTION
- Use test image method for determining image shape when cached attributes are invalid (fixes #133)
- Check if the specific dataset exists within the HDF5 file when checking for existence (fixes #121)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of image shape detection and frame reading for HDF5 datasets.
	- Added properties to check for embedded images and their indices.
- **Bug Fixes**
	- Improved error handling for video file accessibility and dataset existence.
	- Clarified error messages for file access issues.
- **Refactor**
	- Updated methods for better robustness in reading and processing video frames, including dataset checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->