### PR TITLE
Fix saving package files with embedded videos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,3 +110,7 @@ pytest tests/path/to/test_module.py::TestClass::test_method -v
 - CI runs on Ubuntu, Windows, macOS with Python 3.8-3.13
 - All PRs require passing tests and linting
 - Documentation is hosted at https://io.sleap.ai/
+
+## Testing Best Practices
+
+- When adding tests, use global imports at the module-level rather than importing locally within a test function unless strictly needed (e.g., for import checking). Analyze current imports to find the best place to add the import statement and do not duplicate existing imports.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,3 @@ pytest tests/path/to/test_module.py::TestClass::test_method -v
 - CI runs on Ubuntu, Windows, macOS with Python 3.8-3.13
 - All PRs require passing tests and linting
 - Documentation is hosted at https://io.sleap.ai/
-
-## Testing Best Practices
-
-- When adding tests, use global imports at the module-level rather than importing locally within a test function unless strictly needed (e.g., for import checking). Analyze current imports to find the best place to add the import statement and do not duplicate existing imports.

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -26,7 +26,7 @@ def load_slp(filename: str, open_videos: bool = True) -> Labels:
 def save_slp(
     labels: Labels,
     filename: str,
-    embed: bool | str | list[tuple[Video, int]] | None = None,
+    embed: bool | str | list[tuple[Video, int]] | None = False,
     verbose: bool = True,
 ):
     """Save a SLEAP dataset to a `.slp` file.
@@ -38,8 +38,8 @@ def save_slp(
             `"all"`, `"user"`, `"suggestions"`, `"user+suggestions"`, `"source"` or list
             of tuples of `(video, frame_idx)`.
 
-            If `None` is specified (the default) and the labels contains embedded
-            frames, those embedded frames will be re-saved to the new file.
+            If `False` is specified (the default), the source video will be restored
+            if available, otherwise the embedded frames will be re-saved.
 
             If `True` or `"all"`, all labeled frames and suggested frames will be
             embedded.

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import numpy as np
 import h5py
 import simplejson as json
-from typing import Union
+from typing import Union, Optional
 from sleap_io import (
     Video,
     Skeleton,
@@ -173,11 +173,13 @@ def read_videos(labels_path: str, open_backend: bool = True) -> list[Video]:
     return videos
 
 
-def video_to_dict(video: Video) -> dict:
+def video_to_dict(video: Video, labels_path: Optional[str] = None) -> dict:
     """Convert a `Video` object to a JSON-compatible dictionary.
 
     Args:
         video: A `Video` object to convert.
+        labels_path: Path to the labels file being written. Used to determine if the
+            video should use a self-reference (".") or external reference.
 
     Returns:
         A dictionary containing the video metadata.
@@ -201,13 +203,20 @@ def video_to_dict(video: Video) -> dict:
         }
 
     elif type(video.backend) == HDF5Video:
