### PR TITLE
Improve duplication handling in `Labels.merge()`. 

### DIFF
--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1796,6 +1796,9 @@ class Labels:
                                     deduped_basenames = [
                                         Path(f).name for f in deduped_video.filename
                                     ]
+                                    self_basenames = [
+                                        Path(f).name for f in self_video.filename
+                                    ]
                                     for old_idx, basename in enumerate(other_basenames):
                                         if basename in deduped_basenames:
                                             new_idx = deduped_basenames.index(basename)
@@ -1803,6 +1806,15 @@ class Labels:
                                                 deduped_video,
                                                 new_idx,
                                             )
+                                        else: 
+                                            # Cases where the image was a duplicate, present in both self and other. 
+                                            # See Issue #239. 
+                                            if basename in self_basenames:
+                                                new_idx = self_basenames.index(basename)
+                                                frame_idx_map[(other_video, old_idx)] = (
+                                                    self_video,
+                                                    new_idx,
+                                                )
                         elif video_matcher.method == VideoMatchMethod.SHAPE:
                             # Merge videos with same shape
                             merged_video = self_video.merge_with(other_video)

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1806,12 +1806,15 @@ class Labels:
                                                 deduped_video,
                                                 new_idx,
                                             )
-                                        else: 
-                                            # Cases where the image was a duplicate, present in both self and other. 
-                                            # See Issue #239. 
+                                        else:
+                                            # Cases where the image was a duplicate, 
+                                            # present in both self and other labels
+                                            # See Issue #239.
                                             if basename in self_basenames:
                                                 new_idx = self_basenames.index(basename)
-                                                frame_idx_map[(other_video, old_idx)] = (
+                                                frame_idx_map[
+                                                    (other_video, old_idx)
+                                                ] = (
                                                     self_video,
                                                     new_idx,
                                                 )

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1807,17 +1807,18 @@ class Labels:
                                                 new_idx,
                                             )
                                         else:
-                                            # Cases where the image was a duplicate, 
+                                            # Cases where the image was a duplicate,
                                             # present in both self and other labels
                                             # See Issue #239.
-                                            if basename in self_basenames:
-                                                new_idx = self_basenames.index(basename)
-                                                frame_idx_map[
-                                                    (other_video, old_idx)
-                                                ] = (
-                                                    self_video,
-                                                    new_idx,
-                                                )
+                                            assert basename in self_basenames, (
+                                                "Unexpected basename mismatch, \
+                                                    possible file corruption."
+                                            )
+                                            new_idx = self_basenames.index(basename)
+                                            frame_idx_map[(other_video, old_idx)] = (
+                                                self_video,
+                                                new_idx,
+                                            )
                         elif video_matcher.method == VideoMatchMethod.SHAPE:
                             # Merge videos with same shape
                             merged_video = self_video.merge_with(other_video)


### PR DESCRIPTION
This pull request addresses an edge case in the `merge` method of the `sleap_io/model/labels.py` file when merging videos with duplicate images present in both datasets. The fix ensures that frame indices are correctly mapped even when an image is a duplicate. 

Close #239 . 