### PR TITLE
feat(model): Add support for negative frames (pure background)

### DIFF
--- a/sleap_io/model/labeled_frame.py
+++ b/sleap_io/model/labeled_frame.py
@@ -26,6 +26,9 @@ class LabeledFrame:
         video: The `Video` associated with this `LabeledFrame`.
         frame_idx: The index of the `LabeledFrame` in the `Video`.
         instances: List of `Instance` objects associated with this `LabeledFrame`.
+        is_negative: If True, this frame is explicitly marked as containing no
+            instances (a "negative" or background frame for training). This is
+            distinct from frames that are simply empty (e.g., instances were deleted).
 
     Notes:
         Instances of this class are hashed by identity, not by value. This means that
@@ -36,6 +39,7 @@ class LabeledFrame:
     video: Video
     frame_idx: int = field(converter=int)
     instances: list[Instance | PredictedInstance] = field(factory=list)
+    is_negative: bool = field(default=False)
 
     def __len__(self) -> int:
         """Return the number of instances in the frame."""
@@ -61,6 +65,16 @@ class LabeledFrame:
             if type(inst) is Instance:
                 return True
         return False
+
+    @property
+    def is_user_labeled(self) -> bool:
+        """Return True if frame has user instances OR is explicitly negative.
+
+        This property indicates whether the frame represents intentional user
+        annotation, either through labeled instances or explicit marking as a
+        negative/background frame.
+        """
+        return self.has_user_instances or self.is_negative
 
     @property
     def predicted_instances(self) -> list[Instance]:

--- a/tests/model/test_labeled_frame.py
+++ b/tests/model/test_labeled_frame.py
@@ -33,6 +33,58 @@ def test_labeled_frame():
     assert lf.has_user_instances
 
 
+def test_labeled_frame_is_negative():
+    """Test is_negative attribute of LabeledFrame."""
+    video = Video(filename="test")
+    skeleton = Skeleton(["A", "B"])
+
+    # Default is_negative is False
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[])
+    assert lf.is_negative is False
+
+    # Can be set to True
+    lf_negative = LabeledFrame(video=video, frame_idx=1, instances=[], is_negative=True)
+    assert lf_negative.is_negative is True
+
+    # Negative frame can still have instances (e.g., predictions)
+    pred_inst = PredictedInstance([[0, 1], [2, 3]], skeleton=skeleton)
+    lf_negative_with_pred = LabeledFrame(
+        video=video, frame_idx=2, instances=[pred_inst], is_negative=True
+    )
+    assert lf_negative_with_pred.is_negative is True
+    assert len(lf_negative_with_pred) == 1
+
+
+def test_labeled_frame_is_user_labeled():
+    """Test is_user_labeled property of LabeledFrame."""
+    video = Video(filename="test")
+    skeleton = Skeleton(["A", "B"])
+
+    # Frame with user instances is user labeled
+    user_inst = Instance([[0, 1], [2, 3]], skeleton=skeleton)
+    lf_with_user = LabeledFrame(video=video, frame_idx=0, instances=[user_inst])
+    assert lf_with_user.is_user_labeled is True
+
+    # Negative frame (empty) is user labeled
+    lf_negative = LabeledFrame(video=video, frame_idx=1, instances=[], is_negative=True)
+    assert lf_negative.is_user_labeled is True
+
+    # Empty non-negative frame is NOT user labeled
+    lf_empty = LabeledFrame(video=video, frame_idx=2, instances=[])
+    assert lf_empty.is_user_labeled is False
+
+    # Frame with only predictions is NOT user labeled
+    pred_inst = PredictedInstance([[0, 1], [2, 3]], skeleton=skeleton)
+    lf_pred_only = LabeledFrame(video=video, frame_idx=3, instances=[pred_inst])
+    assert lf_pred_only.is_user_labeled is False
+
+    # Negative frame with predictions is user labeled (negative takes precedence)
+    lf_negative_with_pred = LabeledFrame(
+        video=video, frame_idx=4, instances=[pred_inst], is_negative=True
+    )
+    assert lf_negative_with_pred.is_user_labeled is True
+
+
 def test_remove_predictions():
     """Test removing predictions from `LabeledFrame`."""
     inst = Instance([[0, 1], [2, 3]], skeleton=Skeleton(["A", "B"]))


### PR DESCRIPTION
## Summary

Add support for **negative frames** - frames explicitly marked as containing no instances (pure background). These are valuable for training to help models learn what backgrounds look like without any animals present.

- Add `is_negative: bool` attribute to `LabeledFrame`
- Add `is_user_labeled` property combining user instances and negative status
- Add `negative_frames` property to `Labels`
- Update `user_labeled_frames` to include negative frames for training export
- Update `Labels.clean()` to preserve negative frames when removing empty frames
- Add `/negative_frames` HDF5 dataset for persistent SLP storage

## Key Changes

### Data Model
- `LabeledFrame.is_negative: bool = False` - marks frames as intentionally empty
- `LabeledFrame.is_user_labeled` - True if has user instances OR is negative
- `Labels.negative_frames` - returns list of negative frames
- `Labels.user_labeled_frames` - now includes negative frames

### SLP I/O
- `write_negative_frames()` - writes `/negative_frames` dataset with (video_id, frame_idx) markers
- `read_negative_frames()` - reads markers and sets `is_negative` on load
- Uses sparse video IDs for consistency with `/frames` dataset

### Filtering
- `Labels.clean(frames=True)` preserves negative frames

## Example Usage

```python
import sleap_io as sio

# Create a negative frame
lf = sio.LabeledFrame(video=video, frame_idx=42, instances=[], is_negative=True)

# Check if frame is user-labeled (includes negative)
lf.is_user_labeled  # True

# Access all negative frames
labels.negative_frames

# Negative frames included in training export
labels.user_labeled_frames  # includes negative frames

# clean() preserves negative frames
labels.clean(frames=True)  # keeps negative frames, removes empty non-negative
```

## Testing

- 8 new tests covering all functionality
- All 2058 existing tests pass

## Design Decisions

See investigation at `scratch/2026-01-18-negative-frames-support/README.md` for detailed design rationale including:
- Why negative frames go in `/frames` dataset
- Why `/negative_frames` uses HDF5 dataset instead of JSON attrs
- Video ID sync strategy

Related: SLEAP PR640

🤖 Generated with [Claude Code](https://claude.ai/code)