### PR TITLE
feat(ultralytics): Add detection and segmentation format I/O

### DIFF
--- a/sleap_io/io/ultralytics.py
+++ b/sleap_io/io/ultralytics.py
@@ -1,12 +1,15 @@
-"""Handles direct I/O operations for working with Ultralytics YOLO pose format.
+"""Handles direct I/O operations for working with Ultralytics YOLO formats.
 
-Ultralytics YOLO pose format specification:
+Ultralytics YOLO format specification:
 - Directory structure: dataset_root/split/images/ and dataset_root/split/labels/
-- Configuration: data.yaml file defining skeleton and dataset structure
-- Annotation format: Each .txt file contains lines with format:
-  class_id x_center y_center width height x1 y1 v1 x2 y2 v2 ... xn yn vn
+- Configuration: data.yaml file defining dataset structure
+- Supported tasks:
+  - Pose: class_id x_center y_center width height x1 y1 v1 x2 y2 v2 ... xn yn vn
+  - Detection: class_id x_center y_center width height [confidence]
+  - Segmentation: class_id x1 y1 x2 y2 ... xn yn
 - Coordinates: Normalized to [0,1] range, origin at top-left
-- Visibility: 0=not visible, 1=visible but occluded, 2=visible and not occluded
+- Visibility (pose only): 0=not visible, 1=visible but occluded, 2=visible and not
+  occluded
 """
 
 from __future__ import annotations
@@ -25,6 +28,7 @@ from tqdm import tqdm
 from sleap_io.model.instance import Instance, Track
 from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
+from sleap_io.model.roi import ROI, AnnotationType
 from sleap_io.model.skeleton import Edge, Node, Skeleton
 from sleap_io.model.video import Video
 
@@ -38,14 +42,17 @@ def read_labels(
     skeleton: Skeleton | None = None,
     image_size: tuple[int, int] = (480, 640),
 ) -> Labels:
-    """Read Ultralytics YOLO pose dataset and return a `Labels` object.
+    """Read Ultralytics YOLO dataset and return a `Labels` object.
+
+    Automatically detects the annotation format (pose, detection, or segmentation)
+    from the label file content.
 
     Args:
         dataset_path: Path to the Ultralytics dataset root directory containing
             data.yaml.
         split: Dataset split to read ('train', 'val', or 'test'). Defaults to 'train'.
         skeleton: Optional skeleton to use. If not provided, will be inferred from
-            data.yaml.
+            data.yaml. Only required for pose format.
         image_size: Image dimensions (height, width) for coordinate denormalization.
                    Defaults to (480, 640). Will attempt to infer from actual images if
                    available.
@@ -68,9 +75,18 @@ def read_labels(
 
     config = parse_data_yaml(data_yaml_path)
 
-    # Use provided skeleton or create from config
-    if skeleton is None:
+    # Use provided skeleton or create from config (may be None for non-pose tasks)
+    if skeleton is None and "kpt_shape" in config:
         skeleton = create_skeleton_from_config(config)
+
+    # Build class names mapping
+    raw_names = config.get("names", {})
+    if isinstance(raw_names, list):
+        class_names = {i: name for i, name in enumerate(raw_names)}
+    elif isinstance(raw_names, dict):
+        class_names = raw_names
+    else:
+        class_names = {}
 
     # Get paths for the specified split
     split_path = config.get(split, f"{split}/images")
@@ -84,6 +100,7 @@ def read_labels(
 
     # Process all image/label pairs
     labeled_frames = []
+    all_rois: list[ROI] = []
     tracks = {}  # Track synthetic tracks by instance order
 
     for image_file in sorted(images_dir.glob("*")):
@@ -94,18 +111,28 @@ def read_labels(
             video = Video.from_filename(str(image_file))
 
             # Parse label file if it exists
-            instances = []
+            instances: list[Instance] = []
             if label_file.exists():
-                # Get image dimensions - try from video shape first, fallback to reading
-                # image
+                # Get image dimensions - try from video shape first, fallback to
+                # reading image
                 if video.shape is not None:
-                    img_shape = video.shape[:2]
+                    img_shape = video.shape[1:3]
                 else:
                     # Read first frame to get dimensions
                     img = video[0]
                     img_shape = img.shape[:2]
 
-                instances = parse_label_file(label_file, skeleton, img_shape)
+                # Create a default skeleton for parse_label_file if none exists
+                parse_skeleton = skeleton if skeleton is not None else Skeleton()
+                instances, rois = parse_label_file(
+                    label_file,
+                    parse_skeleton,
+                    img_shape,
+                    class_names=class_names,
+                    video=video,
+                    frame_idx=0,
+                )
+                all_rois.extend(rois)
 
                 # Assign tracks to instances based on order
                 for i, instance in enumerate(instances):
@@ -118,10 +145,13 @@ def read_labels(
             frame = LabeledFrame(video=video, frame_idx=0, instances=instances)
             labeled_frames.append(frame)
 
+    skeletons = [skeleton] if skeleton is not None else []
+
     return Labels(
         labeled_frames=labeled_frames,
-        skeletons=[skeleton],
+        skeletons=skeletons,
         tracks=list(tracks.values()),
+        rois=all_rois,
         provenance={"source": str(dataset_path), "split": split},
     )
 
@@ -280,9 +310,10 @@ def write_labels(
     verbose: bool = True,
     use_multiprocessing: bool = False,
     n_workers: int | None = None,
+    task: str = "pose",
     **kwargs,
 ) -> None:
-    """Write Labels to Ultralytics YOLO pose format.
+    """Write Labels to Ultralytics YOLO format.
 
     Args:
         labels: SLEAP Labels object to export.
@@ -299,6 +330,9 @@ def write_labels(
             Default is False.
         n_workers: Number of worker processes. If None, uses CPU count - 1. Only used
             if use_multiprocessing=True.
+        task: YOLO task type. One of ``"pose"`` (default), ``"detect"``, or
+            ``"segment"``. For ``"detect"`` and ``"segment"``, ROIs from the Labels
+            object are written instead of pose instances.
         **kwargs: Additional arguments (unused, for compatibility).
     """
     dataset_path = Path(dataset_path)
