### PR TITLE
chore: Bump version to 0.6.1

### DIFF
--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -3,4 +3,4 @@
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release
 # version.
-__version__ = "0.6.0"
+__version__ = "0.6.1"


### PR DESCRIPTION
## Summary
Bumps version to 0.6.1 for release.

Closes #209 - The CLI vision from that issue has been fully realized with:
- 6 original commands in v0.6.0 (`show`, `convert`, `split`, `filenames`, `render`)
- 8 new commands in v0.6.1 (`merge`, `unsplit`, `fix`, `embed`, `unembed`, `trim`, `reencode`, `transform`)

## Changes
- `sleap_io/version.py`: `0.6.0` → `0.6.1`