### PR TITLE
refactor: Modernize type hints to Python 3.10+ syntax

### DIFF
--- a/sleap_io/codecs/dataframe.py
+++ b/sleap_io/codecs/dataframe.py
@@ -13,7 +13,7 @@ Supported formats:
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Generator, Iterator, Optional, Union
+from typing import TYPE_CHECKING, Generator, Iterator, Literal
 
 import numpy as np
 import pandas as pd
@@ -23,8 +23,6 @@ from sleap_io.model.labels import Labels
 from sleap_io.model.video import Video
 
 if TYPE_CHECKING:
-    from typing_extensions import Literal
-
     from sleap_io.io.slp_lazy import LazyDataStore
 
 # Optional polars support
@@ -108,13 +106,13 @@ def to_dataframe(
     labels: Labels,
     format: DataFrameFormat | str = DataFrameFormat.POINTS,
     *,
-    video: Optional[Video | int] = None,
+    video: Video | int | None = None,
     include_metadata: bool = True,
     include_score: bool = True,
     include_user_instances: bool = True,
     include_predicted_instances: bool = True,
     video_id: Literal["path", "index", "name", "object"] = "path",
-    include_video: Optional[bool] = None,
+    include_video: bool | None = None,
     instance_id: Literal["index", "track"] = "index",
     untracked: Literal["error", "ignore"] = "error",
     backend: Literal["pandas", "polars"] = "pandas",
@@ -213,7 +211,7 @@ def to_dataframe(
             )
 
     # Convert video parameter to index for fast path filtering
-    video_filter_idx: Optional[int] = None
+    video_filter_idx: int | None = None
     if video is not None:
         if isinstance(video, int):
             video_filter_idx = video
@@ -326,13 +324,13 @@ def to_dataframe_iter(
     format: DataFrameFormat | str = DataFrameFormat.POINTS,
     *,
     chunk_size: int | None = None,
-    video: Optional[Video | int] = None,
+    video: Video | int | None = None,
     include_metadata: bool = True,
     include_score: bool = True,
     include_user_instances: bool = True,
     include_predicted_instances: bool = True,
     video_id: Literal["path", "index", "name", "object"] = "path",
-    include_video: Optional[bool] = None,
+    include_video: bool | None = None,
     instance_id: Literal["index", "track"] = "index",
     untracked: Literal["error", "ignore"] = "error",
     backend: Literal["pandas", "polars"] = "pandas",
@@ -541,9 +539,7 @@ def to_dataframe_iter(
         yield df
 
 
-def _format_video(
-    video: Video, labels: Labels, video_id: str
-) -> Union[str, int, Video]:
+def _format_video(video: Video, labels: Labels, video_id: str) -> str | int | Video:
     """Format video based on video_id parameter.
 
     Args:
@@ -1103,7 +1099,7 @@ def _to_points_df_lazy(
     store: "LazyDataStore",
     labels: Labels,
     *,
-    video_filter: Optional[int] = None,
+    video_filter: int | None = None,
     include_metadata: bool = True,
     include_score: bool = True,
     include_user_instances: bool = True,
@@ -1226,7 +1222,7 @@ def _to_instances_df_lazy(
     store: "LazyDataStore",
     labels: Labels,
     *,
-    video_filter: Optional[int] = None,
+    video_filter: int | None = None,
     include_metadata: bool = True,
     include_score: bool = True,
     include_user_instances: bool = True,
@@ -1881,8 +1877,8 @@ def _to_multi_index_df(  # noqa: D417
 def from_dataframe(
     df: pd.DataFrame,
     *,
-    video: Optional[Video] = None,
-    skeleton: Optional["Skeleton"] = None,  # noqa: F821
+    video: Video | None = None,
+    skeleton: "Skeleton | None" = None,  # noqa: F821
     format: DataFrameFormat | str = DataFrameFormat.POINTS,
 ) -> Labels:
     """Create a Labels object from a DataFrame.
@@ -1944,8 +1940,8 @@ def from_dataframe(
 def _from_points_df(
     df: pd.DataFrame,
     *,
-    video: Optional[Video] = None,
-    skeleton: Optional["Skeleton"] = None,  # noqa: F821
+    video: Video | None = None,
+    skeleton: "Skeleton | None" = None,  # noqa: F821
 ) -> Labels:
     """Create Labels from a points format DataFrame (one row per point)."""
     from sleap_io.model.labeled_frame import LabeledFrame
@@ -2207,8 +2203,8 @@ def _from_points_df(
 def _from_instances_df(
     df: pd.DataFrame,
     *,
-    video: Optional[Video] = None,
-    skeleton: Optional["Skeleton"] = None,  # noqa: F821
+    video: Video | None = None,
+    skeleton: "Skeleton | None" = None,  # noqa: F821
 ) -> Labels:
     """Create Labels from an instances format DataFrame (one row per instance)."""
     from sleap_io.model.labeled_frame import LabeledFrame
@@ -2390,8 +2386,8 @@ def _from_instances_df(
 def _from_frames_df(
     df: pd.DataFrame,
     *,
-    video: Optional[Video] = None,
-    skeleton: Optional["Skeleton"] = None,  # noqa: F821
+    video: Video | None = None,
+    skeleton: "Skeleton | None" = None,  # noqa: F821
 ) -> Labels:
     """Create Labels from a frames format DataFrame (one row per frame, wide format)."""
     from sleap_io.model.labeled_frame import LabeledFrame
@@ -2607,8 +2603,8 @@ def _from_frames_df(
 def _from_multi_index_df(
     df: pd.DataFrame,
     *,
-    video: Optional[Video] = None,
-    skeleton: Optional["Skeleton"] = None,  # noqa: F821
+    video: Video | None = None,
+    skeleton: "Skeleton | None" = None,  # noqa: F821
 ) -> Labels:
     """Create Labels from a multi-index format DataFrame (hierarchical columns)."""
     # Handle multi-index columns

--- a/sleap_io/codecs/dictionary.py
+++ b/sleap_io/codecs/dictionary.py
@@ -13,7 +13,7 @@ The dictionary codec is useful for:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from sleap_io.model.instance import Instance, PredictedInstance, Track
 from sleap_io.model.labels import Labels
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 def to_dict(
     labels: Labels,
     *,
-    video: Optional[Video | int] = None,
+    video: Video | int | None = None,
     skip_empty_frames: bool = False,
 ) -> dict[str, Any]:
     """Convert Labels to a primitive dictionary (JSON-serializable).
@@ -72,7 +72,7 @@ def to_dict(
           Python primitives
     """
     # Convert video parameter to index for fast path filtering
-    video_filter_idx: Optional[int] = None
+    video_filter_idx: int | None = None
     if video is not None:
         if isinstance(video, int):
             video_filter_idx = video
@@ -239,7 +239,7 @@ def to_dict(
 def _build_labeled_frames_lazy(
     store: "LazyDataStore",
     *,
-    video_filter: Optional[int] = None,
+    video_filter: int | None = None,
     skip_empty_frames: bool = False,
 ) -> list[dict[str, Any]]:
     """Build labeled frames list directly from LazyDataStore arrays.

--- a/sleap_io/codecs/numpy.py
+++ b/sleap_io/codecs/numpy.py
@@ -7,7 +7,7 @@ array shapes, instance selection, and metadata handling.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 def to_numpy(
     labels: Labels,
     *,
-    video: Optional[Union[Video, int]] = None,
+    video: Video | int | None = None,
     untracked: bool = False,
     return_confidence: bool = False,
     user_instances: bool = True,
@@ -243,12 +243,12 @@ def to_numpy(
 def from_numpy(
     tracks_array: np.ndarray,
     *,
-    videos: Optional[list[Video]] = None,
-    video: Optional[Video] = None,
-    skeletons: Optional[list[Skeleton] | Skeleton] = None,
-    skeleton: Optional[Skeleton] = None,
-    tracks: Optional[list[Track]] = None,
-    track_names: Optional[list[str]] = None,
+    videos: list[Video] | None = None,
+    video: Video | None = None,
+    skeletons: list[Skeleton] | Skeleton | None = None,
+    skeleton: Skeleton | None = None,
+    tracks: list[Track] | None = None,
+    track_names: list[str] | None = None,
     first_frame: int = 0,
     return_confidence: bool = False,
 ) -> Labels:

--- a/sleap_io/io/analysis_h5.py
+++ b/sleap_io/io/analysis_h5.py
@@ -95,7 +95,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
 
 import h5py
 import numpy as np
@@ -119,7 +118,7 @@ from sleap_io.model.video import Video
 
 # Presets define dimension positions in the stored array
 # Format: {dim_name: position} for the tracks array (4D)
-PRESETS: Dict[str, Dict[str, int]] = {
+PRESETS: dict[str, dict[str, int]] = {
     # Standard: (frame, track, node, xy) - intuitive Python indexing
     "standard": {"frame": 0, "track": 1, "node": 2, "xy": 3},
     # MATLAB: (track, xy, node, frame) - SLEAP-compatible column-major
@@ -128,12 +127,12 @@ PRESETS: Dict[str, Dict[str, int]] = {
 
 
 def _get_axis_order(
-    preset: Optional[str],
-    frame_dim: Optional[int],
-    track_dim: Optional[int],
-    node_dim: Optional[int],
-    xy_dim: Optional[int],
-) -> Tuple[Dict[str, int], str]:
+    preset: str | None,
+    frame_dim: int | None,
+    track_dim: int | None,
+    node_dim: int | None,
+    xy_dim: int | None,
+) -> tuple[dict[str, int], str]:
     """Resolve axis ordering from preset or explicit dimensions.
 
     Args:
@@ -187,8 +186,8 @@ def _get_axis_order(
 
 
 def _get_transpose_axes(
-    from_order: Dict[str, int], to_order: Dict[str, int], ndim: int
-) -> Tuple[int, ...]:
+    from_order: dict[str, int], to_order: dict[str, int], ndim: int
+) -> tuple[int, ...]:
     """Compute transpose axes to convert between axis orderings.
 
     Args:
@@ -218,7 +217,7 @@ def _get_transpose_axes(
     return tuple(axes)
 
 
-def _get_dims_tuple(axis_order: Dict[str, int], ndim: int) -> Tuple[str, ...]:
+def _get_dims_tuple(axis_order: dict[str, int], ndim: int) -> tuple[str, ...]:
     """Get dimension names tuple for given axis ordering.
 
     Args:
@@ -248,7 +247,7 @@ def _get_dims_tuple(axis_order: Dict[str, int], ndim: int) -> Tuple[str, ...]:
 # =============================================================================
 
 
-def is_analysis_h5_file(filename: Union[str, Path]) -> bool:
+def is_analysis_h5_file(filename: str | Path) -> bool:
     """Check if file is a SLEAP Analysis HDF5 file.
 
     This distinguishes Analysis HDF5 files from JABS HDF5 files by checking
@@ -275,8 +274,8 @@ def is_analysis_h5_file(filename: Union[str, Path]) -> bool:
 
 
 def read_labels(
-    filename: Union[str, Path],
-    video: Optional[Union[Video, str]] = None,
+    filename: str | Path,
+    video: Video | str | None = None,
 ) -> Labels:
     """Load SLEAP Analysis HDF5 file.
 
@@ -475,16 +474,16 @@ def read_labels(
 
 def _get_occupancy_and_points(
     labels: Labels,
-    video: Optional[Video] = None,
+    video: Video | None = None,
     all_frames: bool = True,
     min_occupancy: float = 0.0,
-) -> Tuple[
+) -> tuple[
     np.ndarray,
     np.ndarray,
     np.ndarray,
     np.ndarray,
     np.ndarray,
-    List[str],
+    list[str],
     int,
 ]:
     """Build numpy matrices with track occupancy and point location data.
@@ -619,17 +618,17 @@ def _get_occupancy_and_points(
 
 def write_labels(
     labels: Labels,
-    filename: Union[str, Path],
+    filename: str | Path,
     *,
-    video: Optional[Union[Video, int]] = None,
-    labels_path: Optional[str] = None,
+    video: Video | int | None = None,
+    labels_path: str | None = None,
     all_frames: bool = True,
     min_occupancy: float = 0.0,
-    preset: Optional[str] = None,
-    frame_dim: Optional[int] = None,
-    track_dim: Optional[int] = None,
-    node_dim: Optional[int] = None,
-    xy_dim: Optional[int] = None,
+    preset: str | None = None,
+    frame_dim: int | None = None,
+    track_dim: int | None = None,
+    node_dim: int | None = None,
+    xy_dim: int | None = None,
     save_metadata: bool = True,
 ) -> None:
     """Save Labels to SLEAP Analysis HDF5 file.
@@ -769,7 +768,7 @@ def write_labels(
         def write_dataset(
             name: str,
             data,
-            dim_names: Optional[tuple] = None,
+            dim_names: tuple | None = None,
         ) -> None:
             if isinstance(data, np.ndarray):
                 ds = f.create_dataset(

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import sys
 from importlib.metadata import version as pkg_version
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import rich_click as click
 from rich import box
@@ -89,8 +89,8 @@ OUTPUT_EXTENSION_TO_FORMAT = {
 
 
 def _resolve_input(
-    input_arg: Optional[Path],
-    input_opt: Optional[Path],
+    input_arg: Path | None,
+    input_opt: Path | None,
     name: str = "input file",
 ) -> Path:
     """Resolve input from positional argument or -i option.
@@ -129,8 +129,8 @@ def _get_package_version(package: str) -> str:
 
 
 def _parse_crop_string(
-    crop_str: Optional[str],
-) -> Optional[tuple]:
+    crop_str: str | None,
+) -> tuple | None:
     """Parse crop string from CLI into crop specification.
 
     Args:
@@ -793,7 +793,7 @@ def _print_video_summary(labels: Labels) -> None:
             console.print(f"  [dim]... +{n_remaining} more without cached metadata[/]")
 
 
-def _print_video_details(labels: Labels, video_index: Optional[int] = None) -> None:
+def _print_video_details(labels: Labels, video_index: int | None = None) -> None:
     """Print detailed video information with consistent field ordering.
 
     Args:
@@ -1154,14 +1154,14 @@ def _print_provenance(labels: Labels, compact: bool = False) -> None:
     help="Print all available details.",
 )
 def show(
-    path_arg: Optional[Path],
-    path_opt: Optional[Path],
+    path_arg: Path | None,
+    path_opt: Path | None,
     lazy: bool,
-    open_videos: Optional[bool],
-    lf_index: Optional[int],
+    open_videos: bool | None,
+    lf_index: int | None,
     skeleton: bool,
     video: bool,
-    video_index: Optional[int],
+    video_index: int | None,
     tracks: bool,
     provenance: bool,
     show_all: bool,
@@ -1259,7 +1259,7 @@ def show(
         click.echo(repr(obj))
 
 
-def _infer_input_format(path: Path) -> Optional[str]:
+def _infer_input_format(path: Path) -> str | None:
     """Infer input format from file path.
 
     Args:
@@ -1287,7 +1287,7 @@ def _infer_input_format(path: Path) -> Optional[str]:
     return None
 
 
-def _infer_output_format(path: Path) -> Optional[str]:
+def _infer_output_format(path: Path) -> str | None:
     """Infer output format from file path.
 
     Args:
@@ -1368,12 +1368,12 @@ def _infer_output_format(path: Path) -> Optional[str]:
     help="Save JSON metadata file for round-trip support (CSV only).",
 )
 def convert(
-    input_arg: Optional[Path],
-    input_opt: Optional[Path],
+    input_arg: Path | None,
+    input_opt: Path | None,
     output_path: Path,
-    input_format: Optional[str],
-    output_format: Optional[str],
-    embed: Optional[str],
+    input_format: str | None,
+    output_format: str | None,
+    embed: str | None,
     csv_format: str,
     scorer: str,
     save_metadata: bool,
@@ -1554,15 +1554,15 @@ def convert(
     help="Embed frames in output files.",
 )
 def split(
-    input_arg: Optional[Path],
-    input_opt: Optional[Path],
+    input_arg: Path | None,
+    input_opt: Path | None,
     output_dir: Path,
     train_fraction: float,
-    val_fraction: Optional[float],
-    test_fraction: Optional[float],
+    val_fraction: float | None,
+    test_fraction: float | None,
     remove_predictions: bool,
-    seed: Optional[int],
-    embed: Optional[str],
+    seed: int | None,
+    embed: str | None,
 ):
     """Split labels into train/val/test sets.
 
@@ -1775,7 +1775,7 @@ def split(
 def unsplit(
     input_files: tuple[Path, ...],
     output_path: Path,
-    embed: Optional[str],
+    embed: str | None,
 ):
     """Merge split files back into a single labels file.
 
@@ -1961,7 +1961,7 @@ def merge(
     track: str,
     frame: str,
     instance: str,
-    embed: Optional[str],
+    embed: str | None,
     verbose: bool,
 ):
     """Merge multiple labels files into one.
@@ -2187,9 +2187,9 @@ def merge(
     help="Show all details: full image lists, source videos, original videos.",
 )
 def filenames(
-    input_arg: Optional[Path],
-    input_opt: Optional[Path],
-    output_path: Optional[Path],
+    input_arg: Path | None,
+    input_opt: Path | None,
+    output_path: Path | None,
     new_filenames: tuple[str, ...],
     filename_map: tuple[tuple[str, str], ...],
     prefix_map: tuple[tuple[str, str], ...],
@@ -2542,18 +2542,18 @@ def filenames(
     help="List available color palettes and exit.",
 )
 def render(
-    input_arg: Optional[Path],
-    input_opt: Optional[Path],
-    output_path: Optional[Path],
-    lf_ind: Optional[int],
-    frame_idx: Optional[int],
-    start_frame_idx: Optional[int],
-    end_frame_idx: Optional[int],
+    input_arg: Path | None,
+    input_opt: Path | None,
+    output_path: Path | None,
+    lf_ind: int | None,
+    frame_idx: int | None,
+    start_frame_idx: int | None,
+    end_frame_idx: int | None,
     video_ind: int,
-    all_frames: Optional[bool],
-    preset: Optional[str],
-    scale: Optional[float],
-    fps: Optional[float],
+    all_frames: bool | None,
+    preset: str | None,
+    scale: float | None,
+    fps: float | None,
     crf: int,
     x264_preset: str,
     color_by: str,
@@ -2564,7 +2564,7 @@ def render(
     alpha: float,
     no_nodes: bool,
     no_edges: bool,
-    crop_str: Optional[str],
+    crop_str: str | None,
     background: str,
     list_colors: bool,
     list_palettes: bool,
@@ -3036,9 +3036,9 @@ def _analyze_skeletons(
     help="Show detailed analysis.",
 )
 def fix(
-    input_arg: Optional[Path],
-    input_opt: Optional[Path],
-    output_path: Optional[Path],
+    input_arg: Path | None,
+    input_opt: Path | None,
+    output_path: Path | None,
     deduplicate_videos: bool,
     remove_unused_skeletons: bool,
     consolidate_skeletons: bool,
@@ -3123,7 +3123,7 @@ def fix(
     has_multi_user_skeletons = len(user_skels) > 1
 
     # Find most frequent user skeleton for consolidation
-    most_frequent_skeleton: Optional[Skeleton] = None
+    most_frequent_skeleton: Skeleton | None = None
     other_user_skeletons: list[Skeleton] = []
     if has_multi_user_skeletons:
         # Sort by user count descending
@@ -3468,8 +3468,8 @@ def fix(
     help="Include suggested frames.",
 )
 def embed(
-    input_arg: Optional[Path],
-    input_opt: Optional[Path],
+    input_arg: Path | None,
+    input_opt: Path | None,
     output_path: Path,
     include_user: bool,
     include_predictions: bool,
@@ -3585,8 +3585,8 @@ def embed(
     help="Output .slp file path.",
 )
 def unembed(
-    input_arg: Optional[Path],
-    input_opt: Optional[Path],
+    input_arg: Path | None,
+    input_opt: Path | None,
     output_path: Path,
 ):
     """Remove embedded frames and restore video references.
@@ -3732,13 +3732,13 @@ def unembed(
     help="H.264 encoding speed/compression trade-off.",
 )
 def trim(
-    input_arg: Optional[Path],
-    input_opt: Optional[Path],
-    output_path: Optional[Path],
-    start_frame: Optional[int],
-    end_frame: Optional[int],
-    video_ind: Optional[int],
-    fps: Optional[float],
+    input_arg: Path | None,
+    input_opt: Path | None,
+    output_path: Path | None,
+    start_frame: int | None,
+    end_frame: int | None,
+    video_ind: int | None,
+    fps: float | None,
     crf: int,
     x264_preset: str,
 ) -> None:
@@ -3775,8 +3775,8 @@ def trim(
     input_path = _resolve_input(input_arg, input_opt, "input file")
 
     # Try to load as labels first, then as video
-    labels: Optional[Labels] = None
-    video: Optional[Video] = None
+    labels: Labels | None = None
+    video: Video | None = None
 
     try:
         result = io_main.load_file(str(input_path), open_videos=True)
@@ -3827,10 +3827,10 @@ def trim(
 def _trim_labels(
     labels: Labels,
     input_path: Path,
-    output_path: Optional[Path],
-    start_frame: Optional[int],
-    end_frame: Optional[int],
-    video_ind: Optional[int],
+    output_path: Path | None,
+    start_frame: int | None,
+    end_frame: int | None,
+    video_ind: int | None,
     video_kwargs: dict[str, Any],
 ) -> None:
     """Trim labels and associated video to a frame range."""
@@ -3915,9 +3915,9 @@ def _trim_labels(
 def _trim_video(
     video: Video,
     input_path: Path,
-    output_path: Optional[Path],
-    start_frame: Optional[int],
-    end_frame: Optional[int],
+    output_path: Path | None,
+    start_frame: int | None,
+    end_frame: int | None,
     video_kwargs: dict[str, Any],
 ) -> None:
     """Trim a standalone video to a frame range."""

--- a/sleap_io/io/coco.py
+++ b/sleap_io/io/coco.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, List, Optional, Union
 
 import numpy as np
 
@@ -23,7 +22,7 @@ from sleap_io.model.skeleton import Edge, Node, Skeleton
 from sleap_io.model.video import Video
 
 
-def parse_coco_json(json_path: Union[str, Path]) -> Dict:
+def parse_coco_json(json_path: str | Path) -> dict:
     """Parse COCO annotation JSON file and validate structure.
 
     Args:
@@ -61,7 +60,7 @@ def parse_coco_json(json_path: Union[str, Path]) -> Dict:
     return data
 
 
-def create_skeleton_from_category(category: Dict) -> Skeleton:
+def create_skeleton_from_category(category: dict) -> Skeleton:
     """Create a Skeleton object from a COCO category definition.
 
     Args:
@@ -132,7 +131,7 @@ def resolve_image_path(image_filename: str, dataset_root: Path) -> Path:
 
 
 def decode_keypoints(
-    keypoints: List[float], num_keypoints: int, skeleton: Skeleton
+    keypoints: list[float], num_keypoints: int, skeleton: Skeleton
 ) -> np.ndarray:
     """Decode COCO keypoint format to numpy array for Instance creation.
 
@@ -184,8 +183,8 @@ def decode_keypoints(
 
 
 def read_labels(
-    json_path: Union[str, Path],
-    dataset_root: Optional[Union[str, Path]] = None,
+    json_path: str | Path,
+    dataset_root: str | Path | None = None,
     grayscale: bool = False,
 ) -> Labels:
     """Read COCO-style pose dataset and return a Labels object.
@@ -347,10 +346,10 @@ def read_labels(
 
 
 def read_labels_set(
-    dataset_path: Union[str, Path],
-    json_files: Optional[List[str]] = None,
+    dataset_path: str | Path,
+    json_files: list[str] | None = None,
     grayscale: bool = False,
-) -> Dict[str, Labels]:
+) -> dict[str, Labels]:
     """Read multiple COCO annotation files and return a dictionary of Labels.
 
     This function is designed to handle datasets with multiple splits (train/val/test)
@@ -391,7 +390,7 @@ def read_labels_set(
 
 def encode_keypoints(
     points_array: np.ndarray, visibility_encoding: str = "ternary"
-) -> List[float]:
+) -> list[float]:
     """Encode numpy array of points into COCO keypoint format.
 
     Args:
@@ -431,9 +430,9 @@ def encode_keypoints(
 
 def convert_labels(
     labels: Labels,
-    image_filenames: Optional[Union[str, List[str]]] = None,
+    image_filenames: str | list[str] | None = None,
     visibility_encoding: str = "ternary",
-) -> Dict:
+) -> dict:
     """Convert a Labels object into COCO-formatted annotations.
 
     Args:
@@ -601,8 +600,8 @@ def convert_labels(
 
 def write_labels(
     labels: Labels,
-    json_path: Union[str, Path],
-    image_filenames: Optional[Union[str, List[str]]] = None,
+    json_path: str | Path,
+    image_filenames: str | list[str] | None = None,
     visibility_encoding: str = "ternary",
 ) -> None:
     """Write Labels to COCO-style JSON annotation file.

--- a/sleap_io/io/csv.py
+++ b/sleap_io/io/csv.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Literal, Optional, Union
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -40,8 +40,8 @@ CSVFormat = Literal["sleap", "dlc", "points", "instances", "frames", "auto"]
 def read_labels(
     filename: str | Path,
     format: CSVFormat = "auto",
-    video: Optional[Union[Video, str]] = None,
-    skeleton: Optional[Skeleton] = None,
+    video: Video | str | None = None,
+    skeleton: Skeleton | None = None,
 ) -> Labels:
     """Read pose data from CSV file and return a Labels object.
 
@@ -120,7 +120,7 @@ def write_labels(
     filename: str | Path,
     format: CSVFormat = "sleap",
     *,
-    video: Optional[Union[Video, int]] = None,
+    video: Video | int | None = None,
     include_score: bool = True,
     include_empty: bool = False,
     scorer: str = "sleap-io",
@@ -264,8 +264,8 @@ def is_csv_file(filename: str | Path) -> bool:
 
 def _read_sleap(
     filename: Path,
-    video: Optional[Union[Video, str]] = None,
-    skeleton: Optional[Skeleton] = None,
+    video: Video | str | None = None,
+    skeleton: Skeleton | None = None,
 ) -> Labels:
     """Read SLEAP Analysis CSV format.
 
@@ -301,7 +301,7 @@ def _read_sleap(
 def _write_sleap(
     labels: Labels,
     filename: Path,
-    video: Optional[Union[Video, int]] = None,
+    video: Video | int | None = None,
     include_score: bool = True,
 ) -> None:
     """Write SLEAP Analysis CSV format.
@@ -346,7 +346,7 @@ def _write_sleap(
 
 def _read_dlc(
     filename: Path,
-    video: Optional[Union[Video, str]] = None,
+    video: Video | str | None = None,
 ) -> Labels:
     """Read DeepLabCut CSV format.
 
@@ -360,7 +360,7 @@ def _read_dlc(
 def _write_dlc(
     labels: Labels,
     filename: Path,
-    video: Optional[Union[Video, int]] = None,
+    video: Video | int | None = None,
     include_score: bool = False,
     scorer: str = "sleap-io",
 ) -> None:
@@ -471,8 +471,8 @@ def _write_dlc(
 def _read_codec_format(
     filename: Path,
     format: str,
-    video: Optional[Union[Video, str]] = None,
-    skeleton: Optional[Skeleton] = None,
+    video: Video | str | None = None,
+    skeleton: Skeleton | None = None,
 ) -> Labels:
     """Read CSV in codec format (points, instances, frames)."""
     from sleap_io.codecs import from_dataframe
@@ -498,7 +498,7 @@ def _write_codec_format(
     labels: Labels,
     filename: Path,
     format: str,
-    video: Optional[Union[Video, int]] = None,
+    video: Video | int | None = None,
     include_score: bool = True,
 ) -> None:
     """Write CSV in codec format (points, instances, frames)."""

--- a/sleap_io/io/dlc.py
+++ b/sleap_io/io/dlc.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -16,7 +15,7 @@ from sleap_io.model.skeleton import Node, Skeleton
 from sleap_io.model.video import Video
 
 
-def is_dlc_file(filename: Union[str, Path]) -> bool:
+def is_dlc_file(filename: str | Path) -> bool:
     """Check if file is a DLC CSV file.
 
     Args:
@@ -48,8 +47,8 @@ def is_dlc_file(filename: Union[str, Path]) -> bool:
 
 
 def load_dlc(
-    filename: Union[str, Path],
-    video_search_paths: Optional[list[Union[str, Path]]] = None,
+    filename: str | Path,
+    video_search_paths: list[str | Path] | None = None,
     **kwargs,
 ) -> Labels:
     """Load DeepLabCut annotations from CSV file.

--- a/sleap_io/io/jabs.py
+++ b/sleap_io/io/jabs.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import re
 import warnings
-from typing import List, Optional, Union
 
 import h5py
 import numpy as np
@@ -62,7 +61,7 @@ JABS_DEFAULT_SKELETON = Skeleton(
 
 
 def read_labels(
-    labels_path: str, skeleton: Optional[Skeleton] = JABS_DEFAULT_SKELETON
+    labels_path: str, skeleton: Skeleton | None = JABS_DEFAULT_SKELETON
 ) -> Labels:
     """Read JABS style pose from a file and return a `Labels` object.
 
@@ -78,7 +77,7 @@ def read_labels(
     Returns:
         Parsed labels as a `Labels` instance.
     """
-    frames: List[LabeledFrame] = []
+    frames: list[LabeledFrame] = []
     # Video name is the pose file minus the suffix
     video_name = re.sub(r"(_pose_est_v[2-6])?\.h5", ".avi", labels_path)
     video = Video.from_filename(video_name)
@@ -187,7 +186,7 @@ def make_simple_skeleton(name: str, num_points: int) -> Skeleton:
 
 
 def prediction_to_instance(
-    data: Union[np.ndarray[np.uint16], np.ndarray[np.float32]],
+    data: np.ndarray[np.uint16] | np.ndarray[np.float32],
     confidence: np.ndarray[np.float32],
     skeleton: Skeleton,
     track: Track = None,
@@ -224,7 +223,7 @@ def prediction_to_instance(
         return Instance(points, skeleton=skeleton, track=track)
 
 
-def get_max_ids_in_video(labels: List[Labels], key: str = "Mouse") -> int:
+def get_max_ids_in_video(labels: list[Labels], key: str = "Mouse") -> int:
     """Determine the maximum number of identities that exist at the same time.
 
     Args:

--- a/sleap_io/io/leap.py
+++ b/sleap_io/io/leap.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 import numpy as np
 
@@ -14,7 +13,7 @@ from sleap_io.model.skeleton import Edge, Node, Skeleton
 from sleap_io.model.video import Video
 
 
-def read_labels(labels_path: str, skeleton: Optional[Skeleton] = None) -> Labels:
+def read_labels(labels_path: str, skeleton: Skeleton | None = None) -> Labels:
     """Read LEAP pose data from a .mat file and return a `Labels` object.
 
     Args:

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Callable
 
 import numpy as np
 
@@ -55,7 +55,7 @@ def save_slp(
     restore_original_videos: bool = True,
     embed_inplace: bool = False,
     verbose: bool = True,
-    plugin: Optional[str] = None,
+    plugin: str | None = None,
     progress_callback: Callable[[int, int], bool] | None = None,
 ):
     """Save a SLEAP dataset to a `.slp` file.
@@ -124,7 +124,7 @@ def load_nwb(filename: str) -> Labels:
 
 def save_nwb(
     labels: Labels,
-    filename: Union[str, Path],
+    filename: str | Path,
     nwb_format: str = "auto",
     append: bool = False,
 ) -> None:
@@ -155,7 +155,7 @@ def save_nwb(
 
 
 def load_labelstudio(
-    filename: str, skeleton: Optional[Union[Skeleton, list[str]]] = None
+    filename: str, skeleton: Skeleton | list[str] | None = None
 ) -> Labels:
     """Read Label Studio-style annotations from a file and return a `Labels` object.
 
@@ -200,7 +200,7 @@ def load_alphatracker(filename: str) -> Labels:
     return alphatracker.read_labels(filename)
 
 
-def load_jabs(filename: str, skeleton: Optional[Skeleton] = None) -> Labels:
+def load_jabs(filename: str, skeleton: Skeleton | None = None) -> Labels:
     """Read JABS-style predictions from a file and return a `Labels` object.
 
     Args:
@@ -217,7 +217,7 @@ def load_jabs(filename: str, skeleton: Optional[Skeleton] = None) -> Labels:
 
 def load_analysis_h5(
     filename: str,
-    video: Optional[Union["Video", str]] = None,
+    video: "Video | str | None" = None,
 ) -> Labels:
     """Load SLEAP Analysis HDF5 file.
 
@@ -246,15 +246,15 @@ def save_analysis_h5(
     labels: Labels,
     filename: str,
     *,
-    video: Optional[Union["Video", int]] = None,
-    labels_path: Optional[str] = None,
+    video: "Video | int | None" = None,
+    labels_path: str | None = None,
     all_frames: bool = True,
     min_occupancy: float = 0.0,
-    preset: Optional[str] = None,
-    frame_dim: Optional[int] = None,
-    track_dim: Optional[int] = None,
-    node_dim: Optional[int] = None,
-    xy_dim: Optional[int] = None,
+    preset: str | None = None,
+    frame_dim: int | None = None,
+    track_dim: int | None = None,
+    node_dim: int | None = None,
+    xy_dim: int | None = None,
     save_metadata: bool = True,
 ) -> None:
     """Save Labels to SLEAP Analysis HDF5 file.
@@ -304,7 +304,7 @@ def save_analysis_h5(
     )
 
 
-def save_jabs(labels: Labels, pose_version: int, root_folder: Optional[str] = None):
+def save_jabs(labels: Labels, pose_version: int, root_folder: str | None = None):
     """Save a SLEAP dataset to JABS pose file format.
 
     Args:
@@ -321,7 +321,7 @@ def save_jabs(labels: Labels, pose_version: int, root_folder: Optional[str] = No
 
 
 def load_dlc(
-    filename: str, video_search_paths: Optional[List[Union[str, Path]]] = None, **kwargs
+    filename: str, video_search_paths: list[str | Path] | None = None, **kwargs
 ) -> Labels:
     """Read DeepLabCut annotations from a CSV file and return a `Labels` object.
 
@@ -341,7 +341,7 @@ def load_dlc(
 def load_ultralytics(
     dataset_path: str,
     split: str = "train",
-    skeleton: Optional[Skeleton] = None,
+    skeleton: Skeleton | None = None,
     **kwargs,
 ) -> Labels:
     """Load an Ultralytics YOLO pose dataset as a SLEAP `Labels` object.
@@ -484,7 +484,7 @@ def _detect_coco_format(json_path: str) -> bool:
 
 def load_leap(
     filename: str,
-    skeleton: Optional[Skeleton] = None,
+    skeleton: Skeleton | None = None,
     **kwargs,
 ) -> Labels:
     """Load a LEAP dataset from a .mat file.
@@ -506,8 +506,8 @@ def load_leap(
 def load_csv(
     filename: str,
     format: str = "auto",
-    video: Optional[Union["Video", str]] = None,
-    skeleton: Optional["Skeleton"] = None,
+    video: "Video | str | None" = None,
+    skeleton: "Skeleton | None" = None,
 ) -> "Labels":
     """Load pose data from a CSV file.
 
@@ -538,7 +538,7 @@ def save_csv(
     labels: "Labels",
     filename: str,
     format: str = "sleap",
-    video: Optional[Union["Video", int]] = None,
+    video: "Video | int | None" = None,
     include_score: bool = True,
     scorer: str = "sleap-io",
     save_metadata: bool = False,
@@ -575,7 +575,7 @@ def save_csv(
 
 def load_coco(
     json_path: str,
-    dataset_root: Optional[str] = None,
+    dataset_root: str | None = None,
     grayscale: bool = False,
     **kwargs,
 ) -> Labels:
@@ -600,7 +600,7 @@ def load_coco(
 def save_coco(
     labels: Labels,
     json_path: str,
-    image_filenames: Optional[Union[str, List[str]]] = None,
+    image_filenames: str | list[str] | None = None,
     visibility_encoding: str = "ternary",
 ):
     """Save a SLEAP dataset to COCO-style JSON annotation format.
@@ -744,8 +744,8 @@ def save_video(
 
 
 def load_file(
-    filename: str | Path, format: Optional[str] = None, **kwargs
-) -> Union[Labels, Video]:
+    filename: str | Path, format: str | None = None, **kwargs
+) -> Labels | Video:
     """Load a file and return the appropriate object.
 
     Args:
@@ -854,7 +854,7 @@ def load_file(
 def save_file(
     labels: Labels,
     filename: str | Path,
-    format: Optional[str] = None,
+    format: str | None = None,
     verbose: bool = True,
     progress_callback: Callable[[int, int], bool] | None = None,
     **kwargs,
@@ -975,7 +975,7 @@ def save_file(
         raise ValueError(f"Unknown format '{format}' for filename: '{filename}'.")
 
 
-def load_skeleton(filename: str | Path) -> Union[Skeleton, List[Skeleton]]:
+def load_skeleton(filename: str | Path) -> Skeleton | list[Skeleton]:
     """Load skeleton(s) from a JSON, YAML, or SLP file.
 
     Args:
@@ -1017,11 +1017,11 @@ def load_skeleton(filename: str | Path) -> Union[Skeleton, List[Skeleton]]:
 
 
 def load_labels_set(
-    path: Union[str, Path, list[Union[str, Path]], dict[str, Union[str, Path]]],
-    format: Optional[str] = None,
+    path: str | Path | list[str | Path] | dict[str, str | Path],
+    format: str | None = None,
     open_videos: bool = True,
     **kwargs,
-) -> LabelsSet:
+) -> "LabelsSet":
     """Load a LabelsSet from multiple files.
 
     Args:
@@ -1105,7 +1105,7 @@ def load_labels_set(
         )
 
 
-def save_skeleton(skeleton: Union[Skeleton, List[Skeleton]], filename: str | Path):
+def save_skeleton(skeleton: Skeleton | list[Skeleton], filename: str | Path):
     """Save skeleton(s) to a JSON or YAML file.
 
     Args:

--- a/sleap_io/io/skeleton.py
+++ b/sleap_io/io/skeleton.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import simplejson as json
 
 from sleap_io.model.skeleton import Edge, Node, Skeleton, Symmetry
 
 
-def decode_skeleton(data: Union[str, Dict]) -> Union[Skeleton, List[Skeleton]]:
+def decode_skeleton(data: str | dict) -> Skeleton | list[Skeleton]:
     """Decode skeleton(s) from JSON data using the default decoder.
 
     Args:
@@ -22,7 +22,7 @@ def decode_skeleton(data: Union[str, Dict]) -> Union[Skeleton, List[Skeleton]]:
     return decoder.decode(data)
 
 
-def encode_skeleton(skeletons: Union[Skeleton, List[Skeleton]]) -> str:
+def encode_skeleton(skeletons: Skeleton | list[Skeleton]) -> str:
     """Encode skeleton(s) to JSON string using the default encoder.
 
     Args:
@@ -35,7 +35,7 @@ def encode_skeleton(skeletons: Union[Skeleton, List[Skeleton]]) -> str:
     return encoder.encode(skeletons)
 
 
-def decode_yaml_skeleton(yaml_data: str) -> Union[Skeleton, List[Skeleton]]:
+def decode_yaml_skeleton(yaml_data: str) -> Skeleton | list[Skeleton]:
     """Decode skeleton(s) from YAML data.
 
     Args:
@@ -48,7 +48,7 @@ def decode_yaml_skeleton(yaml_data: str) -> Union[Skeleton, List[Skeleton]]:
     return decoder.decode(yaml_data)
 
 
-def encode_yaml_skeleton(skeletons: Union[Skeleton, List[Skeleton]]) -> str:
+def encode_yaml_skeleton(skeletons: Skeleton | list[Skeleton]) -> str:
     """Encode skeleton(s) to YAML string.
 
     Args:
@@ -61,7 +61,7 @@ def encode_yaml_skeleton(skeletons: Union[Skeleton, List[Skeleton]]) -> str:
     return encoder.encode(skeletons)
 
 
-def decode_training_config(data: dict) -> Union[Skeleton, List[Skeleton]]:
+def decode_training_config(data: dict) -> Skeleton | list[Skeleton]:
     """Decode skeleton(s) from training config data.
 
     Args:
@@ -86,7 +86,7 @@ def decode_training_config(data: dict) -> Union[Skeleton, List[Skeleton]]:
     )
 
 
-def load_skeleton_from_json(json_data: str) -> Union[Skeleton, List[Skeleton]]:
+def load_skeleton_from_json(json_data: str) -> Skeleton | list[Skeleton]:
     """Load skeleton(s) from JSON data, with automatic training config detection.
 
     Args:
@@ -120,11 +120,11 @@ class SkeletonDecoder:
 
     def __init__(self):
         """Initialize the decoder."""
-        self.decoded_objects: List[
+        self.decoded_objects: list[
             Any
         ] = []  # List of decoded objects indexed by py/id - 1
 
-    def decode(self, data: Union[str, Dict]) -> Union[Skeleton, List[Skeleton]]:
+    def decode(self, data: str | dict) -> Skeleton | list[Skeleton]:
         """Decode skeleton(s) from JSON data.
 
         Args:
@@ -145,7 +145,7 @@ class SkeletonDecoder:
         else:
             return self._decode_skeleton(data)
 
-    def _decode_skeleton(self, data: Dict) -> Skeleton:
+    def _decode_skeleton(self, data: dict) -> Skeleton:
         """Decode a single skeleton from dictionary data.
 
         Args:
@@ -266,7 +266,7 @@ class SkeletonDecoder:
 
         return Skeleton(nodes=nodes, edges=edges, symmetries=symmetries, name=name)
 
-    def _resolve_link_ref(self, node_ref: Union[Dict, int]) -> Node:
+    def _resolve_link_ref(self, node_ref: dict | int) -> Node:
         """Resolve a node reference.
 
         Args:
@@ -298,7 +298,7 @@ class SkeletonDecoder:
 
         raise ValueError(f"Unknown node reference format: {node_ref}")
 
-    def _resolve_edge_type_ref(self, type_data: Dict) -> int:
+    def _resolve_edge_type_ref(self, type_data: dict) -> int:
         """Resolve edge type reference.
 
         Args:
@@ -331,7 +331,7 @@ class SkeletonDecoder:
             # Default to regular edge
             return 1
 
-    def _decode_node(self, data: Dict) -> Node:
+    def _decode_node(self, data: dict) -> Node:
         """Decode a node from jsonpickle format.
 
         Args:
@@ -366,10 +366,10 @@ class SkeletonEncoder:
 
     def __init__(self):
         """Initialize the encoder."""
-        self._object_to_id: Dict[int, int] = {}  # id(object) -> py/id
+        self._object_to_id: dict[int, int] = {}  # id(object) -> py/id
         self._next_id = 1
 
-    def encode(self, skeletons: Union[Skeleton, List[Skeleton]]) -> str:
+    def encode(self, skeletons: Skeleton | list[Skeleton]) -> str:
         """Encode skeleton(s) to JSON string.
 
         Args:
@@ -393,7 +393,7 @@ class SkeletonEncoder:
 
         return json.dumps(data, separators=(", ", ": "))
 
-    def _encode_skeleton(self, skeleton: Skeleton) -> Dict:
+    def _encode_skeleton(self, skeleton: Skeleton) -> dict:
         """Encode a single skeleton to dictionary format.
 
         Args:
@@ -452,7 +452,7 @@ class SkeletonEncoder:
             "nodes": nodes,
         }
 
-    def _encode_edge(self, edge: Edge, edge_idx: int, edge_type: int) -> Dict:
+    def _encode_edge(self, edge: Edge, edge_idx: int, edge_type: int) -> dict:
         """Encode an edge to jsonpickle format.
 
         Args:
@@ -496,7 +496,7 @@ class SkeletonEncoder:
             "type": type_dict,
         }
 
-    def _encode_symmetry(self, symmetry: Symmetry, edge_type: int) -> Dict:
+    def _encode_symmetry(self, symmetry: Symmetry, edge_type: int) -> dict:
         """Encode a symmetry to jsonpickle format.
 
         Args:
@@ -526,7 +526,7 @@ class SkeletonEncoder:
             "type": type_dict,
         }
 
-    def _encode_node(self, node: Node) -> Dict:
+    def _encode_node(self, node: Node) -> dict:
         """Encode a node to jsonpickle format.
 
         Args:
@@ -776,7 +776,7 @@ class SkeletonYAMLDecoder:
     than the jsonpickle format.
     """
 
-    def decode(self, data: Union[str, Dict]) -> Union[Skeleton, List[Skeleton]]:
+    def decode(self, data: str | dict) -> Skeleton | list[Skeleton]:
         """Decode skeleton(s) from YAML data.
 
         Args:
@@ -808,7 +808,7 @@ class SkeletonYAMLDecoder:
 
         raise ValueError(f"Unexpected data format: {type(data)}")
 
-    def decode_dict(self, skeleton_data: Dict, name: str = "Skeleton") -> Skeleton:
+    def decode_dict(self, skeleton_data: dict, name: str = "Skeleton") -> Skeleton:
         """Decode a single skeleton from a dictionary.
 
         This is useful when the skeleton data is embedded in a larger YAML structure.
@@ -822,7 +822,7 @@ class SkeletonYAMLDecoder:
         """
         return self._decode_skeleton(skeleton_data, name)
 
-    def _decode_skeleton(self, data: Dict, name: Optional[str] = None) -> Skeleton:
+    def _decode_skeleton(self, data: dict, name: str | None = None) -> Skeleton:
         """Decode a single skeleton from dictionary data.
 
         Args:
@@ -871,7 +871,7 @@ class SkeletonYAMLEncoder:
     edit manually than the jsonpickle format.
     """
 
-    def encode(self, skeletons: Union[Skeleton, List[Skeleton]]) -> str:
+    def encode(self, skeletons: Skeleton | list[Skeleton]) -> str:
         """Encode skeleton(s) to YAML string.
 
         Args:
@@ -892,7 +892,7 @@ class SkeletonYAMLEncoder:
 
         return yaml.dump(data, default_flow_style=False, sort_keys=False)
 
-    def encode_dict(self, skeleton: Skeleton) -> Dict:
+    def encode_dict(self, skeleton: Skeleton) -> dict:
         """Encode a single skeleton to a dictionary.
 
         This is useful when embedding skeleton data in a larger YAML structure.

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import sys
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional, Union
+from typing import TYPE_CHECKING, Callable
 
 import h5py
 import imageio.v3 as iio
@@ -84,7 +84,7 @@ def make_video(
     labels_path: str,
     video_json: dict,
     open_backend: bool = True,
-    _hdf5_file: Optional[h5py.File] = None,
+    _hdf5_file: h5py.File | None = None,
 ) -> Video:
     """Create a `Video` object from a JSON dictionary.
 
@@ -271,7 +271,7 @@ def read_videos(labels_path: str, open_backend: bool = True) -> list[Video]:
     return videos
 
 
-def video_to_dict(video: Video, labels_path: Optional[str] = None) -> dict:
+def video_to_dict(video: Video, labels_path: str | None = None) -> dict:
     """Convert a `Video` object to a JSON-compatible dictionary.
 
     Args:
@@ -416,7 +416,7 @@ def process_and_embed_frames(
     image_format: str = "png",
     fixed_length: bool = True,
     verbose: bool = True,
-    plugin: Optional[str] = None,
+    plugin: str | None = None,
     progress_callback: Callable[[int, int], bool] | None = None,
 ) -> dict[Video, Video]:
     """Process and embed frames into a SLEAP labels file.
@@ -678,7 +678,7 @@ def embed_frames(
     embed: list[tuple[Video, int]],
     image_format: str = "png",
     verbose: bool = True,
-    plugin: Optional[str] = None,
+    plugin: str | None = None,
     embed_all_videos: bool = True,
     progress_callback: Callable[[int, int], bool] | None = None,
 ):
@@ -735,7 +735,7 @@ def embed_videos(
     labels: Labels,
     embed: bool | str | list[tuple[Video, int]],
     verbose: bool = True,
-    plugin: Optional[str] = None,
+    plugin: str | None = None,
     embed_all_videos: bool = True,
     progress_callback: Callable[[int, int], bool] | None = None,
 ):
@@ -804,7 +804,7 @@ def write_videos(
     labels_path: str,
     videos: list[Video],
     restore_source: bool = False,
-    reference_mode: Optional[VideoReferenceMode] = None,
+    reference_mode: VideoReferenceMode | None = None,
     original_videos: list[Video] | None = None,
     verbose: bool = True,
 ):
@@ -1166,7 +1166,7 @@ def _points_from_hdf5_data(
     pts_data: np.ndarray,
     skeleton: Skeleton,
     is_predicted: bool = False,
-) -> Union["PointsArray", "PredictedPointsArray"]:
+) -> "PointsArray | PredictedPointsArray":
     """Build PointsArray directly from HDF5 structured array data.
 
     This is a fast path that avoids column_stack and intermediate array creation
@@ -1208,7 +1208,7 @@ def read_instances(
     points: np.ndarray,
     pred_points: np.ndarray,
     format_id: float,
-) -> list[Union[Instance, PredictedInstance]]:
+) -> list[Instance | PredictedInstance]:
     """Read `Instance` dataset in a SLEAP labels file.
 
     Args:
@@ -2206,9 +2206,9 @@ def read_labels(labels_path: str, open_videos: bool = True) -> Labels:
 
 
 def read_labels_set(
-    path: Union[str, Path, list[Union[str, Path]], dict[str, Union[str, Path]]],
+    path: str | Path | list[str | Path] | dict[str, str | Path],
     open_videos: bool = True,
-) -> LabelsSet:
+) -> "LabelsSet":
     """Load a LabelsSet from multiple SLP files.
 
     Args:
@@ -2358,7 +2358,7 @@ def write_labels(
     restore_original_videos: bool = True,
     embed_inplace: bool = False,
     verbose: bool = True,
-    plugin: Optional[str] = None,
+    plugin: str | None = None,
     embed_all_videos: bool = True,
     progress_callback: Callable[[int, int], bool] | None = None,
 ):

--- a/sleap_io/io/slp_lazy.py
+++ b/sleap_io/io/slp_lazy.py
@@ -9,7 +9,7 @@ These classes are implementation details - users interact with Labels objects.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterator, Optional, Union
+from typing import TYPE_CHECKING, Iterator
 
 import attrs
 import numpy as np
@@ -58,7 +58,7 @@ class LazyDataStore:
 
     # Metadata
     format_id: float
-    _source_path: Optional[str] = attrs.field(default=None, alias="source_path")
+    _source_path: str | None = attrs.field(default=None, alias="source_path")
 
     def __attrs_post_init__(self) -> None:
         """Validate index bounds on construction."""
@@ -165,7 +165,7 @@ class LazyDataStore:
             instances=instances,
         )
 
-    def _materialize_instance(self, idx: int) -> Union["Instance", "PredictedInstance"]:
+    def _materialize_instance(self, idx: int) -> "Instance | PredictedInstance":
         """Create a single Instance from raw data.
 
         Args:
@@ -324,7 +324,7 @@ class LazyDataStore:
 
     def to_numpy(
         self,
-        video: Optional["Video"] = None,
+        video: "Video | None" = None,
         untracked: bool = False,
         return_confidence: bool = False,
         user_instances: bool = True,
@@ -674,9 +674,7 @@ class LazyFrameList:
         """Return number of frames."""
         return len(self._store)
 
-    def __getitem__(
-        self, idx: Union[int, slice]
-    ) -> Union["LabeledFrame", list["LabeledFrame"]]:
+    def __getitem__(self, idx: int | slice) -> "LabeledFrame | list[LabeledFrame]":
         """Get frame(s) by index or slice.
 
         Args:

--- a/sleap_io/io/ultralytics.py
+++ b/sleap_io/io/ultralytics.py
@@ -15,7 +15,7 @@ import multiprocessing
 import warnings
 from multiprocessing import Pool
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 import imageio.v3 as iio
 import numpy as np
@@ -35,8 +35,8 @@ if TYPE_CHECKING:
 def read_labels(
     dataset_path: str,
     split: str = "train",
-    skeleton: Optional[Skeleton] = None,
-    image_size: Tuple[int, int] = (480, 640),
+    skeleton: Skeleton | None = None,
+    image_size: tuple[int, int] = (480, 640),
 ) -> Labels:
     """Read Ultralytics YOLO pose dataset and return a `Labels` object.
 
@@ -128,9 +128,9 @@ def read_labels(
 
 def read_labels_set(
     dataset_path: str,
-    splits: Optional[List[str]] = None,
-    skeleton: Optional[Skeleton] = None,
-    image_size: Tuple[int, int] = (480, 640),
+    splits: list[str] | None = None,
+    skeleton: Skeleton | None = None,
+    image_size: tuple[int, int] = (480, 640),
 ) -> LabelsSet:
     """Read multiple splits from an Ultralytics dataset as a LabelsSet.
 
@@ -223,7 +223,7 @@ def read_labels_set(
     return LabelsSet(labels=labels_dict)
 
 
-def _save_frame_image(args: Tuple[dict, str, Optional[int]]) -> Optional[str]:
+def _save_frame_image(args: tuple[dict, str, int | None]) -> str | None:
     """Worker function to save a single frame image.
 
     Args:
@@ -273,13 +273,13 @@ def _save_frame_image(args: Tuple[dict, str, Optional[int]]) -> Optional[str]:
 def write_labels(
     labels: Labels,
     dataset_path: str,
-    split_ratios: Dict[str, float] = {"train": 0.8, "val": 0.2},
+    split_ratios: dict[str, float] = {"train": 0.8, "val": 0.2},
     class_id: int = 0,
     image_format: str = "png",
-    image_quality: Optional[int] = None,
+    image_quality: int | None = None,
     verbose: bool = True,
     use_multiprocessing: bool = False,
-    n_workers: Optional[int] = None,
+    n_workers: int | None = None,
     **kwargs,
 ) -> None:
     """Write Labels to Ultralytics YOLO pose format.
@@ -442,14 +442,14 @@ def write_labels(
                     continue
 
 
-def parse_data_yaml(yaml_path: Path) -> Dict:
+def parse_data_yaml(yaml_path: Path) -> dict:
     """Parse Ultralytics data.yaml configuration file."""
     with open(yaml_path, "r") as f:
         config = yaml.safe_load(f)
     return config
 
 
-def create_skeleton_from_config(config: Dict) -> Skeleton:
+def create_skeleton_from_config(config: dict) -> Skeleton:
     """Create a Skeleton object from Ultralytics configuration."""
     kpt_shape = config.get("kpt_shape", [1, 3])
     num_keypoints = kpt_shape[0]
@@ -471,8 +471,8 @@ def create_skeleton_from_config(config: Dict) -> Skeleton:
 
 
 def parse_label_file(
-    label_path: Path, skeleton: Skeleton, image_shape: Tuple[int, int]
-) -> List[Instance]:
+    label_path: Path, skeleton: Skeleton, image_shape: tuple[int, int]
+) -> list[Instance]:
     """Parse a single Ultralytics label file and return instances."""
     instances = []
 
@@ -549,7 +549,7 @@ def write_label_file(
     label_path: Path,
     frame: LabeledFrame,
     skeleton: Skeleton,
-    image_shape: Tuple[int, int],
+    image_shape: tuple[int, int],
     class_id: int = 0,
 ) -> None:
     """Write a single Ultralytics label file for a frame."""
@@ -618,7 +618,7 @@ def write_label_file(
 
 
 def create_data_yaml(
-    yaml_path: Path, skeleton: Skeleton, split_ratios: Dict[str, float]
+    yaml_path: Path, skeleton: Skeleton, split_ratios: dict[str, float]
 ) -> None:
     """Create Ultralytics data.yaml configuration file."""
     # Build skeleton connections
@@ -649,8 +649,8 @@ def create_data_yaml(
 
 
 def create_splits_from_labels(
-    labels: Labels, split_ratios: Dict[str, float]
-) -> Dict[str, Labels]:
+    labels: Labels, split_ratios: dict[str, float]
+) -> dict[str, Labels]:
     """Create dataset splits from Labels using the built-in splitting functionality."""
     split_names = list(split_ratios.keys())
 
@@ -684,8 +684,8 @@ def create_splits_from_labels(
 
 
 def normalize_coordinates(
-    instance: Instance, image_shape: Tuple[int, int]
-) -> List[Tuple[float, float, int]]:
+    instance: Instance, image_shape: tuple[int, int]
+) -> list[tuple[float, float, int]]:
     """Normalize instance point coordinates to [0,1] range."""
     height, width = image_shape
     normalized = []
@@ -707,7 +707,7 @@ def normalize_coordinates(
 
 
 def denormalize_coordinates(
-    normalized_points: List[Tuple[float, float, int]], image_shape: Tuple[int, int]
+    normalized_points: list[tuple[float, float, int]], image_shape: tuple[int, int]
 ) -> np.ndarray:
     """Denormalize coordinates from [0,1] range to pixel coordinates.
 

--- a/sleap_io/io/utils.py
+++ b/sleap_io/io/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 import h5py  # type: ignore[import]
 import numpy as np
@@ -24,9 +24,7 @@ def read_hdf5_dataset(filename: str, dataset: str) -> np.ndarray:
     return data
 
 
-def _overwrite_hdf5_dataset(
-    f: Union[h5py.File, h5py.Group], dataset: str, data: np.ndarray
-):
+def _overwrite_hdf5_dataset(f: h5py.File | h5py.Group, dataset: str, data: np.ndarray):
     """Overwrite dataset in HDF5 file.
 
     Args:
@@ -87,7 +85,7 @@ def write_hdf5_group(filename: str, data: dict[str, np.ndarray]):
     """
 
     def overwrite_hdf5_group(
-        file_or_group: Union[h5py.File, h5py.Group], group_name: str
+        file_or_group: h5py.File | h5py.Group, group_name: str
     ) -> h5py.Group:
         """Overwrite group in HDF5 file.
 
@@ -122,8 +120,8 @@ def write_hdf5_group(filename: str, data: dict[str, np.ndarray]):
 
 
 def read_hdf5_attrs(
-    filename: str, dataset: str = "/", attribute: Optional[str] = None
-) -> Union[Any, dict[str, Any]]:
+    filename: str, dataset: str = "/", attribute: str | None = None
+) -> Any | dict[str, Any]:
     """Read attributes from an HDF5 dataset.
 
     Args:
@@ -155,7 +153,7 @@ def write_hdf5_attrs(filename: str, dataset: str, attributes: dict[str, Any]):
     """
 
     def _overwrite_hdf5_attr(
-        group_or_dataset: Union[h5py.Group, h5py.Dataset], attr_name: str, data: Any
+        group_or_dataset: h5py.Group | h5py.Dataset, attr_name: str, data: Any
     ):
         """Overwrite attribute for group or dataset in HDF5 file.
 

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import sys
 from io import BytesIO
 from pathlib import Path
-from typing import Optional, Tuple
 
 import attrs
 import h5py
@@ -43,7 +42,7 @@ _AVAILABLE_IMAGE_BACKENDS = {
 
 
 # Global default video plugin
-_default_video_plugin: Optional[str] = None
+_default_video_plugin: str | None = None
 
 
 def normalize_plugin_name(plugin: str) -> str:
@@ -81,7 +80,7 @@ def normalize_plugin_name(plugin: str) -> str:
     return aliases[plugin_lower]
 
 
-def set_default_video_plugin(plugin: Optional[str]) -> None:
+def set_default_video_plugin(plugin: str | None) -> None:
     """Set the default video plugin for all subsequently loaded videos.
 
     Args:
@@ -102,7 +101,7 @@ def set_default_video_plugin(plugin: Optional[str]) -> None:
     _default_video_plugin = plugin
 
 
-def get_default_video_plugin() -> Optional[str]:
+def get_default_video_plugin() -> str | None:
     """Get the current default video plugin.
 
     Returns:
@@ -120,7 +119,7 @@ def get_default_video_plugin() -> Optional[str]:
 
 
 # Global default image plugin for encoding/decoding embedded images
-_default_image_plugin: Optional[str] = None
+_default_image_plugin: str | None = None
 
 
 def normalize_image_plugin_name(plugin: str) -> str:
@@ -155,7 +154,7 @@ def normalize_image_plugin_name(plugin: str) -> str:
     return aliases[plugin_lower]
 
 
-def set_default_image_plugin(plugin: Optional[str]) -> None:
+def set_default_image_plugin(plugin: str | None) -> None:
     """Set the default image plugin for encoding/decoding embedded images.
 
     Args:
@@ -176,7 +175,7 @@ def set_default_image_plugin(plugin: Optional[str]) -> None:
     _default_image_plugin = plugin
 
 
-def get_default_image_plugin() -> Optional[str]:
+def get_default_image_plugin() -> str | None:
     """Get the current default image plugin.
 
     Returns:
@@ -228,7 +227,7 @@ def get_available_image_backends() -> list[str]:
 
 
 def get_installation_instructions(
-    plugin: Optional[str] = None, backend_type: str = "video"
+    plugin: str | None = None, backend_type: str = "video"
 ) -> str:
     """Get installation instructions for backend plugins.
 
@@ -312,14 +311,14 @@ class VideoBackend:
     """
 
     filename: str | Path | list[str] | list[Path]
-    grayscale: Optional[bool] = None
+    grayscale: bool | None = None
     keep_open: bool = True
-    _cached_shape: Optional[Tuple[int, int, int, int]] = None
-    _open_reader: Optional[object] = None
-    _fps: Optional[float] = None
+    _cached_shape: tuple[int, int, int, int] | None = None
+    _open_reader: object | None = None
+    _fps: float | None = None
 
     @property
-    def fps(self) -> Optional[float]:
+    def fps(self) -> float | None:
         """Frames per second of the video.
 
         Returns:
@@ -333,7 +332,7 @@ class VideoBackend:
         return self._fps
 
     @fps.setter
-    def fps(self, value: Optional[float]) -> None:
+    def fps(self, value: float | None) -> None:
         """Set the FPS.
 
         Args:
@@ -350,11 +349,11 @@ class VideoBackend:
     def from_filename(
         cls,
         filename: str | list[str],
-        dataset: Optional[str] = None,
-        grayscale: Optional[bool] = None,
+        dataset: str | None = None,
+        grayscale: bool | None = None,
         keep_open: bool = True,
         **kwargs,
-    ) -> VideoBackend:
+    ) -> "VideoBackend":
         """Create a VideoBackend from a filename.
 
         Args:
@@ -483,7 +482,7 @@ class VideoBackend:
         raise NotImplementedError
 
     @property
-    def img_shape(self) -> Tuple[int, int, int]:
+    def img_shape(self) -> tuple[int, int, int]:
         """Shape of a single frame in the video."""
         height, width, channels = self.read_test_frame().shape
         if self.grayscale is None:
@@ -495,7 +494,7 @@ class VideoBackend:
         return int(height), int(width), int(channels)
 
     @property
-    def shape(self) -> Tuple[int, int, int, int]:
+    def shape(self) -> tuple[int, int, int, int]:
         """Shape of the video as a tuple of `(frames, height, width, channels)`.
 
         On first call, this will defer to `num_frames` and `img_shape` to determine the
@@ -741,7 +740,7 @@ class MediaVideo(VideoBackend):
             return n_frames
 
     @property
-    def fps(self) -> Optional[float]:
+    def fps(self) -> float | None:
         """Frames per second from video container metadata.
 
         Returns:
@@ -775,7 +774,7 @@ class MediaVideo(VideoBackend):
             return None
 
     @fps.setter
-    def fps(self, value: Optional[float]) -> None:
+    def fps(self, value: float | None) -> None:
         """Set an explicit FPS override.
 
         Args:
@@ -936,17 +935,17 @@ class HDF5Video(VideoBackend):
             since PyAV doesn't support image decoding.
     """
 
-    dataset: Optional[str] = None
+    dataset: str | None = None
     input_format: str = attrs.field(
         default="channels_last",
         validator=attrs.validators.in_(["channels_last", "channels_first"]),
     )
     frame_map: dict[int, int] = attrs.field(init=False, default=attrs.Factory(dict))
-    source_filename: Optional[str] = None
-    source_inds: Optional[np.ndarray] = None
+    source_filename: str | None = None
+    source_inds: np.ndarray | None = None
     image_format: str = "hdf5"
     channel_order: str = "RGB"
-    plugin: Optional[str] = None
+    plugin: str | None = None
 
     EXTS = ("h5", "hdf5", "slp")
 
@@ -1042,7 +1041,7 @@ class HDF5Video(VideoBackend):
             return f[self.dataset].shape[0]
 
     @property
-    def img_shape(self) -> Tuple[int, int, int]:
+    def img_shape(self) -> tuple[int, int, int]:
         """Shape of a single frame in the video as `(height, width, channels)`."""
         with h5py.File(self.filename, "r") as f:
             ds = f[self.dataset]
@@ -1332,7 +1331,7 @@ class TiffVideo(VideoBackend):
     """
 
     EXTS = ("tif", "tiff")
-    format: Optional[str] = None
+    format: str | None = None
 
     @staticmethod
     def is_multipage(filename: str) -> bool:

--- a/sleap_io/io/video_writing.py
+++ b/sleap_io/io/video_writing.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import TracebackType
-from typing import List, Optional, Type
 
 import attrs
 import imageio
@@ -49,7 +48,7 @@ class VideoWriter:
     crf: int = 25
     preset: str = "superfast"
     output_params: list[str] = attrs.field(factory=list)
-    _writer: "imageio.plugins.ffmpeg.FfmpegFormat.Writer" | None = None
+    _writer: "imageio.plugins.ffmpeg.FfmpegFormat.Writer | None" = None
 
     def build_output_params(self) -> list[str]:
         """Build the output parameters for FFMPEG."""
@@ -103,10 +102,10 @@ class VideoWriter:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
-    ) -> Optional[bool]:
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
         """Context manager exit."""
         self.close()
         return False
@@ -151,7 +150,7 @@ class MJPEGFrameWriter:
     quality: int = 2
 
     output_params: list[str] = attrs.field(factory=list)
-    _writer: "imageio.plugins.ffmpeg.FfmpegFormat.Writer" | None = None
+    _writer: "imageio.plugins.ffmpeg.FfmpegFormat.Writer | None" = None
     _frame_index: int = 0
 
     def build_output_params(self) -> list[str]:
@@ -207,7 +206,7 @@ class MJPEGFrameWriter:
         self._writer.append_data(frame)
         self._frame_index += 1
 
-    def write_frames(self, frames: List[np.ndarray]):
+    def write_frames(self, frames: list[np.ndarray]):
         """Write multiple frames to the MJPEG video.
 
         Args:
@@ -222,10 +221,10 @@ class MJPEGFrameWriter:
 
     def __exit__(
         self,
-        exc_type: Optional[Type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
-    ) -> Optional[bool]:
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
         """Context manager exit."""
         self.close()
         return False

--- a/sleap_io/model/camera.py
+++ b/sleap_io/model/camera.py
@@ -116,7 +116,7 @@ class CameraGroup:
         metadata: Dictionary of metadata.
     """
 
-    cameras: list[Camera] = field(factory=list, validator=instance_of(list))
+    cameras: "list[Camera]" = field(factory=list, validator=instance_of(list))
     metadata: dict = field(factory=dict, validator=instance_of(dict))
 
     def __repr__(self):
@@ -140,19 +140,19 @@ class RecordingSession:
     camera_group: CameraGroup = field(
         factory=CameraGroup, validator=instance_of(CameraGroup)
     )
-    _video_by_camera: dict[Camera, Video] = field(
+    _video_by_camera: "dict[Camera, Video]" = field(
         factory=dict, validator=instance_of(dict)
     )
-    _camera_by_video: dict[Video, Camera] = field(
+    _camera_by_video: "dict[Video, Camera]" = field(
         factory=dict, validator=instance_of(dict)
     )
-    _frame_group_by_frame_idx: dict[int, FrameGroup] = field(
+    _frame_group_by_frame_idx: "dict[int, FrameGroup]" = field(
         factory=dict, validator=instance_of(dict)
     )
     metadata: dict = field(factory=dict, validator=instance_of(dict))
 
     @property
-    def frame_groups(self) -> dict[int, FrameGroup]:
+    def frame_groups(self) -> "dict[int, FrameGroup]":
         """Get dictionary of `FrameGroup` objects by frame index.
 
         Returns:
@@ -170,7 +170,7 @@ class RecordingSession:
         return list(self._video_by_camera.values())
 
     @property
-    def cameras(self) -> list[Camera]:
+    def cameras(self) -> "list[Camera]":
         """Get list of `Camera` objects linked to `Video`s in the `RecordingSession`.
 
         Returns:
@@ -178,7 +178,7 @@ class RecordingSession:
         """
         return list(self._video_by_camera.keys())
 
-    def get_camera(self, video: Video) -> Camera | None:
+    def get_camera(self, video: Video) -> "Camera | None":
         """Get `Camera` associated with `video`.
 
         Args:
@@ -189,7 +189,7 @@ class RecordingSession:
         """
         return self._camera_by_video.get(video, None)
 
-    def get_video(self, camera: Camera) -> Video | None:
+    def get_video(self, camera: "Camera") -> Video | None:
         """Get `Video` associated with `camera`.
 
         Args:
@@ -200,7 +200,7 @@ class RecordingSession:
         """
         return self._video_by_camera.get(camera, None)
 
-    def add_video(self, video: Video, camera: Camera):
+    def add_video(self, video: Video, camera: "Camera"):
         """Add `video` to `RecordingSession` and mapping to `camera`.
 
         Args:
@@ -477,7 +477,7 @@ class InstanceGroup:
         return list(self._instance_by_camera.values())
 
     @property
-    def cameras(self) -> list[Camera]:
+    def cameras(self) -> "list[Camera]":
         """List of `Camera` objects."""
         return list(self._instance_by_camera.keys())
 
@@ -535,7 +535,7 @@ class FrameGroup:
         return self._instance_groups
 
     @property
-    def cameras(self) -> list[Camera]:
+    def cameras(self) -> "list[Camera]":
         """List of `Camera` objects."""
         return list(self._labeled_frame_by_camera.keys())
 

--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -9,8 +9,6 @@ estimated, such as confidence scores.
 
 from __future__ import annotations
 
-from typing import Optional, Union
-
 import attrs
 import numpy as np
 
@@ -414,17 +412,17 @@ class Instance:
 
     points: PointsArray = attrs.field(eq=attrs.cmp_using(eq=np.array_equal))
     skeleton: Skeleton
-    track: Optional[Track] = None
-    tracking_score: Optional[float] = None
-    from_predicted: Optional[PredictedInstance] = None
+    track: Track | None = None
+    tracking_score: float | None = None
+    from_predicted: "PredictedInstance | None" = None
 
     @classmethod
     def empty(
         cls,
         skeleton: Skeleton,
-        track: Optional[Track] = None,
-        tracking_score: Optional[float] = None,
-        from_predicted: Optional[PredictedInstance] = None,
+        track: Track | None = None,
+        tracking_score: float | None = None,
+        from_predicted: "PredictedInstance | None" = None,
     ) -> "Instance":
         """Create an empty instance with no points.
 
@@ -475,9 +473,9 @@ class Instance:
         cls,
         points_data: np.ndarray,
         skeleton: Skeleton,
-        track: Optional[Track] = None,
-        tracking_score: Optional[float] = None,
-        from_predicted: Optional[PredictedInstance] = None,
+        track: Track | None = None,
+        tracking_score: float | None = None,
+        from_predicted: "PredictedInstance | None" = None,
     ) -> "Instance":
         """Create an instance object from a numpy array.
 
@@ -553,14 +551,14 @@ class Instance:
         else:
             return self.points["xy"].copy()
 
-    def __getitem__(self, node: Union[int, str, Node]) -> np.ndarray:
+    def __getitem__(self, node: int | str | Node) -> np.ndarray:
         """Return the point associated with a node."""
         if type(node) is not int:
             node = self.skeleton.index(node)
 
         return self.points[node]
 
-    def __setitem__(self, node: Union[int, str, Node], value):
+    def __setitem__(self, node: int | str | Node, value):
         """Set the point associated with a node.
 
         Args:
@@ -797,7 +795,7 @@ class Instance:
 
         return iou >= iou_threshold
 
-    def bounding_box(self) -> Optional[np.ndarray]:
+    def bounding_box(self) -> np.ndarray | None:
         """Get the bounding box of visible points.
 
         Returns:
@@ -837,9 +835,9 @@ class PredictedInstance(Instance):
     points: PredictedPointsArray = attrs.field(eq=attrs.cmp_using(eq=np.array_equal))
     skeleton: Skeleton
     score: float = 0.0
-    track: Optional[Track] = None
-    tracking_score: Optional[float] = 0
-    from_predicted: Optional[PredictedInstance] = None
+    track: Track | None = None
+    tracking_score: float | None = 0
+    from_predicted: "PredictedInstance | None" = None
 
     def __repr__(self) -> str:
         """Return a readable representation of the instance."""
@@ -862,9 +860,9 @@ class PredictedInstance(Instance):
         cls,
         skeleton: Skeleton,
         score: float = 0.0,
-        track: Optional[Track] = None,
-        tracking_score: Optional[float] = None,
-        from_predicted: Optional[PredictedInstance] = None,
+        track: Track | None = None,
+        tracking_score: float | None = None,
+        from_predicted: "PredictedInstance | None" = None,
     ) -> "PredictedInstance":
         """Create an empty instance with no points."""
         points = PredictedPointsArray.empty(len(skeleton))
@@ -901,11 +899,11 @@ class PredictedInstance(Instance):
         cls,
         points_data: np.ndarray,
         skeleton: Skeleton,
-        point_scores: Optional[np.ndarray] = None,
+        point_scores: np.ndarray | None = None,
         score: float = 0.0,
-        track: Optional[Track] = None,
-        tracking_score: Optional[float] = None,
-        from_predicted: Optional[PredictedInstance] = None,
+        track: Track | None = None,
+        tracking_score: float | None = None,
+        from_predicted: "PredictedInstance | None" = None,
     ) -> "PredictedInstance":
         """Create a predicted instance object from a numpy array."""
         points = cls._convert_points(points_data, skeleton)
@@ -1021,12 +1019,12 @@ class PredictedInstance(Instance):
         self.points = new_points
         self.points["name"] = self.skeleton.node_names
 
-    def __getitem__(self, node: Union[int, str, Node]) -> np.ndarray:
+    def __getitem__(self, node: int | str | Node) -> np.ndarray:
         """Return the point associated with a node."""
         # Inherit from Instance.__getitem__
         return super().__getitem__(node)
 
-    def __setitem__(self, node: Union[int, str, Node], value):
+    def __setitem__(self, node: int | str | Node, value):
         """Set the point associated with a node.
 
         Args:

--- a/sleap_io/model/labeled_frame.py
+++ b/sleap_io/model/labeled_frame.py
@@ -6,7 +6,7 @@ The `LabeledFrame` class is a data structure that contains `Instance`s and
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from attrs import define, field
@@ -35,13 +35,13 @@ class LabeledFrame:
 
     video: Video
     frame_idx: int = field(converter=int)
-    instances: list[Union[Instance, PredictedInstance]] = field(factory=list)
+    instances: list[Instance | PredictedInstance] = field(factory=list)
 
     def __len__(self) -> int:
         """Return the number of instances in the frame."""
         return len(self.instances)
 
-    def __getitem__(self, key: int) -> Union[Instance, PredictedInstance]:
+    def __getitem__(self, key: int) -> Instance | PredictedInstance:
         """Return the `Instance` at `key` index in the `instances` list."""
         return self.instances[key]
 
@@ -222,7 +222,7 @@ class LabeledFrame:
     def merge(
         self,
         other: "LabeledFrame",
-        instance: Optional["InstanceMatcher"] = None,
+        instance: "InstanceMatcher | None" = None,
         frame: str = "auto",
     ) -> tuple[list[Instance], list[tuple[Instance, Instance, str]]]:
         """Merge instances from another frame into this frame.

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterator
 
 import numpy as np
 from attrs import define, field
@@ -71,7 +71,7 @@ class Labels:
     provenance: dict[str, Any] = field(factory=dict)
 
     # Internal lazy state (private, not part of public API)
-    _lazy_store: Optional["LazyDataStore"] = field(
+    _lazy_store: "LazyDataStore | None" = field(
         default=None, repr=False, eq=False, alias="lazy_store"
     )
 
@@ -365,7 +365,7 @@ class Labels:
         """Return a readable representation of the labels."""
         return self.__repr__()
 
-    def copy(self, *, open_videos: Optional[bool] = None) -> Labels:
+    def copy(self, *, open_videos: bool | None = None) -> "Labels":
         """Create a deep copy of the Labels object.
 
         Args:
@@ -485,7 +485,7 @@ class Labels:
 
     def numpy(
         self,
-        video: Optional[Union[Video, int]] = None,
+        video: Video | int | None = None,
         untracked: bool = False,
         return_confidence: bool = False,
         user_instances: bool = True,
@@ -556,7 +556,7 @@ class Labels:
     def to_dict(
         self,
         *,
-        video: Optional[Union[Video, int]] = None,
+        video: Video | int | None = None,
         skip_empty_frames: bool = False,
     ) -> dict:
         """Convert labels to a JSON-serializable dictionary.
@@ -591,13 +591,13 @@ class Labels:
         self,
         format: str = "points",
         *,
-        video: Optional[Union[Video, int]] = None,
+        video: Video | int | None = None,
         include_metadata: bool = True,
         include_score: bool = True,
         include_user_instances: bool = True,
         include_predicted_instances: bool = True,
         video_id: str = "path",
-        include_video: Optional[bool] = None,
+        include_video: bool | None = None,
         backend: str = "pandas",
     ):
         """Convert labels to a pandas or polars DataFrame.
@@ -649,14 +649,14 @@ class Labels:
         self,
         format: str = "points",
         *,
-        chunk_size: Optional[int] = None,
-        video: Optional[Union[Video, int]] = None,
+        chunk_size: int | None = None,
+        video: Video | int | None = None,
         include_metadata: bool = True,
         include_score: bool = True,
         include_user_instances: bool = True,
         include_predicted_instances: bool = True,
         video_id: str = "path",
-        include_video: Optional[bool] = None,
+        include_video: bool | None = None,
         instance_id: str = "index",
         untracked: str = "error",
         backend: str = "pandas",
@@ -901,7 +901,7 @@ class Labels:
     def save(
         self,
         filename: str,
-        format: Optional[str] = None,
+        format: str | None = None,
         embed: bool | str | list[tuple[Video, int]] | None = False,
         restore_original_videos: bool = True,
         embed_inplace: bool = False,
@@ -980,9 +980,9 @@ class Labels:
 
     def render(
         self,
-        save_path: Optional[Union[str, Path]] = None,
+        save_path: str | Path | None = None,
         **kwargs,
-    ) -> Union["Video", list]:
+    ) -> "Video | list":
         """Render video with pose overlays.
 
         Convenience method that delegates to `sleap_io.render_video()`.
@@ -1504,7 +1504,7 @@ class Labels:
 
     def extract(
         self, inds: list[int] | list[tuple[Video, int]] | np.ndarray, copy: bool = True
-    ) -> Labels:
+    ) -> "Labels":
         """Extract a set of frames into a new Labels object.
 
         Args:
@@ -1627,7 +1627,7 @@ class Labels:
         save_dir: str | Path | None = None,
         seed: int | None = None,
         embed: bool = True,
-    ) -> LabelsSet:
+    ) -> "LabelsSet":
         """Make splits for training with embedded images.
 
         Args:
@@ -1728,7 +1728,7 @@ class Labels:
         frame_inds: list[int] | np.ndarray,
         video: Video | int | None = None,
         video_kwargs: dict[str, Any] | None = None,
-    ) -> Labels:
+    ) -> "Labels":
         """Trim the labels to a subset of frames and videos accordingly.
 
         Args:
@@ -1801,8 +1801,8 @@ class Labels:
     def update_from_numpy(
         self,
         tracks_arr: np.ndarray,
-        video: Optional[Union[Video, int]] = None,
-        tracks: Optional[list[Track]] = None,
+        video: Video | int | None = None,
+        tracks: list[Track] | None = None,
         create_missing: bool = True,
     ):
         """Update instances from a numpy array of tracks.
@@ -2033,13 +2033,13 @@ class Labels:
     def merge(
         self,
         other: "Labels",
-        skeleton: Optional[Union[str, "SkeletonMatcher"]] = None,
-        video: Optional[Union[str, "VideoMatcher"]] = None,
-        track: Optional[Union[str, "TrackMatcher"]] = None,
+        skeleton: "str | SkeletonMatcher | None" = None,
+        video: "str | VideoMatcher | None" = None,
+        track: "str | TrackMatcher | None" = None,
         frame: str = "auto",
-        instance: Optional[Union[str, "InstanceMatcher"]] = None,
+        instance: "str | InstanceMatcher | None" = None,
         validate: bool = True,
-        progress_callback: Optional[Callable] = None,
+        progress_callback: Callable | None = None,
         error_mode: str = "continue",
     ) -> "MergeResult":
         """Merge another Labels object into this one.
@@ -2469,10 +2469,10 @@ class Labels:
 
     def _map_instance(
         self,
-        instance: Union[Instance, PredictedInstance],
+        instance: Instance | PredictedInstance,
         skeleton_map: dict[Skeleton, Skeleton],
         track_map: dict[Track, Track],
-    ) -> Union[Instance, PredictedInstance]:
+    ) -> Instance | PredictedInstance:
         """Map an instance to use mapped skeleton and track.
 
         Args:

--- a/sleap_io/model/labels_set.py
+++ b/sleap_io/model/labels_set.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, ItemsView, Iterator, KeysView, Union, ValuesView
+from typing import ItemsView, Iterator, KeysView, ValuesView
 
 import attrs
 
@@ -37,9 +37,9 @@ class LabelsSet:
         >>> labels_set["test"] = test_labels
     """
 
-    labels: Dict[str, Labels] = attrs.field(factory=dict)
+    labels: dict[str, Labels] = attrs.field(factory=dict)
 
-    def __getitem__(self, key: Union[str, int]) -> Labels:
+    def __getitem__(self, key: str | int) -> Labels:
         """Get Labels by name (string) or index (int) for tuple-like access.
 
         Args:
@@ -150,8 +150,8 @@ class LabelsSet:
 
     def save(
         self,
-        save_dir: Union[str, Path],
-        embed: Union[bool, str] = True,
+        save_dir: str | Path,
+        embed: bool | str = True,
         format: str = "slp",
         **kwargs,
     ) -> None:

--- a/sleap_io/model/matching.py
+++ b/sleap_io/model/matching.py
@@ -17,7 +17,7 @@ automatic strategies.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Union
+from typing import Any
 
 import attrs
 import numpy as np
@@ -370,7 +370,7 @@ class SkeletonMatcher:
             Only used when method is OVERLAP. Default is 0.5.
     """
 
-    method: Union[SkeletonMatchMethod, str] = attrs.field(
+    method: SkeletonMatchMethod | str = attrs.field(
         default=SkeletonMatchMethod.STRUCTURE,
         converter=lambda x: SkeletonMatchMethod(x) if isinstance(x, str) else x,
     )
@@ -409,7 +409,7 @@ class InstanceMatcher:
             Not used for IDENTITY method. Default is 5.0.
     """
 
-    method: Union[InstanceMatchMethod, str] = attrs.field(
+    method: InstanceMatchMethod | str = attrs.field(
         default=InstanceMatchMethod.SPATIAL,
         converter=lambda x: InstanceMatchMethod(x) if isinstance(x, str) else x,
     )
@@ -493,7 +493,7 @@ class TrackMatcher:
             or a string that will be converted to the enum. Default is NAME.
     """
 
-    method: Union[TrackMatchMethod, str] = attrs.field(
+    method: TrackMatchMethod | str = attrs.field(
         default=TrackMatchMethod.NAME,
         converter=lambda x: TrackMatchMethod(x) if isinstance(x, str) else x,
     )
@@ -521,7 +521,7 @@ class VideoMatcher:
         check that doesn't include the full leaf-uniqueness algorithm.
     """
 
-    method: Union[VideoMatchMethod, str] = attrs.field(
+    method: VideoMatchMethod | str = attrs.field(
         default=VideoMatchMethod.AUTO,
         converter=lambda x: VideoMatchMethod(x) if isinstance(x, str) else x,
     )

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -7,7 +7,7 @@ a video and its components used in SLEAP.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Any
 
 import attrs
 import h5py
@@ -75,15 +75,15 @@ class Video:
     """
 
     filename: str | list[str]
-    backend: Optional[VideoBackend] = None
+    backend: VideoBackend | None = None
     backend_metadata: dict[str, any] = attrs.field(factory=dict)
-    source_video: Optional[Video] = None
+    source_video: "Video | None" = None
     open_backend: bool = True
 
     EXTS = MediaVideo.EXTS + HDF5Video.EXTS + ImageVideo.EXTS
 
     @property
-    def original_video(self) -> Optional["Video"]:
+    def original_video(self) -> "Video | None":
         """The root video in the provenance chain.
 
         For embedded videos, this returns the ultimate source video by
@@ -142,10 +142,10 @@ class Video:
     def from_filename(
         cls,
         filename: str | list[str],
-        dataset: Optional[str] = None,
-        grayscale: Optional[bool] = None,
+        dataset: str | None = None,
+        grayscale: bool | None = None,
         keep_open: bool = True,
-        source_video: Optional[Video] = None,
+        source_video: "Video | None" = None,
         **kwargs,
     ) -> VideoBackend:
         """Create a Video from a filename.
@@ -189,7 +189,7 @@ class Video:
         )
 
     @property
-    def shape(self) -> Tuple[int, int, int, int] | None:
+    def shape(self) -> tuple[int, int, int, int] | None:
         """Return the shape of the video as (num_frames, height, width, channels).
 
         If the video backend is not set or it cannot determine the shape of the video,
@@ -197,7 +197,7 @@ class Video:
         """
         return self._get_shape()
 
-    def _get_shape(self) -> Tuple[int, int, int, int] | None:
+    def _get_shape(self) -> tuple[int, int, int, int] | None:
         """Return the shape of the video as (num_frames, height, width, channels).
 
         This suppresses errors related to querying the backend for the video shape, such
@@ -236,7 +236,7 @@ class Video:
         self.backend_metadata["grayscale"] = value
 
     @property
-    def fps(self) -> Optional[float]:
+    def fps(self) -> float | None:
         """Return the frames per second of the video.
 
         For MediaVideo backends, this reads FPS from the video container metadata.
@@ -251,7 +251,7 @@ class Video:
         return self.backend_metadata.get("fps")
 
     @fps.setter
-    def fps(self, value: Optional[float]):
+    def fps(self, value: float | None):
         """Set the frames per second.
 
         Args:
@@ -271,7 +271,7 @@ class Video:
             self.backend.fps = value
         self.backend_metadata["fps"] = value
 
-    def frame_to_seconds(self, frame_idx: int) -> Optional[float]:
+    def frame_to_seconds(self, frame_idx: int) -> float | None:
         """Convert a frame index to timestamp in seconds.
 
         Args:
@@ -288,7 +288,7 @@ class Video:
             return None
         return frame_idx / self.fps
 
-    def seconds_to_frame(self, seconds: float) -> Optional[int]:
+    def seconds_to_frame(self, seconds: float) -> int | None:
         """Convert a timestamp in seconds to frame index.
 
         Args:
@@ -399,11 +399,11 @@ class Video:
 
     def open(
         self,
-        filename: Optional[str] = None,
-        dataset: Optional[str] = None,
-        grayscale: Optional[str] = None,
+        filename: str | None = None,
+        dataset: str | None = None,
+        grayscale: str | None = None,
         keep_open: bool = True,
-        plugin: Optional[str] = None,
+        plugin: str | None = None,
     ):
         """Open the video backend for reading.
 
@@ -761,9 +761,9 @@ class Video:
         self,
         save_path: str | Path,
         frame_inds: list[int] | np.ndarray | None = None,
-        fps: Optional[float] = None,
+        fps: float | None = None,
         video_kwargs: dict[str, Any] | None = None,
-    ) -> Video:
+    ) -> "Video":
         """Save video frames to a new video file.
 
         Args:

--- a/sleap_io/rendering/callbacks.py
+++ b/sleap_io/rendering/callbacks.py
@@ -6,7 +6,7 @@ during rendering, giving access to the Skia canvas and rendering metadata.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from attrs import define
@@ -83,9 +83,9 @@ class InstanceContext:
     points: np.ndarray
     skeleton_edges: list[tuple[int, int]]
     node_names: list[str]
-    track_id: Optional[int] = None
-    track_name: Optional[str] = None
-    confidence: Optional[float] = None
+    track_id: int | None = None
+    track_name: str | None = None
+    confidence: float | None = None
     scale: float = 1.0
     offset: tuple[float, float] = (0.0, 0.0)
 
@@ -104,7 +104,7 @@ class InstanceContext:
             (y - self.offset[1]) * self.scale,
         )
 
-    def get_centroid(self) -> Optional[tuple[float, float]]:
+    def get_centroid(self) -> tuple[float, float] | None:
         """Get centroid of valid points.
 
         Returns:
@@ -117,7 +117,7 @@ class InstanceContext:
         mean_pt = valid_points.mean(axis=0)
         return (float(mean_pt[0]), float(mean_pt[1]))
 
-    def get_bbox(self) -> Optional[tuple[float, float, float, float]]:
+    def get_bbox(self) -> tuple[float, float, float, float] | None:
         """Get bounding box of valid points.
 
         Returns:

--- a/sleap_io/rendering/colors.py
+++ b/sleap_io/rendering/colors.py
@@ -7,7 +7,7 @@ to Skia format for rendering pose data.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Literal, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Literal, Sequence
 
 if TYPE_CHECKING:
     import skia
@@ -31,14 +31,13 @@ NAMED_COLORS: dict[str, tuple[int, int, int]] = {
 }
 
 # Type alias for flexible color specification
-# Note: Use Tuple (not tuple) for Python 3.8 compatibility in Union
-ColorSpec = Union[
-    Tuple[int, int, int],  # RGB int tuple: (255, 128, 0)
-    Tuple[float, float, float],  # RGB float tuple: (1.0, 0.5, 0.0)
-    int,  # Grayscale int: 128 → (128, 128, 128)
-    float,  # Grayscale float: 0.5 → (127, 127, 127)
-    str,  # Named, hex, or palette reference
-]
+ColorSpec = (
+    tuple[int, int, int]  # RGB int tuple: (255, 128, 0)
+    | tuple[float, float, float]  # RGB float tuple: (1.0, 0.5, 0.0)
+    | int  # Grayscale int: 128 → (128, 128, 128)
+    | float  # Grayscale float: 0.5 → (127, 127, 127)
+    | str  # Named, hex, or palette reference
+)
 
 # Built-in color palettes as RGB tuples
 PALETTES: dict[str, list[tuple[int, int, int]]] = {
@@ -170,9 +169,7 @@ PaletteName = Literal[
 ColorScheme = Literal["track", "instance", "node", "auto"]
 
 
-def get_palette(
-    name: Union[PaletteName, str], n_colors: int
-) -> list[tuple[int, int, int]]:
+def get_palette(name: PaletteName | str, n_colors: int) -> list[tuple[int, int, int]]:
     """Get n colors from a named palette as RGB tuples.
 
     Args:
@@ -415,8 +412,8 @@ def build_color_map(
     n_instances: int,
     n_nodes: int,
     n_tracks: int,
-    track_indices: Optional[list[int]] = None,
-    palette: Union[PaletteName, str] = "standard",
+    track_indices: list[int] | None = None,
+    palette: PaletteName | str = "standard",
 ) -> dict[str, list[tuple[int, int, int]]]:
     """Build color mapping based on scheme.
 

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -6,7 +6,7 @@ This module provides the main API for rendering pose data with skia-python.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Callable, Literal
 
 import numpy as np
 
@@ -37,20 +37,16 @@ PRESETS: dict[str, dict] = {
 }
 
 # Type alias for crop specification
-# Note: Use Tuple (not tuple) for Python 3.8 compatibility in Union
 # Supports both pixel coordinates (int tuple) and normalized coordinates (float tuple)
-CropSpec = Union[
-    Tuple[int, int, int, int],  # Pixel coordinates
-    Tuple[float, float, float, float],  # Normalized coordinates (0.0-1.0)
-    None,
-]
+CropSpec = (
+    tuple[int, int, int, int]  # Pixel coordinates
+    | tuple[float, float, float, float]  # Normalized coordinates (0.0-1.0)
+    | None
+)
 
 
 def _resolve_crop(
-    crop: Union[
-        Tuple[int, int, int, int],
-        Tuple[float, float, float, float],
-    ],
+    crop: tuple[int, int, int, int] | tuple[float, float, float, float],
     frame_shape: tuple[int, int],
 ) -> tuple[int, int, int, int]:
     """Resolve crop specification to pixel coordinates.
@@ -101,7 +97,7 @@ def _apply_crop(
     frame: np.ndarray,
     instances_points: list[np.ndarray],
     crop: tuple[int, int, int, int],
-    output_size: Optional[tuple[int, int]] = None,
+    output_size: tuple[int, int] | None = None,
 ) -> tuple[np.ndarray, list[np.ndarray], float]:
     """Apply crop to frame and shift instance coordinates.
 
@@ -292,7 +288,7 @@ def render_frame(
     *,
     # Appearance
     color_by: ColorScheme = "instance",
-    palette: Union[PaletteName, str] = "standard",
+    palette: PaletteName | str = "standard",
     marker_shape: MarkerShape = "circle",
     marker_size: float = 4.0,
     line_width: float = 2.0,
@@ -301,15 +297,15 @@ def render_frame(
     show_edges: bool = True,
     scale: float = 1.0,
     # Track info for track coloring
-    track_indices: Optional[list[int]] = None,
+    track_indices: list[int] | None = None,
     n_tracks: int = 0,
     # Callbacks
-    pre_render_callback: Optional[Callable[[RenderContext], None]] = None,
-    post_render_callback: Optional[Callable[[RenderContext], None]] = None,
-    per_instance_callback: Optional[Callable[[InstanceContext], None]] = None,
+    pre_render_callback: Callable[[RenderContext], None] | None = None,
+    post_render_callback: Callable[[RenderContext], None] | None = None,
+    per_instance_callback: Callable[[InstanceContext], None] | None = None,
     # Callback context info
     frame_idx: int = 0,
-    instance_metadata: Optional[list[dict]] = None,
+    instance_metadata: list[dict] | None = None,
 ) -> np.ndarray:
     """Render poses on a single frame.
 
@@ -505,24 +501,20 @@ def render_frame(
 
 
 def render_image(
-    source: Union[
-        "Labels",
-        "LabeledFrame",
-        list[Union["Instance", "PredictedInstance"]],
-    ],
-    save_path: Optional[Union[str, Path]] = None,
+    source: "Labels | LabeledFrame | list[Instance | PredictedInstance]",
+    save_path: str | Path | None = None,
     *,
     # Frame specification (for Labels input)
-    lf_ind: Optional[int] = None,
-    video: Optional[Union["Video", int]] = None,
-    frame_idx: Optional[int] = None,
+    lf_ind: int | None = None,
+    video: "Video | int | None" = None,
+    frame_idx: int | None = None,
     # Image override
-    image: Optional[np.ndarray] = None,
+    image: np.ndarray | None = None,
     # Cropping
     crop: CropSpec = None,
     # Appearance
     color_by: ColorScheme = "auto",
-    palette: Union[PaletteName, str] = "standard",
+    palette: PaletteName | str = "standard",
     marker_shape: MarkerShape = "circle",
     marker_size: float = 4.0,
     line_width: float = 2.0,
@@ -531,11 +523,11 @@ def render_image(
     show_edges: bool = True,
     scale: float = 1.0,
     # Background control
-    background: Union[Literal["video"], ColorSpec] = "video",
+    background: Literal["video"] | ColorSpec = "video",
     # Callbacks
-    pre_render_callback: Optional[Callable[[RenderContext], None]] = None,
-    post_render_callback: Optional[Callable[[RenderContext], None]] = None,
-    per_instance_callback: Optional[Callable[[InstanceContext], None]] = None,
+    pre_render_callback: Callable[[RenderContext], None] | None = None,
+    post_render_callback: Callable[[RenderContext], None] | None = None,
+    per_instance_callback: Callable[[InstanceContext], None] | None = None,
 ) -> np.ndarray:
     """Render single frame with pose overlays.
 
@@ -618,7 +610,7 @@ def render_image(
 
     # Handle background parameter
     use_video = background == "video"
-    background_color: Optional[tuple[int, int, int]] = None
+    background_color: tuple[int, int, int] | None = None
     if not use_video:
         background_color = resolve_color(background)
 
@@ -818,24 +810,24 @@ def render_image(
 
 
 def render_video(
-    source: Union["Labels", list["LabeledFrame"]],
-    save_path: Optional[Union[str, Path]] = None,
+    source: "Labels | list[LabeledFrame]",
+    save_path: str | Path | None = None,
     *,
     # Video selection
-    video: Optional[Union["Video", int]] = None,
+    video: "Video | int | None" = None,
     # Frame selection
-    frame_inds: Optional[list[int]] = None,
-    start: Optional[int] = None,
-    end: Optional[int] = None,
+    frame_inds: list[int] | None = None,
+    start: int | None = None,
+    end: int | None = None,
     include_unlabeled: bool = False,
     # Cropping
     crop: CropSpec = None,
     # Quality/scale
-    preset: Optional[Literal["preview", "draft", "final"]] = None,
+    preset: Literal["preview", "draft", "final"] | None = None,
     scale: float = 1.0,
     # Appearance
     color_by: ColorScheme = "auto",
-    palette: Union[PaletteName, str] = "standard",
+    palette: PaletteName | str = "standard",
     marker_shape: MarkerShape = "circle",
     marker_size: float = 4.0,
     line_width: float = 2.0,
@@ -843,20 +835,20 @@ def render_video(
     show_nodes: bool = True,
     show_edges: bool = True,
     # Video encoding
-    fps: Optional[float] = None,
+    fps: float | None = None,
     codec: str = "libx264",
     crf: int = 25,
     x264_preset: str = "superfast",
     # Background control
-    background: Union[Literal["video"], ColorSpec] = "video",
+    background: Literal["video"] | ColorSpec = "video",
     # Callbacks
-    pre_render_callback: Optional[Callable[[RenderContext], None]] = None,
-    post_render_callback: Optional[Callable[[RenderContext], None]] = None,
-    per_instance_callback: Optional[Callable[[InstanceContext], None]] = None,
+    pre_render_callback: Callable[[RenderContext], None] | None = None,
+    post_render_callback: Callable[[RenderContext], None] | None = None,
+    per_instance_callback: Callable[[InstanceContext], None] | None = None,
     # Progress
-    progress_callback: Optional[Callable[[int, int], bool]] = None,
+    progress_callback: Callable[[int, int], bool] | None = None,
     show_progress: bool = True,
-) -> Union["Video", list[np.ndarray]]:
+) -> "Video | list[np.ndarray]":
     """Render video with pose overlays.
 
     Args:
@@ -932,7 +924,7 @@ def render_video(
 
     # Handle background parameter
     use_video = background == "video"
-    background_color: Optional[tuple[int, int, int]] = None
+    background_color: tuple[int, int, int] | None = None
     if not use_video:
         background_color = resolve_color(background)
 
@@ -1063,7 +1055,7 @@ def render_video(
 
     # Resolve crop bounds once (before the loop)
     # We need the video shape to resolve normalized coordinates
-    crop_bounds: Optional[tuple[int, int, int, int]] = None
+    crop_bounds: tuple[int, int, int, int] | None = None
     if crop is not None:
         if hasattr(target_video, "shape") and target_video.shape is not None:
             h, w = target_video.shape[1:3]

--- a/sleap_io/rendering/shapes.py
+++ b/sleap_io/rendering/shapes.py
@@ -6,7 +6,7 @@ locations using Skia.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Literal, Optional
+from typing import TYPE_CHECKING, Callable, Literal
 
 if TYPE_CHECKING:
     import skia
@@ -21,7 +21,7 @@ def draw_circle_marker(
     y: float,
     size: float,
     fill_paint: "skia.Paint",
-    edge_paint: Optional["skia.Paint"] = None,
+    edge_paint: "skia.Paint | None" = None,
 ) -> None:
     """Draw a filled circle marker, optionally with edge.
 
@@ -44,7 +44,7 @@ def draw_square_marker(
     y: float,
     size: float,
     fill_paint: "skia.Paint",
-    edge_paint: Optional["skia.Paint"] = None,
+    edge_paint: "skia.Paint | None" = None,
 ) -> None:
     """Draw a filled square marker, optionally with edge.
 
@@ -71,7 +71,7 @@ def draw_diamond_marker(
     y: float,
     size: float,
     fill_paint: "skia.Paint",
-    edge_paint: Optional["skia.Paint"] = None,
+    edge_paint: "skia.Paint | None" = None,
 ) -> None:
     """Draw a diamond (rotated square) marker.
 
@@ -102,7 +102,7 @@ def draw_triangle_marker(
     y: float,
     size: float,
     fill_paint: "skia.Paint",
-    edge_paint: Optional["skia.Paint"] = None,
+    edge_paint: "skia.Paint | None" = None,
 ) -> None:
     """Draw a triangle marker (pointing up).
 
@@ -134,7 +134,7 @@ def draw_cross_marker(
     y: float,
     size: float,
     fill_paint: "skia.Paint",
-    edge_paint: Optional["skia.Paint"] = None,
+    edge_paint: "skia.Paint | None" = None,
 ) -> None:
     """Draw a cross/plus marker.
 
@@ -170,7 +170,7 @@ MARKER_FUNCS: dict[
             float,
             float,
             "skia.Paint",
-            Optional["skia.Paint"],
+            "skia.Paint | None",
         ],
         None,
     ],
@@ -192,7 +192,7 @@ def get_marker_func(
         float,
         float,
         "skia.Paint",
-        Optional["skia.Paint"],
+        "skia.Paint | None",
     ],
     None,
 ]:


### PR DESCRIPTION
## Summary

Modernizes type hint syntax across the codebase to use Python 3.10+ features, following up on PR #322 which bumped the minimum Python version.

- Replace `Union[X, Y]` with `X | Y` (~118 instances)
- Replace `Optional[X]` with `X | None` (~325 instances)  
- Replace `List/Dict/Tuple/Set` with `list/dict/tuple/set` (~48 instances)
- Migrate `typing_extensions.Literal` to `typing.Literal`

## Key Changes

**29 files modified** across all packages:
- `sleap_io/model/` - 7 files
- `sleap_io/io/` - 17 files
- `sleap_io/codecs/` - 3 files
- `sleap_io/rendering/` - 4 files

## Design Decision

**Kept `from __future__ import annotations`** - The original investigation suggested removing it, but this was incorrect. PEP 563 (postponed annotation evaluation) was supposed to become the default in Python 3.10 but was [postponed indefinitely](https://peps.python.org/pep-0563/#abstract) due to breaking runtime introspection in libraries like `attrs`, `pydantic`, and `dataclasses`. 

Without it, forward references (e.g., a class method returning `Self`) require manual quoting, which is error-prone.

## Testing

- All 1707 tests passing
- Linting clean (`ruff format` + `ruff check`)

🤖 Generated with [Claude Code](https://claude.ai/code)