### PR TITLE
chore: Bump minimum Python version from 3.8 to 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup UV
       uses: astral-sh/setup-uv@v6
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
     - name: Build distributions
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,12 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python: ["3.8", "3.13"]
-        exclude:
-          - os: "macos-latest"
-            python: "3.8"
-          - os: "windows-latest"
-            python: "3.8"
+        python: ["3.10", "3.11", "3.12", "3.13"]
 
     name: Tests (${{ matrix.os }}, Python ${{ matrix.python }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,10 @@ authors = [
     {name = "David Samy", email = "davidasamy@gmail.com"},
     {name = "Talmo Pereira", email = "talmo@salk.edu"}]
 description="Standalone utilities for working with pose data from SLEAP and other tools."
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 keywords = ["sleap", "pose tracking", "pose estimation", "behavior"]
 license = {text = "BSD-3-Clause"}
 classifiers = [
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -85,7 +83,7 @@ exclude = ["site"]
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -1318,9 +1318,10 @@ def test_write_labels_verbose_propagation(slp_minimal, tmp_path):
     temp_slp = tmp_path / "test_write_labels_prop.slp"
 
     # Mock embed_videos to verify verbose is correctly passed
-    with mock.patch("sleap_io.io.slp.embed_videos") as mock_embed_videos, mock.patch(
-        "sleap_io.io.slp.write_videos"
-    ) as mock_write_videos:
+    with (
+        mock.patch("sleap_io.io.slp.embed_videos") as mock_embed_videos,
+        mock.patch("sleap_io.io.slp.write_videos") as mock_write_videos,
+    ):
         write_labels(temp_slp, labels, embed="user", verbose=True)
 
         # Check that verbose=True was passed to embed_videos
@@ -1330,9 +1331,10 @@ def test_write_labels_verbose_propagation(slp_minimal, tmp_path):
         assert mock_write_videos.call_args.kwargs["verbose"] is True
 
     # Check with verbose=False
-    with mock.patch("sleap_io.io.slp.embed_videos") as mock_embed_videos, mock.patch(
-        "sleap_io.io.slp.write_videos"
-    ) as mock_write_videos:
+    with (
+        mock.patch("sleap_io.io.slp.embed_videos") as mock_embed_videos,
+        mock.patch("sleap_io.io.slp.write_videos") as mock_write_videos,
+    ):
         write_labels(temp_slp, labels, embed="user", verbose=False)
 
         # Check that verbose=False was passed to embed_videos


### PR DESCRIPTION
## Summary

Bump minimum Python version from 3.8 to 3.10, and standardize CI/build workflows on Python 3.13.

## Key Changes

- **pyproject.toml**: `requires-python = ">=3.10"`, remove 3.8/3.9 classifiers, ruff `target-version = "py310"`
- **ci.yml**: Test matrix now `[3.10, 3.11, 3.12, 3.13]` on all platforms (removed 3.8 exclusions)
- **build.yml, docs.yml, pr-preview.yml**: Updated to Python 3.13

## Rationale

This aligns the declared minimum with the de facto minimum imposed by optional dependencies:
- `av` (PyAV): requires Python >=3.10
- `polars`: requires Python >=3.10

All core dependencies already support Python 3.10+. No breaking changes expected.

## Test Plan

- [ ] CI passes on all Python versions (3.10, 3.11, 3.12, 3.13)
- [ ] CI passes on all platforms (Ubuntu, Windows, macOS)
- [ ] Build workflow succeeds
- [ ] Docs workflow succeeds

## Follow-up PRs (optional)

1. Remove `from __future__ import annotations` (33 files)
2. Migrate `typing_extensions.Literal` → `typing.Literal`
3. Modernize type hints (`Union` → `|`, `Optional` → `| None`)

🤖 Generated with [Claude Code](https://claude.ai/code)