### PR TITLE
Add open_videos parameter to Labels.replace_filenames method

### DIFF
--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -999,6 +999,7 @@ class Labels:
         new_filenames: list[str | Path] | None = None,
         filename_map: dict[str | Path, str | Path] | None = None,
         prefix_map: dict[str | Path, str | Path] | None = None,
+        open_videos: bool = True,
     ):
         """Replace video filenames.
 
@@ -1008,6 +1009,9 @@ class Labels:
             filename_map: Dictionary mapping old filenames (keys) to new filenames
                 (values).
             prefix_map: Dictionary mapping old prefixes (keys) to new prefixes (values).
+            open_videos: If `True` (the default), attempt to open the video backend for
+                I/O after replacing the filename. If `False`, the backend will not be
+                opened (useful for operations with costly file existence checks).
 
         Notes:
             Only one of the argument types can be provided.
@@ -1032,7 +1036,7 @@ class Labels:
                 )
 
             for video, new_filename in zip(self.videos, new_filenames):
-                video.replace_filename(new_filename)
+                video.replace_filename(new_filename, open=open_videos)
 
         elif filename_map is not None:
             for video in self.videos:
@@ -1044,10 +1048,10 @@ class Labels:
                                 new_fns.append(new_fn)
                             else:
                                 new_fns.append(fn)
-                        video.replace_filename(new_fns)
+                        video.replace_filename(new_fns, open=open_videos)
                     else:
                         if Path(video.filename) == Path(old_fn):
-                            video.replace_filename(new_fn)
+                            video.replace_filename(new_fn, open=open_videos)
 
         elif prefix_map is not None:
             for video in self.videos:
@@ -1062,12 +1066,12 @@ class Labels:
                                 new_fns.append(new_prefix / fn.relative_to(old_prefix))
                             else:
                                 new_fns.append(fn)
-                        video.replace_filename(new_fns)
+                        video.replace_filename(new_fns, open=open_videos)
                     else:
                         fn = Path(video.filename)
                         if fn.as_posix().startswith(old_prefix.as_posix()):
                             video.replace_filename(
-                                new_prefix / fn.relative_to(old_prefix)
+                                new_prefix / fn.relative_to(old_prefix), open=open_videos
                             )
 
     def extract(

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -457,6 +457,50 @@ def test_replace_filenames():
     assert labels.video.filename == ["test/imgs/img0.png", "test/imgs/img1.png"]
 
 
+def test_replace_filenames_open_videos():
+    """Test that open_videos=False prevents video backend from opening."""
+    # Create videos that won't exist on disk
+    labels = Labels(
+        videos=[
+            Video.from_filename("nonexistent_a.mp4"),
+            Video.from_filename("nonexistent_b.mp4"),
+        ]
+    )
+
+    # Test with open_videos=True (default) - should attempt to open backend
+    labels.replace_filenames(
+        new_filenames=["new_nonexistent_a.mp4", "new_nonexistent_b.mp4"]
+    )
+    # Backend should be None since files don't exist
+    assert labels.videos[0].backend is None
+    assert labels.videos[1].backend is None
+    assert labels.videos[0].filename == "new_nonexistent_a.mp4"
+    assert labels.videos[1].filename == "new_nonexistent_b.mp4"
+
+    # Test with open_videos=False - should not attempt to open backend
+    labels.replace_filenames(
+        new_filenames=["final_a.mp4", "final_b.mp4"], open_videos=False
+    )
+    # Backend should still be None, but filenames should be updated
+    assert labels.videos[0].backend is None
+    assert labels.videos[1].backend is None
+    assert labels.videos[0].filename == "final_a.mp4"
+    assert labels.videos[1].filename == "final_b.mp4"
+
+    # Test with filename_map and open_videos=False
+    labels.replace_filenames(
+        filename_map={"final_a.mp4": "mapped_a.mp4", "final_b.mp4": "mapped_b.mp4"},
+        open_videos=False,
+    )
+    assert labels.videos[0].filename == "mapped_a.mp4"
+    assert labels.videos[1].filename == "mapped_b.mp4"
+
+    # Test with prefix_map and open_videos=False
+    labels.replace_filenames(prefix_map={"mapped_": "prefixed_"}, open_videos=False)
+    assert labels.videos[0].filename == "prefixed_a.mp4"
+    assert labels.videos[1].filename == "prefixed_b.mp4"
+
+
 def test_split(slp_real_data, tmp_path):
     # n = 0
     labels = Labels()


### PR DESCRIPTION
Fixes #211

Adds `open_videos=False` parameter to `Labels.replace_filenames` method to avoid costly file existence checks for operations with many files on network storage.

## Changes
- Added `open_videos=True` parameter (default) to `replace_filenames` method
- Parameter controls whether video backends are opened after filename replacement
- Mirrors behavior of `sio.load_slp(open_videos=False)` for consistency
- Works with all three replacement modes (`new_filenames`, `filename_map`, `prefix_map`)
- Added comprehensive tests covering all replacement modes

Generated with [Claude Code](https://claude.ai/code)