### PR TITLE
Bump to v0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,11 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-14"]
-        python: ["3.8", "3.12"]
+        python: ["3.8", "3.13"]
         exclude:
           - os: "macos-14"
+            python: "3.8"
+          - os: "windows-latest"
             python: "3.8"
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -217,3 +217,30 @@ labels.save("labels_with_new_skeleton.slp")
 ```
 
 **See also:** [`Labels.replace_skeleton`](model.md#sleap_io.Labels.replace_skeleton)
+
+
+## Convert to and from numpy arrays
+
+A common use case is when we have a single video with tracks and we want to apply some temporal filtering operations like interpolation or smoothing. For these, it's much more convenient to work with temporally contiguous arrays rather than the data structures used the our data model.
+
+For this use case, we can leverage [`Labels.numpy`](model.md#sleap_io.Labels.numpy) and [`Labels.update_from_numpy`](model.md#sleap_io.Labels.update_from_numpy):
+
+```py
+import sleap_io as sio
+
+# Load predictions
+labels = sio.load_file("predictions.slp")
+
+# Convert to array of shape (n_frames, n_tracks, n_nodes, xy)
+trx = labels.numpy()
+
+# ... manipulate the array...
+
+# Update the labels with the changes
+labels.update_from_numpy(trx)
+
+# Save the filtered version
+labels.save("predictions.filtered.slp")
+```
+
+For a more full-featured library for processing tracked poses, check out [`movement`](https://movement.neuroinformatics.dev/).

--- a/docs/model.md
+++ b/docs/model.md
@@ -25,3 +25,13 @@
 ::: sleap_io.Video
 
 ::: sleap_io.SuggestionFrame
+
+::: sleap_io.Camera
+
+::: sleap_io.CameraGroup
+
+::: sleap_io.FrameGroup
+
+::: sleap_io.InstanceGroup
+
+::: sleap_io.RecordingSession

--- a/sleap_io/model/camera.py
+++ b/sleap_io/model/camera.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-
 import attrs
 import numpy as np
 from attrs import define, field

--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -2,4 +2,4 @@
 
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release version.
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
- Bumped to v0.3.0
- Include an example demonstrating how to convert labels to and from numpy arrays for easier manipulation during temporal filtering operations.