### PR TITLE
Add source/target filenames and version to merge provenance

### DIFF
--- a/tests/model/test_merging_integration.py
+++ b/tests/model/test_merging_integration.py
@@ -377,6 +377,13 @@ class TestLabelsMerge:
         assert "timestamp" in merge_record
         assert merge_record["source_labels"]["n_frames"] == 1
         assert merge_record["result"]["frames_merged"] == 1
+        # Verify new provenance fields
+        assert "source_filename" in merge_record
+        assert "target_filename" in merge_record
+        assert "sleap_io_version" in merge_record
+        # In-memory labels have None for filenames
+        assert merge_record["source_filename"] is None
+        assert merge_record["target_filename"] is None
 
     def test_merge_auto_video_matching_with_identical_shapes(self):
         """Test AUTO video matching with multiple videos of identical shape.


### PR DESCRIPTION
## Summary

- Adds `source_filename`, `target_filename`, and `sleap_io_version` fields to merge history provenance records
- Enables better audit trails when tracking data lineage through label merges
- Filenames are `None` when Labels are created in-memory (not loaded from disk)

## Key Changes

- **`sleap_io/model/labels.py`**: Enhanced `Labels.merge()` to capture source/target filenames from provenance and sleap-io version
- **Tests**: Updated existing provenance tests and added new test cases for filename scenarios

## Example Usage

```python
# After merging predictions.slp into labels.slp
labels.provenance["merge_history"][-1]
# Returns:
# {
#     "timestamp": "2025-01-07T14:30:00.123456",
#     "source_filename": "predictions.slp",  # or None if in-memory
#     "target_filename": "labels.slp",       # or None if in-memory
#     "source_labels": {"n_frames": 100, "n_videos": 1, ...},
#     "strategy": "smart",
#     "sleap_io_version": "0.6.0",
#     "result": {"frames_merged": 100, "instances_added": 500, "conflicts": 0}
# }
```

## API Changes

The merge provenance schema now includes three additional fields:
- `source_filename`: Path of the source Labels (from `other.provenance.get("filename")`)
- `target_filename`: Path of the target Labels (from `self.provenance.get("filename")`)  
- `sleap_io_version`: Version string of sleap-io that performed the merge

## Testing

- Updated `test_labels_merge_provenance_tracking()` to verify new fields
- Added `test_labels_merge_provenance_with_filenames()` for file-based Labels
- Added `test_labels_merge_provenance_mixed_filenames()` for mixed scenarios
- Updated `TestLabelsMerge.test_merge_provenance()` integration test

## Design Decisions

- **Filenames can be `None`**: In-memory Labels (not loaded from disk) will have `None` for their filenames. This is intentional and informative - it signals the data source was programmatically created.
- **No nested provenance copying**: We capture only the filename, not the full provenance tree of the source. This avoids unbounded growth in chain/circular merge scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)