### PR TITLE
feat: Support reading SLP files written by h5wasm (sleap-io.js)

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1280,7 +1280,12 @@ def read_metadata(labels_path: str) -> dict:
         A dict containing the metadata from a SLEAP labels file.
     """
     md = read_hdf5_attrs(labels_path, "metadata", "json")
-    return json.loads(md.decode())
+    if isinstance(md, bytes):
+        md = md.decode()
+    elif isinstance(md, np.ndarray):
+        md = md.tobytes().decode()
+    # If md is already a str (e.g., h5py vlen string), use as-is.
+    return json.loads(md)
 
 
 def read_skeletons(labels_path: str) -> list[Skeleton]:
@@ -1501,6 +1506,16 @@ def read_instances(
                 point_id_end,
                 tracking_score,
             ) = instance_data
+
+        # Cast index values to int for h5wasm compatibility. h5wasm may write
+        # all columns as float64, which can't be used as list indices or slice
+        # bounds. Safe for compound dtypes too: int(numpy.int64(x)) -> int.
+        instance_id = int(instance_id)
+        skeleton_id = int(skeleton_id)
+        track_id = int(track_id)
+        from_predicted = int(from_predicted)
+        point_id_start = int(point_id_start)
+        point_id_end = int(point_id_end)
 
         skeleton = skeletons[skeleton_id]
         track = tracks[track_id] if track_id >= 0 else None

--- a/sleap_io/io/slp_lazy.py
+++ b/sleap_io/io/slp_lazy.py
@@ -213,6 +213,14 @@ class LazyDataStore:
                 tracking_score,
             ) = inst_row
 
+        # Cast index values to int for h5wasm compatibility (float64 columns).
+        instance_id = int(instance_id)
+        skeleton_id = int(skeleton_id)
+        track_id = int(track_id)
+        from_predicted = int(from_predicted)
+        point_id_start = int(point_id_start)
+        point_id_end = int(point_id_end)
+
         skeleton = self.skeletons[skeleton_id]
         track = self.tracks[track_id] if track_id >= 0 else None
 

--- a/sleap_io/io/utils.py
+++ b/sleap_io/io/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -17,10 +18,28 @@ def read_hdf5_dataset(filename: str, dataset: str) -> np.ndarray:
         dataset: Path to a dataset.
 
     Returns:
-        The data as an array.
+        The data as an array. If the dataset is a flat 2D array with a
+        ``"field_names"`` JSON attribute (as written by h5wasm), it will be
+        converted to a structured array so that field-name access works
+        identically to compound-dtype datasets written by h5py.
     """
     with h5py.File(filename, "r") as f:
