### PR TITLE
feat: Add FPS video property support

### DIFF
--- a/sleap_io/io/nwb_annotations.py
+++ b/sleap_io/io/nwb_annotations.py
@@ -319,7 +319,7 @@ def sleap_video_to_nwb_image_series(
     else:
         height, width = 0, 0
 
-    fps = getattr(sleap_video, "fps", 30.0)
+    fps = sleap_video.fps if sleap_video.fps is not None else 30.0
 
     starting_frame = list(range(len(filename)))  # needs to match length of filenames
 


### PR DESCRIPTION
## Summary

Add FPS (frames per second) as a retrievable and settable property on Video objects. This enables:
- Reading FPS from video container metadata (MediaVideo)
- Explicitly setting FPS for backends without inherent FPS (ImageVideo, HDF5Video, TiffVideo)
- Converting frame indices to timestamps in seconds
- Preserving FPS when reencoding videos via `Video.save()` or `sio render`
- Persisting FPS in SLP file format for round-trip preservation

## Key Changes

- **VideoBackend base class**: Added `_fps` attribute with `fps` property getter/setter
- **MediaVideo**: Reads FPS from container metadata using OpenCV (`CAP_PROP_FPS`) or imageio (`get_meta_data()["fps"]`)
- **HDF5Video**: Reads FPS from HDF5 dataset attributes when present (for embedded videos)
- **Video wrapper**: Unified `fps` property with `backend_metadata` caching on close
- **Timestamp utilities**: `frame_to_seconds()` and `seconds_to_frame()` methods
- **Video.save()**: Now preserves source video FPS or accepts custom FPS parameter
- **SLP serialization**: FPS stored in `video_to_dict()` and restored in `make_video()`
- **Embedded videos**: FPS stored in HDF5 attrs for inheritance from source video

## Example Usage

```python
import sleap_io as sio

# Read FPS from MediaVideo (automatic from container)
video = sio.Video.from_filename("test.mp4")
print(video.fps)  # 15.0

# Set FPS explicitly for ImageVideo
video = sio.Video.from_filename("images/")
video.fps = 30.0

# Timestamp conversion utilities
video.frame_to_seconds(150)  # 10.0 (at 15 fps)
video.seconds_to_frame(5.0)  # 75

# FPS preserved when saving
new_video = video.save("output.mp4")  # Uses source FPS
new_video = video.save("output.mp4", fps=30.0)  # Custom FPS

# FPS preserved in SLP format round-trip
sio.save_slp(labels, "test.slp")  # Stores FPS
labels = sio.load_slp("test.slp")  # Restores FPS
```

## API Changes

### New Properties
- `Video.fps` → `Optional[float]`: Get/set FPS
- `VideoBackend.fps` → `Optional[float]`: Get/set FPS (base class)

### New Methods
- `Video.frame_to_seconds(frame_idx: int) → Optional[float]`
- `Video.seconds_to_frame(seconds: float) → Optional[int]`

### Modified Methods
- `Video.save()`: Added `fps` parameter

## Testing

- 22 new tests added across 3 test files
- All 1436 tests pass
- Tests cover:
  - FPS extraction from all backend types
  - FPS getter/setter validation
  - Timestamp conversion utilities
  - SLP serialization round-trip
  - Embedded video FPS inheritance
  - Backward compatibility with files without FPS

## Design Decisions

1. **MediaVideo FPS is read-only by default**: FPS comes from container metadata, but can be overridden via setter if needed
2. **No FORMAT_ID bump**: FPS is stored as optional field with None default - backward compatible
3. **Fallback behavior**: NWB conversion falls back to 30 FPS when video FPS is None
4. **VFR detection out of scope**: Variable frame rate detection via PTS analysis deferred for future

🤖 Generated with [Claude Code](https://claude.ai/code)