### PR TITLE
chore: Bump version to 0.6.5

### DIFF
--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -3,4 +3,4 @@
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release
 # version.
-__version__ = "0.6.4"
+__version__ = "0.6.5"


### PR DESCRIPTION
## Summary
- Bump version from 0.6.4 to 0.6.5 for upcoming release

## Key Changes
- Version bump in `sleap_io/version.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)