### PR TITLE
fix: LabelImage.Info instance relinking for lazy labels

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -3542,6 +3542,8 @@ def read_label_images(
                     instance=instance,
                     score=obj_score,
                 )
+                # Store raw index for deferred resolution (lazy loading)
+                objects[label_id]._instance_idx = instance_idx
 
         source = sources[i] if i < len(sources) else ""
 
@@ -3670,12 +3672,12 @@ def write_label_images(
 
             track_idx = tracks.index(info.track) if info.track in tracks else -1
 
-            instance_idx = -1
+            instance_idx = info._instance_idx  # Use stored index as default
             if instances is not None and info.instance is not None:
                 try:
                     instance_idx = instances.index(info.instance)
                 except ValueError:
-                    pass
+                    pass  # Keep stored _instance_idx
 
             obj_score = info.score if info.score is not None else float("nan")
             obj_rows.append((label_id, track_idx, instance_idx, obj_score))

--- a/sleap_io/model/label_image.py
+++ b/sleap_io/model/label_image.py
@@ -72,6 +72,12 @@ class LabelImage:
         instance: "Instance | None" = None
         score: float | None = None
 
+        # Private: deferred instance index for lazy loading. When label images
+        # are read from a file without materialized instances (e.g., lazy mode),
+        # this stores the raw instance_idx so it can be resolved later or
+        # written back as-is.
+        _instance_idx: int = attrs.field(default=-1, repr=False, eq=False, init=False)
+
     data: np.ndarray = attrs.field()
     objects: dict[int, Info] = Factory(dict)
     video: "Video | None" = attrs.field(default=None)

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -319,27 +319,25 @@ class Labels:
                 new_bbox._instance_idx = -1
             new_bboxes.append(new_bbox)
 
-        # Build instance identity set for relinking label image objects
-        instance_set = {id(inst): inst for inst in all_instances}
-
         # Deep copy label images, relinking videos, tracks, and instances
         new_label_images = []
         for li in self.label_images:
             new_li = deepcopy(li)
             if li.video is not None:
                 new_li.video = video_map.get(id(li.video), new_li.video)
-            # Use ORIGINAL li.objects for id lookup, set on deepcopy
+            # Use ORIGINAL li.objects for track id lookup, set on deepcopy
             for label_id, orig_info in li.objects.items():
                 if label_id in new_li.objects:
+                    new_info = new_li.objects[label_id]
                     if orig_info.track is not None:
-                        new_li.objects[label_id].track = track_map.get(
-                            id(orig_info.track), new_li.objects[label_id].track
+                        new_info.track = track_map.get(
+                            id(orig_info.track), new_info.track
                         )
-                    if orig_info.instance is not None:
-                        new_li.objects[label_id].instance = instance_set.get(
-                            id(orig_info.instance),
-                            new_li.objects[label_id].instance,
-                        )
+                    # Resolve deferred instance link from _instance_idx
+                    idx = new_info._instance_idx
+                    if new_info.instance is None and 0 <= idx < len(all_instances):
+                        new_info.instance = all_instances[idx]
+                        new_info._instance_idx = -1
             new_label_images.append(new_li)
 
         return Labels(

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -5020,6 +5020,77 @@ def test_label_image_slp_lazy(tmp_path):
     np.testing.assert_array_equal(rli.data, data)
 
 
+def test_label_image_instance_lazy_roundtrip(tmp_path):
+    """Label image instance_idx should survive a lazy load -> save round-trip."""
+    skeleton = Skeleton(nodes=["a", "b"], edges=[("a", "b")], name="test")
+    video = Video.from_filename("test.mp4")
+    instance = Instance.from_numpy(
+        np.array([[10, 20], [30, 40]], dtype=np.float32),
+        skeleton=skeleton,
+    )
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[instance])
+    li = UserLabelImage(
+        data=np.array([[0, 1], [0, 0]], dtype=np.int32),
+        objects={1: LabelImage.Info(instance=instance)},
+        video=video,
+        frame_idx=0,
+    )
+    labels = Labels(labeled_frames=[lf], label_images=[li])
+
+    path1 = str(tmp_path / "original.slp")
+    save_slp(labels, path1)
+
+    # Lazy load -> save (should preserve instance_idx via _instance_idx)
+    lazy = load_slp(path1, lazy=True)
+    assert lazy.label_images[0].objects[1].instance is None
+    assert lazy.label_images[0].objects[1]._instance_idx == 0
+
+    path2 = str(tmp_path / "roundtrip.slp")
+    save_slp(lazy, path2)
+
+    # Verify the round-tripped file still has the association
+    reloaded = load_slp(path2)
+    assert len(reloaded.label_images) == 1
+    assert reloaded.label_images[0].objects[1].instance is not None
+    assert (
+        reloaded.label_images[0].objects[1].instance
+        is reloaded.labeled_frames[0].instances[0]
+    )
+
+
+def test_label_image_instance_lazy_materialize(tmp_path):
+    """Label image instance should be resolved when lazy Labels is materialized."""
+    skeleton = Skeleton(nodes=["a", "b"], edges=[("a", "b")], name="test")
+    video = Video.from_filename("test.mp4")
+    instance = Instance.from_numpy(
+        np.array([[10, 20], [30, 40]], dtype=np.float32),
+        skeleton=skeleton,
+    )
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[instance])
+    li = UserLabelImage(
+        data=np.array([[0, 1], [0, 0]], dtype=np.int32),
+        objects={1: LabelImage.Info(instance=instance)},
+        video=video,
+        frame_idx=0,
+    )
+    labels = Labels(labeled_frames=[lf], label_images=[li])
+
+    path = str(tmp_path / "test.slp")
+    save_slp(labels, path)
+
+    lazy = load_slp(path, lazy=True)
+    assert lazy.label_images[0].objects[1].instance is None
+    assert lazy.label_images[0].objects[1]._instance_idx == 0
+
+    materialized = lazy.materialize()
+    assert materialized.label_images[0].objects[1].instance is not None
+    assert (
+        materialized.label_images[0].objects[1].instance
+        is materialized.labeled_frames[0].instances[0]
+    )
+    assert materialized.label_images[0].objects[1]._instance_idx == -1
+
+
 # -- h5wasm compatibility tests --
 
 

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -5556,15 +5556,19 @@ def test_labels_copy_preserves_label_images(slp_minimal, tmp_path):
 
 
 def test_labels_materialize_label_images(tmp_path):
-    """materialize() deep copies label_images, relinking video/track refs."""
+    """materialize() deep copies label_images, relinking video/track/instance refs."""
     video = Video(filename="test.mp4")
     track = Track(name="t1")
     skeleton = Skeleton(["A"])
+    instance = Instance.from_numpy(
+        np.array([[10, 20]], dtype=np.float32), skeleton=skeleton
+    )
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[instance])
 
     li = UserLabelImage(
         data=np.array([[0, 1], [2, 0]], dtype=np.int32),
         objects={
-            1: LabelImage.Info(track=track, category="neuron"),
+            1: LabelImage.Info(track=track, category="neuron", instance=instance),
             2: LabelImage.Info(category="glia"),
         },
         video=video,
@@ -5572,6 +5576,7 @@ def test_labels_materialize_label_images(tmp_path):
     )
 
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         tracks=[track],
         skeletons=[skeleton],
