### PR TITLE
docs: Update version examples in install.md to 0.6.0

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -285,13 +285,13 @@ For reproducible builds, pin to a specific version or commit:
 
 ```toml
 # Pin to version
-"sleap-io[all]==0.5.8"
+"sleap-io[all]==0.6.0"
 
 # Pin to specific commit
 "sleap-io[all] @ git+https://github.com/talmolab/sleap-io.git@abc1234"
 
 # Pin to tag
-"sleap-io[all] @ git+https://github.com/talmolab/sleap-io.git@v0.5.8"
+"sleap-io[all] @ git+https://github.com/talmolab/sleap-io.git@v0.6.0"
 ```
 
 ---


### PR DESCRIPTION
## Summary

Updates two version examples in `docs/install.md` that still referenced v0.5.8 to use v0.6.0 for consistency with the upcoming release.

## Changes

- Line 288: `"sleap-io[all]==0.5.8"` → `"sleap-io[all]==0.6.0"`
- Line 294: `"sleap-io[all] @ git+...@v0.5.8"` → `"sleap-io[all] @ git+...@v0.6.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)