### PR TITLE
Add CLI theming and enhanced version info

### DIFF
--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -12,11 +12,33 @@ from click.testing import CliRunner
 from sleap_io.io.cli import cli
 from sleap_io.model.labels import Labels
 from sleap_io.model.skeleton import Skeleton
+from sleap_io.version import __version__
 
 
 def _data_path(rel: str) -> Path:
     root = Path(__file__).resolve().parents[2] / "tests" / "data"
     return root / rel
+
+
+def test_version_shows_plugin_info():
+    """Test that --version shows sleap-io version and plugin status."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+
+    # Check main version line
+    assert f"sleap-io {__version__}" in out
+
+    # Check sections are present
+    assert "Core:" in out
+    assert "Video plugins:" in out
+    assert "Optional:" in out
+
+    # Check specific packages are listed
+    assert "numpy:" in out
+    assert "opencv:" in out
+    assert "pyav:" in out
 
 
 def test_cat_summary_typical_slp():


### PR DESCRIPTION
## Summary

Adds rich-click theming and enhanced version output to the CLI as part of the CLI improvement effort (#209).

- Configure `solarized-slim` theme for clean, minimal appearance
- Add branded help text with rich markup formatting
- Enhanced `--version` flag showing installed plugin status

## Key Changes

- **Theme:** `solarized-slim` with `TEXT_MARKUP = "rich"` for styled help
- **Version output:** Shows sleap-io version, Python version, and dependency status:
  - Core: numpy, h5py, imageio
  - Video plugins: opencv, pyav, imageio-ffmpeg  
  - Optional: pymatreader
- **Error epilogue:** Links to io.sleap.ai for documentation on errors
- **Help text:** Rich markup with examples in main CLI docstring

## Example Usage

```bash
$ sio --version
sleap-io 0.5.8
python 3.12.11

Core:
  numpy: 2.4.0
  h5py: 3.15.1
  imageio: 2.37.2

Video plugins:
  opencv: 4.11.0.86
  pyav: 15.1.0
  imageio-ffmpeg: 0.6.0

Optional:
  pymatreader: 1.1.0

$ sio --help
Usage: sio [OPTIONS] COMMAND [ARGS]...

sleap-io - Standalone utilities for pose tracking data.
Read, write, and manipulate pose data from SLEAP, NWB, COCO, DeepLabCut, and
other formats.
Examples:
    $ sio cat labels.slp
    $ sio cat labels.slp --skeleton

+-Options:--------------------------------------------------------------------+
| --version  Show version and plugin info, then exit.                         |
| --help     Show this message and exit.                                      |
+-----------------------------------------------------------------------------+
+-Commands:-------------------------------------------------------------------+
| cat  Print a summary and optional details.                                  |
+-----------------------------------------------------------------------------+
```

## Testing

- Added `test_version_shows_plugin_info()` to verify version output
- All existing CLI tests pass

## Design Decisions

- **Theme choice:** `solarized-slim` selected for clean, minimal look with warm colors
- **Version detail level:** Shows installed vs "not installed" for optional deps to help users debug plugin issues
- **Rich markup:** Used for help text styling (not markdown) to support `[bold]`, `[dim]`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)