### PR TITLE
fix: Preserve ROIs/masks in lazy copy and fix COCO empty segmentation fallback

### DIFF
--- a/sleap_io/io/coco.py
+++ b/sleap_io/io/coco.py
@@ -423,7 +423,7 @@ def read_labels(
 
                     # Create bbox ROI if no segmentation was processed
                     bbox = annotation.get("bbox")
-                    if bbox is not None and segmentation is None:
+                    if bbox is not None and not segmentation:
                         x, y, w, h = bbox
                         roi = ROI.from_bbox(x, y, w, h, **roi_kwargs)
                         rois.append(roi)

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -449,6 +449,8 @@ class Labels:
                 suggestions=[deepcopy(s) for s in self.suggestions],
                 sessions=[deepcopy(s) for s in self.sessions],
                 provenance=dict(self.provenance),
+                rois=[deepcopy(r) for r in self.rois],
+                masks=[deepcopy(m) for m in self.masks],
                 lazy_store=new_store,
             )
         else:

--- a/tests/io/test_coco.py
+++ b/tests/io/test_coco.py
@@ -1804,6 +1804,45 @@ class TestCOCOROIMaskIO:
         decoded = coco._decode_coco_rle(rle["counts"], rle["size"])
         np.testing.assert_array_equal(decoded, mask)
 
+    def test_coco_detection_empty_segmentation_fallback_to_bbox(self, tmp_path):
+        """Test that annotations with segmentation=[] fall back to bbox ROI."""
+        img_path = tmp_path / "img.png"
+        img_path.touch()
+
+        data = {
+            "images": [
+                {"id": 1, "file_name": "img.png", "height": 100, "width": 200},
+            ],
+            "annotations": [
+                {
+                    "id": 1,
+                    "image_id": 1,
+                    "category_id": 1,
+                    "segmentation": [],
+                    "bbox": [10, 20, 30, 40],
+                    "area": 1200,
+                    "iscrowd": 0,
+                },
+            ],
+            "categories": [{"id": 1, "name": "animal"}],
+        }
+
+        json_path = tmp_path / "empty_seg.json"
+        with open(json_path, "w") as f:
+            json.dump(data, f)
+
+        labels = coco.read_labels(json_path, dataset_root=tmp_path)
+
+        # Empty segmentation list should fall back to bbox
+        assert len(labels.rois) == 1
+        roi = labels.rois[0]
+        assert roi.category == "animal"
+        minx, miny, maxx, maxy = roi.bounds
+        assert minx == pytest.approx(10.0)
+        assert miny == pytest.approx(20.0)
+        assert maxx == pytest.approx(40.0)
+        assert maxy == pytest.approx(60.0)
+
     def test_coco_detection_with_polygon_read(self, tmp_path):
         """Test reading polygon segmentation creates ROI with correct coords."""
         img_path = tmp_path / "img.png"

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -5477,6 +5477,39 @@ def test_labels_materialize_rois_and_masks(tmp_path):
     assert materialized.masks[1].track is None
 
 
+def test_labels_copy_preserves_rois_and_masks(slp_minimal, tmp_path):
+    """Test that lazy copy preserves ROIs and masks."""
+    labels = load_slp(slp_minimal)
+    video = labels.videos[0]
+
+    roi = ROI.from_bbox(10, 20, 30, 40, video=video, frame_idx=0, category="test")
+    mask = SegmentationMask.from_numpy(
+        np.ones((5, 5), dtype=bool), video=video, frame_idx=0, category="fg"
+    )
+    labels.rois.append(roi)
+    labels.masks.append(mask)
+
+    # Save and reload lazily
+    out_path = tmp_path / "with_rois.slp"
+    labels.save(str(out_path))
+    lazy_labels = load_slp(str(out_path), lazy=True)
+
+    assert len(lazy_labels.rois) == 1
+    assert len(lazy_labels.masks) == 1
+
+    # Copy the lazy labels
+    labels_copy = lazy_labels.copy()
+
+    assert len(labels_copy.rois) == 1
+    assert labels_copy.rois[0].category == "test"
+    assert len(labels_copy.masks) == 1
+    assert labels_copy.masks[0].category == "fg"
+
+    # Verify independence
+    labels_copy.rois.clear()
+    assert len(lazy_labels.rois) == 1
+
+
 def test_labels_get_masks_by_annotation_type():
     """get_masks filters by annotation_type."""
     video = Video(filename="test.mp4")


### PR DESCRIPTION
## Summary
- Fix two edge cases found during v0.6.5 release code review
- Lazy `Labels.copy()` now preserves ROIs and masks
- COCO reader falls back to bbox ROI when `segmentation` is `[]`

## Key Changes
- **`sleap_io/model/labels.py`**: Add `rois` and `masks` to the lazy copy path (previously omitted, causing silent data loss)
- **`sleap_io/io/coco.py`**: Change `segmentation is None` to `not segmentation` to handle both `None` and `[]`

## Testing
- `test_labels_copy_preserves_rois_and_masks`: Verifies lazy save/load/copy roundtrip preserves ROIs and masks
- `test_coco_detection_empty_segmentation_fallback_to_bbox`: Verifies `segmentation: []` with valid bbox creates bbox ROI

🤖 Generated with [Claude Code](https://claude.com/claude-code)