### PR TITLE
Add literate-nav plugin to mkdocs.yml for better API documentation navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,8 @@ plugins:
         - scripts/gen_ref_pages.py
         - scripts/gen_changelog.py
   - section-index
+  - literate-nav:
+      nav_file: SUMMARY.md
   - mkdocstrings:
       default_handler: python
       handlers:


### PR DESCRIPTION
## Summary

This PR adds the `mkdocs-literate-nav` plugin to the mkdocs configuration to improve the organization and navigation of the API documentation pages.

## Key Changes

- Added `literate-nav` plugin to `mkdocs.yml` with `nav_file: SUMMARY.md` configuration

## Rationale

The literate-nav plugin allows for better organization of documentation navigation by using a dedicated SUMMARY.md file, which provides more flexibility in structuring the API documentation compared to hardcoded navigation in mkdocs.yml.

🤖 Generated with [Claude Code](https://claude.ai/code)