### PR TITLE
Fix NaN handling in Label Studio writer

### DIFF
--- a/sleap_io/io/labelstudio.py
+++ b/sleap_io/io/labelstudio.py
@@ -151,6 +151,11 @@ def convert_labels(labels: Labels) -> List[dict]:
             )
 
             for point in instance.points:
+                # Skip points with NaN coordinates as they are not JSON compliant
+                # and Label Studio doesn't support them
+                if math.isnan(point["xy"][0]) or math.isnan(point["xy"][1]):
+                    continue
+
                 point_id = str(uuid.uuid4())
 
                 # add this point

--- a/tests/io/test_labelstudio.py
+++ b/tests/io/test_labelstudio.py
@@ -1,7 +1,14 @@
 """Tests for functions in the sleap_io.io.labelstudio file."""
 
-from sleap_io import Labels
-from sleap_io.io.labelstudio import convert_labels, parse_tasks, read_labels
+import numpy as np
+
+from sleap_io import Instance, LabeledFrame, Labels, Skeleton, Video
+from sleap_io.io.labelstudio import (
+    convert_labels,
+    parse_tasks,
+    read_labels,
+    write_labels,
+)
 from sleap_io.io.slp import read_labels as slp_read_labels
 
 
@@ -37,3 +44,46 @@ def test_read_labels(ls_multianimal):
     ls_labels = read_labels(file_path, skeleton)
     _ = round_trip_labels(ls_labels)
     # assert ls_labels == rt_labels # TODO(TP): Fix equality check
+
+
+def test_write_labels_with_nan_points(tmp_path):
+    """Test that instances with NaN points can be written without errors."""
+    # Create a skeleton
+    skeleton = Skeleton(["node1", "node2", "node3"])
+
+    # Create a video with known dimensions
+    video = Video(filename="test_video.mp4")
+    video.backend_metadata["shape"] = (10, 100, 100, 3)
+
+    # Create an instance with some NaN points
+    points_array = np.array(
+        [
+            [10.0, 20.0],  # node1: valid point
+            [np.nan, np.nan],  # node2: missing point
+            [30.0, 40.0],  # node3: valid point
+        ]
+    )
+    instance = Instance.from_numpy(points_array, skeleton=skeleton)
+
+    # Create a labeled frame
+    labeled_frame = LabeledFrame(video=video, frame_idx=0, instances=[instance])
+    labels = Labels(labeled_frames=[labeled_frame])
+
+    # Write to file - this should not raise an error
+    output_path = tmp_path / "test_output.json"
+    write_labels(labels, str(output_path))
+
+    # Verify the file was created
+    assert output_path.exists()
+
+    # Read back and verify only valid points are present
+    ls_dicts = convert_labels(labels)
+    assert len(ls_dicts) == 1
+
+    # Count the keypoint annotations (should be 2, not 3, since one has NaN)
+    keypoint_annots = [
+        annot
+        for annot in ls_dicts[0]["annotations"][0]["result"]
+        if annot["type"] == "keypointlabels"
+    ]
+    assert len(keypoint_annots) == 2  # Only node1 and node3, node2 was skipped


### PR DESCRIPTION
## Summary

Fixes #246 by filtering out points with NaN coordinates before JSON serialization when writing to Label Studio format.

## Problem

When writing labels to Label Studio JSON format, points with NaN coordinates were included in the output. When `simplejson.dump()` attempted to serialize these NaN values, it raised:

```
ValueError: Out of range float values are not JSON compliant: np.float64(nan)
```

## Research Findings

- Label Studio's JSON format only supports numeric coordinates (percentages 0-100)
- NaN values in Label Studio cause bugs and keypoint disappearance (Label Studio Issue #3116)
- Missing/invisible keypoints should be omitted from the JSON entirely, not represented as NaN
- The sleap-io reader already skips NaN points when reading (line 273 in labelstudio.py)

## Solution

Modified `convert_labels()` in `sleap_io/io/labelstudio.py` to check and skip points with NaN coordinates before adding them to the output dictionary. This ensures:
- No JSON serialization errors
- Consistent behavior with the Label Studio reader
- Alignment with Label Studio's expected format
- Matches how other backends (ultralytics, JABS) handle missing points

## Changes

- **sleap_io/io/labelstudio.py**: Added NaN check in `convert_labels()` to skip invalid points
- **tests/io/test_labelstudio.py**: Added test case to verify instances with NaN points can be written successfully

## Testing

```bash
uv run pytest tests/io/test_labelstudio.py -xvs
```

All tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)