### PR TITLE
Fix docs version dropdown ordering

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,3 +61,31 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv run mike deploy --update-aliases --allow-empty --push dev
+
+      - name: Reorder versions.json on gh-pages
+        if: ${{ github.event_name == 'release' || github.event_name == 'push' }}
+        run: |
+          # Copy the reordering script to temp location before switching branches
+          cp scripts/reorder_versions.py /tmp/reorder_versions.py
+          
+          # Fetch and checkout gh-pages branch
+          git fetch origin gh-pages
+          git checkout gh-pages
+          
+          # Run the reordering script
+          uv run python /tmp/reorder_versions.py versions.json
+          
+          # Commit and push if there are changes
+          if git diff --quiet; then
+            echo "No changes to versions.json"
+          else
+            git add versions.json
+            git commit -m "Reorder versions.json for proper version dropdown sorting"
+            git push origin gh-pages
+          fi
+          
+          # Switch back to the original branch
+          git checkout -
+          
+          # Clean up temp file
+          rm /tmp/reorder_versions.py

--- a/scripts/reorder_versions.py
+++ b/scripts/reorder_versions.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Reorder versions.json for proper version dropdown sorting in mike docs."""
+
+import json
+import sys
+from packaging import version
+
+def reorder_versions(filepath="versions.json"):
+    """Reorder versions.json to fix version dropdown ordering.
+    
+    Orders versions as: dev -> newest -> oldest
+    
+    Args:
+        filepath: Path to versions.json file.
+    """
+    # Read current versions.json
+    with open(filepath, 'r') as f:
+        versions = json.load(f)
+    
+    # Separate dev version from others
+    dev_versions = [v for v in versions if v['version'] == 'dev']
+    regular_versions = [v for v in versions if v['version'] != 'dev']
+    
+    # Sort regular versions by semantic version of title (removing 'v' prefix)
+    # reverse=True for newest first
+    def get_version_key(v):
+        title = v['title']
+        # Remove 'v' prefix if present
+        if title.startswith('v'):
+            title = title[1:]
+        try:
+            return version.parse(title)
+        except:
+            return version.parse('0.0.0')
+    
+    regular_versions.sort(key=get_version_key, reverse=True)
+    
+    # Combine: dev first, then sorted regular versions (newest to oldest)
+    sorted_versions = dev_versions + regular_versions
+    
+    # Write back
+    with open(filepath, 'w') as f:
+        json.dump(sorted_versions, f, indent=2)
+    
+    print(f"Reordered {len(sorted_versions)} versions in {filepath}")
+    if sorted_versions:
+        print(f"Order: {' -> '.join([v['title'] for v in sorted_versions[:5]])}{'...' if len(sorted_versions) > 5 else ''}")
+
+if __name__ == "__main__":
+    filepath = sys.argv[1] if len(sys.argv) > 1 else "versions.json"
+    reorder_versions(filepath)


### PR DESCRIPTION
## Summary

Fixes the jumbled ordering in the docs version dropdown by adding a post-processing step to reorder `versions.json` on the `gh-pages` branch.

## Key Changes

- **Added `scripts/reorder_versions.py`**: Python script that sorts versions by semantic version
- **Updated `.github/workflows/docs.yml`**: Added step to run reordering script after mike deployments
- **Ordering**: Ensures versions appear as: `dev → newest → oldest` (e.g., `dev → v0.5.2 → v0.5.1 → v0.4.1 → ...`)

## Problem

The current `versions.json` has inconsistent naming between older versions (`0.x.x` in version field, `vX.Y.Z` in title) and newer versions (`vX.Y.Z` in both fields). Since mike sorts by the `version` field, this causes newer versions like `v0.5.2` to appear after older versions like `0.4.1` in the dropdown.

## Solution

- Script extracts semantic version from the `title` field (handling both `v0.x.x` and `0.x.x` formats)
- Sorts all regular versions newest to oldest  
- Places `dev` version at the top
- Runs automatically after every docs deployment (both release and dev)

## Testing

The script can be tested locally:
```bash
# Download current versions.json
curl -O https://raw.githubusercontent.com/talmolab/sleap-io/refs/heads/gh-pages/versions.json

# Run the script
uv run python scripts/reorder_versions.py versions.json
```

🤖 Generated with [Claude Code](https://claude.ai/code)