### PR TITLE
Add repr for mv classes

### DIFF
--- a/sleap_io/model/camera.py
+++ b/sleap_io/model/camera.py
@@ -321,6 +321,35 @@ class Camera:
         """
         return session.get_video(camera=self)
 
+    def __repr__(self) -> str:
+        """Return a readable representation of the camera."""
+        matrix_str = (
+            "identity" if np.array_equal(self.matrix, np.eye(3)) else "non-identity"
+        )
+        dist_str = "zero" if np.array_equal(self.dist, np.zeros(5)) else "non-zero"
+        size_str = "None" if self.size is None else self.size
+        rvec_str = (
+            "zero"
+            if np.array_equal(self.rvec, np.zeros(3))
+            else np.array2string(self.rvec, precision=2, suppress_small=True)
+        )
+        tvec_str = (
+            "zero"
+            if np.array_equal(self.tvec, np.zeros(3))
+            else np.array2string(self.tvec, precision=2, suppress_small=True)
+        )
+        name_str = self.name if self.name is not None else "None"
+        return (
+            "Camera("
+            f"matrix={matrix_str},"
+            f"dist={dist_str},"
+            f"size={size_str},"
+            f"rvec={rvec_str},"
+            f"tvec={tvec_str},"
+            f"name={name_str}"
+            ")"
+        )
+
 
 @define(eq=False)  # Set eq to false to make class hashable
 class InstanceGroup:

--- a/sleap_io/model/camera.py
+++ b/sleap_io/model/camera.py
@@ -27,6 +27,11 @@ class CameraGroup:
     cameras: list[Camera] = field(factory=list, validator=instance_of(list))
     metadata: dict = field(factory=dict, validator=instance_of(dict))
 
+    def __repr__(self):
+        """Return a readable representation of the camera group."""
+        camera_names = ",".join([c.name or "None" for c in self.cameras])
+        return f"CameraGroup(cameras={len(self.cameras)}:{camera_names})"
+
 
 @define(eq=False)  # Set eq to false to make class hashable
 class RecordingSession:

--- a/sleap_io/model/camera.py
+++ b/sleap_io/model/camera.py
@@ -149,6 +149,16 @@ class RecordingSession:
         # Remove camera from video mapping
         self._video_by_camera.pop(camera)
 
+    def __repr__(self) -> str:
+        """Return a readable representation of the session."""
+        return (
+            "RecordingSession("
+            f"camera_group={len(self.camera_group.cameras)}cameras,"
+            f"videos={len(self.videos)},"
+            f"frame_groups={len(self.frame_groups)}"
+            ")"
+        )
+
 
 @define(eq=False)  # Set eq to false to make class hashable
 class Camera:

--- a/sleap_io/model/camera.py
+++ b/sleap_io/model/camera.py
@@ -414,6 +414,11 @@ class InstanceGroup:
         """
         return self._instance_by_camera.get(camera, None)
 
+    def __repr__(self) -> str:
+        """Return a readable representation of the instance group."""
+        cameras_str = ",".join([c.name or "None" for c in self.cameras])
+        return f"InstanceGroup(cameras={len(self.cameras)}:{cameras_str})"
+
 
 @define(eq=False)  # Set eq to false to make class hashable
 class FrameGroup:

--- a/sleap_io/model/camera.py
+++ b/sleap_io/model/camera.py
@@ -29,8 +29,8 @@ class CameraGroup:
 
     def __repr__(self):
         """Return a readable representation of the camera group."""
-        camera_names = ",".join([c.name or "None" for c in self.cameras])
-        return f"CameraGroup(cameras={len(self.cameras)}:{camera_names})"
+        camera_names = ", ".join([c.name or "None" for c in self.cameras])
+        return f"CameraGroup(cameras={len(self.cameras)}:[{camera_names}])"
 
 
 @define(eq=False)  # Set eq to false to make class hashable
@@ -153,8 +153,8 @@ class RecordingSession:
         """Return a readable representation of the session."""
         return (
             "RecordingSession("
-            f"camera_group={len(self.camera_group.cameras)}cameras,"
-            f"videos={len(self.videos)},"
+            f"camera_group={len(self.camera_group.cameras)}cameras, "
+            f"videos={len(self.videos)}, "
             f"frame_groups={len(self.frame_groups)}"
             ")"
         )
@@ -341,11 +341,11 @@ class Camera:
         name_str = self.name if self.name is not None else "None"
         return (
             "Camera("
-            f"matrix={matrix_str},"
-            f"dist={dist_str},"
-            f"size={size_str},"
-            f"rvec={rvec_str},"
-            f"tvec={tvec_str},"
+            f"matrix={matrix_str}, "
+            f"dist={dist_str}, "
+            f"size={size_str}, "
+            f"rvec={rvec_str}, "
+            f"tvec={tvec_str}, "
             f"name={name_str}"
             ")"
         )
