### PR TITLE
feat: Add PR-local docs preview deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,13 +13,8 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - ".github/workflows/docs.yml"
-  pull_request:
-    types: [opened, reopened, synchronize]
-    paths:
-      - "sleap_io/**"
-      - "docs/**"
-      - "mkdocs.yml"
-      - ".github/workflows/docs.yml"
+  # NOTE: PR docs previews are now handled by pr-preview.yml
+  # This workflow only deploys the 'dev' version from main branch pushes
 
 # Prevent race conditions when PR is merged (last PR commit + push to main)
 # Only one docs deployment runs at a time; additional runs queue up
@@ -92,7 +87,7 @@ jobs:
           done
 
       - name: Build docs (dev)
-        if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'push' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EAGER_IMPORT: "1"  # Force eager imports for docs introspection
@@ -104,7 +99,7 @@ jobs:
           uv run mike deploy --update-aliases --allow-empty dev
 
       - name: Push docs (dev)
-        if: ${{ (github.event_name == 'push' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ github.event_name == 'push' }}
         run: |
           # Push with retry logic to handle race conditions
           for i in {1..3}; do
@@ -125,7 +120,7 @@ jobs:
           done
 
       - name: Reorder versions.json on gh-pages
-        if: ${{ (github.event_name == 'release' || github.event_name == 'push' || github.event_name == 'pull_request') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        if: ${{ github.event_name == 'release' || github.event_name == 'push' }}
         run: |
           # Copy the reordering script to temp location before switching branches
           cp scripts/reorder_versions.py /tmp/reorder_versions.py

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,100 @@
+# PR-local documentation preview deployment
+# Each PR gets its own isolated preview at https://io.sleap.ai/pr/{number}/
+# This prevents parallel PRs from clobbering each other's docs
+name: Docs - PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    paths:
+      - "sleap_io/**"
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/pr-preview.yml"
+
+# Per-PR concurrency: each PR gets its own group, allowing parallel PR previews
+# cancel-in-progress: true means new pushes to the same PR cancel previous builds
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write       # To push to gh-pages branch
+  pull-requests: write  # To post comments on PRs
+
+jobs:
+  deploy:
+    name: Deploy Preview
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Build docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EAGER_IMPORT: "1"  # Force eager imports for docs introspection
+        run: uv run mkdocs build --site-dir _site
+
+      - name: Deploy PR Preview
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: _site
+          target-folder: pr/${{ github.event.number }}
+          commit-message: "Deploy PR #${{ github.event.number }} preview"
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docs-preview
+          message: |
+            ## Docs Preview
+
+            | | |
+            |---|---|
+            | **Preview URL** | https://io.sleap.ai/pr/${{ github.event.number }}/ |
+            | **Commit** | `${{ github.event.pull_request.head.sha }}` |
+
+            _This preview will be removed when the PR is closed._
+
+  cleanup:
+    name: Cleanup Preview
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove PR preview
+        run: |
+          if [ -d "pr/${{ github.event.number }}" ]; then
+            rm -rf "pr/${{ github.event.number }}"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "Remove PR #${{ github.event.number }} preview" || echo "Nothing to commit"
+            git push
+          else
+            echo "Preview directory pr/${{ github.event.number }} does not exist"
+          fi
+
+      - name: Comment on PR (cleanup)
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docs-preview
+          message: |
+            ## Docs Preview
+
+            Preview has been removed.


### PR DESCRIPTION
## Summary

This PR implements PR-local documentation previews to prevent parallel PRs from clobbering each other's docs on the shared `dev` version.

**Key Changes:**
- New `pr-preview.yml` workflow deploys each PR to an isolated subdirectory (`pr/{number}/`)
- Updated `docs.yml` to remove PR trigger (PRs now use the new workflow)
- Each PR gets its own preview URL at `https://io.sleap.ai/pr/{number}/`
- Automatic cleanup when PRs are closed
- Sticky PR comments show preview URL and update on each push

## How It Works

| Event | Previous Behavior | New Behavior |
|-------|-------------------|--------------|
| PR opened/updated | Deploy to `dev/` (clobbers other PRs) | Deploy to `pr/{number}/` (isolated) |
| PR closed | No cleanup | Automatically removes `pr/{number}/` |
| Main branch push | Deploy to `dev/` | Deploy to `dev/` (unchanged) |
| Release published | Deploy to `v{X.Y.Z}/` | Deploy to `v{X.Y.Z}/` (unchanged) |

## URL Structure

```
https://io.sleap.ai/
├── dev/             # Main branch docs (via mike)
├── v0.2.5/          # Release docs (via mike)
├── latest -> v0.2.5 # Alias
└── pr/
    ├── 123/         # PR #123 preview
    └── 456/         # PR #456 preview
```

## Test Plan

- [ ] Verify this PR triggers the new `pr-preview.yml` workflow
- [ ] Verify preview is deployed to `https://io.sleap.ai/pr/{PR_NUMBER}/`
- [ ] Verify sticky comment is posted with preview URL
- [ ] Verify production docs at `https://io.sleap.ai/` are unaffected
- [ ] After merging: verify preview is cleaned up

## Safety

- Production docs remain unaffected (mike only writes to version directories)
- Release and main branch deployment unchanged
- PR previews are isolated in `pr/` subdirectory

---
Generated with [Claude Code](https://claude.ai/claude-code)