### PR TITLE
ci: Add summary job to support docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,3 +115,33 @@ jobs:
           fail_ci_if_error: true
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  # This job aggregates all CI results into a single check for branch protection.
+  # It succeeds if all jobs passed OR were correctly skipped (e.g., docs-only changes).
+  ci:
+    name: CI
+    if: always()
+    needs: [changes, lint, tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI status
+        run: |
+          echo "changes: ${{ needs.changes.result }}"
+          echo "lint: ${{ needs.lint.result }}"
+          echo "tests: ${{ needs.tests.result }}"
+
+          # Fail if any job failed or was cancelled
+          if [[ "${{ needs.changes.result }}" == "failure" || "${{ needs.changes.result }}" == "cancelled" ]]; then
+            echo "::error::changes job failed or was cancelled"
+            exit 1
+          fi
+          if [[ "${{ needs.lint.result }}" == "failure" || "${{ needs.lint.result }}" == "cancelled" ]]; then
+            echo "::error::lint job failed or was cancelled"
+            exit 1
+          fi
+          if [[ "${{ needs.tests.result }}" == "failure" || "${{ needs.tests.result }}" == "cancelled" ]]; then
+            echo "::error::tests job failed or was cancelled"
+            exit 1
+          fi
+
+          echo "All CI checks passed or were correctly skipped!"


### PR DESCRIPTION
## Summary

Adds a CI aggregation job that enables docs-only PRs to pass required status checks without running unnecessary tests.

## Problem

Currently, branch protection requires these checks to pass:
- `Lint`
- `Tests (ubuntu-latest, Python 3.8)`
- `Tests (ubuntu-latest, Python 3.13)`
- `Tests (windows-latest, Python 3.13)`
- `Tests (macos-latest, Python 3.13)`

When docs-only PRs are opened, the path filtering correctly skips these jobs - but **skipped** jobs don't satisfy required checks. Only **success** does. This blocks PRs like #304 from merging.

## Solution

Add a single "CI" job that:
1. **Always runs** (via `if: always()`) - even when other jobs are skipped
2. **Aggregates results** - checks that all dependent jobs either succeeded OR were correctly skipped
3. **Provides a single status check** - replaces 5 individual required checks with 1

### How it works

```yaml
ci:
  name: CI
  if: always()
  needs: [changes, lint, tests]
```

The job checks `needs.*.result` for each dependency:
- `success` → ✅ job passed
- `skipped` → ✅ job was correctly skipped (no code changes)
- `failure` or `cancelled` → ❌ fail the CI check

## After Merging

Update branch protection settings:

1. Go to Settings → Branches → `main` → Edit
2. Under "Require status checks to pass", remove:
   - `Lint`
   - `Tests (ubuntu-latest, Python 3.8)`
   - `Tests (ubuntu-latest, Python 3.13)`
   - `Tests (windows-latest, Python 3.13)`
   - `Tests (macos-latest, Python 3.13)`
3. Add: `CI`

This will unblock #304 and all future docs-only PRs.

## Testing

- CI will run on this PR itself (with code changes, so full suite runs)
- After merge + branch protection update, docs-only PRs will have "CI" pass immediately

🤖 Generated with [Claude Code](https://claude.ai/code)