### PR TITLE
docs: Refresh README to reflect current capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,136 +6,172 @@
 [![PyPI](https://img.shields.io/pypi/v/sleap-io?label=PyPI)](https://pypi.org/project/sleap-io)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sleap-io)
 
-Standalone utilities for working with animal pose tracking data.
+A standalone Python library and CLI for working with animal pose tracking data. Read, write, convert, and manipulate pose data across formats with minimal dependencies.
 
-This is intended to be a complement to the core [SLEAP](https://github.com/talmolab/sleap)
-package that aims to provide functionality for interacting with pose tracking-related
-data structures and file formats with minimal dependencies. This package *does not*
-have any functionality related to labeling, training, or inference.
+Complements the core [SLEAP](https://github.com/talmolab/sleap) package but does *not* include labeling, training, or inference.
 
-**📚 [Documentation](https://io.sleap.ai)** - Comprehensive guides and API reference
+**[Documentation](https://io.sleap.ai)** | **[Examples](https://io.sleap.ai/examples)** | **[CLI Reference](https://io.sleap.ai/cli)**
+
+## Features
+
+- **Multi-format I/O** -- Read and write [SLEAP](https://io.sleap.ai/formats/#sleap-native-format-slp), [NWB](https://io.sleap.ai/formats/#nwb-format-nwb), [COCO](https://io.sleap.ai/formats/#coco-format-json), [DeepLabCut](https://io.sleap.ai/formats/#deeplabcut-format-h5-csv), [Ultralytics YOLO](https://io.sleap.ai/formats/#ultralytics-yolo-format), [JABS](https://io.sleap.ai/formats/#jabs-format-h5), [Label Studio](https://io.sleap.ai/formats/#label-studio-format-json), [CSV](https://io.sleap.ai/formats/#csv-format-csv), [Analysis HDF5](https://io.sleap.ai/formats/#sleap-analysis-hdf5-format-h5), [AlphaTracker](https://io.sleap.ai/formats/#alphatracker-format), and [LEAP](https://io.sleap.ai/formats/#leap-format-mat) formats
+- **CLI tools** -- Inspect, convert, render, and transform data from the command line (`sio show`, `sio convert`, `sio render`, `sio transform`)
+- **Rendering** -- Produce publication-quality videos and images with pose overlays, customizable colors, markers, and presets
+- **Transforms** -- Crop, scale, rotate, pad, and flip videos with automatic coordinate adjustment
+- **Merging** -- Combine annotations from multiple sources with flexible matching strategies
+- **Codecs** -- Convert to/from NumPy arrays, DataFrames (pandas/polars), and dictionaries
+- **Video I/O** -- Read any video format via pluggable backends (FFMPEG, OpenCV, PyAV) with a NumPy-like interface
+- **Lazy loading** -- Load large SLP files up to 90x faster by deferring object creation
+- **Dataset splits** -- Create train/val/test splits and export to formats like Ultralytics YOLO
 
 ## Installation
 
-### From PyPI
-```
-pip install sleap-io
+### Quick start (no install needed)
+
+Run CLI commands instantly with [`uvx`](https://docs.astral.sh/uv/):
+
+```bash
+uvx sleap-io show labels.slp
+uvx sleap-io convert -i labels.slp -o labels.nwb
 ```
 
-### From source (latest version)
-```
-pip install git+https://github.com/talmolab/sleap-io.git@main
+### Install as CLI tool
+
+```bash
+uv tool install "sleap-io[all]"
+sio show labels.slp
 ```
 
-For video backend support, install with extras:
-```
-pip install sleap-io[opencv]  # For OpenCV backend (fastest)
-pip install sleap-io[ffmpeg]   # For FFMPEG backend (most reliable)
-pip install sleap-io[pyav]     # For PyAV backend (balanced)
-pip install sleap-io[all]      # For all video backends
+### Install as Python library
+
+```bash
+pip install "sleap-io[all]"
+# or: uv add "sleap-io[all]"
+# or: conda install -c conda-forge sleap-io
 ```
 
-For development, use one of the following:
+### From source
+
+```bash
+pip install "sleap-io[all] @ git+https://github.com/talmolab/sleap-io.git@main"
 ```
-uv sync --all-extras           # Recommended: install with uv
+
+### Optional extras
+
+Video support works out of the box via `imageio-ffmpeg`. Optional extras provide faster backends and additional format support:
+
+| Extra | Purpose |
+|-------|---------|
+| `opencv` | Faster video backend |
+| `pyav` | Alternative video backend |
+| `mat` | LEAP `.mat` file support |
+| `polars` | Fast DataFrame operations |
+| `all` | All of the above |
+
+### Development
+
+```bash
+git clone https://github.com/talmolab/sleap-io.git && cd sleap-io
+uv sync --all-extras
 ```
-```
-conda env create -f environment.yml
-```
-```
-pip install -e .[dev,all]      # Install with all extras for development
-```
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for more information on development.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for more details.
 
 ## Usage
 
-### Load and save in different formats
+### CLI
 
-```py
+```bash
+# Inspect a labels file
+sio show labels.slp
+
+# Convert between formats
+sio convert -i labels.slp -o labels.nwb
+
+# Render video with pose overlays
+sio render -i predictions.slp -o output.mp4
+
+# Transform (scale, crop, rotate) with coordinate adjustment
+sio transform labels.slp --scale 0.5 -o scaled.slp
+```
+
+### Python
+
+#### Load and convert between formats
+
+```python
 import sleap_io as sio
 
-# Load from SLEAP file.
+labels = sio.load_file("predictions.slp")
+labels.save("predictions.nwb")
+```
+
+Format is auto-detected from the extension. See [supported formats](https://io.sleap.ai/formats/).
+
+#### Convert to NumPy arrays
+
+```python
 labels = sio.load_file("predictions.slp")
 
-# Save to NWB file.
-sio.save_file(labels, "predictions.nwb")
-# Or:
-# labels.save("predictions.nwb")
+trx = labels.numpy()  # (n_frames, n_tracks, n_nodes, 2)
+trx_with_scores = labels.numpy(return_confidence=True)  # (n_frames, n_tracks, n_nodes, 3)
 ```
 
-### Convert labels to raw arrays
+#### Create labels from scratch
 
-```py
-import sleap_io as sio
-
-labels = sio.load_slp("tests/data/slp/centered_pair_predictions.slp")
-
-# Convert predictions to point coordinates in a single array.
-trx = labels.numpy()
-n_frames, n_tracks, n_nodes, xy = trx.shape
-assert xy == 2
-
-# Convert to array with confidence scores appended.
-trx_with_scores = labels.numpy(return_confidence=True)
-n_frames, n_tracks, n_nodes, xy_score = trx.shape 
-assert xy_score == 3
-```
-
-### Read video data
-
-```py
-import sleap_io as sio
-
-video = sio.load_video("test.mp4")
-n_frames, height, width, channels = video.shape
-
-frame = video[0]
-height, width, channels = frame.shape
-```
-
-### Create labels from raw data
-
-```py
+```python
 import sleap_io as sio
 import numpy as np
 
-# Create skeleton.
 skeleton = sio.Skeleton(
     nodes=["head", "thorax", "abdomen"],
     edges=[("head", "thorax"), ("thorax", "abdomen")]
 )
 
-# Create video.
-video = sio.load_video("test.mp4")
-
-# Create instance.
 instance = sio.Instance.from_numpy(
-    points=np.array([
-        [10.2, 20.4],
-        [5.8, 15.1],
-        [0.3, 10.6],
-    ]),
+    points=np.array([[10.2, 20.4], [5.8, 15.1], [0.3, 10.6]]),
     skeleton=skeleton
 )
 
-# Create labeled frame.
+video = sio.load_video("test.mp4")
 lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[instance])
-
-# Create labels.
 labels = sio.Labels(videos=[video], skeletons=[skeleton], labeled_frames=[lf])
-
-# Save.
 labels.save("labels.slp")
 ```
 
+#### Render poses
+
+```python
+labels = sio.load_file("predictions.slp")
+labels.render("output.mp4")                      # Full video
+labels.render("preview.mp4", preset="preview")   # Fast 0.25x preview
+sio.render_image(labels[0], "frame.png")         # Single frame
+```
+
+#### Merge annotations
+
+```python
+base = sio.load_file("manual_annotations.slp")
+predictions = sio.load_file("predictions.slp")
+base.merge(predictions)
+base.save("merged.slp")
+```
+
+#### Create training splits
+
+```python
+labels = sio.load_file("labels.slp")
+labels.make_training_splits(n_train=0.8, n_val=0.1, n_test=0.1, save_dir="splits/", seed=42)
+```
+
+See the **[Examples](https://io.sleap.ai/examples)** page for more recipes including NWB export, video re-encoding, skeleton replacement, path fixing, and YOLO/COCO export.
+
 ## Support
-For technical inquiries specific to this package, please [open an Issue](https://github.com/talmolab/sleap-io/issues)
-with a description of your problem or request.
 
-For general SLEAP usage, see the [main website](https://sleap.ai).
+For technical inquiries, please [open an Issue](https://github.com/talmolab/sleap-io/issues).
 
-Other questions? Reach out to `talmo@salk.edu`.
+For general SLEAP usage, see [sleap.ai](https://sleap.ai).
 
 ## License
-This package is distributed under a BSD 3-Clause License and can be used without
-restrictions. See [`LICENSE`](LICENSE) for details.
+
+BSD 3-Clause License. See [`LICENSE`](LICENSE) for details.


### PR DESCRIPTION
## Summary

- Rewrites the README to better showcase sleap-io's full feature set beyond basic I/O
- Modernizes installation instructions to lead with `uvx`/`uv` for zero-install CLI usage
- Adds a comprehensive Features section covering all major capabilities

## Key Changes

- **Features section**: Lists all capabilities — multi-format I/O (11 formats), CLI tools, rendering, transforms, merging, codecs, video I/O, lazy loading, and dataset splits with links to docs
- **Installation**: Reorganized around use cases (quick start with `uvx`, CLI tool install, Python library, from source) instead of just `pip install`. Extras shown in a table
- **CLI examples**: New section showing `sio show`, `sio convert`, `sio render`, and `sio transform` commands
- **Python examples**: Added rendering, merging, and training splits alongside the existing load/save, numpy, and create-from-scratch examples
- **Streamlined prose**: Tighter intro, removed emoji, consolidated support section, linked to full docs/examples/CLI reference

## Testing

Documentation-only change, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)