### PR TITLE
Bump version to 0.5.2

### DIFF
--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -3,4 +3,4 @@
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release
 # version.
-__version__ = "0.5.1"
+__version__ = "0.5.2"


### PR DESCRIPTION
## Summary
Bumps package version from 0.5.1 to 0.5.2 in preparation for the next release.

## Changes
- Updated `__version__` in `sleap_io/version.py` from "0.5.1" to "0.5.2"

🤖 Generated with [Claude Code](https://claude.ai/code)