### PR TITLE
Fix `Instance.same_pose_as()` bug with NaN coordinates

### DIFF
--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -671,9 +671,9 @@ class Instance:
         Notes:
             Two instances are considered to have the same pose if:
             - They have the same skeleton structure
-            - When tolerance is None: All coordinates match exactly (including NaN values)
-            - When tolerance is specified: All visible points are within tolerance distance
-              and NaN patterns match exactly
+            - When tolerance is None: All coordinates match exactly (including NaN)
+            - When tolerance is specified: All visible points are within tolerance
+              distance and NaN patterns match exactly
         """
         # Check skeleton compatibility
         if not self.skeleton.matches(other.skeleton):

--- a/tests/model/test_instance.py
+++ b/tests/model/test_instance.py
@@ -350,7 +350,7 @@ def test_instance_same_pose_as():
         np.array([[50.0, 50.0], [60.0, 60.0]]), skeleton=skeleton
     )
 
-    # Test with default tolerance
+    # Test with specified tolerance  
     assert inst1.same_pose_as(inst2, tolerance=5.0)
     assert not inst1.same_pose_as(inst3, tolerance=5.0)
 
@@ -363,7 +363,7 @@ def test_instance_same_pose_as():
     inst4 = Instance.from_numpy(
         np.array([[10.0, 10.0], [15.0, 15.0], [20.0, 20.0]]), skeleton=skeleton2
     )
-    assert not inst1.same_pose_as(inst4)
+    assert not inst1.same_pose_as(inst4)  # Different skeletons
 
     # Test with different visibility patterns
     inst5 = Instance.from_numpy(
@@ -381,7 +381,36 @@ def test_instance_same_pose_as():
     inst8 = Instance.from_numpy(
         np.array([[np.nan, np.nan], [np.nan, np.nan]]), skeleton=skeleton
     )
-    assert inst7.same_pose_as(inst8)
+    assert inst7.same_pose_as(inst8)  # Both have all NaN - should be equal
+
+def test_instance_same_pose_as_identical_with_nan():
+    """Test Instance.same_pose_as() bug with identical instances containing NaN values.
+    
+    This test demonstrates a bug where identical instances with some NaN coordinates
+    that are marked as visible are incorrectly identified as having different poses 
+    due to NaN distance calculations.
+    """
+    skeleton = Skeleton(["head", "thorax", "tail"])
+    
+    # Create two identical instances 
+    inst1 = Instance.from_numpy(
+        np.array([[10.0, 10.0], [20.0, 20.0], [30.0, 30.0]]), skeleton=skeleton
+    )
+    inst2 = Instance.from_numpy(
+        np.array([[10.0, 10.0], [20.0, 20.0], [30.0, 30.0]]), skeleton=skeleton
+    )
+    
+    # Manually set identical NaN coordinates but keep them marked as visible
+    # This simulates the scenario where tracking data has NaN coordinates but points are still considered "visible"
+    inst1.points["xy"][1] = [np.nan, np.nan]  # thorax has NaN coords
+    inst2.points["xy"][1] = [np.nan, np.nan]  # thorax has NaN coords
+    inst1.points["visible"][1] = True
+    inst2.points["visible"][1] = True
+    
+    # These instances are identical and should return True
+    # Test both exact comparison and tolerance-based comparison
+    assert inst1.same_pose_as(inst2), "Identical instances with NaN values should be considered the same pose (exact)"
+    assert inst1.same_pose_as(inst2, tolerance=5.0), "Identical instances with NaN values should be considered the same pose (tolerance)"
 
 
 def test_instance_same_identity_as():

--- a/tests/model/test_instance.py
+++ b/tests/model/test_instance.py
@@ -350,7 +350,7 @@ def test_instance_same_pose_as():
         np.array([[50.0, 50.0], [60.0, 60.0]]), skeleton=skeleton
     )
 
-    # Test with specified tolerance  
+    # Test with specified tolerance
     assert inst1.same_pose_as(inst2, tolerance=5.0)
     assert not inst1.same_pose_as(inst3, tolerance=5.0)
 
@@ -383,34 +383,41 @@ def test_instance_same_pose_as():
     )
     assert inst7.same_pose_as(inst8)  # Both have all NaN - should be equal
 
+
 def test_instance_same_pose_as_identical_with_nan():
     """Test Instance.same_pose_as() bug with identical instances containing NaN values.
-    
+
     This test demonstrates a bug where identical instances with some NaN coordinates