+        # Determine if we should use self-reference or external reference
+        use_self_reference = (
+            video.backend.has_embedded_images and 
+            labels_path is not None and 
+            Path(video.filename).resolve() == Path(labels_path).resolve()
+        )
+        
         return {
             "filename": video_filename,
             "backend": {
                 "type": "HDF5Video",
                 "shape": video.shape,
                 "filename": (
-                    "." if video.backend.has_embedded_images else video_filename
+                    "." if use_self_reference else video_filename
                 ),
                 "dataset": video.backend.dataset,
                 "input_format": video.backend.input_format,
@@ -353,7 +362,7 @@ def embed_video(
 
         grp = f.require_group(f"{group}/source_video")
         grp.attrs["json"] = json.dumps(
-            video_to_dict(source_video), separators=(",", ":")
+            video_to_dict(source_video, labels_path), separators=(",", ":")
         )
 
     return embedded_video
@@ -546,7 +555,7 @@ def process_and_embed_frames(
             # Store source video metadata
             grp = f.require_group(f"{group}/source_video")
             grp.attrs["json"] = json.dumps(
-                video_to_dict(source_video), separators=(",", ":")
+                video_to_dict(source_video, labels_path), separators=(",", ":")
             )
 
             # Store the embedded video for return
@@ -730,7 +739,7 @@ def write_videos(
     # Write video metadata
     video_jsons = []
     for video_ind, video in sorted(videos_to_write, key=lambda x: x[0]):
-        video_json = video_to_dict(video)
+        video_json = video_to_dict(video, labels_path)
         video_jsons.append(np.bytes_(json.dumps(video_json, separators=(",", ":"))))
 
     with h5py.File(labels_path, "a") as f:

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1939,10 +1939,10 @@ def write_labels(
     if Path(labels_path).exists():
         Path(labels_path).unlink()
 
-    if embed:
+    if embed and embed != False:
         embed_videos(labels_path, labels, embed, verbose=verbose)
     write_videos(
-        labels_path, labels.videos, restore_source=(embed == "source"), verbose=verbose
+        labels_path, labels.videos, restore_source=(embed == "source" or embed is False), verbose=verbose
     )
     write_tracks(labels_path, labels.tracks)
     write_suggestions(labels_path, labels.suggestions, labels.videos)

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -205,19 +205,17 @@ def video_to_dict(video: Video, labels_path: Optional[str] = None) -> dict:
     elif type(video.backend) == HDF5Video:
         # Determine if we should use self-reference or external reference
         use_self_reference = (
-            video.backend.has_embedded_images and 
-            labels_path is not None and 
-            Path(video.filename).resolve() == Path(labels_path).resolve()
+            video.backend.has_embedded_images
+            and labels_path is not None
+            and Path(video.filename).resolve() == Path(labels_path).resolve()
         )
-        
+
         return {
             "filename": video_filename,
             "backend": {
                 "type": "HDF5Video",
                 "shape": video.shape,
-                "filename": (
-                    "." if use_self_reference else video_filename
-                ),
+                "filename": ("." if use_self_reference else video_filename),
                 "dataset": video.backend.dataset,
                 "input_format": video.backend.input_format,
                 "convert_range": False,
@@ -658,7 +656,7 @@ def write_videos(
             re-embed the embedded images. If `False` (the default), will re-embed images
             that were previously embedded.
         verbose: If `True` (the default), display a progress bar when embedding frames.
-    
+
     Raises:
         ValueError: If attempting to save with `restore_source=True` when it would create
             a self-referential path (i.e., the video references the file being saved).
@@ -1968,7 +1966,10 @@ def write_labels(
     if embed and embed != False:
         embed_videos(labels_path, labels, embed, verbose=verbose)
     write_videos(
-        labels_path, labels.videos, restore_source=(embed == "source" or embed is False), verbose=verbose
+        labels_path,
+        labels.videos,
+        restore_source=(embed == "source" or embed is False),
+        verbose=verbose,
     )
     write_tracks(labels_path, labels.tracks)
     write_suggestions(labels_path, labels.suggestions, labels.videos)

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -606,7 +606,7 @@ class Labels:
         self,
         filename: str,
         format: Optional[str] = None,
-        embed: bool | str | list[tuple[Video, int]] | None = None,
+        embed: bool | str | list[tuple[Video, int]] | None = False,
         verbose: bool = True,
         **kwargs,
     ):
@@ -622,8 +622,8 @@ class Labels:
                 list of tuples of `(video, frame_idx)`.
             verbose: If `True` (the default), display a progress bar when embedding frames.
 
-                If `None` is specified (the default) and the labels contains embedded
-                frames, those embedded frames will be re-saved to the new file.
+                If `False` is specified (the default), the source video will be
+                restored if available, otherwise the embedded frames will be re-saved.
 
                 If `True` or `"all"`, all labeled frames and suggested frames will be
                 embedded.


### PR DESCRIPTION
## Summary

This PR fixes issue #175 by changing the default `embed` parameter to `False` for fast-saving of `.pkg.slp` files without re-exporting embedded images.

## Changes

1. **Changed default `embed` parameter to `False`** in `save_file()`, `save_slp()`, and `Labels.save()`
   - Updated docstrings to reflect new default behavior
   - Enables fast-saving by default

2. **Added self-referential path detection**
   - Raises `ValueError` when attempting to save with `embed=False` over the same file
   - Prevents data loss from overwriting the file being referenced

3. **Fixed video referencing logic**
   - Updated `video_to_dict()` to correctly handle external references
   - Only uses self-reference (".") when video points to file being written
   - When no source video exists, references the original .pkg.slp file

4. **Added comprehensive tests**
   - Test default `embed=False` behavior
   - Test self-referential path detection
   - Test mixed video scenarios (embedded + external)
   - Test source video restoration vs external file referencing

## Behavior

With these changes:
- `labels.save("file.slp")` now defaults to `embed=False` (fast save)
- When source video is available, it's restored
- When no source video exists, references the original .pkg.slp file
- Explicitly use `embed=True` to re-embed frames

Fixes #175

🤖 Generated with [Claude Code](https://claude.ai/code)