### PR TITLE
Fix sparse video indexing while writing slp files

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1229,12 +1229,14 @@ def write_lfs(labels_path: str, labels: Labels):
         ):
             dataset = video.backend.dataset
             # Extract video ID from dataset name (e.g., "video15/video" → 15)
-            if "/" in dataset:
+            try:
                 video_group = dataset.split("/")[0]
                 if video_group.startswith("video"):
-                    video_id_str = video_group[5:]  # Remove "video" prefix
-                    if video_id_str.isdigit():
-                        video_idx_id_map[video_idx] = int(video_id_str)
+                    video_id = int(video_group[5:])  # Remove "video" prefix and convert
+                    video_idx_id_map[video_idx] = video_id
+            except (ValueError, IndexError):
+                # If parsing fails, keep the default sequential index
+                pass
     for lf in labels:
         frame_id = len(frames)
         instance_id_start = len(instances)

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -2859,3 +2859,89 @@ def test_save_slp_non_sparse_videos(tmp_path, slp_minimal):
     loaded_labels = load_slp(str(output_path))
     assert len(loaded_labels.videos) == len(labels.videos)
     assert len(loaded_labels) == len(labels)
+
+
+def test_save_slp_video_dataset_edge_cases(
+    tmp_path, slp_minimal_pkg, small_robot_video
+):
+    """Test video ID extraction with edge case dataset names.
+
+    Covers lines 1232, 1234, 1236: Tests negative branches where dataset
+    parsing falls back to sequential indexing.
+    """
+    # Load a skeleton and create labels with multiple videos for edge cases
+    skeleton = read_skeletons(slp_minimal_pkg)[0]
+
+    # Create 3 videos (using the same video file for all 3)
+    videos = [Video(small_robot_video.filename) for _ in range(3)]
+
+    # Create minimal labels with the 3 videos
+    # Create points matching the skeleton's nodes
+    num_nodes = len(skeleton.nodes)
+    labels = Labels(
+        videos=videos,
+        skeletons=[skeleton],
+        labeled_frames=[
+            LabeledFrame(
+                video=videos[i],
+                frame_idx=0,
+                instances=[
+                    Instance.from_numpy(
+                        points_data=np.array(
+                            [[10.0 + i + j, 20.0 + i + j] for j in range(num_nodes)]
+                        ),
+                        skeleton=skeleton,
+                    )
+                ],
+            )
+            for i in range(3)
+        ],
+    )
+
+    # Save with embedded videos
+    embedded_path = tmp_path / "embedded.slp"
+    save_slp(labels, str(embedded_path), restore_original_videos=False)
+
+    # Modify the HDF5 file to create edge cases
+    with h5py.File(embedded_path, "r+") as f:
+        videos_json = [json.loads(vj.decode("utf-8")) for vj in f["videos_json"][:]]
+
+        # Edge case 1: dataset without "/" (line 1232 negative branch)
+        if "video0" in f:
+            f.move("video0", "video_noSlash")
+            videos_json[0]["backend"]["dataset"] = "video_noSlash"
+
+        # Edge case 2: dataset with "/" but doesn't start with "video" (line 1234)
+        if "video1" in f:
+            f.move("video1", "other1")
+            videos_json[1]["backend"]["dataset"] = "other1/video"
+
+        # Edge case 3: dataset like "videoABC/video" - non-numeric (line 1236)
+        if "video2" in f:
+            f.move("video2", "videoABC")
+            videos_json[2]["backend"]["dataset"] = "videoABC/video"
+
+        # Write back modified videos_json
+        del f["videos_json"]
+        f.create_dataset(
+            "videos_json",
+            data=[
+                np.bytes_(json.dumps(vj, separators=(",", ":"))) for vj in videos_json
+            ],
+            maxshape=(None,),
+        )
+
+    # Load the modified file - should handle edge cases with fallback
+    loaded_labels = load_slp(str(embedded_path))
+    assert len(loaded_labels.videos) == 3
+    assert len(loaded_labels) == 3
+
+    # Resave to exercise write path with edge case dataset names
+    # This is the key part that exercises lines 1232, 1234, 1236
+    resaved_path = tmp_path / "resaved.slp"
+    save_slp(loaded_labels, str(resaved_path), restore_original_videos=False)
+
+    # Verify round-trip works
+    final_labels = load_slp(str(resaved_path))
+    assert len(final_labels.videos) == 3
+    assert len(final_labels) == 3


### PR DESCRIPTION
## Summary

Fixes a bug where sparse video indexing was not preserved when writing and re-reading SLP files with embedded videos. Previously, when saving labels with sparse video indices (e.g., videos indexed as 0, 5, 10, 15, 20 instead of 0, 1, 2, 3, 4), the video IDs were incorrectly mapped to sequential list indices, causing data to be lost or misaligned when the file was reloaded.

## Key Changes

- **Added sparse video ID extraction** (`sleap_io/io/slp.py:1217-1236`): Created a `video_idx_id_map` dictionary that extracts the original video ID from the HDF5 dataset name (e.g., `"video15/video"` → `15`) for embedded videos
- **Updated frame writing logic** (`sleap_io/io/slp.py:1305`): Changed from using sequential list index to using the mapped video ID when writing frame data
- **Added round-trip test** (`tests/io/test_slp.py:2836-2845`): Verifies that saving and loading SLP files with sparse video indices preserves all data correctly

## Testing

New test case `test_load_slp_with_sparse_video_indices` now includes:
- Round-trip test: saves an SLP file with sparse video indices (using HDF5 backend) and loads it back
- Verifies that all 5 videos and 10 frames are preserved correctly
- Ensures each video has the expected 2 frames
- Validates image shapes remain correct after round-trip

## Design Decisions

**Why extract video IDs from dataset names?**
When videos are embedded in HDF5 format with sparse indexing, the actual video ID is encoded in the HDF5 dataset group name (e.g., `"video15/video"`). The list index in `labels.videos` doesn't reflect this sparse ID, so we need to extract it to maintain the original indexing scheme.

**Fallback to sequential indexing:** The code defaults to using the list index (`video_idx_id_map[video_idx] = video_idx`) for non-embedded videos or when the dataset name doesn't follow the expected pattern, ensuring backward compatibility with existing workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)