-    that are marked as visible are incorrectly identified as having different poses 
+    that are marked as visible are incorrectly identified as having different poses
     due to NaN distance calculations.
     """
     skeleton = Skeleton(["head", "thorax", "tail"])
-    
-    # Create two identical instances 
+
+    # Create two identical instances
     inst1 = Instance.from_numpy(
         np.array([[10.0, 10.0], [20.0, 20.0], [30.0, 30.0]]), skeleton=skeleton
     )
     inst2 = Instance.from_numpy(
         np.array([[10.0, 10.0], [20.0, 20.0], [30.0, 30.0]]), skeleton=skeleton
     )
-    
+
     # Manually set identical NaN coordinates but keep them marked as visible
-    # This simulates the scenario where tracking data has NaN coordinates but points are still considered "visible"
+    # This simulates the scenario where tracking data has NaN coordinates but
+    # points are still considered "visible"
     inst1.points["xy"][1] = [np.nan, np.nan]  # thorax has NaN coords
     inst2.points["xy"][1] = [np.nan, np.nan]  # thorax has NaN coords
     inst1.points["visible"][1] = True
     inst2.points["visible"][1] = True
-    
+
     # These instances are identical and should return True
     # Test both exact comparison and tolerance-based comparison
-    assert inst1.same_pose_as(inst2), "Identical instances with NaN values should be considered the same pose (exact)"
-    assert inst1.same_pose_as(inst2, tolerance=5.0), "Identical instances with NaN values should be considered the same pose (tolerance)"
+    assert inst1.same_pose_as(inst2), (
+        "Identical instances with NaN values should be considered the same pose (exact)"
+    )
+    assert inst1.same_pose_as(inst2, tolerance=5.0), (
+        "Identical instances with NaN values should be considered the same pose "
+        "(tolerance)"
+    )
 
 
 def test_instance_same_identity_as():


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in `Instance.same_pose_as()` where identical instances containing NaN coordinates would incorrectly return `False`. The root cause was that NaN values in distance calculations broke the comparison logic (`nan <= tolerance` is always `False`).

The fix introduces a two-mode comparison system:
- **Exact comparison (new default)**: `tolerance=None` uses `np.array_equal(equal_nan=True)` 
- **Tolerance-based comparison**: When `tolerance` is specified, ensures NaN patterns match exactly before comparing non-NaN values

## Key Changes

### Core Fix
- **Fixed NaN handling bug**: Identical instances with NaN coordinates now correctly return `True`
- **Two-mode comparison**: Exact mode (default) and tolerance-based mode with proper NaN handling
- **Robust distance calculation**: Only calculates distances for non-NaN coordinates in tolerance mode

### API Changes
- **Breaking**: Default `tolerance` parameter changed from `5.0` to `None`
- **Enhanced behavior**: Default now uses exact comparison including proper NaN handling
- **Backward compatibility**: Tolerance-based comparisons work as before when `tolerance` is specified

### Implementation Details
- Uses `np.array_equal(self.numpy(), other.numpy(), equal_nan=True)` for exact comparison
- In tolerance mode: validates NaN patterns match, then compares only non-NaN coordinate pairs
- Maintains all existing functionality and performance characteristics

## Example Usage

```python
from sleap_io.model.instance import Instance
from sleap_io.model.skeleton import Skeleton
import numpy as np

skeleton = Skeleton(["head", "thorax", "tail"])

# Create instances with some NaN coordinates
inst1 = Instance.from_numpy([[1, 2], [np.nan, np.nan], [5, 6]], skeleton=skeleton)
inst2 = Instance.from_numpy([[1, 2], [np.nan, np.nan], [5, 6]], skeleton=skeleton)

# Exact comparison (new default behavior)
assert inst1.same_pose_as(inst2)  # True - identical including NaN

# Tolerance-based comparison  
assert inst1.same_pose_as(inst2, tolerance=1.0)  # True - within tolerance

# Different instances
inst3 = Instance.from_numpy([[1, 2], [3, 4], [5, 6]], skeleton=skeleton)
assert not inst1.same_pose_as(inst3)  # False - different visibility patterns
```

## Test Plan

- [x] **New test added**: `test_instance_same_pose_as_identical_with_nan` reproduces the original bug and verifies fix
- [x] **All existing tests pass**: Confirms backward compatibility maintained
- [x] **Manual verification**: Both exact and tolerance modes work correctly
- [x] **Edge cases covered**: All-NaN instances, mixed NaN/non-NaN, different skeletons
- [x] **Linting**: Code passes all ruff formatting and style checks

## Migration Guide

**For existing code using default behavior:**
```python
# Before (was using tolerance=5.0 by default)
if inst1.same_pose_as(inst2):  # Used tolerance-based comparison

# After (now uses exact comparison by default)  
if inst1.same_pose_as(inst2):  # Uses exact comparison including NaN handling

# To maintain old behavior, explicitly specify tolerance
if inst1.same_pose_as(inst2, tolerance=5.0):  # Tolerance-based comparison
```

## Design Decisions

### Why change the default behavior?
1. **Exact comparison is more intuitive**: Users expect identical instances to be considered "same pose"
2. **NaN handling**: Previous default couldn't handle NaN coordinates properly
3. **Performance**: Exact comparison via `np.array_equal` is faster than distance calculations
4. **Consistency**: Aligns with other comparison methods in the codebase

### Why maintain tolerance-based mode?
1. **Backward compatibility**: Existing workflows depend on tolerance-based comparisons
2. **Practical use cases**: Comparing poses with small coordinate differences due to tracking noise
3. **Flexibility**: Users can choose the appropriate comparison mode for their use case

## Future Considerations

- Consider adding `rtol` and `atol` parameters for `np.allclose`-style comparison in tolerance mode
- Potential optimization: cache `numpy()` arrays if performance becomes an issue
- Could extend to support per-node tolerance values for fine-grained control

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>