-        data = f[dataset][()]
+        ds = f[dataset]
+        data = ds[()]
+        # h5wasm writes flat 2D arrays with column names in a "field_names"
+        # JSON attribute instead of compound dtypes. Convert to a structured
+        # array so downstream code can use field-name access unchanged.
+        if data.ndim == 2 and data.dtype.names is None:
+            field_names_raw = ds.attrs.get("field_names", None)
+            if field_names_raw is not None:
+                if isinstance(field_names_raw, (bytes, np.bytes_)):
+                    field_names_raw = field_names_raw.decode()
+                field_names = json.loads(field_names_raw)
+                dtype = [(name, data.dtype) for name in field_names]
+                structured = np.empty(data.shape[0], dtype=dtype)
+                for i, name in enumerate(field_names):
+                    structured[name] = data[:, i]
+                return structured
     return data
 
 

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -37,6 +37,7 @@ from sleap_io import (
 )
 from sleap_io.io.slp import (
     ExportCancelled,
+    _points_from_hdf5_data,
     camera_group_to_dict,
     camera_to_dict,
     can_use_fast_path,
@@ -57,6 +58,7 @@ from sleap_io.io.slp import (
     read_labels_set,
     read_masks,
     read_metadata,
+    read_negative_frames,
     read_points,
     read_pred_points,
     read_rois,
@@ -483,8 +485,6 @@ def test_negative_frames_no_dataset_when_empty(tmp_path):
 
 def test_read_negative_frames_missing_dataset(tmp_path):
     """Test read_negative_frames returns empty set when dataset doesn't exist."""
-    from sleap_io.io.slp import read_negative_frames
-
     # Create a minimal HDF5 file without negative_frames
     path = tmp_path / "test.h5"
     with h5py.File(path, "w") as f:
@@ -4960,3 +4960,232 @@ def test_label_image_slp_lazy(tmp_path):
     assert rli.objects[1].category == "cell"
     assert rli.objects[1].track.name == "t1"
     np.testing.assert_array_equal(rli.data, data)
+
+
+# -- h5wasm compatibility tests --
+
+
+def test_read_hdf5_dataset_flat_array(tmp_path):
+    """Test that read_hdf5_dataset converts flat arrays with field_names attr."""
+    path = str(tmp_path / "flat.h5")
+
+    # Simulate h5wasm output: flat 2D float64 array with field_names attribute
+    flat_data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype="<f8")
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset("data", data=flat_data)
+        ds.attrs["field_names"] = json.dumps(["a", "b", "c"])
+
+    result = read_hdf5_dataset(path, "data")
+
+    # Should be a structured array with named fields
+    assert result.dtype.names == ("a", "b", "c")
+    assert len(result) == 2
+    np.testing.assert_array_equal(result["a"], [1.0, 4.0])
+    np.testing.assert_array_equal(result["b"], [2.0, 5.0])
+    np.testing.assert_array_equal(result["c"], [3.0, 6.0])
+
+
+def test_read_hdf5_dataset_flat_array_bytes_attr(tmp_path):
+    """Test flat array conversion when field_names attr is bytes."""
+    path = str(tmp_path / "flat_bytes.h5")
+
+    flat_data = np.array([[10.0, 20.0]], dtype="<f8")
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset("data", data=flat_data)
+        # Write as bytes (fixed-length H5T_STRING, as h5wasm may produce)
+        ds.attrs["field_names"] = np.bytes_(json.dumps(["x", "y"]))
+
+    result = read_hdf5_dataset(path, "data")
+    assert result.dtype.names == ("x", "y")
+    np.testing.assert_array_equal(result["x"], [10.0])
+    np.testing.assert_array_equal(result["y"], [20.0])
+
+
+def test_read_hdf5_dataset_compound_unchanged(tmp_path):
+    """Test that compound dtype datasets pass through unchanged."""
+    path = str(tmp_path / "compound.h5")
+
+    dtype = np.dtype([("x", "<f8"), ("y", "<f8")])
+    data = np.array([(1.0, 2.0), (3.0, 4.0)], dtype=dtype)
+    with h5py.File(path, "w") as f:
+        f.create_dataset("data", data=data)
+
+    result = read_hdf5_dataset(path, "data")
+    assert result.dtype == dtype
+    np.testing.assert_array_equal(result["x"], [1.0, 3.0])
+
+
+def test_read_hdf5_dataset_1d_unchanged(tmp_path):
+    """Test that 1D flat arrays (e.g., WKB bytes) pass through unchanged."""
+    path = str(tmp_path / "flat1d.h5")
+
+    data = np.array([1, 2, 3, 4], dtype=np.uint8)
+    with h5py.File(path, "w") as f:
+        f.create_dataset("data", data=data)
+
+    result = read_hdf5_dataset(path, "data")
+    assert result.ndim == 1
+    assert result.dtype == np.uint8
+    np.testing.assert_array_equal(result, data)
+
+
+def test_read_h5wasm_points(tmp_path):
+    """Test _points_from_hdf5_data works with flat arrays converted to structured."""
+    path = str(tmp_path / "points.h5")
+
+    # Simulate h5wasm points: flat float64 array with field_names
+    pts = np.array([[100.0, 200.0, 1.0, 0.0], [150.0, 250.0, 0.0, 1.0]], dtype="<f8")
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset("points", data=pts)
+        ds.attrs["field_names"] = json.dumps(["x", "y", "visible", "complete"])
+
+    pts_data = read_hdf5_dataset(path, "points")
+    skeleton = Skeleton(nodes=["A", "B"])
+    points_array = _points_from_hdf5_data(pts_data, skeleton, is_predicted=False)
+
+    assert points_array["xy"][0, 0] == 100.0
+    assert points_array["xy"][0, 1] == 200.0
+    assert points_array["xy"][1, 0] == 150.0
+    assert points_array["xy"][1, 1] == 250.0
+    assert points_array["visible"][0] == 1.0
+    assert points_array["visible"][1] == 0.0
+
+
+def test_read_h5wasm_pred_points(tmp_path):
+    """Test _points_from_hdf5_data works with predicted points from flat arrays."""
+    path = str(tmp_path / "pred_points.h5")
+
+    pts = np.array(
+        [[100.0, 200.0, 1.0, 0.0, 0.95], [150.0, 250.0, 1.0, 1.0, 0.80]],
+        dtype="<f8",
+    )
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset("pred_points", data=pts)
+        ds.attrs["field_names"] = json.dumps(["x", "y", "visible", "complete", "score"])
+
+    pts_data = read_hdf5_dataset(path, "pred_points")
+    skeleton = Skeleton(nodes=["A", "B"])
+    points_array = _points_from_hdf5_data(pts_data, skeleton, is_predicted=True)
+
+    assert points_array["score"][0] == 0.95
+    assert points_array["score"][1] == 0.80
+
+
+def test_read_h5wasm_negative_frames(tmp_path):
+    """Test read_negative_frames with h5wasm-style flat array."""
+    path = str(tmp_path / "neg_frames.h5")
+
+    # h5wasm writes negative_frames as flat int64 array
+    data = np.array([[0, 5], [0, 10], [1, 3]], dtype="<i8")
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset("negative_frames", data=data)
+        ds.attrs["field_names"] = json.dumps(["video_id", "frame_idx"])
+
+    result = read_negative_frames(str(path))
+    assert result == {(0, 5), (0, 10), (1, 3)}
+
+
+def test_read_metadata_bytes(tmp_path):
+    """Test read_metadata with bytes attribute (standard h5py)."""
+    path = str(tmp_path / "meta_bytes.h5")
+    metadata = {"version": "1.2", "skeletons": []}
+    with h5py.File(path, "w") as f:
+        grp = f.require_group("metadata")
+        grp.attrs["json"] = json.dumps(metadata).encode()
+
+    result = read_metadata(str(path))
+    assert result == metadata
+
+
+def test_read_metadata_str(tmp_path):
+    """Test read_metadata with str attribute (h5py vlen string)."""
+    path = str(tmp_path / "meta_str.h5")
+    metadata = {"version": "1.2", "skeletons": []}
+    with h5py.File(path, "w") as f:
+        grp = f.require_group("metadata")
+        # h5py writes Python str as vlen string by default
+        grp.attrs["json"] = json.dumps(metadata)
+
+    result = read_metadata(str(path))
+    assert result == metadata
+
+
+def test_read_metadata_ndarray(tmp_path):
+    """Test read_metadata with uint8 ndarray attribute."""
+    path = str(tmp_path / "meta_arr.h5")
+    metadata = {"version": "1.2", "skeletons": []}
+    json_bytes = json.dumps(metadata).encode()
+    with h5py.File(path, "w") as f:
+        grp = f.require_group("metadata")
+        grp.attrs.create("json", np.frombuffer(json_bytes, dtype=np.uint8))
+
+    result = read_metadata(str(path))
+    assert result == metadata
+
+
+def test_read_h5wasm_instances_float64_indices(tmp_path):
+    """Test that float64 index values from h5wasm are handled in read_instances."""
+    path = str(tmp_path / "instances.h5")
+
+    # Create a minimal SLP-like file with h5wasm-style flat arrays
+    skeleton = Skeleton(nodes=["A", "B"])
+
+    # Points: 2 points for 1 instance
+    pts = np.array([[10.0, 20.0, 1.0, 0.0], [30.0, 40.0, 1.0, 0.0]], dtype="<f8")
+
+    # Instance data: all float64 (as h5wasm would write)
+    # Fields: instance_id, instance_type, frame_id, skeleton, track,
+    #         from_predicted, score, point_id_start, point_id_end, tracking_score
+    inst = np.array([[0.0, 0.0, 0.0, 0.0, -1.0, -1.0, 0.0, 0.0, 2.0, 0.0]], dtype="<f8")
+
+    with h5py.File(path, "w") as f:
+        ds_pts = f.create_dataset("points", data=pts)
+        ds_pts.attrs["field_names"] = json.dumps(["x", "y", "visible", "complete"])
+
+        ds_inst = f.create_dataset("instances", data=inst)
+        ds_inst.attrs["field_names"] = json.dumps(
+            [
+                "instance_id",
+                "instance_type",
+                "frame_id",
+                "skeleton",
+                "track",
+                "from_predicted",
+                "score",
+                "point_id_start",
+                "point_id_end",
+                "tracking_score",
+            ]
+        )
+
+        # Empty pred_points (compound dtype, as if no predictions)
+        pred_dtype = np.dtype(
+            [
+                ("x", "<f8"),
+                ("y", "<f8"),
+                ("visible", "?"),
+                ("complete", "?"),
+                ("score", "<f8"),
+            ]
+        )
+        f.create_dataset("pred_points", data=np.array([], dtype=pred_dtype))
+
+    points = read_hdf5_dataset(path, "points")
+    pred_points = read_hdf5_dataset(path, "pred_points")
+
+    instances = read_instances(
+        path,
+        skeletons=[skeleton],
+        tracks=[],
+        points=points,
+        pred_points=pred_points,
+        format_id=1.2,
+    )
+
+    assert len(instances) == 1
+    inst0 = instances[0]
+    assert isinstance(inst0, Instance)
+    assert inst0.skeleton == skeleton
+    assert inst0.track is None
+    np.testing.assert_array_equal(inst0["A"]["xy"], [10.0, 20.0])
+    np.testing.assert_array_equal(inst0["B"]["xy"], [30.0, 40.0])


### PR DESCRIPTION
## Summary
- Adds transparent conversion of h5wasm flat 2D arrays (with `field_names` JSON attribute) to structured arrays in `read_hdf5_dataset()`
- Adds `int()` casts for float64 index values in `read_instances()` and lazy `_materialize_instance()`
- Makes `read_metadata()` robust to `bytes`, `str`, and `np.ndarray` attribute types

Closes #376

## Key Changes
- **`sleap_io/io/utils.py`**: `read_hdf5_dataset()` detects flat 2D arrays with a `field_names` attribute and converts them to structured arrays so all downstream field-name access works unchanged
- **`sleap_io/io/slp.py`**: `int()` casts on index variables after tuple unpacking in `read_instances()`; `read_metadata()` handles multiple string representations
- **`sleap_io/io/slp_lazy.py`**: Same `int()` casts in `_materialize_instance()` for the lazy loading path

## Design Decisions
- **Central fix in `read_hdf5_dataset()`** rather than per-function patches — this single conversion point fixes field-name access for all readers (points, instances, negative frames, ROIs, masks, bboxes, label images) without touching each one individually
- **`int()` casts are still needed separately** because even after structured array conversion, all fields share the same dtype (float64), so integer-typed index values must be explicitly cast before use as list indices or slice bounds
- Compound dtype datasets (from Python h5py) skip the conversion entirely — `data.dtype.names` is already set, so backward compatibility is guaranteed

## Testing
- 11 new tests covering: flat→structured conversion, bytes attr decoding, compound/1D passthrough, h5wasm-style points/pred_points/negative_frames/instances, and all 3 metadata string types
- All 161 existing SLP tests pass (4 pre-existing cv2 failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)