### PR TITLE
chore: Bump version to 0.6.2

### DIFF
--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -3,4 +3,4 @@
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release
 # version.
-__version__ = "0.6.1"
+__version__ = "0.6.2"


### PR DESCRIPTION
## Summary
Bump version from 0.6.1 to 0.6.2 in preparation for the next release.

## Changes
- Updated `sleap_io/version.py` to version 0.6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)