@@ -5595,6 +5600,11 @@ def test_labels_materialize_label_images(tmp_path):
         if info.track is not None:
             assert info.track is materialized.tracks[0]
             assert info.track is not lazy.tracks[0]
+
+    # Instance in objects resolved via _instance_idx
+    assert mat_li.objects[1].instance is materialized.labeled_frames[0].instances[0]
+    assert mat_li.objects[1]._instance_idx == -1
+    assert mat_li.objects[2].instance is None
 
 
 def test_labels_get_masks_predicted():


### PR DESCRIPTION
## Summary
- Fixes #383: `materialize()` instance relinking for label images now uses deferred `_instance_idx` resolution instead of `id()`-based identity lookup
- Adds `_instance_idx` field to `LabelImage.Info`, matching the existing pattern in `ROI`, `SegmentationMask`, and `BoundingBox`
- Preserves instance index during lazy round-trips (load → save without materializing)

## Key Changes
- **`LabelImage.Info`**: Added `_instance_idx` private attrs field for deferred instance index storage
- **`read_label_images()`**: Stores raw instance index on each `Info` object after construction
- **`write_label_images()`**: Falls back to `info._instance_idx` (instead of `-1`) when instance is unresolved
- **`Labels.materialize()`**: Replaced `instance_set` `id()`-based lookup with `_instance_idx` index resolution

## Testing
- `test_label_image_instance_lazy_roundtrip`: Verifies instance index survives lazy load → save
- `test_label_image_instance_lazy_materialize`: Verifies instance is resolved on materialize
- Updated `test_labels_materialize_label_images` to cover instance relinking

## Design Decisions
Follows the exact `_instance_idx` deferred resolution pattern already established by ROI (`roi.py:93`), SegmentationMask (`mask.py:136`), and BoundingBox (`bbox.py:71`) rather than introducing a new mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)