@@ -309,13 +343,40 @@ def write_labels(
     if not np.isclose(total_ratio, 1.0):
         raise ValueError(f"Split ratios must sum to 1.0, got {total_ratio}")
 
-    if len(labels.skeletons) == 0:
-        raise ValueError("Labels must have at least one skeleton")
+    if task == "pose":
+        if len(labels.skeletons) == 0:
+            raise ValueError("Labels must have at least one skeleton for pose task")
+        skeleton = labels.skeletons[0]
+    else:
+        skeleton = None
 
-    skeleton = labels.skeletons[0]
+    # Build class names from ROI categories for non-pose tasks
+    if task in ("detect", "segment"):
+        class_names = _build_class_names_from_rois(labels.rois)
+    else:
+        class_names = {0: "animal"}
 
     # Create data.yaml configuration
-    create_data_yaml(dataset_path / "data.yaml", skeleton, split_ratios)
+    create_data_yaml(
+        dataset_path / "data.yaml",
+        skeleton,
+        split_ratios,
+        task=task,
+        class_names=class_names,
+    )
+
+    # For non-pose tasks, we write ROIs directly without splitting
+    if task in ("detect", "segment"):
+        _write_roi_labels(
+            labels,
+            dataset_path,
+            split_ratios,
+            class_names,
+            image_format,
+            image_quality,
+            verbose,
+        )
+        return
 
     # Split the labels if multiple splits requested
     if len(split_ratios) == 1:
@@ -442,6 +503,102 @@ def write_labels(
                     continue
 
 
+def _build_class_names_from_rois(rois: list[ROI]) -> dict[int, str]:
+    """Build a class ID to name mapping from ROI categories.
+
+    Args:
+        rois: List of ROIs to extract categories from.
+
+    Returns:
+        A dictionary mapping integer class IDs to category name strings.
+    """
+    categories = sorted({roi.category for roi in rois if roi.category})
+    if not categories:
+        return {0: "object"}
+    return {i: name for i, name in enumerate(categories)}
+
+
+def _write_roi_labels(
+    labels: Labels,
+    dataset_path: Path,
+    split_ratios: dict[str, float],
+    class_names: dict[int, str],
+    image_format: str,
+    image_quality: int | None,
+    verbose: bool,
+) -> None:
+    """Write ROI-based labels (detection/segmentation) to Ultralytics format.
+
+    Args:
+        labels: Labels object with ROIs.
+        dataset_path: Output dataset path.
+        split_ratios: Split ratio mapping.
+        class_names: Class ID to name mapping.
+        image_format: Image format string.
+        image_quality: Image quality parameter.
+        verbose: Whether to show progress.
+    """
+    # Reverse class_names to get name -> id mapping
+    name_to_id = {v: k for k, v in class_names.items()}
+
+    # Group ROIs by video
+    rois_by_video: dict[str, list[ROI]] = {}
+    for roi in labels.rois:
+        if roi.video is not None:
+            key = str(roi.video.filename)
+            if key not in rois_by_video:
+                rois_by_video[key] = []
+            rois_by_video[key].append(roi)
+
+    # Use first split for all data (ROIs don't support splitting yet)
+    split_name = list(split_ratios.keys())[0]
+    images_dir = dataset_path / split_name / "images"
+    labels_dir = dataset_path / split_name / "labels"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    labels_dir.mkdir(parents=True, exist_ok=True)
+
+    video_keys = sorted(rois_by_video.keys())
+    iterator = (
+        tqdm(video_keys, desc=f"Writing {split_name}", disable=not verbose)
+        if verbose
+        else video_keys
+    )
+
+    for lf_idx, video_path in enumerate(iterator):
+        rois = rois_by_video[video_path]
+        video = rois[0].video
+
+        # Read image to get shape and save it
+        try:
+            frame_img = video[0]
+            if frame_img is None:
+                continue
+
+            if frame_img.ndim == 3 and frame_img.shape[-1] == 1:
+                frame_img = np.squeeze(frame_img, axis=-1)
+
+            image_filename = f"{lf_idx:07d}.{image_format}"
+            image_path = images_dir / image_filename
+
+            save_kwargs = {}
+            if image_format.lower() in ["jpg", "jpeg"] and image_quality is not None:
+                save_kwargs["quality"] = image_quality
+            elif image_format.lower() == "png" and image_quality is not None:
+                save_kwargs["compress_level"] = min(9, max(0, image_quality))
+
+            iio.imwrite(image_path, frame_img, **save_kwargs)
+
+            height_px, width_px = frame_img.shape[:2]
+        except Exception as e:
+            warnings.warn(f"Error processing {video_path}: {e}, skipping.")
+            continue
+
+        # Write label file
+        label_filename = f"{lf_idx:07d}.txt"
+        label_path = labels_dir / label_filename
+        write_roi_label_file(label_path, rois, (height_px, width_px), name_to_id)
+
+
 def parse_data_yaml(yaml_path: Path) -> dict:
     """Parse Ultralytics data.yaml configuration file."""
     with open(yaml_path, "r") as f:
@@ -470,11 +627,61 @@ def create_skeleton_from_config(config: dict) -> Skeleton:
     return Skeleton(nodes=nodes, edges=edges, name="ultralytics_skeleton")
 
 
+def detect_line_format(parts: list[str]) -> str:
+    """Detect the YOLO annotation format from a single line's parsed values.
+
+    Args:
+        parts: List of string values from a single annotation line.
+
+    Returns:
+        One of ``"detection"``, ``"detection_conf"``, ``"segmentation"``, or
+        ``"pose"``.
+    """
+    n = len(parts)
+    if n == 5:
+        return "detection"
+    if n == 6:
+        return "detection_conf"
+    # Check for pose format: 5 + 3*k values
+    remainder = n - 5
+    if remainder > 0 and remainder % 3 == 0:
+        return "pose"
+    # Even number of values after class_id -> segmentation polygon
+    if (n - 1) % 2 == 0 and n > 5:
+        return "segmentation"
+    return "pose"
+
+
 def parse_label_file(
-    label_path: Path, skeleton: Skeleton, image_shape: tuple[int, int]
-) -> list[Instance]:
-    """Parse a single Ultralytics label file and return instances."""
-    instances = []
+    label_path: Path,
+    skeleton: Skeleton,
+    image_shape: tuple[int, int],
+    class_names: dict[int, str] | None = None,
+    video: Video | None = None,
+    frame_idx: int = 0,
+) -> tuple[list[Instance], list[ROI]]:
+    """Parse a single Ultralytics label file and return instances and ROIs.
+
+    The format is auto-detected per line based on the number of values:
+
+    - **5 values**: Detection (``class_id x_center y_center width height``)
+    - **6 values**: Detection with confidence
+    - **5 + 3k values**: Pose (existing keypoint format)
+    - **Even count > 5 with (n-1) even**: Segmentation polygon
+
+    Args:
+        label_path: Path to the ``.txt`` label file.
+        skeleton: Skeleton to use for pose instances.
+        image_shape: Image dimensions ``(height, width)`` for denormalization.
+        class_names: Optional mapping from class ID to category name.
+        video: Optional ``Video`` to associate with ROIs.
+        frame_idx: Frame index for ROIs. Defaults to 0.
+
+    Returns:
+        A tuple of ``(instances, rois)`` parsed from the file.
+    """
+    instances: list[Instance] = []
+    rois: list[ROI] = []
 
     with open(label_path, "r") as f:
         for line_num, line in enumerate(f):
@@ -490,59 +697,99 @@ def parse_label_file(
                     )
                     continue
 
-                _ = int(parts[0])  # class_id - not used but part of YOLO format
-                x_center, y_center, width, height = map(float, parts[1:5])
-
-                # Parse keypoints
-                keypoint_data = parts[5:]
-                if len(keypoint_data) % 3 != 0:
-                    warnings.warn(
-                        f"Invalid keypoint data in {label_path} line {line_num}"
-                    )
-                    continue
-
-                num_keypoints = len(keypoint_data) // 3
-                if num_keypoints != len(skeleton.nodes):
-                    warnings.warn(
-                        f"Keypoint count mismatch: expected {len(skeleton.nodes)}, "
-                        f"got {num_keypoints} in {label_path} line {line_num}"
-                    )
-                    continue
-
-                # Convert normalized coordinates to pixel coordinates
-                height_px, width_px = image_shape
-                points = []
-
-                for i in range(num_keypoints):
-                    x_norm = float(keypoint_data[i * 3])
-                    y_norm = float(keypoint_data[i * 3 + 1])
-                    visibility = int(keypoint_data[i * 3 + 2])
-
-                    # Denormalize coordinates
-                    x_px = x_norm * width_px
-                    y_px = y_norm * height_px
-
-                    # Convert visibility: 0=not visible, 1=occluded, 2=visible
-                    is_visible = visibility > 0
-
-                    if visibility == 0:
-                        # Not visible - use NaN coordinates
-                        points.append([np.nan, np.nan, False])
-                    else:
-                        points.append([x_px, y_px, is_visible])
-
-                # Create instance from numpy array
-                points_array = np.array(points, dtype=np.float32)
-                instance = Instance.from_numpy(
-                    points_data=points_array, skeleton=skeleton
+                fmt = detect_line_format(parts)
+                class_id = int(parts[0])
+                category = (
+                    class_names.get(class_id, "") if class_names is not None else ""
                 )
-                instances.append(instance)
+                height_px, width_px = image_shape
+
+                if fmt in ("detection", "detection_conf"):
+                    x_center, y_center, w_norm, h_norm = map(float, parts[1:5])
+                    score = float(parts[5]) if fmt == "detection_conf" else None
+
+                    # Denormalize to pixel coordinates
+                    w_px = w_norm * width_px
+                    h_px = h_norm * height_px
+                    x_px = x_center * width_px - w_px / 2
+                    y_px = y_center * height_px - h_px / 2
+
+                    roi = ROI.from_bbox(
+                        x_px,
+                        y_px,
+                        w_px,
+                        h_px,
+                        annotation_type=AnnotationType.BOUNDING_BOX,
+                        category=category,
+                        score=score,
+                        video=video,
+                        frame_idx=frame_idx,
+                    )
+                    rois.append(roi)
+
+                elif fmt == "segmentation":
+                    # class_id x1 y1 x2 y2 ... xn yn
+                    coord_values = list(map(float, parts[1:]))
+                    coords = []
+                    for i in range(0, len(coord_values), 2):
+                        x_px = coord_values[i] * width_px
+                        y_px = coord_values[i + 1] * height_px
+                        coords.append((x_px, y_px))
+
+                    roi = ROI.from_polygon(
+                        coords,
+                        annotation_type=AnnotationType.SEGMENTATION,
+                        category=category,
+                        video=video,
+                        frame_idx=frame_idx,
+                    )
+                    rois.append(roi)
+
+                else:
+                    # Pose format (existing behavior)
+                    x_center, y_center, width, height = map(float, parts[1:5])
+                    keypoint_data = parts[5:]
+                    if len(keypoint_data) % 3 != 0:
+                        warnings.warn(
+                            f"Invalid keypoint data in {label_path} line {line_num}"
+                        )
+                        continue
+
+                    num_keypoints = len(keypoint_data) // 3
+                    if num_keypoints != len(skeleton.nodes):
+                        warnings.warn(
+                            f"Keypoint count mismatch: expected "
+                            f"{len(skeleton.nodes)}, got {num_keypoints} in "
+                            f"{label_path} line {line_num}"
+                        )
+                        continue
+
+                    points = []
+                    for i in range(num_keypoints):
+                        x_norm = float(keypoint_data[i * 3])
+                        y_norm = float(keypoint_data[i * 3 + 1])
+                        visibility = int(keypoint_data[i * 3 + 2])
+
+                        x_px = x_norm * width_px
+                        y_px = y_norm * height_px
+
+                        is_visible = visibility > 0
+                        if visibility == 0:
+                            points.append([np.nan, np.nan, False])
+                        else:
+                            points.append([x_px, y_px, is_visible])
+
+                    points_array = np.array(points, dtype=np.float32)
+                    instance = Instance.from_numpy(
+                        points_data=points_array, skeleton=skeleton
+                    )
+                    instances.append(instance)
 
             except (ValueError, IndexError) as e:
                 warnings.warn(f"Error parsing line {line_num} in {label_path}: {e}")
                 continue
 
-    return instances
+    return instances, rois
 
 
 def write_label_file(
@@ -552,7 +799,7 @@ def write_label_file(
     image_shape: tuple[int, int],
     class_id: int = 0,
 ) -> None:
-    """Write a single Ultralytics label file for a frame."""
+    """Write a single Ultralytics pose label file for a frame."""
     height_px, width_px = image_shape
 
     with open(label_path, "w") as f:
@@ -617,28 +864,98 @@ def write_label_file(
             f.write(" ".join(line_parts) + "\n")
 
 
-def create_data_yaml(
-    yaml_path: Path, skeleton: Skeleton, split_ratios: dict[str, float]
+def write_roi_label_file(
+    label_path: Path,
+    rois: list[ROI],
+    image_shape: tuple[int, int],
+    name_to_id: dict[str, int],
 ) -> None:
-    """Create Ultralytics data.yaml configuration file."""
-    # Build skeleton connections
-    skeleton_connections = []
-    for edge in skeleton.edges:
-        src_idx = skeleton.nodes.index(edge.source)
-        dst_idx = skeleton.nodes.index(edge.destination)
-        skeleton_connections.append([src_idx, dst_idx])
+    """Write a single Ultralytics label file for detection/segmentation ROIs.
 
-    # Create flip indices (identity mapping by default)
-    flip_idx = list(range(len(skeleton.nodes)))
+    Args:
+        label_path: Path to write the label file.
+        rois: List of ROIs for this image.
+        image_shape: Image dimensions ``(height, width)``.
+        name_to_id: Mapping from category name to class ID.
+    """
+    height_px, width_px = image_shape
 
-    config = {
+    with open(label_path, "w") as f:
+        for roi in rois:
+            class_id = name_to_id.get(roi.category, 0)
+
+            if roi.annotation_type == AnnotationType.SEGMENTATION and not roi.is_bbox:
+                # Write segmentation polygon
+                coords = list(roi.geometry.exterior.coords)[:-1]  # Remove closing pt
+                line_parts = [str(class_id)]
+                for x, y in coords:
+                    line_parts.append(f"{x / width_px:.6f}")
+                    line_parts.append(f"{y / height_px:.6f}")
+                f.write(" ".join(line_parts) + "\n")
+            else:
+                # Write detection bounding box
+                minx, miny, maxx, maxy = roi.bounds
+                x_center = ((minx + maxx) / 2) / width_px
+                y_center = ((miny + maxy) / 2) / height_px
+                w = (maxx - minx) / width_px
+                h = (maxy - miny) / height_px
+
+                line_parts = [
+                    str(class_id),
+                    f"{x_center:.6f}",
+                    f"{y_center:.6f}",
+                    f"{w:.6f}",
+                    f"{h:.6f}",
+                ]
+                if roi.score is not None:
+                    line_parts.append(f"{roi.score:.6f}")
+
+                f.write(" ".join(line_parts) + "\n")
+
+
+def create_data_yaml(
+    yaml_path: Path,
+    skeleton: Skeleton | None,
+    split_ratios: dict[str, float],
+    task: str = "pose",
+    class_names: dict[int, str] | None = None,
+) -> None:
+    """Create Ultralytics data.yaml configuration file.
+
+    Args:
+        yaml_path: Path to write the YAML file.
+        skeleton: Skeleton for pose tasks. Can be ``None`` for non-pose tasks.
+        split_ratios: Mapping of split names to ratios.
+        task: YOLO task type (``"pose"``, ``"detect"``, or ``"segment"``).
+        class_names: Optional class name mapping. Defaults to ``{0: "animal"}``.
+    """
+    if class_names is None:
+        class_names = {0: "animal"}
+
+    config: dict = {
         "path": ".",
-        "names": {0: "animal"},
-        "kpt_shape": [len(skeleton.nodes), 3],
-        "flip_idx": flip_idx,
-        "skeleton": skeleton_connections,
-        "node_names": [node.name for node in skeleton.nodes],
+        "names": class_names,
     }
+
+    if task != "pose":
+        config["task"] = task
+    else:
+        # Pose-specific fields
+        if skeleton is not None:
+            # Build skeleton connections
+            skeleton_connections = []
+            for edge in skeleton.edges:
+                src_idx = skeleton.nodes.index(edge.source)
+                dst_idx = skeleton.nodes.index(edge.destination)
+                skeleton_connections.append([src_idx, dst_idx])
+
+            # Create flip indices (identity mapping by default)
+            flip_idx = list(range(len(skeleton.nodes)))
+
+            config["kpt_shape"] = [len(skeleton.nodes), 3]
+            config["flip_idx"] = flip_idx
+            config["skeleton"] = skeleton_connections
+            config["node_names"] = [node.name for node in skeleton.nodes]
 
     # Add split paths
     for split_name in split_ratios.keys():

--- a/tests/io/test_ultralytics.py
+++ b/tests/io/test_ultralytics.py
@@ -23,6 +23,7 @@ from sleap_io.io.main import load_file, load_ultralytics, save_file, save_ultral
 from sleap_io.io.ultralytics import (
     create_skeleton_from_config,
     denormalize_coordinates,
+    detect_line_format,
     normalize_coordinates,
     parse_data_yaml,
     parse_label_file,
@@ -30,7 +31,9 @@ from sleap_io.io.ultralytics import (
     read_labels_set,
     write_label_file,
     write_labels,
+    write_roi_label_file,
 )
+from sleap_io.model.roi import AnnotationType
 
 
 def test_parse_data_yaml(ultralytics_data_yaml):
@@ -58,9 +61,10 @@ def test_create_skeleton_from_config(ultralytics_data_yaml):
 def test_parse_label_file(ultralytics_dataset, ultralytics_skeleton):
     """Test parsing of individual label files."""
     label_file = Path(ultralytics_dataset) / "train" / "labels" / "image_001.txt"
-    instances = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
+    instances, rois = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
 
     assert len(instances) == 1
+    assert len(rois) == 0
     instance = instances[0]
     assert len(instance.points) == 5
     assert instance.skeleton == ultralytics_skeleton
@@ -76,9 +80,10 @@ def test_parse_label_file(ultralytics_dataset, ultralytics_skeleton):
 def test_parse_label_file_multi_instance(ultralytics_dataset, ultralytics_skeleton):
     """Test parsing of label file with multiple instances."""
     label_file = Path(ultralytics_dataset) / "train" / "labels" / "image_002.txt"
-    instances = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
+    instances, rois = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
 
     assert len(instances) == 2
+    assert len(rois) == 0
     for instance in instances:
         assert len(instance.points) == 5
         assert instance.skeleton == ultralytics_skeleton
@@ -416,8 +421,9 @@ def test_empty_label_file(tmp_path, ultralytics_skeleton):
     label_file = tmp_path / "empty.txt"
     label_file.write_text("")
 
-    instances = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
+    instances, rois = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
     assert len(instances) == 0
+    assert len(rois) == 0
 
 
 def test_malformed_label_file(tmp_path, ultralytics_skeleton):
@@ -426,8 +432,9 @@ def test_malformed_label_file(tmp_path, ultralytics_skeleton):
     label_file.write_text("invalid line\n0 0.5\n")  # incomplete data
 
     # Should not crash, but warn and skip invalid lines
-    instances = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
+    instances, rois = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
     assert len(instances) == 0  # Both lines are invalid
+    assert len(rois) == 0
 
 
 def test_keypoint_count_mismatch_warning(tmp_path):
@@ -440,7 +447,7 @@ def test_keypoint_count_mismatch_warning(tmp_path):
     label_file.write_text("0 0.5 0.5 0.2 0.4 0.1 0.1 2 0.2 0.2 2\n")  # Only 2 keypoints
 
     with pytest.warns(UserWarning, match="Keypoint count mismatch"):
-        instances = parse_label_file(label_file, skeleton, (100, 100))
+        instances, rois = parse_label_file(label_file, skeleton, (100, 100))
 
     assert len(instances) == 0  # Instance rejected due to mismatch
 
@@ -847,7 +854,7 @@ def test_parse_label_file_edge_cases(tmp_path, ultralytics_skeleton):
     label_file.write_text("0 0.5 0.5 0.2 0.2 0.1 0.1 2 0.2 0.2 2 0.3 0.3 1\n")
 
     with pytest.warns(UserWarning, match="Keypoint count mismatch"):
-        instances = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
+        instances, rois = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
     assert len(instances) == 0  # Should skip the malformed instance
 
     # Test parsing error with invalid data
@@ -855,7 +862,7 @@ def test_parse_label_file_edge_cases(tmp_path, ultralytics_skeleton):
     label_file.write_text("not_a_number 0.5 0.5 0.2 0.2\n")
 
     with pytest.warns(UserWarning, match="Error parsing line"):
-        instances = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
+        instances, rois = parse_label_file(label_file, ultralytics_skeleton, (480, 640))
     assert len(instances) == 0
 
 
@@ -888,12 +895,17 @@ def test_parse_label_file_with_invalid_keypoint_count(tmp_path):
     """Test parse_label_file with keypoints % 3 != 0."""
     skeleton = Skeleton([Node("a"), Node("b")])
 
-    # Create label file with incomplete keypoint data (8 values instead of 6 or 9)
+    # Create label file with incomplete keypoint data: 10 values after bbox (not % 3)
+    # Total parts = 15, remainder from 5 = 10, 10 % 3 != 0, (15-1)%2 == 0 -> seg
+    # Use 13 total values: remainder = 8, 8%3!=0, (13-1)%2==0 -> seg format
+    # Actually need something that triggers pose: 5 + 3k. Use 5+3=8 total (3 kpts)
+    # but skeleton has 2 nodes -> mismatch.
     label_file = tmp_path / "invalid_keypoints.txt"
-    label_file.write_text("0 0.5 0.5 0.2 0.2 0.1 0.1 2 0.2\n")  # 8 values after bbox
+    # 8 total values: 5 bbox + 3 kp data = 1 keypoint, but skeleton expects 2
+    label_file.write_text("0 0.5 0.5 0.2 0.2 0.1 0.1 2\n")
 
-    with pytest.warns(UserWarning, match="Invalid keypoint data"):
-        instances = parse_label_file(label_file, skeleton, (480, 640))
+    with pytest.warns(UserWarning, match="Keypoint count mismatch"):
+        instances, rois = parse_label_file(label_file, skeleton, (480, 640))
     assert len(instances) == 0
 
 
@@ -1246,3 +1258,200 @@ def test_read_labels_set_roundtrip(tmp_path, slp_minimal):
     # Total frames should match original (allowing for rounding in splits)
     total_frames = sum(len(split_labels) for split_labels in labels_set.values())
     assert abs(total_frames - len(labels)) <= 1
+
+
+# Detection and Segmentation Format Tests
+
+
+def test_ultralytics_format_autodetect():
+    """Verify the auto-detection picks the right format."""
+    # 5 values = detection
+    assert detect_line_format(["0", "0.5", "0.5", "0.2", "0.3"]) == "detection"
+    # 6 values = detection with confidence
+    assert detect_line_format(["0", "0.5", "0.5", "0.2", "0.3", "0.9"]) == (
+        "detection_conf"
+    )
+    # 8 values (5 + 3*1) = pose
+    assert detect_line_format(["0"] * 8) == "pose"
+    # 11 values (5 + 3*2) = pose
+    assert detect_line_format(["0"] * 11) == "pose"
+    # 9 values: (9-1)%2==0 and 9>5 -> segmentation (4 polygon points)
+    assert detect_line_format(["0"] * 9) == "segmentation"
+    # 13 values: (13-5)=8, 8%3!=0, (13-1)%2==0 -> segmentation
+    assert detect_line_format(["0"] * 13) == "segmentation"
+
+
+def _create_detection_dataset(base_path, with_confidence=False):
+    """Helper to create a detection-format Ultralytics dataset."""
+    base_path.mkdir(parents=True, exist_ok=True)
+
+    # data.yaml
+    data_config = {
+        "path": ".",
+        "task": "detect",
+        "names": {0: "cat", 1: "dog"},
+        "train": "train/images",
+    }
+    with open(base_path / "data.yaml", "w") as f:
+        yaml.dump(data_config, f)
+
+    # Image and labels
+    images_dir = base_path / "train" / "images"
+    labels_dir = base_path / "train" / "labels"
+    images_dir.mkdir(parents=True)
+    labels_dir.mkdir(parents=True)
+
+    img = np.zeros((100, 200, 3), dtype=np.uint8)
+    iio.imwrite(images_dir / "frame_000.png", img)
+
+    # Detection label: class_id x_center y_center width height [confidence]
+    if with_confidence:
+        label_content = "0 0.5 0.5 0.4 0.6 0.95\n1 0.25 0.25 0.2 0.3 0.85\n"
+    else:
+        label_content = "0 0.5 0.5 0.4 0.6\n1 0.25 0.25 0.2 0.3\n"
+    (labels_dir / "frame_000.txt").write_text(label_content)
+
+    return img.shape[:2]
+
+
+def test_ultralytics_detection_read_write_roundtrip(tmp_path):
+    """Create detection-format labels, read, verify ROIs, write back."""
+    dataset_path = tmp_path / "det_dataset"
+    _create_detection_dataset(dataset_path)
+
+    # Read
+    labels = read_labels(str(dataset_path), split="train")
+
+    assert len(labels.labeled_frames) == 1
+    assert len(labels.rois) == 2
+
+    # Check first ROI (cat)
+    roi0 = labels.rois[0]
+    assert roi0.category == "cat"
+    assert roi0.annotation_type == AnnotationType.BOUNDING_BOX
+    assert roi0.score is None
+    assert roi0.is_bbox
+
+    # Check second ROI (dog)
+    roi1 = labels.rois[1]
+    assert roi1.category == "dog"
+
+    # Verify both ROIs have valid bounding boxes with nonzero area
+    for roi in labels.rois:
+        assert roi.area > 0
+
+    # Write back
+    out_path = tmp_path / "det_out"
+    write_labels(
+        labels,
+        str(out_path),
+        split_ratios={"train": 1.0},
+        task="detect",
+        verbose=False,
+    )
+
+    # Verify data.yaml
+    out_config = parse_data_yaml(out_path / "data.yaml")
+    assert out_config["task"] == "detect"
+    assert "kpt_shape" not in out_config
+
+    # Read back and verify
+    labels2 = read_labels(str(out_path), split="train")
+    assert len(labels2.rois) == 2
+
+
+def test_ultralytics_detection_with_confidence(tmp_path):
+    """Detection format with 6 values per line (includes confidence score)."""
+    dataset_path = tmp_path / "det_conf_dataset"
+    _create_detection_dataset(dataset_path, with_confidence=True)
+
+    labels = read_labels(str(dataset_path), split="train")
+
+    assert len(labels.rois) == 2
+    assert labels.rois[0].score == pytest.approx(0.95)
+    assert labels.rois[0].category == "cat"
+    assert labels.rois[1].score == pytest.approx(0.85)
+    assert labels.rois[1].category == "dog"
+
+
+def test_ultralytics_segmentation_read_write_roundtrip(tmp_path):
+    """Test segmentation format parsing and writing at label file level."""
+    # Test parsing segmentation format directly
+    label_file = tmp_path / "seg.txt"
+    # 9 values: class_id + 4 polygon points (not divisible by 3 after bbox)
+    label_file.write_text("0 0.1 0.1 0.9 0.2 0.8 0.9 0.2 0.8\n")
+
+    skeleton = Skeleton()
+    instances, rois = parse_label_file(
+        label_file, skeleton, (100, 200), class_names={0: "animal"}
+    )
+
+    assert len(instances) == 0
+    assert len(rois) == 1
+    roi = rois[0]
+    assert roi.annotation_type == AnnotationType.SEGMENTATION
+    assert roi.category == "animal"
+    assert roi.area > 0
+
+    # Verify polygon vertices
+    coords = list(roi.geometry.exterior.coords)
+    assert len(coords) == 5  # 4 vertices + closing point
+
+    # Verify first vertex denormalized correctly
+    assert abs(coords[0][0] - 0.1 * 200) < 1e-4
+    assert abs(coords[0][1] - 0.1 * 100) < 1e-4
+
+    # Write back and verify roundtrip
+    name_to_id = {"animal": 0}
+    label_out = tmp_path / "seg_out.txt"
+    write_roi_label_file(label_out, rois, (100, 200), name_to_id)
+
+    # Re-parse and compare
+    instances2, rois2 = parse_label_file(
+        label_out, skeleton, (100, 200), class_names={0: "animal"}
+    )
+    assert len(rois2) == 1
+    roi2 = rois2[0]
+    assert roi2.annotation_type == AnnotationType.SEGMENTATION
+
+    # Areas should match closely
+    assert abs(roi.area - roi2.area) / roi.area < 0.01
+
+
+def test_ultralytics_coordinate_normalization_detection(tmp_path):
+    """Verify coordinates normalize/denormalize correctly for detection."""
+    # Create a simple detection label
+    label_file = tmp_path / "det.txt"
+    # x_center=0.5, y_center=0.5, w=0.4, h=0.6 on 200x100 image
+    label_file.write_text("0 0.5 0.5 0.4 0.6\n")
+
+    skeleton = Skeleton()
+    instances, rois = parse_label_file(
+        label_file, skeleton, (100, 200), class_names={0: "obj"}
+    )
+
+    assert len(instances) == 0
+    assert len(rois) == 1
+
+    roi = rois[0]
+    minx, miny, maxx, maxy = roi.bounds
+
+    # Expected pixel coords:
+    # w_px = 0.4 * 200 = 80, h_px = 0.6 * 100 = 60
+    # x = 0.5*200 - 80/2 = 60, y = 0.5*100 - 60/2 = 20
+    assert abs(minx - 60.0) < 1e-4
+    assert abs(miny - 20.0) < 1e-4
+    assert abs(maxx - 140.0) < 1e-4
+    assert abs(maxy - 80.0) < 1e-4
+
+    # Write back and verify normalization
+    label_out = tmp_path / "det_out.txt"
+    write_roi_label_file(label_out, [roi], (100, 200), {"obj": 0})
+
+    content = label_out.read_text().strip()
+    parts = content.split()
+    assert parts[0] == "0"
+    assert float(parts[1]) == pytest.approx(0.5, abs=1e-4)
+    assert float(parts[2]) == pytest.approx(0.5, abs=1e-4)
+    assert float(parts[3]) == pytest.approx(0.4, abs=1e-4)
+    assert float(parts[4]) == pytest.approx(0.6, abs=1e-4)


### PR DESCRIPTION
## Summary
- Extends Ultralytics YOLO I/O to support detection and segmentation formats alongside the existing pose format
- Auto-detects annotation format from label file content based on value count per line
- Reading creates `ROI` objects (bounding boxes or polygons) stored in `Labels.rois`
- Writing supports a `task` parameter (`"pose"`, `"detect"`, `"segment"`) to control output format

## Key Changes
- **`sleap_io/io/ultralytics.py`**: 
  - `parse_label_file` returns `tuple[list[Instance], list[ROI]]` and auto-detects format
  - Added `detect_line_format()` for format auto-detection
  - Added `write_roi_label_file()` for writing detection/segmentation ROIs
  - `write_labels` gains `task` parameter for non-pose export
  - Fixed `video.shape` indexing for correct `(height, width)` extraction
- **`tests/io/test_ultralytics.py`**: 5 new tests for detection/segmentation formats

## API Changes
- `parse_label_file` now returns `tuple[list[Instance], list[ROI]]`
- `write_labels` gains `task: str = "pose"` parameter
- New public functions: `detect_line_format`, `write_roi_label_file`

Replaces #354 (rebased onto main after #351 was squash-merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)