### PR TITLE
Update merge strategy

### DIFF
--- a/docs/merging.md
+++ b/docs/merging.md
@@ -168,6 +168,21 @@ Retains all instances from both datasets without filtering duplicates.
 result = base_labels.merge(new_labels, frame_strategy="keep_both")
 ```
 
+### Update tracks strategy
+
+Updates the track assignments and tracking scores of existing instances based on spatial matches with new instances, while preserving the original pose annotations.
+
+This strategy preserves the original pose data and **does not** add new or remove existing instances!
+
+!!! example "When to use"
+    
+    - Updating track identities after running a tracking algorithm
+    - Merging tracking information from different tracking runs
+
+```python title="Using update tracks strategy"
+result = base_labels.merge(new_labels, frame_strategy="update_tracks")
+```
+
 ## Matching configuration
 
 Matching determines which objects correspond between datasets. Different matchers handle various scenarios and data inconsistencies.

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1663,6 +1663,8 @@ class Labels:
                 - "keep_original": Keep original frames
                 - "keep_new": Replace with new frames
                 - "keep_both": Keep all frames
+                - "update_tracks": Update track and score of the original instances
+                    from the new instances.
             validate: If True, validate for conflicts before merging.
             progress_callback: Optional callback for progress updates.
                 Should accept (current, total, message) arguments.

--- a/sleap_io/model/matching.py
+++ b/sleap_io/model/matching.py
@@ -112,6 +112,7 @@ class FrameStrategy(str, Enum):
     KEEP_ORIGINAL = "keep_original"
     KEEP_NEW = "keep_new"
     KEEP_BOTH = "keep_both"
+    UPDATE_TRACKS = "update_tracks"
 
 
 class ErrorMode(str, Enum):

--- a/tests/model/test_merging_integration.py
+++ b/tests/model/test_merging_integration.py
@@ -59,6 +59,32 @@ class TestLabeledFrameMerge:
         assert merged[0] is inst2
         assert len(conflicts) == 0
 
+    def test_merge_update_tracks(self):
+        """Test frame merge with update_tracks strategy."""
+        skeleton = Skeleton(["head", "tail"])
+        video = Video(filename="test.mp4", open_backend=False)
+
+        frame1 = LabeledFrame(video=video, frame_idx=0)
+        inst1 = Instance.from_numpy(np.array([[10, 10], [20, 20]]), skeleton=skeleton)
+        frame1.instances = [inst1]
+
+        frame2 = LabeledFrame(video=video, frame_idx=0)
+        inst2 = PredictedInstance.from_numpy(
+            np.array([[10, 10], [20, 20]]), skeleton=skeleton
+        )
+        inst2.track = Track(name="track1")
+        frame2.instances = [inst2]
+
+        # Merge with keep_both strategy
+        merged, conflicts = frame1.merge(frame2, strategy="update_tracks")
+
+        assert len(merged) == 1
+        assert inst1 in merged
+        assert inst2 not in merged
+        assert inst1.track == inst2.track
+        assert inst1.tracking_score == inst2.tracking_score
+        assert len(conflicts) == 0
+
     def test_merge_keep_both(self):
         """Test frame merge with keep_both strategy."""
         skeleton = Skeleton(["head", "tail"])


### PR DESCRIPTION
In this PR, the `smart` merge strategy is updated for cases where both instances are predictions. Previously, the instance with the higher score was selected. Now, when both are predicted instances, the newer prediction is always chosen.

This PR also introduces a new `update_tracks` merge strategy for `LabeledFrame.merge()` that allows updating track assignments and tracking scores while preserving original pose annotations. 