### PR TITLE
docs: Update documentation for annotation architecture (PRs 401-408)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -953,12 +953,16 @@ for mask in li.to_masks():
 
 ### Merge segmentation results
 
-Combine label images from multiple SLP files into one (e.g., after parallel batch processing).
+Combine label images from multiple SLP files into one (e.g., after parallel
+batch processing). This uses [`merge_label_images()`][sleap_io.merge_label_images],
+a specialized function that copies compressed HDF5 chunks directly between files
+without decompressing pixel data — much faster than loading everything into
+memory with [`Labels.merge()`](merging.md).
 
 ```python title="merge_segmentation.py" linenums="1"
 import sleap_io as sio
 
-# Merge multiple batch results — copies compressed chunks directly
+# Merge batch results at the file level (no decompression needed)
 merged = sio.merge_label_images(
     ["batch_0.slp", "batch_1.slp", "batch_2.slp"],
     "all_frames.slp",
@@ -966,9 +970,13 @@ merged = sio.merge_label_images(
 print(f"Merged: {len(merged.label_images)} total frames")
 ```
 
-!!! tip
-    For chunked-format sources (v2.2), merge copies raw compressed data without
-    decompression — it's I/O-bound, not CPU-bound.
+!!! info "Why not `Labels.merge()`?"
+    [`Labels.merge()`](merging.md) loads all data into Python objects, which is
+    necessary for matching and resolving conflicts between keypoint annotations.
+    For label images — which are typically non-overlapping frame batches from
+    parallel segmentation — `merge_label_images()` skips all of that and
+    concatenates the compressed pixel chunks directly. This makes it I/O-bound
+    rather than CPU-bound.
 
 !!! note "See also"
     - [Merging: Label images](merging.md#merging-label-images): Full merge documentation

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -861,30 +861,42 @@ For datasets too large to hold in memory, write frames one at a time with consta
 import numpy as np
 import sleap_io as sio
 
-video = sio.load_video("microscopy.tif")  # shape: (n_frames, H, W, channels)
-
-# Shared dict accumulates track mappings across frames
-shared_tracks = {}
+# Load source video for frame data and metadata
+video = sio.load_video("microscopy.tif")  # shape: (n_frames, height, width, channels)
 
 # Stream frames to SLP — file is created lazily on first add()
+# video is optional: associates all label images with this video in the SLP file
 with sio.LabelImageWriter("output.slp", video=video) as writer:
-    for frame_idx in range(n_frames):
-        mask = run_segmentation(frame_idx)  # your segmentation function
+    for frame_idx in range(len(video)):
+        # Read the frame and run your segmentation model
+        mask = run_segmentation(video[frame_idx])  # returns (H, W) int32
+
         li = sio.PredictedLabelImage.from_numpy(
             mask, video=video, frame_idx=frame_idx,
-            tracks=shared_tracks, create_tracks=True,
             source="cellpose:nuclei", score=1.0,
         )
         writer.add(li)
 # File finalized and closed on context exit
 ```
 
-!!! info "Accumulating tracks"
-    Passing a dict as ``tracks`` with ``create_tracks=True`` turns it into a shared
-    accumulator — existing entries are reused and new label IDs get fresh ``Track``
-    objects added to the dict in place. This gives cross-frame identity without
-    requiring all data in memory. The writer auto-collects new tracks from each
-    ``add()`` call.
+!!! info "Tracking across frames"
+    By default, each frame's objects are independent — no cross-frame identity.
+    To link objects across frames, pass a shared dict as ``tracks`` with
+    ``create_tracks=True``:
+
+    ```python
+    shared_tracks = {}  # accumulates {label_id: Track} across frames
+
+    li = sio.PredictedLabelImage.from_numpy(
+        mask, video=video, frame_idx=frame_idx,
+        tracks=shared_tracks, create_tracks=True,  # reuse existing, create new
+        source="cellpose:nuclei", score=1.0,
+    )
+    ```
+
+    Existing entries in the dict are reused and new label IDs get fresh ``Track``
+    objects added in place. This gives cross-frame identity without requiring all
+    data in memory. The writer auto-collects new tracks from each ``add()`` call.
 
 !!! tip "Memory and performance"
     The writer uses the chunked HDF5 format with gzip compression. Only one frame's

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -917,26 +917,33 @@ import sleap_io as sio
 
 # Load — pixel data is lazy (metadata queries don't decompress)
 labels = sio.load_slp("segmentation.slp")
-li = labels.label_images[0]
-print(li.frame_idx, li.n_objects)  # no decompression yet
 
-# Extract all frames as (T, H, W) numpy array
-all_masks = np.stack([li.data for li in labels.label_images])
+# Access label images through frames (annotations are nested in LabeledFrames)
+lf = labels[0]  # first labeled frame
+print(lf.frame_idx, len(lf.label_images))  # no decompression yet
+
+# Inspect a single label image
+li = lf.label_images[0]
+print(li.n_objects, li.tracks, li.categories)  # still no decompression
+
+# Extract all frames as (n_frames, height, width) numpy array
+# .data triggers lazy decompression for each frame
+all_label_images = labels.label_images  # flattened view across all frames
+all_masks = np.stack([li.data for li in all_label_images])
 
 # Export as TIFF stack (with sidecar metadata JSON)
-sio.save_label_images("masks.tif", labels.label_images, stack=True)
+sio.save_label_images("masks.tif", all_label_images, stack=True)
 
-# Decompose one frame into per-object binary masks
-individual_masks = li.to_masks()
-for mask in individual_masks:
-    print(f"{mask.track}: {mask.area} pixels")
+# Decompose one frame into per-object binary SegmentationMasks
+for mask in li.to_masks():
+    print(f"{mask.category}: {mask.area} pixels")
 ```
 
 ??? example "Expected output shapes"
     For a dataset with 42 frames at 592x608 with 21 objects:
 
     - `all_masks.shape`: `(42, 592, 608)`, dtype `int32`
-    - `individual_masks`: list of 21 `SegmentationMask` objects
+    - `li.to_masks()`: list of 21 [`SegmentationMask`](model/regions.md#segmentation-masks) objects
     - Each mask: boolean array `(592, 608)` for one object
 
 !!! note "See also"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -709,23 +709,13 @@ video = sio.load_video("test.mp4")
 print(sio.get_default_video_plugin())  # "FFMPEG"
 ```
 
-!!! info "Backend trade-offs"
+!!! info "Video backend trade-offs"
 
-    **OpenCV** (`opencv`):
-
-    - ✅ Generally faster for frame reading
-    - ❌ May have compatibility issues on some platforms
-    - ❌ Frame seeking may be less accurate for some codecs
-
-    - ✅ Works out of the box (bundled with sleap-io)
-    - ✅ More reliable and cross-platform
-    - ✅ Better seeking accuracy
-    - ✅ Always installed with sleap-io (default)
-    - ❌ May be slower than OpenCV
-
-    **PyAV** (`pyav`):
-
-    - ✅ Alternative FFMPEG wrapper with different performance characteristics
+    | Backend | Install | Speed | Notes |
+    |---------|---------|-------|-------|
+    | **FFMPEG** (`FFMPEG`) | Bundled (always available) | Moderate | Default. Most reliable, best seeking accuracy |
+    | **OpenCV** (`opencv`) | `pip install sleap-io[opencv]` | Fastest | May have platform-specific issues |
+    | **PyAV** (`pyav`) | `pip install sleap-io[pyav]` | Fast | Alternative FFMPEG wrapper |
 
 Choose which backend to use when encoding frames in `.pkg.slp` files with `sio.save_slp()`.
 
@@ -753,18 +743,16 @@ print(sio.get_default_image_plugin())  # "opencv"
 
 !!! info "Image backend options"
 
-    **OpenCV** (`opencv`):
+    | Backend | Install | Notes |
+    |---------|---------|-------|
+    | **imageio** (`imageio`) | Bundled (always available) | Default. Encodes in RGB channel order |
+    | **OpenCV** (`opencv`) | `pip install sleap-io[opencv]` | Faster encoding. Encodes in BGR internally |
 
-    - ✅ Generally faster encoding
-    - Encodes in BGR channel order
-
-    - ✅ Always installed with sleap-io (default)
-    - ✅ More reliable and cross-platform
-    - Encodes in RGB channel order
+    RGB/BGR conversion is handled automatically — frames always load in RGB regardless of which backend was used for encoding.
 
 !!! note "Plugin vs backend terminology"
     - **Video plugins**: Used by `sio.load_video()` for reading video files (`opencv`, `FFMPEG`, `pyav`)
-    - **Image plugins**: Used by `sio.save_slp()` for encoding embedded frames (`opencv`, `imageio`)
+    - **Image plugins**: Used by `sio.save_slp()` for encoding embedded frames in `.pkg.slp` files (`opencv`, `imageio`)
     - Both can be set via `set_default_*_plugin()` functions
 
 !!! note "See also"

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -785,12 +785,12 @@ Convert a `(T, H, W)` integer mask array into an SLP file with object metadata.
 import numpy as np
 import sleap_io as sio
 
-# Load masks from segmentation tool output — (T, H, W) int32
-# 0 = background, 1+ = object IDs
-masks = np.load("cellpose_masks.npy")
+# Load masks from segmentation tool output — (n_frames, height, width) int32
+# 0 = background, 1+ = object IDs per frame
+masks = np.load("cellpose_masks.npy")  # e.g., shape (100, 512, 512)
 
-# Create video reference
-video = sio.Video("microscopy.tif")
+# Load the source video
+video = sio.load_video("microscopy.tif")  # shape: (n_frames, height, width, channels)
 
 # Convert to PredictedLabelImages with shared tracks across frames
 label_images = sio.PredictedLabelImage.from_stack(
@@ -798,14 +798,8 @@ label_images = sio.PredictedLabelImage.from_stack(
     create_tracks=True, score=1.0,
 )
 
-# Collect tracks for serialization
-tracks = list({
-    info.track for li in label_images
-    for info in li.objects.values() if info.track is not None
-})
-
-# Save
-labels = sio.Labels(label_images=label_images, videos=[video], tracks=tracks)
+# Build Labels — label_images are distributed to LabeledFrames automatically
+labels = sio.Labels(label_images=label_images, videos=[video])
 labels.save("segmentation.slp")
 ```
 
@@ -839,11 +833,13 @@ Convert per-object binary masks from tools like [SAM](https://github.com/faceboo
 import numpy as np
 import sleap_io as sio
 
-# Per-object binary masks from SAM — (N, H, W) bool
-sam_masks = np.load("sam_masks.npy")  # e.g., shape (5, 512, 512)
+# Per-object binary masks from SAM — (n_objects, height, width) bool array
+# Each mask[i] is a binary mask for one detected object in a single frame
+sam_masks = np.load("sam_masks.npy")  # e.g., shape (5, 512, 512) = 5 objects
 object_scores = [0.95, 0.92, 0.88, 0.85, 0.80]
 
-video = sio.Video("microscopy.tif")
+# Load the source video (e.g., a single-frame or multi-frame TIFF)
+video = sio.load_video("microscopy.tif")  # shape: (n_frames, height, width, channels)
 
 # Create a PredictedLabelImage with tracks and per-object scores
 li = sio.PredictedLabelImage.from_binary_masks(
@@ -854,13 +850,15 @@ li = sio.PredictedLabelImage.from_binary_masks(
     video=video, frame_idx=0, source="sam",
 )
 
-labels = sio.Labels(label_images=[li], videos=[video])
+# Add the label image to a Labels dataset via a LabeledFrame
+labels = sio.Labels(videos=[video])
+labels.add_label_image(li)
 labels.save("sam_output.slp")
 ```
 
 !!! tip "When to use which import method"
-    - **`from_binary_masks`**: You have N separate boolean masks per object (SAM, Mask R-CNN).
-    - **`from_stack`**: You have a `(T, H, W)` integer array where each pixel value is an object ID (Cellpose, StarDist).
+    - **`from_binary_masks`**: You have per-object boolean masks for a single frame — shape `(n_objects, H, W)` (SAM, Mask R-CNN).
+    - **`from_stack`**: You have a `(n_frames, H, W)` integer array where each pixel value is an object ID (Cellpose, StarDist).
     - **`from_numpy`**: You have a single `(H, W)` integer array for one frame.
 
 !!! note "See also"
@@ -875,7 +873,7 @@ For datasets too large to hold in memory, write frames one at a time with consta
 import numpy as np
 import sleap_io as sio
 
-video = sio.Video("microscopy.tif")
+video = sio.load_video("microscopy.tif")  # shape: (n_frames, H, W, channels)
 
 # Shared dict accumulates track mappings across frames
 shared_tracks = {}

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -20,7 +20,7 @@ This page provides practical examples for common tasks with sleap-io. Each examp
 
 ### Create labels from raw data
 
-Build a complete labels dataset programmatically.
+Build a complete [`Labels`][sleap_io.Labels] dataset programmatically from a [`Skeleton`][sleap_io.Skeleton], [`Video`][sleap_io.Video], and [`Instance`][sleap_io.Instance] objects.
 
 ```python title="create_labels.py" linenums="1"
 import sleap_io as sio
@@ -56,12 +56,17 @@ labels.save("labels.slp")
 ```
 
 ??? tip "Creating predicted instances"
-    To create predictions with confidence scores:
+    To create predictions with confidence scores, include scores as the third
+    column of the points array:
     ```python
-    predicted_instance = sio.PredictedInstance.from_numpy(
-        points=points_array,
-        confidence=confidence_array,  # Shape: (n_nodes,)
-        skeleton=skeleton
+    predicted = sio.PredictedInstance.from_numpy(
+        np.array([
+            [10.2, 20.4, 0.9],   # head (x, y, score)
+            [5.8, 15.1, 0.8],    # thorax
+            [0.3, 10.6, 0.7],    # abdomen
+        ]),
+        skeleton=skeleton,
+        score=0.85,  # instance-level confidence
     )
     ```
 
@@ -73,7 +78,7 @@ labels.save("labels.slp")
 
 ### Convert labels to raw arrays
 
-Extract pose data as NumPy arrays for analysis or visualization.
+Extract pose data as NumPy arrays for analysis or visualization using [`Labels.numpy()`][sleap_io.Labels.numpy].
 
 ```python title="labels_to_numpy.py" linenums="1"
 import sleap_io as sio
@@ -104,7 +109,7 @@ assert xy_score == 3  # x, y, and confidence score
 
 ### Load and save in different formats
 
-Convert between supported formats with automatic format detection.
+Convert between supported formats with automatic format detection using [`load_file()`][sleap_io.load_file] and [`Labels.save()`][sleap_io.Labels.save].
 
 ```python title="format_conversion.py" linenums="1"
 import sleap_io as sio
@@ -158,40 +163,47 @@ sio.save_nwb(labels, "dataset_export.nwb", nwb_format="annotations_export")
 Include detailed experimental metadata when saving training annotations.
 
 ```python title="nwb_metadata.py" linenums="1"
-from sleap_io.io.nwb_annotations import save_labels
+import sleap_io as sio
 
-# Save with comprehensive metadata
-save_labels(
-    labels,
-    "training_data.nwb",
-    session_description="Mouse skilled reaching task - training dataset",
-    identifier="mouse_01_session_03_annotations",
-    session_start_time="2024-01-15T09:30:00",
-    annotator="John Doe",
-    nwb_kwargs={
-        # Session metadata
-        "session_id": "session_003",
-        "experimenter": ["John Doe", "Jane Smith"],
-        "lab": "Motor Control Lab",
-        "institution": "University of Example",
+labels = sio.load_file("labels.slp")
 
-        # Experimental details
-        "experiment_description": "Skilled reaching task with food pellet reward",
-        "protocol": "Protocol 2024-001",
-        "surgery": "Cranial window implant over M1",
-
-        # Subject information
-        "subject": {
-            "subject_id": "mouse_01",
-            "age": "P90",
-            "sex": "M",
-            "species": "Mus musculus",
-            "strain": "C57BL/6J",
-            "weight": "25g"
-        }
-    }
-)
+# Basic save with default metadata
+sio.save_nwb(labels, "training_data.nwb", nwb_format="annotations")
 ```
+
+??? tip "Advanced: custom NWB metadata (internal API)"
+    The public `save_nwb()` uses default metadata. To customize session
+    descriptions, subject info, and other NWB fields, use the internal
+    `save_labels()` function. This is not part of the public API and may
+    change between versions.
+
+    ```python
+    from sleap_io.io.nwb_annotations import save_labels
+
+    save_labels(
+        labels,
+        "training_data.nwb",
+        session_description="Mouse skilled reaching task - training dataset",
+        identifier="mouse_01_session_03_annotations",
+        session_start_time="2024-01-15T09:30:00",
+        annotator="John Doe",
+        nwb_kwargs={
+            "session_id": "session_003",
+            "experimenter": ["John Doe", "Jane Smith"],
+            "lab": "Motor Control Lab",
+            "institution": "University of Example",
+            "experiment_description": "Skilled reaching task with food pellet reward",
+            "subject": {
+                "subject_id": "mouse_01",
+                "age": "P90",
+                "sex": "M",
+                "species": "Mus musculus",
+                "strain": "C57BL/6J",
+                "weight": "25g",
+            },
+        },
+    )
+    ```
 
 !!! tip "Metadata best practices"
     Include as much metadata as possible for reproducibility:
@@ -204,41 +216,50 @@ save_labels(
 ### Export dataset with embedded videos
 
 Create self-contained NWB files with video frames for sharing complete datasets.
+The simplest approach uses the public API:
 
 ```python title="nwb_export.py" linenums="1"
-from sleap_io.io.nwb_annotations import export_labels, export_labeled_frames
+import sleap_io as sio
 
-# Method 1: Export complete dataset with all videos
-export_labels(
-    labels,
-    output_dir="export/",
-    nwb_filename="complete_dataset.nwb",
-    as_training=True,      # Include manual annotations
-    include_videos=True,    # Embed all video frames
-    include_skeleton=True   # Include skeleton definition
-)
+labels = sio.load_file("labels.slp")
 
-# Method 2: Export only frames with labels as a new video
-export_labeled_frames(
-    labels,
-    output_path="labeled_frames.avi",         # MJPEG video output
-    labels_output_path="labeled_frames.nwb",  # Corresponding labels
-    fps=30.0,                                  # Output frame rate
-    scale=1.0                                  # Video scale factor
-)
-
-# The export includes a FrameMap JSON file tracking frame origins
-import json
-with open("labeled_frames.frame_map.json", "r") as f:
-    frame_map = json.load(f)
-    print(f"Exported {frame_map['total_frames']} frames from {len(frame_map['videos'])} videos")
+# Export annotations with embedded video frames to NWB
+sio.save_nwb(labels, "dataset_export.nwb", nwb_format="annotations_export")
 ```
 
-!!! info "Export formats"
+??? tip "Advanced: fine-grained export control"
+    For more control over the export process (e.g., custom filenames, multi-subject
+    support), use the internal export functions directly. These are not part of the
+    public API and may change between versions.
 
-    - **Full export**: Includes all video frames, creating large but complete files
-    - **Labeled frames only**: Exports just frames with annotations, reducing file size
-    - **Frame provenance**: JSON metadata tracks which frames came from which source videos
+    ```python
+    from sleap_io.io.nwb_annotations import export_labels, export_labeled_frames
+
+    # Export annotations + MJPEG video + frame map to a directory
+    export_labels(
+        labels,
+        output_dir="export/",
+        mjpeg_filename="annotated_frames.avi",
+        frame_map_filename="frame_map.json",
+        nwb_filename="pose_training.nwb",
+        clean=True,  # Remove empty frames and predictions before export
+    )
+
+    # Or export just labeled frames with provenance tracking
+    frame_map = export_labeled_frames(
+        labels,
+        frame_map_path="export/frame_map.json",
+        mjpeg_path="export/labeled_frames.avi",
+        nwb_path="export/labeled_frames.nwb",
+    )
+    print(f"Exported {frame_map.total_frames} frames")
+    ```
+
+!!! info "Export contents"
+
+    - **NWB file**: Annotations in PoseTraining format with skeleton definition
+    - **MJPEG video**: Labeled frames re-encoded as a seekable MJPEG video
+    - **Frame map JSON**: Provenance metadata tracking which frames came from which source videos
 
 ### Convert between NWB and other formats
 
@@ -472,22 +493,27 @@ import numpy as np
 
 labels = sio.load_file("predictions.slp")
 
-# Convert to array of shape (n_frames, n_tracks, n_nodes, xy)
+# Convert to array — shape: (n_frames, n_tracks, n_nodes, 2)
 trx = labels.numpy()
 
-# Apply temporal filtering (example: simple moving average)
-window_size = 5
-trx_filtered = np.convolve(trx.reshape(-1), np.ones(window_size)/window_size, mode='same').reshape(trx.shape)
+# Apply temporal smoothing along the frame axis (axis=0)
+# This moving average operates independently per track/node/coordinate
+kernel = np.ones(5) / 5
+trx_smoothed = np.apply_along_axis(
+    lambda x: np.convolve(x, kernel, mode="same"), axis=0, arr=trx
+)
 
-# Update the labels with filtered data
-labels.update_from_numpy(trx_filtered)
+# Update the labels with smoothed coordinates
+labels.update_from_numpy(trx_smoothed)
 
-# Save the filtered version
-labels.save("predictions.filtered.slp")
+# Save the smoothed version
+labels.save("predictions.smoothed.slp")
 ```
 
-??? tip "Advanced filtering with movement"
-    For more sophisticated analysis and filtering, check out the [`movement`](https://movement.neuroinformatics.dev/) library for pose processing.
+!!! tip "Advanced filtering with movement"
+    For more sophisticated temporal filtering (Kalman, median, Savitzky-Golay),
+    check out the [`movement`](https://movement.neuroinformatics.dev/) library
+    which provides purpose-built tools for pose trajectory processing.
 
 !!! warning
     When updating from numpy, the array shape must match the original data structure exactly.
@@ -539,15 +565,18 @@ def on_progress(current, total):
 labels.save("labels.pkg.slp", embed="user", progress_callback=on_progress)
 ```
 
-**Cancellation support:**
+**Cancellation support** (e.g., for GUI integration where a user can click "Cancel"):
 
 ```python title="embed_with_cancel.py" linenums="1"
+import sleap_io as sio
 from sleap_io.io.slp import ExportCancelled
 
-cancelled = False
+labels = sio.load_file("labels.slp")
+
+cancelled = False  # Set to True from another thread/signal to cancel
 
 def on_progress(current, total):
-    return not cancelled  # Return False to cancel
+    return not cancelled  # Return False to cancel the export
 
 try:
     labels.save("output.pkg.slp", embed="user", progress_callback=on_progress)
@@ -991,14 +1020,14 @@ import sleap_io as sio
 
 labels = sio.load_slp("predictions.slp")
 
-# Render full video
+# Render full video (MP4 with skeleton overlays at source resolution)
 labels.render("output.mp4")
 
-# Fast preview (0.25x resolution)
+# Fast preview for iteration (0.25x resolution, faster encoding)
 labels.render("preview.mp4", preset="preview")
 
-# Single frame to image
-sio.render_image(labels.labeled_frames[0], "frame.png")
+# Single frame to PNG image
+sio.render_image(labels[0], "frame.png")
 ```
 
 ```bash title="CLI"

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,85 +6,76 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sleap-io)
 [![PyPI](https://img.shields.io/pypi/v/sleap-io?label=PyPI)](https://pypi.org/project/sleap-io)
 
-Standalone utilities for working with animal pose tracking data.
+A standalone Python library and CLI for working with animal pose tracking data.
+Read, write, convert, and manipulate pose data across formats with minimal
+dependencies.
 
-This is intended to be a complement to the core [SLEAP](https://github.com/talmolab/sleap)
-package that aims to provide functionality for interacting with pose tracking-related
-data structures and file formats with minimal dependencies. This package *does not*
-have any functionality related to labeling, training, or inference.
+Complements the core [SLEAP](https://github.com/talmolab/sleap) package but
+does *not* include labeling, training, or inference.
 
 ## Features
 
-The main purpose of this library is to provide utilities to load/save from different
-[formats](formats/) for pose data and standardize them into our common [Data Model](model/index.md).
-
-- Read/write labels in [SLP](formats/#sleap_io.load_slp), [NWB](formats/#sleap_io.load_nwb), [AlphaTracker](formats/#sleap_io.load_alphatracker), [DeepLabCut](formats/#sleap_io.load_dlc), [JABS](formats/#sleap_io.load_jabs), [LabelStudio](formats/#sleap_io.load_labelstudio), [LEAP](formats/#sleap_io.load_leap), [CSV](formats/#csv-format-csv) and [Ultralytics YOLO](formats/#sleap_io.load_ultralytics) formats.
-- Support for [LabelsSet](model/labels.md#sleap_io.LabelsSet) to manage multiple dataset splits (train/val/test) and export to different formats.
-- [Read videos in any format](formats/#sleap_io.load_video), work them in a [numpy-like interface](model/video.md#sleap_io.Video) whether the video files are accessible or not, and [easily save them out](formats/#sleap_io.save_video).
-
-This enables ease-of-use through format-agnostic operations that make it easy to work
-with pose data, including utilities for common tasks. Some of these include:
-
-- [Create labels from a custom format](examples.md#create-labels-from-raw-data)
-- [Convert labels to numpy arrays for analysis](examples.md#convert-labels-to-raw-arrays)
-- [Fix video paths in the labels](examples.md#fix-video-paths)
-- [Make training/validation/test splits](examples.md#make-trainingvalidationtest-splits)
-- [Convert to Ultralytics YOLO format](examples.md#convert-to-ultralytics-yolo-format)
-- [Replace a skeleton](examples.md#replace-skeleton)
-
-See [Examples](examples.md) for more usage examples and recipes.
-
+- **Multi-format I/O** -- Read and write [SLEAP](formats/index.md#sleap-native-format-slp), [NWB](formats/index.md#nwb-format-nwb), [COCO](formats/index.md#coco-format-json), [DeepLabCut](formats/index.md#deeplabcut-format-h5-csv), [Ultralytics YOLO](formats/index.md#ultralytics-yolo-format), [JABS](formats/index.md#jabs-format-h5), [Label Studio](formats/index.md#label-studio-format-json), [CSV](formats/index.md#csv-format-csv), [Analysis HDF5](formats/index.md#sleap-analysis-hdf5-format-h5), [AlphaTracker](formats/index.md#alphatracker-format), and [LEAP](formats/index.md#leap-format-mat) formats
+- **CLI tools** -- Inspect, convert, render, and transform data from the command line ([reference](cli.md))
+- **Rendering** -- Produce publication-quality videos and images with pose overlays, customizable colors, markers, and presets ([guide](rendering.md))
+- **Transforms** -- Crop, scale, rotate, pad, and flip videos with automatic coordinate adjustment ([guide](transforms.md))
+- **Merging** -- Combine annotations from multiple sources with flexible matching strategies ([guide](merging.md))
+- **Codecs** -- Convert to/from NumPy arrays, DataFrames (pandas/polars), and dictionaries ([guide](codecs.md))
+- **Video I/O** -- Read any video format via pluggable backends (FFMPEG, OpenCV, PyAV) with a NumPy-like interface ([model](model/video.md))
+- **Lazy loading** -- Load large SLP files up to 90x faster by deferring object creation ([details](formats/slp.md#lazy-loading))
+- **Dataset splits** -- Create train/val/test splits and export to formats like Ultralytics YOLO ([example](examples.md#make-trainingvalidationtest-splits))
 
 ## Installation
 
-### From PyPI
-```
-pip install sleap-io
-```
-
-or
-
-```
-conda install -c conda-forge sleap-io
+```bash
+pip install "sleap-io[all]"
 ```
 
-### From source (latest version)
-```
-pip install git+https://github.com/talmolab/sleap-io.git@main
+Or use without installing:
+
+```bash
+uvx sleap-io show labels.slp
 ```
 
-### Optional Dependencies
+See [Installation](install.md) for all options including `uv`, `conda`, CLI tool install, and development setup.
 
-Video support is included by default via imageio-ffmpeg. For faster video backends or additional format support:
-```
-pip install sleap-io[opencv]  # For OpenCV backend (fastest)
-pip install sleap-io[pyav]     # For PyAV backend (balanced speed/features)
-pip install sleap-io[mat]      # For LEAP .mat file support
-pip install sleap-io[all]      # All optional backends and formats
-```
+## Quick start
 
-### Development Installation
+### CLI
 
-For development, use one of the following:
-```
-uv sync --all-extras           # Recommended: install with uv
-```
-```
-conda env create -f environment.yml
-```
-```
-pip install -e .[dev,all]      # Install with all extras for development
+```bash
+sio show labels.slp                                    # Inspect a file
+sio convert -i labels.slp -o labels.nwb                # Convert formats
+sio render -i predictions.slp -o output.mp4            # Render video
+sio transform labels.slp --scale 0.5 -o scaled.slp    # Transform
 ```
 
+### Python
+
+```python
+import sleap_io as sio
+
+# Load and convert between formats
+labels = sio.load_file("predictions.slp")
+labels.save("predictions.nwb")
+
+# Convert to NumPy arrays
+trx = labels.numpy()  # (n_frames, n_tracks, n_nodes, 2)
+
+# Merge annotations from multiple sources
+base = sio.load_file("manual_annotations.slp")
+base.merge(sio.load_file("predictions.slp"))
+base.save("merged.slp")
+```
+
+See [Examples](examples.md) for more recipes including creating labels from scratch, NWB export, rendering, skeleton replacement, and YOLO/COCO export.
 
 ## Support
-For technical inquiries specific to this package, please [open an Issue](https://github.com/talmolab/sleap-io/issues)
-with a description of your problem or request.
 
-For general SLEAP usage, see the [main website](https://sleap.ai).
+For technical inquiries, please [open an Issue](https://github.com/talmolab/sleap-io/issues).
 
-Other questions? Reach out to `talmo@salk.edu`.
+For general SLEAP usage, see [sleap.ai](https://sleap.ai).
 
 ## License
-This package is distributed under a BSD 3-Clause License and can be used without
-restrictions. See [`LICENSE`](https://github.com/talmolab/sleap-io/blob/main/LICENSE) for details.
+
+BSD 3-Clause License. See [`LICENSE`](https://github.com/talmolab/sleap-io/blob/main/LICENSE) for details.

--- a/docs/merging.md
+++ b/docs/merging.md
@@ -568,6 +568,58 @@ masks by the centroid of their bounding box.
 New frames (no matching frame in the target) always copy all annotations from the
 source, regardless of strategy.
 
+### Example: merging with annotations
+
+```pycon
+>>> import sleap_io as sio
+>>> import numpy as np
+>>> skeleton = sio.Skeleton(["head", "thorax", "abdomen"])
+>>> video = sio.Video("test.mp4", open_backend=False)
+>>> inst1 = sio.Instance.from_numpy(
+...     np.array([[10, 20], [30, 40], [50, 60]]),
+...     skeleton=skeleton,
+... )
+>>> lf1 = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst1])
+>>> lf1.bboxes.append(sio.UserBoundingBox(
+...     x1=5, y1=15, x2=55, y2=65, video=video, frame_idx=0,
+... ))
+>>> base = sio.Labels(labeled_frames=[lf1])
+>>> inst2 = sio.PredictedInstance.from_numpy(
+...     np.array([[10, 20, 0.9], [30, 40, 0.8], [50, 60, 0.7]]),
+...     skeleton=skeleton,
+...     score=0.9,
+... )
+>>> lf2 = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst2])
+>>> lf2.bboxes.append(sio.PredictedBoundingBox(
+...     x1=6, y1=16, x2=56, y2=66, video=video, frame_idx=0, score=0.9,
+... ))
+>>> base.merge(sio.Labels(labeled_frames=[lf2]))
+>>> print(len(base[0].bboxes))
+
+```
+
+### Per-modality spatial matching
+
+For `auto` and `update_tracks` strategies, annotations are paired by centroid
+distance. Each annotation type extracts its centroid differently:
+
+| Modality | Centroid source |
+|----------|----------------|
+| Centroids | `(x, y)` coordinates directly |
+| Bounding boxes | `centroid_xy` property (box center) |
+| ROIs | `centroid_xy` property (geometry centroid) |
+| Segmentation masks | Centroid of `bbox` (bounding box center) |
+
+The matching threshold is controlled by the `instance` parameter — the same
+threshold applies to both instance matching and annotation matching:
+
+```python
+from sleap_io.model.matching import InstanceMatcher
+
+# Use a wider threshold (10px) for annotation matching
+base.merge(other, instance=InstanceMatcher(method="spatial", threshold=10.0))
+```
+
 ---
 
 ## Merging label images

--- a/docs/model/index.md
+++ b/docs/model/index.md
@@ -59,6 +59,11 @@ classDiagram
         +Video video
         +int frame_idx
         +instances
+        +centroids
+        +bboxes
+        +masks
+        +label_images
+        +rois
     }
     class SuggestionFrame:::labels {
         +Video video
@@ -140,6 +145,16 @@ classDiagram
         +to_masks()
     }
 
+    class Centroid:::regions {
+        <<abstract>>
+        +float x
+        +float y
+    }
+    class UserCentroid:::regions
+    class PredictedCentroid:::regions {
+        +float score
+    }
+
     Skeleton "1" *-- "1..*" Node
     Skeleton "1" *-- "0..*" Edge
     Skeleton "1" *-- "0..*" Symmetry
@@ -162,6 +177,8 @@ classDiagram
     InstanceGroup --> Instance
     InstanceGroup --> Camera
 
+    Centroid <|-- UserCentroid
+    Centroid <|-- PredictedCentroid
     BoundingBox <|-- UserBoundingBox
     BoundingBox <|-- PredictedBoundingBox
     ROI <|-- UserROI
@@ -171,6 +188,11 @@ classDiagram
     LabelImage <|-- UserLabelImage
     LabelImage <|-- PredictedLabelImage
     LabelImage --> SegmentationMask : to_masks()
+    LabeledFrame --> Centroid
+    LabeledFrame --> BoundingBox
+    LabeledFrame --> ROI
+    LabeledFrame --> SegmentationMask
+    LabeledFrame --> LabelImage
 
     classDef poses fill:#0097a7,stroke:#00796b,color:#fff
     classDef labels fill:#43a047,stroke:#2e7d32,color:#fff
@@ -200,6 +222,9 @@ classDiagram
 | [`RecordingSession`](3d.md) | [3D](3d.md) | Multi-camera recording linking cameras to videos |
 | [`FrameGroup`](3d.md) | [3D](3d.md) | Matched labeled frames across views at one time point |
 | [`InstanceGroup`](3d.md) | [3D](3d.md) | Same animal matched across cameras, with optional 3D points |
+| [`Centroid`](regions.md) | [Regions](regions.md) | Abstract base centroid point annotation |
+| [`UserCentroid`](regions.md) | [Regions](regions.md) | Human-annotated centroid |
+| [`PredictedCentroid`](regions.md) | [Regions](regions.md) | Model-predicted centroid with score |
 | [`ROI`](regions.md) | [Regions](regions.md) | Vector geometry annotation (polygon, etc.) |
 | [`SegmentationMask`](regions.md) | [Regions](regions.md) | Run-length encoded pixel mask |
 | [`BoundingBox`](regions.md) | [Regions](regions.md) | Axis-aligned or rotated bounding box |

--- a/docs/model/labels.md
+++ b/docs/model/labels.md
@@ -114,6 +114,57 @@ You can also index with a `(video, frame_idx)` tuple:
 lf = labels[video, 0]  # same as labels.find(video, 0)[0]
 ```
 
+### Fast lookups
+
+`Labels` maintains lazy indices for O(1) frame and track lookups. Use
+`get_frame()` instead of `find()` when you need a single frame:
+
+```pycon
+>>> import sleap_io as sio
+>>> import numpy as np
+>>> skeleton = sio.Skeleton(["head", "thorax", "abdomen"])
+>>> video = sio.Video("test.mp4", open_backend=False)
+>>> track = sio.Track("animal")
+>>> inst = sio.Instance.from_numpy(
+...     np.array([[10, 20], [5, 15], [0, 10]]),
+...     skeleton=skeleton,
+...     track=track,
+... )
+>>> lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
+>>> labels = sio.Labels(labeled_frames=[lf])
+>>> print(labels.get_frame(video, 0))
+>>> print(labels.get_frame(video, 999))
+
+```
+
+Track-level queries return all annotations for a given track across frames,
+sorted by frame index:
+
+```pycon
+>>> import sleap_io as sio
+>>> import numpy as np
+>>> skeleton = sio.Skeleton(["head", "thorax", "abdomen"])
+>>> video = sio.Video("test.mp4", open_backend=False)
+>>> track = sio.Track("animal")
+>>> inst = sio.Instance.from_numpy(
+...     np.array([[10, 20], [5, 15], [0, 10]]),
+...     skeleton=skeleton,
+...     track=track,
+... )
+>>> lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
+>>> labels = sio.Labels(labeled_frames=[lf])
+>>> annotations = labels.get_track_annotations(video, track)
+>>> print(len(annotations))
+
+```
+
+After batch mutations (e.g., changing `frame_idx` or track assignments
+directly), call `reindex()` to rebuild the indices:
+
+```python
+labels.reindex()
+```
+
 ### Array conversion
 
 Convert all tracked instances to a NumPy array for numerical analysis:
@@ -170,6 +221,23 @@ new_skeleton = sio.Skeleton(["HEAD", "BODY", "TAIL"])
 labels.replace_skeleton(new_skeleton)
 ```
 
+**Adding spatial annotations** inserts annotations into the appropriate frame,
+creating the frame if needed:
+
+```python
+labels.add_centroid(sio.UserCentroid(x=100, y=200, video=video, frame_idx=0))
+labels.add_bbox(sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60, video=video, frame_idx=0))
+labels.add_mask(mask)
+labels.add_label_image(label_image)
+labels.add_roi(roi)
+```
+
+!!! note "See also"
+
+    See [Regions](regions.md) for details on creating spatial annotation objects
+    and [Working with annotations in frames](regions.md#working-with-annotations-in-frames)
+    for more examples.
+
 ### Saving
 
 Save labels to any supported format. The format is inferred from the file extension:
@@ -189,7 +257,7 @@ labels.save("output.pkg.slp", embed=True)
 
 ## Labeled frames
 
-A [`LabeledFrame`](#sleap_io.LabeledFrame) contains all annotations for a single frame of a [`Video`](video.md). Each frame holds a list of [`Instance`](poses.md) and/or [`PredictedInstance`](poses.md) objects.
+A [`LabeledFrame`](#sleap_io.LabeledFrame) contains all annotations for a single frame of a [`Video`](video.md). Each frame holds a list of [`Instance`](poses.md) and/or [`PredictedInstance`](poses.md) objects, along with optional spatial annotations: [`centroids`](regions.md), [`bboxes`](regions.md) (bounding boxes), [`masks`](regions.md) (segmentation masks), [`label_images`](regions.md), and [`rois`](regions.md) (regions of interest).
 
 ```pycon
 >>> import sleap_io as sio
@@ -324,6 +392,11 @@ classDiagram
         +Video video
         +int frame_idx
         +List~Instance~ instances
+        +List~Centroid~ centroids
+        +List~BoundingBox~ bboxes
+        +List~SegmentationMask~ masks
+        +List~LabelImage~ label_images
+        +List~ROI~ rois
     }
 
     class Instance {
@@ -363,6 +436,11 @@ classDiagram
     Instance "0..*" --> "1" Skeleton : uses
     Instance "0..*" --> "0..1" Track : belongs to
     SuggestionFrame "0..*" --> "1" Video : references
+    LabeledFrame "1" *-- "0..*" Centroid : centroids
+    LabeledFrame "1" *-- "0..*" BoundingBox : bboxes
+    LabeledFrame "1" *-- "0..*" SegmentationMask : masks
+    LabeledFrame "1" *-- "0..*" LabelImage : label_images
+    LabeledFrame "1" *-- "0..*" ROI : rois
     LabelsSet "1" *-- "1..*" Labels : contains
 ```
 

--- a/docs/model/regions.md
+++ b/docs/model/regions.md
@@ -12,24 +12,24 @@ automatically.
 
 sleap-io provides five spatial annotation types with different trade-offs:
 
-- **`Centroid`** — lightweight point annotation representing the center of an
+- **[`Centroid`][sleap_io.Centroid]** — lightweight point annotation representing the center of an
   object with `x`, `y`, and optional `z` coordinates. Supports conversion to
-  and from single-node [`Instance`](poses.md) objects. Has `UserCentroid` and
-  `PredictedCentroid` subtypes.
-- **`BoundingBox`** — axis-aligned or rotated rectangles, stored as corner
-  coordinates. Has `UserBoundingBox` and `PredictedBoundingBox` subtypes for
+  and from single-node [`Instance`](poses.md) objects. Has [`UserCentroid`][sleap_io.UserCentroid] and
+  [`PredictedCentroid`][sleap_io.PredictedCentroid] subtypes.
+- **[`BoundingBox`][sleap_io.BoundingBox]** — axis-aligned or rotated rectangles, stored as corner
+  coordinates. Has [`UserBoundingBox`][sleap_io.UserBoundingBox] and [`PredictedBoundingBox`][sleap_io.PredictedBoundingBox] subtypes for
   distinguishing human annotations from model outputs.
-- **`ROI`** — arbitrary vector geometry via Shapely (polygons, multi-polygons,
-  etc.). Can be static (whole video) or per-frame. Has `UserROI` and
-  `PredictedROI` subtypes.
-- **`SegmentationMask`** — per-pixel binary masks stored as run-length encoding
-  for compactness. One mask per object. Has `UserSegmentationMask` and
-  `PredictedSegmentationMask` subtypes.
-- **`LabelImage`** — dense per-pixel integer label image storing **all** objects
+- **[`ROI`][sleap_io.ROI]** — arbitrary vector geometry via Shapely (polygons, multi-polygons,
+  etc.). Can be static (whole video) or per-frame. Has [`UserROI`][sleap_io.UserROI] and
+  [`PredictedROI`][sleap_io.PredictedROI] subtypes.
+- **[`SegmentationMask`][sleap_io.SegmentationMask]** — per-pixel binary masks stored as run-length encoding
+  for compactness. One mask per object. Has [`UserSegmentationMask`][sleap_io.UserSegmentationMask] and
+  [`PredictedSegmentationMask`][sleap_io.PredictedSegmentationMask] subtypes.
+- **[`LabelImage`][sleap_io.LabelImage]** — dense per-pixel integer label image storing **all** objects
   for a frame in one array. Standard output of instance segmentation tools like
   [Cellpose](https://www.cellpose.org/) and
-  [StarDist](https://github.com/stardist/stardist). Has `UserLabelImage` and
-  `PredictedLabelImage` subtypes.
+  [StarDist](https://github.com/stardist/stardist). Has [`UserLabelImage`][sleap_io.UserLabelImage] and
+  [`PredictedLabelImage`][sleap_io.PredictedLabelImage] subtypes.
 
 All five base classes are **abstract** — use the `User*` or `Predicted*`
 subclass to create instances. All five can be associated with a video, frame,
@@ -83,10 +83,10 @@ and `labels.rois` properties return flattened views across all frames.
 
 ## Centroids
 
-A `Centroid` represents a single point at the center of an object. Centroids
+A [`Centroid`][sleap_io.Centroid] represents a single point at the center of an object. Centroids
 are the primary annotation type for **object detection** workflows where full
-pose skeletons are not needed. `Centroid` is abstract — use `UserCentroid` or
-`PredictedCentroid`.
+pose skeletons are not needed. `Centroid` is abstract — use [`UserCentroid`][sleap_io.UserCentroid] or
+[`PredictedCentroid`][sleap_io.PredictedCentroid].
 
 Centroids support optional 3D coordinates (`z`), interconversion with
 single-node [`Instance`](poses.md) objects, and the same video/frame/track
@@ -159,7 +159,7 @@ with pose-based workflows:
 
 ### User vs. predicted centroids
 
-`UserCentroid` and `PredictedCentroid` distinguish human annotations from
+[`UserCentroid`][sleap_io.UserCentroid] and [`PredictedCentroid`][sleap_io.PredictedCentroid] distinguish human annotations from
 model predictions. `PredictedCentroid` adds a `score` field for confidence:
 
 ```pycon
@@ -196,10 +196,10 @@ Every centroid can carry optional metadata:
 
 ## Bounding boxes
 
-A `BoundingBox` represents a rectangular region defined by its corner
+A [`BoundingBox`][sleap_io.BoundingBox] represents a rectangular region defined by its corner
 coordinates (`x1`, `y1`, `x2`, `y2`) and an optional rotation angle. Bounding
 boxes are the primary annotation type for object detection workflows.
-`BoundingBox` is abstract — use `UserBoundingBox` or `PredictedBoundingBox`.
+`BoundingBox` is abstract — use [`UserBoundingBox`][sleap_io.UserBoundingBox] or [`PredictedBoundingBox`][sleap_io.PredictedBoundingBox].
 
 ### Direct construction
 
@@ -248,7 +248,7 @@ the top-left corner:
 
 ### User vs. predicted bounding boxes
 
-`UserBoundingBox` and `PredictedBoundingBox` distinguish human annotations from
+[`UserBoundingBox`][sleap_io.UserBoundingBox] and [`PredictedBoundingBox`][sleap_io.PredictedBoundingBox] distinguish human annotations from
 model predictions. `PredictedBoundingBox` adds a `score` field for confidence:
 
 ```pycon
@@ -305,11 +305,11 @@ Every bounding box can carry optional metadata:
 
 ## Regions of interest
 
-An `ROI` represents a vector geometry annotation using
+An [`ROI`][sleap_io.ROI] represents a vector geometry annotation using
 [Shapely](https://shapely.readthedocs.io/) geometries. ROIs are suitable for
 defining arenas, exclusion zones, or arbitrary spatial regions: anything that
 is naturally described by a polygon or set of polygons rather than a simple
-rectangle. `ROI` is abstract — use `UserROI` or `PredictedROI`.
+rectangle. `ROI` is abstract — use [`UserROI`][sleap_io.UserROI] or [`PredictedROI`][sleap_io.PredictedROI].
 
 ### Static vs. temporal ROIs
 
@@ -413,7 +413,7 @@ GeoJSON-aware tools:
 
 ### User vs. predicted ROIs
 
-`UserROI` and `PredictedROI` distinguish human annotations from model
+[`UserROI`][sleap_io.UserROI] and [`PredictedROI`][sleap_io.PredictedROI] distinguish human annotations from model
 predictions. `PredictedROI` adds a `score` field for confidence:
 
 ```pycon
@@ -436,11 +436,11 @@ predictions. `PredictedROI` adds a `score` field for confidence:
 
 ## Segmentation masks
 
-A `SegmentationMask` stores per-pixel binary annotations in a compact
+A [`SegmentationMask`][sleap_io.SegmentationMask] stores per-pixel binary annotations in a compact
 run-length encoded (RLE) format. RLE avoids storing the full raster array,
 making masks efficient for storage and serialization while still supporting
 fast conversion to and from numpy arrays. `SegmentationMask` is abstract — use
-`UserSegmentationMask` or `PredictedSegmentationMask`.
+[`UserSegmentationMask`][sleap_io.UserSegmentationMask] or [`PredictedSegmentationMask`][sleap_io.PredictedSegmentationMask].
 
 ### From a numpy array
 
@@ -515,7 +515,7 @@ with the mask's score.
 
 ### User vs. predicted segmentation masks
 
-`UserSegmentationMask` and `PredictedSegmentationMask` distinguish human
+[`UserSegmentationMask`][sleap_io.UserSegmentationMask] and [`PredictedSegmentationMask`][sleap_io.PredictedSegmentationMask] distinguish human
 annotations from model predictions. `PredictedSegmentationMask` adds `score`
 and optional `score_map` fields:
 
@@ -542,13 +542,13 @@ using zlib compression to avoid bloating files.
 
 ## Label images
 
-A `LabelImage` stores dense per-pixel instance segmentation for a single video
+A [`LabelImage`][sleap_io.LabelImage] stores dense per-pixel instance segmentation for a single video
 frame, where each pixel value encodes which object occupies that pixel. Unlike a
-`SegmentationMask` — which is a binary mask for a single object — a
+[`SegmentationMask`][sleap_io.SegmentationMask] — which is a binary mask for a single object — a
 `LabelImage` stores **all** objects in one integer array. Background pixels are
 `0`, and each positive integer identifies a distinct object. The `objects` dict
 maps these IDs to metadata (track, category, name). `LabelImage` is abstract —
-use `UserLabelImage` or `PredictedLabelImage`.
+use [`UserLabelImage`][sleap_io.UserLabelImage] or [`PredictedLabelImage`][sleap_io.PredictedLabelImage].
 
 ### From a numpy array
 
@@ -802,7 +802,7 @@ the label image's scale and offset.
 
 ### User vs. predicted label images
 
-`UserLabelImage` and `PredictedLabelImage` distinguish human annotations from
+[`UserLabelImage`][sleap_io.UserLabelImage] and [`PredictedLabelImage`][sleap_io.PredictedLabelImage] distinguish human annotations from
 model predictions. `PredictedLabelImage` adds `score` and optional `score_map`
 fields, and per-object scores can be set via `LabelImage.Info.score`:
 

--- a/docs/model/regions.md
+++ b/docs/model/regions.md
@@ -1,13 +1,21 @@
 # Regions
 
-Beyond keypoint poses, sleap-io supports spatial annotation types: bounding
-boxes, regions of interest (vector polygons), segmentation masks (raster), and
-label images (dense instance segmentation). These can be associated with videos,
-frames, tracks, and instances, and are stored on the [`Labels`](labels.md) object
-via `labels.bboxes`, `labels.rois`, `labels.masks`, and `labels.label_images`.
+Beyond keypoint poses, sleap-io supports spatial annotation types: centroids,
+bounding boxes, regions of interest (vector polygons), segmentation masks
+(raster), and label images (dense instance segmentation). Annotations are
+**nested per-frame** on [`LabeledFrame`](labels.md) — each frame stores its own
+lists of annotations (e.g., `lf.centroids`, `lf.bboxes`, `lf.masks`). The
+[`Labels`](labels.md) object provides flattened convenience properties
+(`labels.centroids`, `labels.bboxes`, etc.) that aggregate across all frames,
+as well as `add_*()` methods for inserting annotations into the correct frame
+automatically.
 
-sleap-io provides four spatial annotation types with different trade-offs:
+sleap-io provides five spatial annotation types with different trade-offs:
 
+- **`Centroid`** — lightweight point annotation representing the center of an
+  object with `x`, `y`, and optional `z` coordinates. Supports conversion to
+  and from single-node [`Instance`](poses.md) objects. Has `UserCentroid` and
+  `PredictedCentroid` subtypes.
 - **`BoundingBox`** — axis-aligned or rotated rectangles, stored as corner
   coordinates. Has `UserBoundingBox` and `PredictedBoundingBox` subtypes for
   distinguishing human annotations from model outputs.
@@ -23,12 +31,166 @@ sleap-io provides four spatial annotation types with different trade-offs:
   [StarDist](https://github.com/stardist/stardist). Has `UserLabelImage` and
   `PredictedLabelImage` subtypes.
 
-All four base classes are **abstract** — use the `User*` or `Predicted*`
-subclass to create instances. All four can be associated with a video, frame,
-track, and instance. They are stored on [`Labels`](labels.md) via
-`labels.bboxes`, `labels.rois`, `labels.masks`, and `labels.label_images`, and
-can be converted between each other (bbox -> ROI -> mask, mask -> bbox, label
-image <-> masks, label image -> bboxes).
+All five base classes are **abstract** — use the `User*` or `Predicted*`
+subclass to create instances. All five can be associated with a video, frame,
+track, and instance. They are stored on [`LabeledFrame`](labels.md) and
+accessible via frame-level attributes or the flattened [`Labels`](labels.md)
+properties. The four geometry types can be converted between each other
+(bbox -> ROI -> mask, mask -> bbox, label image <-> masks, label image -> bboxes).
+
+---
+
+## Working with annotations in frames
+
+Since annotations are nested in [`LabeledFrame`](labels.md), you can add them
+directly to a frame or use the convenience methods on [`Labels`](labels.md).
+
+### Adding to a frame directly
+
+```pycon
+>>> import sleap_io as sio
+>>> video = sio.Video("test.mp4", open_backend=False)
+>>> lf = sio.LabeledFrame(video=video, frame_idx=0)
+>>> bbox = sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60, video=video, frame_idx=0)
+>>> lf.bboxes.append(bbox)
+>>> print(len(lf.bboxes))
+
+```
+
+### Adding via Labels convenience methods
+
+The `add_centroid()`, `add_bbox()`, `add_mask()`, `add_label_image()`, and
+`add_roi()` methods find or create the appropriate `LabeledFrame` and append
+the annotation:
+
+```pycon
+>>> import sleap_io as sio
+>>> video = sio.Video("test.mp4", open_backend=False)
+>>> labels = sio.Labels(videos=[video])
+>>> centroid = sio.UserCentroid(x=100, y=200, video=video, frame_idx=0)
+>>> labels.add_centroid(centroid)
+>>> bbox = sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60, video=video, frame_idx=0)
+>>> labels.add_bbox(bbox)
+>>> print(len(labels.centroids))
+>>> print(len(labels.bboxes))
+
+```
+
+The `labels.centroids`, `labels.bboxes`, `labels.masks`, `labels.label_images`,
+and `labels.rois` properties return flattened views across all frames.
+
+---
+
+## Centroids
+
+A `Centroid` represents a single point at the center of an object. Centroids
+are the primary annotation type for **object detection** workflows where full
+pose skeletons are not needed. `Centroid` is abstract — use `UserCentroid` or
+`PredictedCentroid`.
+
+Centroids support optional 3D coordinates (`z`), interconversion with
+single-node [`Instance`](poses.md) objects, and the same video/frame/track
+metadata as other annotation types.
+
+### Direct construction
+
+```pycon
+>>> import sleap_io as sio
+>>> video = sio.Video("test.mp4", open_backend=False)
+>>> centroid = sio.UserCentroid(
+...     x=100.0, y=200.0,
+...     video=video, frame_idx=0,
+... )
+>>> print(centroid.xy)
+>>> print(centroid.yx)
+
+```
+
+### From an Instance
+
+Create a centroid from an existing pose `Instance` using one of three methods:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "thorax", "abdomen"])
+>>> inst = sio.Instance.from_numpy(
+...     np.array([[10, 20], [30, 40], [50, 60]]),
+...     skeleton=skeleton,
+... )
+>>> centroid = sio.UserCentroid.from_instance(inst)
+>>> print(centroid.xy)
+
+```
+
+The `method` parameter controls how the center point is computed:
+
+| Method | Behavior |
+|--------|----------|
+| `"center_of_mass"` | Mean of all visible point coordinates (default) |
+| `"bbox_center"` | Center of the bounding box of visible points |
+| `"anchor"` | Coordinates of a specific node (requires `node` argument) |
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "thorax", "abdomen"])
+>>> inst = sio.Instance.from_numpy(
+...     np.array([[10, 20], [30, 40], [50, 60]]),
+...     skeleton=skeleton,
+... )
+>>> anchor_c = sio.UserCentroid.from_instance(inst, method="anchor", node="head")
+>>> print(anchor_c.xy)
+
+```
+
+### Converting back to an Instance
+
+A centroid can be converted to a single-node `Instance` for interoperability
+with pose-based workflows:
+
+```pycon
+>>> import sleap_io as sio
+>>> centroid = sio.UserCentroid(x=30.0, y=40.0)
+>>> inst = centroid.to_instance()
+>>> print(inst.numpy())
+
+```
+
+### User vs. predicted centroids
+
+`UserCentroid` and `PredictedCentroid` distinguish human annotations from
+model predictions. `PredictedCentroid` adds a `score` field for confidence:
+
+```pycon
+>>> import sleap_io as sio
+>>> user_c = sio.UserCentroid(x=10, y=20)
+>>> print(user_c.is_predicted)
+>>> pred_c = sio.PredictedCentroid(x=10, y=20, score=0.95)
+>>> print(pred_c.score)
+>>> print(pred_c.is_predicted)
+
+```
+
+When using `from_instance()`, the return type matches the input:
+`PredictedInstance` produces `PredictedCentroid`, `Instance` produces
+`UserCentroid`.
+
+### Metadata fields
+
+Every centroid can carry optional metadata:
+
+| Field       | Type               | Description                                  |
+| ----------- | ------------------ | -------------------------------------------- |
+| `video`     | [`Video`](video.md) `\| None`    | Associated video                             |
+| `frame_idx` | `int \| None`      | Frame index within the video                 |
+| `track`     | [`Track`](poses.md) `\| None`    | Tracking identity across frames              |
+| `tracking_score` | `float \| None` | Confidence of track identity assignment    |
+| `instance`  | [`Instance`](poses.md) `\| None` | Linked pose instance                         |
+| `z`         | `float \| None`    | Optional Z-coordinate for 3D data            |
+| `category`  | `str`              | Class label (e.g., `"cell"`)                 |
+| `name`      | `str`              | Human-readable name                          |
+| `source`    | `str`              | How the centroid was computed (e.g., `"center_of_mass"`) |
 
 ---
 
@@ -908,13 +1070,30 @@ classDiagram
         +ndarray score_map
     }
 
-    class Labels:::labels {
+    class Centroid:::regions {
+        <<abstract>>
+        +float x
+        +float y
+        +xy
+        +to_instance()
+        +from_instance()
+    }
+
+    class UserCentroid:::regions
+    class PredictedCentroid:::regions {
+        +float score
+    }
+
+    class LabeledFrame:::labels {
+        +centroids
         +bboxes
         +rois
         +masks
         +label_images
     }
 
+    Centroid <|-- UserCentroid
+    Centroid <|-- PredictedCentroid
     BoundingBox <|-- UserBoundingBox
     BoundingBox <|-- PredictedBoundingBox
     ROI <|-- UserROI
@@ -931,10 +1110,11 @@ classDiagram
     LabelImage --> SegmentationMask : to_masks()
     LabelImage --> BoundingBox : to_bboxes()
     SegmentationMask --> LabelImage : from_masks()
-    Labels "1" *-- "0..*" BoundingBox
-    Labels "1" *-- "0..*" ROI
-    Labels "1" *-- "0..*" SegmentationMask
-    Labels "1" *-- "0..*" LabelImage
+    LabeledFrame "1" *-- "0..*" Centroid
+    LabeledFrame "1" *-- "0..*" BoundingBox
+    LabeledFrame "1" *-- "0..*" ROI
+    LabeledFrame "1" *-- "0..*" SegmentationMask
+    LabeledFrame "1" *-- "0..*" LabelImage
 
     classDef regions fill:#d32f2f,stroke:#c62828,color:#fff
     classDef labels fill:#43a047,stroke:#2e7d32,color:#fff
@@ -942,7 +1122,7 @@ classDiagram
 
 !!! note "See also"
 
-    - **[Labels & Frames](labels.md)**: Accessing bounding boxes, ROIs, masks, and label images from a `Labels` dataset via `labels.bboxes`, `labels.rois`, `labels.masks`, and `labels.label_images`, including filtered queries with `get_bboxes()`, `get_rois()`, `get_masks()`, and `get_label_images()`.
+    - **[Labels & Frames](labels.md)**: Accessing annotations from a `Labels` dataset via `labels.centroids`, `labels.bboxes`, `labels.rois`, `labels.masks`, and `labels.label_images`, including filtered queries with `get_centroids()`, `get_bboxes()`, `get_rois()`, `get_masks()`, and `get_label_images()`.
     - **[Rendering](../rendering.md)**: Visualizing segmentation overlays and bounding boxes on video frames.
     - **[TIFF Format](../formats/tiff.md)**: Reading and writing label images as TIFF files with sidecar metadata.
     - **[SLP Format](../formats/slp.md#label-images)**: HDF5 storage layout for label images (blob and chunked formats).
@@ -951,6 +1131,12 @@ classDiagram
 ---
 
 ## API reference
+
+::: sleap_io.Centroid
+
+::: sleap_io.UserCentroid
+
+::: sleap_io.PredictedCentroid
 
 ::: sleap_io.BoundingBox
 

--- a/docs/model/regions.md
+++ b/docs/model/regions.md
@@ -865,7 +865,7 @@ time to an SLP file with constant memory usage:
 ```python
 import sleap_io as sio
 
-video = sio.Video("microscopy.tif")
+video = sio.load_video("microscopy.tif")
 with sio.LabelImageWriter("output.slp", video=video) as writer:
     for frame_idx, mask in enumerate(segmentation_results):
         li = sio.PredictedLabelImage.from_numpy(

--- a/hooks/markdown_exec_pycon.py
+++ b/hooks/markdown_exec_pycon.py
@@ -86,13 +86,23 @@ def _run_pycon_interleaved(code: str) -> str:
 
 
 def _highlight_pycon(code: str) -> str:
-    """Syntax-highlight pycon code using Pygments and return HTML."""
+    """Syntax-highlight pycon code using Pygments and return HTML.
+
+    Produces the same ``<div class="highlight"><pre><code>...</code></pre></div>``
+    structure that ``pymdownx.superfences`` generates for normal fenced code
+    blocks. The ``<code>`` wrapper is required for Material theme CSS rules
+    (font-size, overflow, padding) to apply correctly.
+    """
     from pygments import highlight
     from pygments.formatters import HtmlFormatter
     from pygments.lexers import PythonConsoleLexer
 
-    formatter = HtmlFormatter(nowrap=False, cssclass="highlight")
-    return highlight(code, PythonConsoleLexer(), formatter)
+    formatter = HtmlFormatter(nowrap=True)
+    highlighted = highlight(code, PythonConsoleLexer(), formatter)
+    return (
+        f'<div class="highlight"><pre><span></span><code>{highlighted}'
+        f"</code></pre></div>"
+    )
 
 
 def _custom_pycon_formatter(


### PR DESCRIPTION
## Summary

Comprehensive documentation audit and overhaul following PRs 401-408 (annotation architecture changes). Covers new API documentation, broken example fixes, rendering fixes, and home page modernization.

## Key Changes

### New documentation for annotation architecture (PRs 401-408)
- **`docs/model/regions.md`** (+276/-50): Added full `Centroid`/`UserCentroid`/`PredictedCentroid` documentation (was zero). Added "Working with annotations in frames" section. Updated intro to explain annotation nesting in `LabeledFrame`. Updated class diagram. Added API reference directives. Hyperlinked all class references.
- **`docs/model/labels.md`** (+80): Added "Fast lookups" section (`get_frame()`, `get_track_annotations()`, `reindex()`). Added `add_*()` annotation methods to Manipulation section. Updated `LabeledFrame` description and mermaid diagram with annotation fields.
- **`docs/model/index.md`** (+25): Added `Centroid` classes to quick reference table and class diagram.
- **`docs/merging.md`** (+52): Added annotation merge code example, per-modality spatial matching table, `InstanceMatcher` threshold example.

### Critical example fixes (red team review)
- **`nwb_export.py`**: Completely fabricated function signatures — rewrote with correct `export_labels()`/`export_labeled_frames()` APIs, leading with public `sio.save_nwb()`
- **`nwb_metadata.py`**: Was using private `save_labels()` as primary example — restructured around public `sio.save_nwb()` with internal API in collapsible tip
- **`update_from_numpy.py`**: `np.convolve(trx.reshape(-1))` was mixing filtering across frame/track/node/xy boundaries — replaced with correct `np.apply_along_axis(..., axis=0)`
- **`create_labels.py` tip**: `PredictedInstance.from_numpy()` was using nonexistent `points`/`confidence` params — fixed to 3-column array pattern

### Segmentation example improvements
- Clarified array dimensions: `(n_objects, height, width)` for binary masks, `(n_frames, height, width)` for stacks (was ambiguous `N`/`T`)
- `sio.Video("microscopy.tif")` → `sio.load_video()` with shape comments
- `Labels(label_images=[...])` → `labels.add_label_image()` to reflect nesting model
- Streaming example: show `video[frame_idx]` passed to segmentation, explain `LabelImageWriter` video param, separate tracking into opt-in admonition
- Extract example: frame-based access, lazy vs eager comments, fix variable shadowing
- Merge example: explain why `merge_label_images()` exists vs `Labels.merge()`

### Other fixes
- **`hooks/markdown_exec_pycon.py`**: `pycon` code blocks were rendering with oversized font and overflowing into TOC — root cause was missing `<code>` wrapper that Material theme CSS targets for `font-size: .85em` and `overflow: auto`
- **`docs/index.md`**: Modernized home page to match README (concise install, feature list with links, quick start)
- **`docs/examples.md`**: Fixed garbled backend trade-off admonitions (FFMPEG/imageio entries were orphaned under OpenCV heading)
- Added hyperlinks throughout Basics, Format, and Regions sections

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `docs/model/regions.md` | +276/-50 | Centroids, frame nesting, hyperlinks, diagram |
| `docs/examples.md` | +354/-261 | Critical bug fixes, segmentation, backends |
| `docs/index.md` | +47/-56 | Home page modernization |
| `docs/model/labels.md` | +80 | Fast lookups, add_*(), diagram |
| `docs/merging.md` | +52 | Annotation merge examples |
| `docs/model/index.md` | +25 | Centroid in table + diagram |
| `hooks/markdown_exec_pycon.py` | +13/-3 | Fix pycon code block rendering |

## Related

- #410 — Filed issue for annotation metadata sync gap (video/frame_idx not updated on `lf.*.append()`)

## Testing

- All pycon examples pre-validated via `scratch/2026-04-07-docs-audit/verify_examples.py`
- Local `mkdocs serve` build verified for all updated pages
- CI spelling check passed, deploy preview built successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)