@@ -416,8 +416,8 @@ class InstanceGroup:
 
     def __repr__(self) -> str:
         """Return a readable representation of the instance group."""
-        cameras_str = ",".join([c.name or "None" for c in self.cameras])
-        return f"InstanceGroup(cameras={len(self.cameras)}:{cameras_str})"
+        cameras_str = ", ".join([c.name or "None" for c in self.cameras])
+        return f"InstanceGroup(cameras={len(self.cameras)}:[{cameras_str}])"
 
 
 @define(eq=False)  # Set eq to false to make class hashable
@@ -469,11 +469,11 @@ class FrameGroup:
 
     def __repr__(self) -> str:
         """Return a readable representation of the frame group."""
-        cameras_str = ",".join([c.name or "None" for c in self.cameras])
+        cameras_str = ", ".join([c.name or "None" for c in self.cameras])
         return (
             f"FrameGroup("
             f"frame_idx={self.frame_idx},"
             f"instance_groups={len(self.instance_groups)},"
-            f"cameras={len(self.cameras)}:{cameras_str}"
+            f"cameras={len(self.cameras)}:[{cameras_str}]"
             f")"
         )

--- a/sleap_io/model/camera.py
+++ b/sleap_io/model/camera.py
@@ -466,3 +466,14 @@ class FrameGroup:
             `LabeledFrame` associated with `camera` or None if not found.
         """
         return self._labeled_frame_by_camera.get(camera, None)
+
+    def __repr__(self) -> str:
+        """Return a readable representation of the frame group."""
+        cameras_str = ",".join([c.name or "None" for c in self.cameras])
+        return (
+            f"FrameGroup("
+            f"frame_idx={self.frame_idx},"
+            f"instance_groups={len(self.instance_groups)},"
+            f"cameras={len(self.cameras)}:{cameras_str}"
+            f")"
+        )

--- a/tests/model/test_camera.py
+++ b/tests/model/test_camera.py
@@ -228,6 +228,13 @@ def test_camera_get_video():
     assert camera.get_video(session) is None
 
 
+def test_camera_repr(camera_group_345: CameraGroup):
+    """Test camera repr method."""
+    camera_group = camera_group_345
+    camera = camera_group.cameras[0]
+    repr_str = str(camera)
+
+
 def test_recording_session_videos():
     """Test `RecordingSession.videos` property."""
     camera_1 = Camera()

--- a/tests/model/test_camera.py
+++ b/tests/model/test_camera.py
@@ -452,3 +452,9 @@ def test_recording_session_init(camera_group_345: CameraGroup):
     assert session._camera_by_video == camera_by_video
     assert session.frame_groups == frame_group_by_frame_idx
     assert session.metadata == metadata
+
+
+def test_recording_session_repr(recording_session_345: RecordingSession):
+    """Test recording session repr method."""
+    session = recording_session_345
+    repr_str = str(session)

--- a/tests/model/test_camera.py
+++ b/tests/model/test_camera.py
@@ -320,6 +320,15 @@ def test_camera_group_cameras():
     assert camera_group.cameras == []
 
 
+def test_camera_group_repr(camera_group_345: CameraGroup):
+    camera_group = camera_group_345
+    repr_str = str(camera_group)
+
+    for cam_idx, camera in enumerate(camera_group.cameras):
+        camera.name = f"camera_{cam_idx}"
+    repr_str = str(camera_group)
+
+
 def test_instance_group_init(
     camera_group_345: CameraGroup,
 ):

--- a/tests/model/test_camera.py
+++ b/tests/model/test_camera.py
@@ -431,6 +431,11 @@ def test_frame_group_init(camera_group_345: CameraGroup):
     assert frame_group.metadata == metadata
 
 
+def test_frame_group_repr(frame_group_345: FrameGroup):
+    frame_group = frame_group_345
+    repr_str = str(frame_group)
+
+
 def test_recording_session_init(camera_group_345: CameraGroup):
     """Test recording session initialization.
 

--- a/tests/model/test_camera.py
+++ b/tests/model/test_camera.py
@@ -381,6 +381,11 @@ def test_instance_group_init(
     assert instance_group.metadata == metadata
 
 
+def test_instance_group_repr(instance_group_345: InstanceGroup):
+    instance_group = instance_group_345
+    repr_str = str(instance_group)
+
+
 def test_frame_group_init(camera_group_345: CameraGroup):
     """Test frame group initialization.
 


### PR DESCRIPTION
This PR adds much needed repr methods for the MV classes. This is what the repr output looks like:
```python
Camera(matrix=identity, dist=zero, size=None, rvec=[0.   0.   0.64], tvec=[ 1.8 -2.4  0. ], name=None)
CameraGroup(cameras=2:[camera_0, camera_1])
InstanceGroup(cameras=2:[None, None])
FrameGroup(frame_idx=0,instance_groups=1,cameras=2:[None, None])
RecordingSession(camera_group=2cameras, videos=2, frame_groups=1)
```
.