### PR TITLE
Implement `update_from_numpy` method for instance updating from tracks array

### DIFF
--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -145,44 +145,44 @@ def test_labels_numpy(labels_predictions: Labels):
     """Test the numpy method and its inverse update_from_numpy."""
     # Test conversion to numpy array
     tracks_arr = labels_predictions.numpy()
-    
+
     # Verify the shape
     assert tracks_arr.shape[0] > 0  # At least one frame
     assert tracks_arr.shape[1] > 0  # At least one track
     assert tracks_arr.shape[2] > 0  # At least one node
     assert tracks_arr.shape[3] == 2  # x, y coordinates
-    
+
     # Create a modified copy of the array
     modified_arr = tracks_arr.copy()
-    
+
     # Modify some points
     if not np.all(np.isnan(modified_arr[0, 0, 0])):
         modified_arr[0, 0, 0] = modified_arr[0, 0, 0] + 5  # Move x by 5 pixels
-    
+
     # Create a new labels object to test update_from_numpy
     new_labels = Labels()
     new_labels.videos = [labels_predictions.video]
     new_labels.skeletons = [labels_predictions.skeleton]
     new_labels.tracks = labels_predictions.tracks
-    
+
     # Test update_from_numpy
     new_labels.update_from_numpy(modified_arr)
-    
+
     # Test getting numpy array with confidence scores
     tracks_arr_with_conf = labels_predictions.numpy(return_confidence=True)
     assert tracks_arr_with_conf.shape[3] == 3  # x, y, confidence
-    
+
     # Test update_from_numpy with confidence scores
     confidence_arr = np.ones_like(tracks_arr_with_conf)
     confidence_arr[:, :, :, :2] = tracks_arr  # Set xy coords
     confidence_arr[:, :, :, 2] = 0.75  # Set all confidence to 0.75
-    
+
     # Test update with confidence scores
     new_labels.update_from_numpy(confidence_arr)
-    
+
     # Verify confidence scores were updated by checking scores directly in instances
     found_score = False
-    
+
     # Check by accessing through numpy with scores=True
     for lf in new_labels.labeled_frames:
         for inst in lf.predicted_instances:
@@ -197,7 +197,7 @@ def test_labels_numpy(labels_predictions: Labels):
                         break
         if found_score:
             break
-    
+
     assert found_score, "No points with confidence scores found after update"
 
 


### PR DESCRIPTION
 Introduce a method to synchronize instances with numpy arrays, allowing for updates and the creation of new instances based on modified data. Include tests to verify functionality and correctness of updates.

---

**Note:** This PR was implemented entirely through *vibes* using the following prompt + GitHub Copilot in Agent mode with Claude 3.7 Sonnet and thinking mode:

```
Can you add a `update_from_numpy` method to the `Labels` class?

This should take the output of `Labels.numpy()` and update the corresponding `Instance` and `PredictedInstance` objects and their underlying `PointsArray` data in place.

- The numpy array is specific to a single video, so this should need to be specified as an input argument unless it is a single-video project, in which case it's automatically inferred.
- Knowing which instance to update within a frame requires knowing which track each slice of the second dimension of the numpy array corresponds to. In the case where the `Labels.tracks` attribute has the same length as the `tracks_arr.shape[1]` (`tracks_arr` is the output of `Labels.numpy()` in this example), then we can assume that they correspond to each other. In this case, match the instances to slices of the numpy array by checking for the track index, similar to the logic in `Labels.numpy()`. As a fallback, allow the user to provide the `tracks` (list of `Track` objects) that the second dimension of `tracks_arr` corresponds to.
- If a corresponding instance didn't exist in the frame, a new one should be created as a `PredictedInstance` with dummy confidences/scores (= 1.0). Control whether new instances should be created if a match can't be found by using a keyword argument called `create_missing: bool = True`.
- Use google style docstrings and `black` formatting with max line length of 88.
- When running tests, don't forget to activate the conda environment (`sleap-io`).
```

This did get stuck after a few iterations, after which I stopped and started a new chat session after accepting all changes and prepended the prompt with this:

```
See below for the previous prompt that described how the `update_from_numpy()` method was meant to be implemented. Keep troubleshooting the test until it passes.
```

Then, to further improve test coverage, I generated the coverage report with:

```
pytest tests/model/test_labels.py -v --cov=sleap_io --cov-report=json
coverage annotate --include="*/sleap_io/model/labels.py"
```

which produced a file in `sleap_io/model/labels.py,cover` that had line-by-line coverage annotations. I added the coverage in as context and started a new agent session with this prompt to generate more tests:

```
Can you increase the test coverage for the `update_from_numpy()` method in the `Labels` class?

See the coverage report. Feel free to add more separate tests to cover the individual branches in the code.
```

I did this a couple of times to keep increasing coverage. Then I began to automate the workflow with this prompt:

````
Can you run the tests with the following command to check the coverage and make sure the tests run?

```
conda activate sleap-io && pytest tests/model/test_labels.py -v --cov=sleap_io --cov-report=json && coverage annotate --include="*/sleap_io/model/labels.py"
```

Then check the `sleap_io/model/labels.py,cover` file for coverage changes.
````