### PR TITLE
Add `Labels.extract`, `Labels.trim` and `Video.save`

### DIFF
--- a/sleap_io/model/labeled_frame.py
+++ b/sleap_io/model/labeled_frame.py
@@ -27,7 +27,7 @@ class LabeledFrame:
     """
 
     video: Video
-    frame_idx: int
+    frame_idx: int = field(converter=int)
     instances: list[Union[Instance, PredictedInstance]] = field(factory=list)
 
     def __len__(self) -> int:

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -71,7 +71,6 @@ class Video:
 
     def __deepcopy__(self, memo):
         """Deep copy the video object."""
-
         if id(self) in memo:
             return memo[id(self)]
 

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -6,9 +6,10 @@ a video and its components used in SLEAP.
 
 from __future__ import annotations
 import attrs
-from typing import Tuple, Optional, Optional
+from typing import Tuple, Optional, Optional, Any
 import numpy as np
 from sleap_io.io.video_reading import VideoBackend, MediaVideo, HDF5Video, ImageVideo
+from sleap_io.io.video_writing import VideoWriter
 from sleap_io.io.utils import is_file_accessible
 from pathlib import Path
 import h5py
@@ -321,6 +322,19 @@ class Video:
     def close(self):
         """Close the video backend."""
         if self.backend is not None:
+            # Try to remember values from previous backend if available and not
+            # specified.
+            try:
+                self.backend_metadata["dataset"] = getattr(
+                    self.backend, "dataset", None
+                )
+                self.backend_metadata["grayscale"] = getattr(
+                    self.backend, "grayscale", None
+                )
+                self.backend_metadata["shape"] = getattr(self.backend, "shape", None)
+            except:
+                pass
+
             del self.backend
             self.backend = None
 

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -390,3 +390,31 @@ class Video:
                 self.open()
             else:
                 self.close()
+
+    def save(
+        self,
+        save_path: str | Path,
+        frame_inds: list[int] | np.ndarray | None = None,
+        video_kwargs: dict[str, Any] | None = None,
+    ) -> Video:
+        """Save video frames to a new video file.
+
+        Args:
+            save_path: Path to the new video file. Should end in MP4.
+            frame_inds: Frame indices to save. Can be specified as a list or array of
+                frame integers. If not specified, saves all video frames.
+            video_kwargs: A dictionary of keyword arguments to provide to
+                `sio.save_video` for video compression.
+
+        Returns:
+            A new `Video` object pointing to the new video file.
+        """
+        video_kwargs = {} if video_kwargs is None else video_kwargs
+        frame_inds = np.arange(len(self)) if frame_inds is None else frame_inds
+
+        with VideoWriter(save_path, **video_kwargs) as vw:
+            for frame_ind in frame_inds:
+                vw(self[frame_ind])
+
+        new_video = Video.from_filename(save_path, grayscale=self.grayscale)
+        return new_video

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -69,6 +69,32 @@ class Video:
                 # prevent the user from building the Video object entirely.
                 pass
 
+    def __deepcopy__(self, memo):
+        """Deep copy the video object."""
+
+        if id(self) in memo:
+            return memo[id(self)]
+
+        reopen = False
+        if self.is_open:
+            reopen = True
+            self.close()
+
+        new_video = Video(
+            filename=self.filename,
+            backend=None,
+            backend_metadata=self.backend_metadata,
+            source_video=self.source_video,
+            open_backend=self.open_backend,
+        )
+
+        memo[id(self)] = new_video
+
+        if reopen:
+            self.open()
+
+        return new_video
+
     @classmethod
     def from_filename(
         cls,

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -759,3 +759,9 @@ def test_labels_trim(centered_pair, tmpdir):
     assert trimmed_labels.video.shape == (100, 384, 384, 1)
     assert trimmed_labels[0].frame_idx == 0
     assert_equal(trimmed_labels[0].numpy(), labels[(labels.video, 100)].numpy())
+
+    labels.videos.append(Video.from_filename("fake.mp4"))
+    with pytest.raises(ValueError):
+        labels.trim(new_path, np.arange(100, 200))
+
+    labels.trim(new_path, np.arange(100, 200), video=0)

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -747,3 +747,15 @@ def test_labels_replace_skeleton(slp_real_data):
     inst = labels[0][0]
     assert inst.skeleton == new_skel
     assert_allclose(inst.numpy(), [[np.nan, np.nan], [np.nan, np.nan]])
+
+
+def test_labels_trim(centered_pair, tmpdir):
+    labels = load_slp(centered_pair)
+
+    new_path = tmpdir / "trimmed.slp"
+    trimmed_labels = labels.trim(new_path, np.arange(100, 200))
+    assert len(trimmed_labels) == 100
+    assert trimmed_labels.video.filename == Path(new_path).with_suffix(".mp4")
+    assert trimmed_labels.video.shape == (100, 384, 384, 1)
+    assert trimmed_labels[0].frame_idx == 0
+    assert_equal(trimmed_labels[0].numpy(), labels[(labels.video, 100)].numpy())

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -77,7 +77,7 @@ def test_video_open_close(centered_pair_low_quality_path, centered_pair_frame_pa
     video.close()
     assert video.is_open is False
     assert video.backend is None
-    assert video.shape is None
+    assert video.shape == (1100, 384, 384, 1)
 
     video.open()
     assert video.is_open is True


### PR DESCRIPTION
- `LabeledFrame.frame_idx`: Now always converted to `int` type.
- `Video.close()`: Now caches backend metadata to `Video.backend_metadata` to persist metadata on close.
- `copy.deepcopy()` now works on `Video` objects even if backend is open.
- `Video.save(save_path: str | Path, frame_inds: list[int] | np.ndarray | None = None, video_kwargs: dict[str, Any] | None = None)`: Method to save a video file to an MP4 using `VideoWriter` with an optional subset of frames.
- `Labels.extract(inds: list[int] | list[tuple[Video, int]] | np.ndarray, copy: bool = True)`: Add method to extract a subset of frames from the labels, optionally making a copy, and return a new `Labels` object.
- `Labels.trim(save_path: str | Path, frame_inds: list[int] | np.ndarray, video: Video | int | None = None, video_kwargs: dict[str, Any] | None = None)`: Add method to extract a subset of the labels, write a video clip with the extracted friends, and adjust frame indices to match the clip.