### PR TITLE
Implemenet SLP format v1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 .vscode/
 
 .DS_Store
+
+# Serena
+.serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+sleap-io is a standalone utility library for working with animal pose tracking data. It provides:
+- Reading/writing pose tracking data in various formats (SLEAP, NWB, Label Studio, JABS)
+- Data structure manipulation and conversion
+- Video I/O operations
+- Minimal dependencies (no labeling, training, or inference functionality)
+
+## Key Architecture
+
+### Core Data Model (`sleap_io/model/`)
+- **Skeleton**: Defines skeletal structure with nodes, edges, and symmetries
+- **Instance**: Represents pose instances (predicted or manual) with associated tracks
+- **LabeledFrame**: Container for frames with labeled instances
+- **Labels**: Top-level container for entire datasets
+- **Video**: Video container and metadata management
+- **Camera**: Multi-camera support for 3D reconstruction
+
+### I/O System (`sleap_io/io/`)
+- **Main API**: High-level functions in `main.py` (`load_file`, `save_file`, etc.)
+- **Format-specific modules**: `slp.py`, `nwb.py`, `labelstudio.py`, `jabs.py`
+- **Video backends**: Abstracted reading/writing in `video_reading.py` and `video_writing.py`
+
+## Development Commands
+
+### Environment Setup
+```bash
+# Conda (recommended)
+conda env create -f environment.yml
+conda activate sleap-io
+
+# Pip development install
+pip install -e .[dev]
+```
+
+### Linting
+```bash
+# Format check (MUST pass before committing)
+black --check sleap_io tests
+
+# Docstring style check
+pydocstyle --convention=google sleap_io/
+```
+
+### Testing
+```bash
+# Run full test suite with coverage
+pytest --cov=sleap_io --cov-report=xml tests/
+
+# Run specific test module
+pytest tests/io/test_slp.py -v
+
+# Check line-by-line coverage for a module
+conda activate sleap-io && pytest tests/model/test_labels.py -v --cov=sleap_io --cov-report=json && coverage annotate --include="*/sleap_io/model/labels.py"
+
+# Watch mode for development
+ptw
+```
+
+### Building
+```bash
+# Build wheel
+python -m build --wheel
+
+# Build documentation locally
+mike serve
+```
+
+## Code Style Requirements
+
+1. **Formatting**: Use `black` with max line length of 88
+2. **Docstrings**: Google style, document "Attributes" section in class-level docstring
+3. **Type hints**: Always include for function arguments and return types
+4. **Import order**: Standard library, third-party, local (enforced by black)
+
+## Testing Guidelines
+
+1. Use existing fixtures from `tests/fixtures/` when possible
+2. Create minimal synthetic data for new tests rather than files
+3. Use `tmp_path` for any I/O operations in tests
+4. Write multiple focused tests rather than one complex test
+5. Place tests in corresponding module under `tests/` (e.g., `sleap_io/io/slp.py` → `tests/io/test_slp.py`)
+6. Never create new test modules unless a new package module was created
+
+## Common Development Tasks
+
+### Adding a New I/O Format
+1. Create module in `sleap_io/io/` with reader/writer functions
+2. Add format detection to `sleap_io/io/main.py`
+3. Create comprehensive tests in `tests/io/`
+4. Update documentation with format specifications
+
+### Working with Video Backends
+- Video reading is abstracted through `VideoBackend` classes
+- Supported backends: MediaVideo (imageio-ffmpeg), HDF5Video, ImageVideo
+- Backend selection is automatic based on file format
+
+### Running a Single Test
+```bash
+pytest tests/path/to/test_module.py::TestClass::test_method -v
+```
+
+## Important Notes
+
+- Version is defined in `sleap_io/version.py`
+- CI runs on Ubuntu, Windows, macOS with Python 3.8-3.13
+- All PRs require passing tests and linting
+- Documentation is hosted at https://io.sleap.ai/

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1022,7 +1022,7 @@ def write_metadata(labels_path: str, labels: Labels):
 
     with h5py.File(labels_path, "a") as f:
         grp = f.require_group("metadata")
-        grp.attrs["format_id"] = 1.2
+        grp.attrs["format_id"] = 1.3
         grp.attrs["json"] = np.bytes_(json.dumps(md, separators=(",", ":")))
 
 
@@ -1092,7 +1092,7 @@ def read_instances(
                 point_id_start,
                 point_id_end,
             ) = instance_data
