### PR TITLE
Update ndx-pose dependency to version >=0.2.1 in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - numpy
   - opencv
   - pynwb
-  - ndx-pose<0.2.0
+  - ndx-pose >=0.2.1
   - pytest
   - pytest-cov
   - black


### PR DESCRIPTION
To match the `ndx-pose` dependency version in pyproject.toml introduced in #143