### PR TITLE
chore: Remove skia-python<=138.0 version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "rich_click",
     "shapely>=2.0",
     "lazy-loader>=0.4",
-    "skia-python>=87.0,<=138.0",
+    "skia-python>=87.0",
     "colorcet>=3.0"]
 dynamic = ["version", "readme"]
 


### PR DESCRIPTION
## Summary

- Remove the upper version pin on `skia-python` (`<=138.0`) that was introduced in #351 as a workaround for missing Python 3.13 wheels.

## Context

The pin was needed because `skia-python` 144.0 had a botched PyPI upload that omitted cp313 wheels. Upstream has since fixed this:

- [kyamagu/skia-python#359](https://github.com/kyamagu/skia-python/issues/359) (closed)
- [kyamagu/skia-python#360](https://github.com/kyamagu/skia-python/pull/360) (merged)
- **skia-python 144.0.post2** (released 2026-03-18) has complete cp313 wheels for all platforms.

## Test plan

- [ ] CI passes on all Python versions including 3.13

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)