-            tracking_score = np.zeros_like(instance_score)
+            tracking_score = 0.0
         elif format_id >= 1.2:
             (
                 instance_id,
@@ -1169,7 +1169,7 @@ def write_lfs(labels_path: str, labels: Labels):
             ("score", "f4"),
             ("point_id_start", "u8"),
             ("point_id_end", "u8"),
-            ("tracking_score", "f4"),  # FORMAT_ID >= 1.2
+            ("tracking_score", "f4"),  # FORMAT_ID >= 1.2 (1.3 adds explicit handling)
         ]
     )
     frame_dtype = np.dtype(

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -66,6 +66,7 @@ import sys
 import h5py
 from unittest import mock
 from tqdm import tqdm
+import numpy as np
 
 
 def test_read_labels(slp_typical, slp_simple_skel, slp_minimal):
@@ -1251,6 +1252,129 @@ def test_write_labels_verbose_propagation(slp_minimal, tmp_path):
 
         # Check that verbose=False was passed to write_videos
         assert mock_write_videos.call_args.kwargs["verbose"] is False
+
+
+def test_format_id_1_3_tracking_score(tmp_path):
+    """Test that FORMAT_ID 1.3 properly handles tracking_score field."""
+    # Create test data with tracking scores
+    skeleton = Skeleton(["A", "B", "C"])
+    track = Track("track1")
+
+    # Create instances with tracking scores
+    inst1 = Instance(
+        [[1, 2], [3, 4], [5, 6]], skeleton=skeleton, track=track, tracking_score=0.95
+    )
+    inst2 = PredictedInstance(
+        [[7, 8], [9, 10], [11, 12]],
+        skeleton=skeleton,
+        track=track,
+        score=0.8,
+        tracking_score=0.75,
+    )
+
+    # Create labeled frames and labels
+    video = Video.from_filename("fake.mp4")
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst1, inst2])
+    labels = Labels(
+        videos=[video], skeletons=[skeleton], tracks=[track], labeled_frames=[lf]
+    )
+
+    # Save with FORMAT_ID 1.3
+    test_path = tmp_path / "test_format_1_3.slp"
+    write_labels(test_path, labels)
+
+    # Verify FORMAT_ID is 1.3
+    format_id = read_hdf5_attrs(test_path, "metadata", "format_id")
+    assert format_id == 1.3
+
+    # Load and verify tracking scores are preserved
+    loaded_labels = read_labels(test_path)
+    loaded_inst1 = loaded_labels.labeled_frames[0].instances[0]
+    loaded_inst2 = loaded_labels.labeled_frames[0].instances[1]
+
+    assert isinstance(loaded_inst1, Instance)
+    assert loaded_inst1.tracking_score == 0.95
+
+    assert isinstance(loaded_inst2, PredictedInstance)
+    assert loaded_inst2.tracking_score == 0.75
+    assert loaded_inst2.score == 0.8
+
+
+def test_format_id_backward_compatibility(tmp_path):
+    """Test backward compatibility when reading files with older FORMAT_ID."""
+    # Create test data
+    skeleton = Skeleton(["A", "B"])
+    track = Track("track1")
+
+    # Create instances
+    inst = Instance([[1, 2], [3, 4]], skeleton=skeleton, track=track)
+    pred_inst = PredictedInstance(
+        [[5, 6], [7, 8]], skeleton=skeleton, track=track, score=0.9
+    )
+
+    video = Video.from_filename("fake.mp4")
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst, pred_inst])
+    labels = Labels(
+        videos=[video], skeletons=[skeleton], tracks=[track], labeled_frames=[lf]
+    )
+
+    # Save the file
+    test_path = tmp_path / "test_format_old.slp"
+    write_labels(test_path, labels)
+
+    # Manually modify the format_id to simulate an older file
+    with h5py.File(test_path, "r+") as f:
+        f["metadata"].attrs["format_id"] = 1.1
+
+        # Also need to modify the instances dataset to remove tracking_score field
+        # Read existing data
+        instances_data = f["instances"][:]
+
+        # Create new dtype without tracking_score
+        old_dtype = np.dtype(
+            [
+                ("instance_id", "i8"),
+                ("instance_type", "u1"),
+                ("frame_id", "u8"),
+                ("skeleton", "u4"),
+                ("track", "i4"),
+                ("from_predicted", "i8"),
+                ("score", "f4"),
+                ("point_id_start", "u8"),
+                ("point_id_end", "u8"),
+            ]
+        )
+
+        # Copy data to new array without tracking_score
+        old_instances = np.zeros(len(instances_data), dtype=old_dtype)
+        for i, inst_data in enumerate(instances_data):
+            # Copy all fields except tracking_score
+            old_instances[i] = (
+                inst_data["instance_id"],
+                inst_data["instance_type"],
+                inst_data["frame_id"],
+                inst_data["skeleton"],
+                inst_data["track"],
+                inst_data["from_predicted"],
+                inst_data["score"],
+                inst_data["point_id_start"],
+                inst_data["point_id_end"],
+            )
+
+        # Delete and recreate dataset
+        del f["instances"]
+        f.create_dataset("instances", data=old_instances, dtype=old_dtype)
+
+    # Load with older format - tracking_score should default to 0.0
+    loaded_labels = read_labels(test_path)
+    loaded_inst = loaded_labels.labeled_frames[0].instances[0]
+    loaded_pred_inst = loaded_labels.labeled_frames[0].instances[1]
+
+    assert isinstance(loaded_inst, Instance)
+    assert loaded_inst.tracking_score == 0.0
+
+    assert isinstance(loaded_pred_inst, PredictedInstance)
+    assert loaded_pred_inst.tracking_score == 0.0
 
 
 def test_save_slp_verbose_propagation(tmp_path):


### PR DESCRIPTION
This doesn't change much other than add some explicit checks to support `FORMAT_ID = 1.3`. The goal was to support changes from https://github.com/talmolab/sleap/pull/1302, but we already supported the tracking score on `Instance`s.