### PR TITLE
fix: Remove video/frame_idx from annotation objects (#410)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -864,12 +864,13 @@ li = sio.PredictedLabelImage.from_binary_masks(
     create_tracks=True,          # auto-create one Track per mask
     scores=object_scores,        # per-object confidence → Info.score
     score=0.9,                   # image-level confidence
-    video=video, frame_idx=0, source="sam",
+    source="sam",
 )
 
 # Add the label image to a Labels dataset via a LabeledFrame
-labels = sio.Labels(videos=[video])
-labels.add_label_image(li)
+lf = sio.LabeledFrame(video=video, frame_idx=0)
+lf.append(li)
+labels = sio.Labels(labeled_frames=[lf])
 labels.save("sam_output.slp")
 ```
 
@@ -901,7 +902,7 @@ with sio.LabelImageWriter("output.slp", video=video) as writer:
         mask = run_segmentation(video[frame_idx])  # returns (H, W) int32
 
         li = sio.PredictedLabelImage.from_numpy(
-            mask, video=video, frame_idx=frame_idx,
+            mask,
             source="cellpose:nuclei", score=1.0,
         )
         writer.add(li)
@@ -917,7 +918,7 @@ with sio.LabelImageWriter("output.slp", video=video) as writer:
     shared_tracks = {}  # accumulates {label_id: Track} across frames
 
     li = sio.PredictedLabelImage.from_numpy(
-        mask, video=video, frame_idx=frame_idx,
+        mask,
         tracks=shared_tracks, create_tracks=True,  # reuse existing, create new
         source="cellpose:nuclei", score=1.0,
     )

--- a/docs/formats/tiff.md
+++ b/docs/formats/tiff.md
@@ -55,7 +55,7 @@ label_images = sio.load_label_images(
 )
 ```
 
-Each returned [`LabelImage`][sleap_io.LabelImage] has `frame_idx` set to its position in the stack (0, 1, 2, ...).
+Each returned [`LabelImage`][sleap_io.LabelImage] corresponds to one frame in the stack, ordered by position (0, 1, 2, ...).
 
 ## Writing
 
@@ -91,7 +91,6 @@ masks_stack = np.stack(masks)  # (T, H, W) int32
 video = sio.Video(filename="experiment.tif")
 label_images = sio.PredictedLabelImage.from_stack(
     masks_stack,
-    video=video,
     source="cellpose:nuclei",
     create_tracks=True,
     score=1.0,
@@ -101,7 +100,11 @@ label_images = sio.PredictedLabelImage.from_stack(
 sio.save_label_images("cellpose_masks.tif", label_images)
 
 # Or save as SLP (preserves tracks, categories, and provenance)
-labels = sio.Labels(label_images=label_images, videos=[video])
+labeled_frames = [
+    sio.LabeledFrame(video=video, frame_idx=i, label_images=[li])
+    for i, li in enumerate(label_images)
+]
+labels = sio.Labels(labeled_frames=labeled_frames, videos=[video])
 labels.provenance["segmentation_model"] = "cellpose"
 labels.provenance["cellpose_diameter"] = 25
 labels.save("cellpose_masks.slp")

--- a/docs/merging.md
+++ b/docs/merging.md
@@ -580,8 +580,8 @@ source, regardless of strategy.
 ...     skeleton=skeleton,
 ... )
 >>> lf1 = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst1])
->>> lf1.bboxes.append(sio.UserBoundingBox(
-...     x1=5, y1=15, x2=55, y2=65, video=video, frame_idx=0,
+>>> lf1.append(sio.UserBoundingBox(
+...     x1=5, y1=15, x2=55, y2=65,
 ... ))
 >>> base = sio.Labels(labeled_frames=[lf1])
 >>> inst2 = sio.PredictedInstance.from_numpy(
@@ -590,8 +590,8 @@ source, regardless of strategy.
 ...     score=0.9,
 ... )
 >>> lf2 = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst2])
->>> lf2.bboxes.append(sio.PredictedBoundingBox(
-...     x1=6, y1=16, x2=56, y2=66, video=video, frame_idx=0, score=0.9,
+>>> lf2.append(sio.PredictedBoundingBox(
+...     x1=6, y1=16, x2=56, y2=66, score=0.9,
 ... ))
 >>> base.merge(sio.Labels(labeled_frames=[lf2]))
 >>> print(len(base[0].bboxes))

--- a/docs/model/labels.md
+++ b/docs/model/labels.md
@@ -221,15 +221,15 @@ new_skeleton = sio.Skeleton(["HEAD", "BODY", "TAIL"])
 labels.replace_skeleton(new_skeleton)
 ```
 
-**Adding spatial annotations** inserts annotations into the appropriate frame,
-creating the frame if needed:
+**Adding spatial annotations** to a frame by appending to its annotation lists:
 
 ```python
-labels.add_centroid(sio.UserCentroid(x=100, y=200, video=video, frame_idx=0))
-labels.add_bbox(sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60, video=video, frame_idx=0))
-labels.add_mask(mask)
-labels.add_label_image(label_image)
-labels.add_roi(roi)
+lf = labels.get(video, 0)  # get or create LabeledFrame for frame 0
+lf.append(sio.UserCentroid(x=100, y=200))
+lf.append(sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60))
+lf.append(mask)
+lf.append(label_image)
+lf.append(roi)
 ```
 
 !!! note "See also"

--- a/docs/model/regions.md
+++ b/docs/model/regions.md
@@ -7,8 +7,7 @@ bounding boxes, regions of interest (vector polygons), segmentation masks
 lists of annotations (e.g., `lf.centroids`, `lf.bboxes`, `lf.masks`). The
 [`Labels`](labels.md) object provides flattened convenience properties
 (`labels.centroids`, `labels.bboxes`, etc.) that aggregate across all frames,
-as well as `add_*()` methods for inserting annotations into the correct frame
-automatically.
+and query methods (e.g., `labels.get_centroids()`) for filtered access.
 
 sleap-io provides five spatial annotation types with different trade-offs:
 
@@ -32,8 +31,8 @@ sleap-io provides five spatial annotation types with different trade-offs:
   [`PredictedLabelImage`][sleap_io.PredictedLabelImage] subtypes.
 
 All five base classes are **abstract** — use the `User*` or `Predicted*`
-subclass to create instances. All five can be associated with a video, frame,
-track, and instance. They are stored on [`LabeledFrame`](labels.md) and
+subclass to create instances. All five can be associated with a track and
+instance. They are stored on [`LabeledFrame`](labels.md) and
 accessible via frame-level attributes or the flattened [`Labels`](labels.md)
 properties. The four geometry types can be converted between each other
 (bbox -> ROI -> mask, mask -> bbox, label image <-> masks, label image -> bboxes).
@@ -42,35 +41,18 @@ properties. The four geometry types can be converted between each other
 
 ## Working with annotations in frames
 
-Since annotations are nested in [`LabeledFrame`](labels.md), you can add them
-directly to a frame or use the convenience methods on [`Labels`](labels.md).
-
-### Adding to a frame directly
+Since annotations are nested in [`LabeledFrame`](labels.md), you add them
+directly to a frame's annotation lists.
 
 ```pycon
 >>> import sleap_io as sio
 >>> video = sio.Video("test.mp4", open_backend=False)
 >>> lf = sio.LabeledFrame(video=video, frame_idx=0)
->>> bbox = sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60, video=video, frame_idx=0)
->>> lf.bboxes.append(bbox)
->>> print(len(lf.bboxes))
-
-```
-
-### Adding via Labels convenience methods
-
-The `add_centroid()`, `add_bbox()`, `add_mask()`, `add_label_image()`, and
-`add_roi()` methods find or create the appropriate `LabeledFrame` and append
-the annotation:
-
-```pycon
->>> import sleap_io as sio
->>> video = sio.Video("test.mp4", open_backend=False)
->>> labels = sio.Labels(videos=[video])
->>> centroid = sio.UserCentroid(x=100, y=200, video=video, frame_idx=0)
->>> labels.add_centroid(centroid)
->>> bbox = sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60, video=video, frame_idx=0)
->>> labels.add_bbox(bbox)
+>>> bbox = sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60)
+>>> lf.append(bbox)
+>>> centroid = sio.UserCentroid(x=100, y=200)
+>>> lf.append(centroid)
+>>> labels = sio.Labels(labeled_frames=[lf])
 >>> print(len(labels.centroids))
 >>> print(len(labels.bboxes))
 
@@ -89,17 +71,14 @@ pose skeletons are not needed. `Centroid` is abstract — use [`UserCentroid`][s
 [`PredictedCentroid`][sleap_io.PredictedCentroid].
 
 Centroids support optional 3D coordinates (`z`), interconversion with
-single-node [`Instance`](poses.md) objects, and the same video/frame/track
-metadata as other annotation types.
+single-node [`Instance`](poses.md) objects, and the same track/instance metadata as other annotation types.
 
 ### Direct construction
 
 ```pycon
 >>> import sleap_io as sio
->>> video = sio.Video("test.mp4", open_backend=False)
 >>> centroid = sio.UserCentroid(
 ...     x=100.0, y=200.0,
-...     video=video, frame_idx=0,
 ... )
 >>> print(centroid.xy)
 >>> print(centroid.yx)
@@ -182,8 +161,6 @@ Every centroid can carry optional metadata:
 
 | Field       | Type               | Description                                  |
 | ----------- | ------------------ | -------------------------------------------- |
-| `video`     | [`Video`](video.md) `\| None`    | Associated video                             |
-| `frame_idx` | `int \| None`      | Frame index within the video                 |
 | `track`     | [`Track`](poses.md) `\| None`    | Tracking identity across frames              |
 | `tracking_score` | `float \| None` | Confidence of track identity assignment    |
 | `instance`  | [`Instance`](poses.md) `\| None` | Linked pose instance                         |
@@ -205,10 +182,8 @@ boxes are the primary annotation type for object detection workflows.
 
 ```pycon
 >>> import sleap_io as sio
->>> video = sio.Video("test.mp4", open_backend=False)
 >>> bbox = sio.UserBoundingBox(
 ...     x1=75, y1=160, x2=125, y2=240,
-...     video=video, frame_idx=0,
 ... )
 >>> print(bbox.area)
 >>> print(bbox.xyxy)
@@ -227,8 +202,7 @@ corner coordinates:
 
 ```pycon
 >>> import sleap_io as sio
->>> video = sio.Video("test.mp4", open_backend=False)
->>> bbox2 = sio.UserBoundingBox.from_xyxy(75, 160, 125, 240, video=video, frame_idx=0)
+>>> bbox2 = sio.UserBoundingBox.from_xyxy(75, 160, 125, 240)
 >>> print(bbox2.x_center)
 >>> print(bbox2.width)
 
@@ -239,8 +213,7 @@ the top-left corner:
 
 ```pycon
 >>> import sleap_io as sio
->>> video = sio.Video("test.mp4", open_backend=False)
->>> bbox3 = sio.UserBoundingBox.from_xywh(75, 160, 50, 80, video=video, frame_idx=0)
+>>> bbox3 = sio.UserBoundingBox.from_xywh(75, 160, 50, 80)
 >>> print(bbox3.x_center)
 >>> print(bbox3.y_center)
 
@@ -253,15 +226,13 @@ model predictions. `PredictedBoundingBox` adds a `score` field for confidence:
 
 ```pycon
 >>> import sleap_io as sio
->>> video = sio.Video("test.mp4", open_backend=False)
 >>> user_bbox = sio.UserBoundingBox(
 ...     x1=75, y1=160, x2=125, y2=240,
-...     video=video, frame_idx=0,
 ... )
 >>> print(user_bbox.is_predicted)
 >>> pred_bbox = sio.PredictedBoundingBox(
 ...     x1=75, y1=160, x2=125, y2=240,
-...     video=video, frame_idx=0, score=0.95,
+...     score=0.95,
 ... )
 >>> print(pred_bbox.score)
 >>> print(pred_bbox.is_predicted)
@@ -276,10 +247,9 @@ meaningful for axis-aligned rectangles:
 
 ```pycon
 >>> import sleap_io as sio
->>> video = sio.Video("test.mp4", open_backend=False)
 >>> rotated = sio.UserBoundingBox(
 ...     x1=75, y1=160, x2=125, y2=240,
-...     angle=0.785, video=video, frame_idx=0,
+...     angle=0.785,
 ... )
 >>> print(rotated.is_rotated)
 >>> print(rotated.corners.shape)
@@ -293,8 +263,6 @@ Every bounding box can carry optional metadata:
 
 | Field       | Type               | Description                                  |
 | ----------- | ------------------ | -------------------------------------------- |
-| `video`     | [`Video`](video.md) `\| None`    | Associated video                             |
-| `frame_idx` | `int \| None`      | Frame index within the video                 |
 | `track`     | [`Track`](poses.md) `\| None`    | Tracking identity across frames              |
 | `instance`  | [`Instance`](poses.md) `\| None` | Linked pose instance                         |
 | `category`  | `str`              | Class label (e.g., `"mouse"`)                |
@@ -313,9 +281,7 @@ rectangle. `ROI` is abstract — use [`UserROI`][sleap_io.UserROI] or [`Predicte
 
 ### Static vs. temporal ROIs
 
-An ROI is **static** when `frame_idx` is `None`, meaning it applies to all
-frames of the video (e.g., an arena boundary). When `frame_idx` is set, the ROI
-applies only to that specific frame.
+ROIs can be **static** (applying to all frames of a video) or **frame-bound** (attached to a specific `LabeledFrame`). Static ROIs are stored in `Labels.static_rois` and have a `video` attribute. Frame-bound ROIs are stored on individual `LabeledFrame.rois` lists.
 
 ### From polygon coordinates
 
@@ -342,7 +308,6 @@ Construct an ROI directly from any Shapely geometry object:
 >>> roi = sio.UserROI(geometry=box(10, 20, 100, 200), video=video)
 >>> print(roi.area)
 >>> print(roi.bounds)
->>> print(roi.is_static)
 
 ```
 
@@ -352,10 +317,8 @@ Any `BoundingBox` can be converted to an `ROI` with `.to_roi()`:
 
 ```pycon
 >>> import sleap_io as sio
->>> video = sio.Video("test.mp4", open_backend=False)
 >>> bbox = sio.UserBoundingBox(
 ...     x1=75, y1=160, x2=125, y2=240,
-...     video=video, frame_idx=0,
 ... )
 >>> roi_from_bbox = bbox.to_roi()
 >>> print(roi_from_bbox.area)
@@ -447,11 +410,10 @@ fast conversion to and from numpy arrays. `SegmentationMask` is abstract — use
 ```pycon
 >>> import numpy as np
 >>> import sleap_io as sio
->>> video = sio.Video("test.mp4", open_backend=False)
 >>> mask_data = np.zeros((480, 640), dtype=bool)
 >>> mask_data[100:200, 150:300] = True  # rectangular region
 >>> mask = sio.UserSegmentationMask.from_numpy(
-...     mask_data, video=video, frame_idx=0,
+...     mask_data,
 ... )
 >>> print(mask.area)
 >>> print(mask.height)
@@ -869,7 +831,7 @@ video = sio.load_video("microscopy.tif")
 with sio.LabelImageWriter("output.slp", video=video) as writer:
     for frame_idx, mask in enumerate(segmentation_results):
         li = sio.PredictedLabelImage.from_numpy(
-            mask, video=video, frame_idx=frame_idx,
+            mask,
             source="cellpose:nuclei", create_tracks=True, score=1.0,
         )
         writer.add(li)
@@ -951,7 +913,6 @@ labels = sio.load_slp("large_dataset.slp")
 # Metadata queries — no decompression
 li = labels.get_label_images(frame_idx=42)[0]
 print(li.tracks)      # free
-print(li.frame_idx)   # free
 print(li.height)      # free (cached from metadata)
 
 # Pixel data decompressed on first access, then cached
@@ -980,18 +941,16 @@ geometrically meaningful:
 | `LabelImage`        | `list[BoundingBox]`   | `li.to_bboxes()`                  |
 | `list[SegmentationMask]` | `LabelImage`     | `UserLabelImage.from_masks(masks)` |
 
-All conversions preserve metadata (video, frame_idx, track, instance, name,
+All conversions preserve metadata (track, instance, name,
 category, source) when applicable. `to_bbox()` and `to_bboxes()` preserve
 prediction semantics (`Predicted*` inputs produce `Predicted*` outputs with
 scores). Other conversions return `User*` types.
 
 ```pycon
 >>> import sleap_io as sio
->>> video = sio.Video("test.mp4", open_backend=False)
 >>> # BoundingBox -> ROI -> SegmentationMask -> polygon ROI
 >>> bbox = sio.UserBoundingBox(
 ...     x1=40, y1=35, x2=60, y2=65,
-...     video=video, frame_idx=0,
 ... )
 >>> roi = bbox.to_roi()
 >>> print(roi.area)
@@ -1029,7 +988,6 @@ classDiagram
         <<abstract>>
         +geometry
         +str name
-        +is_static
         +to_mask()
         +explode()
     }

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -389,14 +389,13 @@ def _load_overlay(
         raise click.ClickException(f"No label images loaded from: {overlay_path}")
 
     if frame_idx is not None:
-        matches = [li for li in label_images if li.frame_idx == frame_idx]
-        if not matches:
+        if frame_idx < 0 or frame_idx >= len(label_images):
             n_frames = len(label_images)
             raise click.ClickException(
                 f"--overlay frame index {frame_idx} out of range. "
                 f"Overlay has {n_frames} frames."
             )
-        return matches[0]
+        return label_images[frame_idx]
 
     return label_images
 

--- a/sleap_io/io/coco.py
+++ b/sleap_io/io/coco.py
@@ -400,8 +400,6 @@ def read_labels(
                     # keypoints
                     roi_kwargs = dict(
                         category=cat_name,
-                        video=video,
-                        frame_idx=frame_idx,
                         instance=instance,
                     )
 
@@ -437,8 +435,6 @@ def read_labels(
                             w,
                             h,
                             category=cat_name,
-                            video=video,
-                            frame_idx=frame_idx,
                             instance=instance,
                         )
                         bboxes.append(bbox_obj)
@@ -446,8 +442,6 @@ def read_labels(
                     # Detection-only annotation: create ROIs/masks/bboxes
                     roi_kwargs = dict(
                         category=cat_name,
-                        video=video,
-                        frame_idx=frame_idx,
                     )
 
                     # Handle segmentation field
@@ -496,14 +490,22 @@ def read_labels(
                             )
                         bboxes.append(bbox_obj)
 
-        # Create labeled frame
+        # Create labeled frame with annotations attached directly
         if instances or image_id in image_annotations:
             labeled_frame = LabeledFrame(
                 video=video, frame_idx=frame_idx, instances=instances
             )
+            labeled_frame.rois.extend(rois)
+            labeled_frame.masks.extend(masks)
+            labeled_frame.bboxes.extend(bboxes)
             labeled_frames.append(labeled_frame)
 
-    return Labels(labeled_frames=labeled_frames, rois=rois, masks=masks, bboxes=bboxes)
+        # Reset per-frame annotation lists
+        rois = []
+        masks = []
+        bboxes = []
+
+    return Labels(labeled_frames=labeled_frames)
 
 
 def read_labels_set(
@@ -770,145 +772,146 @@ def convert_labels(
 
         image_id_counter += 1
 
-    # Export ROIs as COCO annotations
-    for roi in labels.rois:
-        # Get or create category
-        cat_name = roi.category if roi.category else "object"
-        if cat_name not in category_name_to_id:
-            category = {
-                "id": category_id_counter,
-                "name": cat_name,
+    # Export ROIs, masks, and bboxes as COCO annotations (iterate by frame)
+    for lf in labels.labeled_frames:
+        for roi in lf.rois:
+            # Get or create category
+            cat_name = roi.category if roi.category else "object"
+            if cat_name not in category_name_to_id:
+                category = {
+                    "id": category_id_counter,
+                    "name": cat_name,
+                }
+                coco_data["categories"].append(category)
+                category_name_to_id[cat_name] = category_id_counter
+                category_id_counter += 1
+            category_id = category_name_to_id[cat_name]
+
+            # Find image_id for this ROI
+            image_id = _get_or_create_image_id(
+                lf.video,
+                lf.frame_idx,
+                video_frame_to_image_id,
+                coco_data,
+                image_id_counter,
+            )
+            if image_id >= image_id_counter:
+                image_id_counter = image_id + 1
+
+            annotation = {
+                "id": annotation_id_counter,
+                "image_id": image_id,
+                "category_id": category_id,
+                "iscrowd": 0,
             }
-            coco_data["categories"].append(category)
-            category_name_to_id[cat_name] = category_id_counter
-            category_id_counter += 1
-        category_id = category_name_to_id[cat_name]
 
-        # Find image_id for this ROI
-        image_id = _get_or_create_image_id(
-            roi.video,
-            roi.frame_idx,
-            video_frame_to_image_id,
-            coco_data,
-            image_id_counter,
-        )
-        if image_id >= image_id_counter:
-            image_id_counter = image_id + 1
+            # Write ROI as polygon segmentation with bounding box
+            coords = list(roi.geometry.exterior.coords)
+            flat = []
+            for x, y in coords[:-1]:  # Exclude closing vertex
+                flat.extend([float(x), float(y)])
+            annotation["segmentation"] = [flat]
+            minx, miny, maxx, maxy = roi.bounds
+            annotation["bbox"] = [
+                minx,
+                miny,
+                maxx - minx,
+                maxy - miny,
+            ]
+            annotation["area"] = float(roi.area)
 
-        annotation = {
-            "id": annotation_id_counter,
-            "image_id": image_id,
-            "category_id": category_id,
-            "iscrowd": 0,
-        }
+            coco_data["annotations"].append(annotation)
+            annotation_id_counter += 1
 
-        # Write ROI as polygon segmentation with bounding box
-        coords = list(roi.geometry.exterior.coords)
-        flat = []
-        for x, y in coords[:-1]:  # Exclude closing vertex
-            flat.extend([float(x), float(y)])
-        annotation["segmentation"] = [flat]
-        minx, miny, maxx, maxy = roi.bounds
-        annotation["bbox"] = [
-            minx,
-            miny,
-            maxx - minx,
-            maxy - miny,
-        ]
-        annotation["area"] = float(roi.area)
+        # Export masks as COCO RLE annotations
+        for seg_mask in lf.masks:
+            cat_name = seg_mask.category if seg_mask.category else "object"
+            if cat_name not in category_name_to_id:
+                category = {
+                    "id": category_id_counter,
+                    "name": cat_name,
+                }
+                coco_data["categories"].append(category)
+                category_name_to_id[cat_name] = category_id_counter
+                category_id_counter += 1
+            category_id = category_name_to_id[cat_name]
 
-        coco_data["annotations"].append(annotation)
-        annotation_id_counter += 1
+            image_id = _get_or_create_image_id(
+                lf.video,
+                lf.frame_idx,
+                video_frame_to_image_id,
+                coco_data,
+                image_id_counter,
+            )
+            if image_id >= image_id_counter:
+                image_id_counter = image_id + 1
 
-    # Export masks as COCO RLE annotations
-    for seg_mask in labels.masks:
-        cat_name = seg_mask.category if seg_mask.category else "object"
-        if cat_name not in category_name_to_id:
-            category = {
-                "id": category_id_counter,
-                "name": cat_name,
+            # COCO expects full-frame masks; resample if scaled/offset
+            export_mask = seg_mask
+            if seg_mask.has_spatial_transform:
+                target_h, target_w = seg_mask.image_extent
+                export_mask = seg_mask.resampled(target_h, target_w)
+
+            mask_data = export_mask.data
+            rle = _encode_coco_rle(mask_data)
+
+            bbox_xywh = export_mask.bbox
+            annotation = {
+                "id": annotation_id_counter,
+                "image_id": image_id,
+                "category_id": category_id,
+                "segmentation": rle,
+                "bbox": list(bbox_xywh),
+                "area": float(export_mask.area),
+                "iscrowd": 1,
             }
-            coco_data["categories"].append(category)
-            category_name_to_id[cat_name] = category_id_counter
-            category_id_counter += 1
-        category_id = category_name_to_id[cat_name]
 
-        image_id = _get_or_create_image_id(
-            seg_mask.video,
-            seg_mask.frame_idx,
-            video_frame_to_image_id,
-            coco_data,
-            image_id_counter,
-        )
-        if image_id >= image_id_counter:
-            image_id_counter = image_id + 1
+            coco_data["annotations"].append(annotation)
+            annotation_id_counter += 1
 
-        # COCO expects full-frame masks; resample if scaled/offset
-        export_mask = seg_mask
-        if seg_mask.has_spatial_transform:
-            target_h, target_w = seg_mask.image_extent
-            export_mask = seg_mask.resampled(target_h, target_w)
+        # Export bounding boxes as COCO bbox annotations (skip instance-linked bboxes
+        # since those are already represented in the keypoint annotations above).
+        # Note: Rotated bboxes are not supported by COCO format.
+        # BoundingBox.xywh raises ValueError for rotated boxes.
+        for bbox_obj in lf.bboxes:
+            if bbox_obj.instance is not None:
+                continue
+            cat_name = bbox_obj.category if bbox_obj.category else "object"
+            if cat_name not in category_name_to_id:
+                category = {
+                    "id": category_id_counter,
+                    "name": cat_name,
+                }
+                coco_data["categories"].append(category)
+                category_name_to_id[cat_name] = category_id_counter
+                category_id_counter += 1
+            category_id = category_name_to_id[cat_name]
 
-        mask_data = export_mask.data
-        rle = _encode_coco_rle(mask_data)
+            image_id = _get_or_create_image_id(
+                lf.video,
+                lf.frame_idx,
+                video_frame_to_image_id,
+                coco_data,
+                image_id_counter,
+            )
+            if image_id >= image_id_counter:
+                image_id_counter = image_id + 1
 
-        bbox_xywh = export_mask.bbox
-        annotation = {
-            "id": annotation_id_counter,
-            "image_id": image_id,
-            "category_id": category_id,
-            "segmentation": rle,
-            "bbox": list(bbox_xywh),
-            "area": float(export_mask.area),
-            "iscrowd": 1,
-        }
-
-        coco_data["annotations"].append(annotation)
-        annotation_id_counter += 1
-
-    # Export bounding boxes as COCO bbox annotations (skip instance-linked bboxes
-    # since those are already represented in the keypoint annotations above).
-    # Note: Rotated bboxes are not supported by COCO format.
-    # BoundingBox.xywh raises ValueError for rotated boxes.
-    for bbox_obj in labels.bboxes:
-        if bbox_obj.instance is not None:
-            continue
-        cat_name = bbox_obj.category if bbox_obj.category else "object"
-        if cat_name not in category_name_to_id:
-            category = {
-                "id": category_id_counter,
-                "name": cat_name,
+            x, y, w, h = bbox_obj.xywh
+            annotation = {
+                "id": annotation_id_counter,
+                "image_id": image_id,
+                "category_id": category_id,
+                "bbox": [float(x), float(y), float(w), float(h)],
+                "area": float(bbox_obj.area),
+                "iscrowd": 0,
             }
-            coco_data["categories"].append(category)
-            category_name_to_id[cat_name] = category_id_counter
-            category_id_counter += 1
-        category_id = category_name_to_id[cat_name]
 
-        image_id = _get_or_create_image_id(
-            bbox_obj.video,
-            bbox_obj.frame_idx,
-            video_frame_to_image_id,
-            coco_data,
-            image_id_counter,
-        )
-        if image_id >= image_id_counter:
-            image_id_counter = image_id + 1
+            if isinstance(bbox_obj, PredictedBoundingBox):
+                annotation["score"] = float(bbox_obj.score)
 
-        x, y, w, h = bbox_obj.xywh
-        annotation = {
-            "id": annotation_id_counter,
-            "image_id": image_id,
-            "category_id": category_id,
-            "bbox": [float(x), float(y), float(w), float(h)],
-            "area": float(bbox_obj.area),
-            "iscrowd": 0,
-        }
-
-        if isinstance(bbox_obj, PredictedBoundingBox):
-            annotation["score"] = float(bbox_obj.score)
-
-        coco_data["annotations"].append(annotation)
-        annotation_id_counter += 1
+            coco_data["annotations"].append(annotation)
+            annotation_id_counter += 1
 
     return coco_data
 
@@ -1026,7 +1029,17 @@ def read_coco_panoptic(
     # Track pool: shared across frames for thing segments
     track_pool: dict[int, Track] = {}
 
-    label_images = []
+    # Build image_id -> file_name mapping
+    image_filenames = []
+    image_id_to_idx = {}
+    for img in data.get("images", []):
+        image_id_to_idx[img["id"]] = len(image_filenames)
+        image_filenames.append(img.get("file_name", ""))
+
+    # Create a single video from the image filenames
+    video = Video(filename=image_filenames) if image_filenames else Video(filename="")
+
+    labeled_frames = []
     frame_idx = 0
     for ann in data.get("annotations", []):
         png_filename = ann["file_name"]
@@ -1065,12 +1078,13 @@ def read_coco_panoptic(
         li = UserLabelImage(
             data=label_data,
             objects=objects,
-            frame_idx=frame_idx,
         )
-        label_images.append(li)
+        lf = LabeledFrame(video=video, frame_idx=frame_idx)
+        lf.label_images.append(li)
+        labeled_frames.append(lf)
         frame_idx += 1
 
-    return Labels(label_images=label_images)
+    return Labels(labeled_frames=labeled_frames)
 
 
 def write_coco_panoptic(

--- a/sleap_io/io/geojson.py
+++ b/sleap_io/io/geojson.py
@@ -91,5 +91,4 @@ def _feature_to_roi(feature: dict) -> ROI:
         name=props.get("name", ""),
         category=props.get("category", ""),
         source=props.get("source", ""),
-        frame_idx=props.get("frame_idx"),
     )

--- a/sleap_io/io/jabs.py
+++ b/sleap_io/io/jabs.py
@@ -245,7 +245,6 @@ def _static_object_to_roi(name: str, coords: np.ndarray, video: Video) -> ROI:
         category=category,
         source="jabs",
         video=video,
-        frame_idx=None,
     )
 
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -992,6 +992,8 @@ def write_videos(
 
     # First determine which videos need embedding
     for video_ind, video in enumerate(videos):
+        if video is None:
+            continue
         # Check if video has an open backend with embedded images
         has_backend_with_embedded = (
             type(video.backend) is HDF5Video and video.backend.has_embedded_images
@@ -1138,6 +1140,8 @@ def write_videos(
     # so we only need to store source_video (immediate parent).
     with h5py.File(labels_path, "a") as f:
         for video_ind, video in enumerate(videos):
+            if video is None:
+                continue
             dataset = f"video{video_ind}"
 
             # If original_videos is provided (e.g., during embedding), use those
@@ -1149,7 +1153,10 @@ def write_videos(
                 if reference_mode == VideoReferenceMode.EMBED and original_videos:
                     # For embed mode, save the pre-embedding video as source
                     source_to_save = pre_embed_video
-                elif pre_embed_video.source_video is not None:
+                elif (
+                    pre_embed_video is not None
+                    and pre_embed_video.source_video is not None
+                ):
                     source_to_save = pre_embed_video.source_video
 
             # Write source_video metadata to the video group
@@ -2590,29 +2597,28 @@ def _read_labels_lazy(labels_path: str, open_videos: bool = True) -> Labels:
     lazy_frames = LazyFrameList(lazy_store)
 
     # Read ROIs, masks, bboxes, and label images eagerly (typically small count)
-    rois = read_rois(labels_path, videos, tracks)
-    masks = read_masks(labels_path, videos, tracks)
-    bboxes = read_bboxes(labels_path, videos, tracks)
-    centroids = read_centroids(labels_path, videos, tracks)
-    label_images, li_file = read_label_images(labels_path, videos, tracks)
+    roi_tuples = read_rois(labels_path, videos, tracks)
+    mask_tuples = read_masks(labels_path, videos, tracks)
+    bbox_tuples = read_bboxes(labels_path, videos, tracks)
+    centroid_tuples = read_centroids(labels_path, videos, tracks)
+    li_tuples, li_file = read_label_images(labels_path, videos, tracks)
 
     # Build per-frame annotation dicts for lazy materialization
-    def _build_ann_by_frame(annotations, videos):
+    def _build_ann_by_frame(ann_tuples):
         by_frame = {}
         undistributed = []
-        for ann in annotations:
-            if ann.video is not None and ann.frame_idx is not None:
-                vid_idx = videos.index(ann.video) if ann.video in videos else -1
-                key = (vid_idx, ann.frame_idx)
+        for ann, vid_idx, fidx in ann_tuples:
+            if vid_idx >= 0 and fidx >= 0:
+                key = (vid_idx, fidx)
                 by_frame.setdefault(key, []).append(ann)
             else:
                 undistributed.append(ann)
         return by_frame, undistributed
 
-    c_by_frame, c_undist = _build_ann_by_frame(centroids, videos)
-    b_by_frame, b_undist = _build_ann_by_frame(bboxes, videos)
-    m_by_frame, m_undist = _build_ann_by_frame(masks, videos)
-    r_by_frame, r_undist = _build_ann_by_frame(rois, videos)
+    c_by_frame, c_undist = _build_ann_by_frame(centroid_tuples)
+    b_by_frame, b_undist = _build_ann_by_frame(bbox_tuples)
+    m_by_frame, m_undist = _build_ann_by_frame(mask_tuples)
+    r_by_frame, r_undist = _build_ann_by_frame(roi_tuples)
 
     lazy_store._centroid_by_frame = c_by_frame
     lazy_store._bbox_by_frame = b_by_frame
@@ -2625,15 +2631,7 @@ def _read_labels_lazy(labels_path: str, open_videos: bool = True) -> Labels:
     lazy_store._undistributed_rois = r_undist
 
     # Label images use the same pattern
-    li_by_frame: dict[tuple[int, int], list] = {}
-    li_undist: list = []
-    for li in label_images:
-        if li.video is not None and li.frame_idx is not None:
-            vid_idx = videos.index(li.video) if li.video in videos else -1
-            key = (vid_idx, li.frame_idx)
-            li_by_frame.setdefault(key, []).append(li)
-        else:
-            li_undist.append(li)
+    li_by_frame, li_undist = _build_ann_by_frame(li_tuples)
     lazy_store._label_image_by_frame = li_by_frame
     lazy_store._undistributed_label_images = li_undist
 
@@ -2698,7 +2696,7 @@ def read_rois(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
-) -> list[ROI]:
+) -> list[tuple[ROI, int, int]]:
     """Read ROI annotations from a SLEAP labels file.
 
     Args:
@@ -2710,7 +2708,9 @@ def read_rois(
             associations will not be restored.
 
     Returns:
-        A list of ROI objects. Returns an empty list if no ROIs are stored.
+        A list of ``(roi, video_idx, frame_idx)`` tuples. ``video_idx`` and
+        ``frame_idx`` are the routing context read from the file (``-1``
+        means undistributable). Returns an empty list if no ROIs are stored.
     """
     import shapely
 
@@ -2762,7 +2762,6 @@ def read_rois(
         video = videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(row["frame_idx"])
-        frame_idx = None if frame_idx_val == -1 else frame_idx_val
 
         track_idx = int(row["track"])
         track = tracks[track_idx] if 0 <= track_idx < len(tracks) else None
@@ -2791,7 +2790,6 @@ def read_rois(
             category=categories[i] if i < len(categories) else "",
             source=sources[i] if i < len(sources) else "",
             video=video,
-            frame_idx=frame_idx,
             track=track,
             tracking_score=tracking_score,
             instance=instance,
@@ -2807,7 +2805,7 @@ def read_rois(
 
         # Store raw index for deferred resolution (lazy loading)
         roi._instance_idx = instance_idx
-        rois.append(roi)
+        rois.append((roi, video_idx, frame_idx_val))
 
     return rois
 
@@ -2818,6 +2816,7 @@ def write_rois(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
+    contexts: list[tuple[int, int]] | None = None,
 ) -> None:
     """Write ROI annotations to a SLEAP labels file.
 
@@ -2828,9 +2827,14 @@ def write_rois(
         tracks: List of Track objects for index mapping.
         instances: Optional list of Instance/PredictedInstance objects for index
             mapping. If provided, ROI instance associations will be persisted.
+        contexts: Parallel list of ``(video_idx, frame_idx)`` routing context
+            for each ROI. If ``None``, defaults to ``(-1, -1)`` for all.
     """
     if not rois:
         return
+
+    if contexts is None:
+        contexts = [(-1, -1)] * len(rois)
 
     import shapely
 
@@ -2856,15 +2860,14 @@ def write_rois(
     names = []
     sources = []
 
-    for roi in rois:
+    for i_roi, roi in enumerate(rois):
         wkb = shapely.to_wkb(roi.geometry)
         wkb_start = wkb_offset
         wkb_end = wkb_offset + len(wkb)
         wkb_chunks.append(np.frombuffer(wkb, dtype=np.uint8))
         wkb_offset = wkb_end
 
-        video_idx = videos.index(roi.video) if roi.video in videos else -1
-        frame_idx = roi.frame_idx if roi.frame_idx is not None else -1
+        video_idx, frame_idx = contexts[i_roi]
         track_idx = tracks.index(roi.track) if roi.track in tracks else -1
 
         instance_idx = roi._instance_idx  # Use stored index as default
@@ -2923,7 +2926,7 @@ def read_bboxes(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
-) -> list[BoundingBox]:
+) -> list[tuple[BoundingBox, int, int]]:
     """Read bounding box annotations from a SLEAP labels file.
 
     Args:
@@ -2935,8 +2938,9 @@ def read_bboxes(
             associations will not be restored.
 
     Returns:
-        A list of BoundingBox objects. Returns an empty list if no bboxes are
-        stored.
+        A list of ``(bbox, video_idx, frame_idx)`` tuples. ``video_idx`` and
+        ``frame_idx`` are the routing context read from the file (``-1``
+        means undistributable). Returns an empty list if no bboxes are stored.
     """
     with h5py.File(labels_path, "r") as f:
         if "bboxes" not in f:
@@ -2961,7 +2965,7 @@ def _read_bboxes_columnar(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None,
-) -> list[BoundingBox]:
+) -> list[tuple[BoundingBox, int, int]]:
     """Read bboxes from columnar /bboxes group (v2.0+ format)."""
     x1_arr = grp["x1"][:]
     y1_arr = grp["y1"][:]
@@ -2982,10 +2986,9 @@ def _read_bboxes_columnar(
     bboxes: list[BoundingBox] = []
     for i in range(len(x1_arr)):
         video_idx = int(video_arr[i])
-        video = videos[video_idx] if 0 <= video_idx < len(videos) else None
+        videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(frame_idx_arr[i])
-        frame_idx = None if frame_idx_val == -1 else frame_idx_val
 
         track_idx = int(track_arr[i])
         track = tracks[track_idx] if 0 <= track_idx < len(tracks) else None
@@ -3016,8 +3019,6 @@ def _read_bboxes_columnar(
             x2=float(x2_arr[i]),
             y2=float(y2_arr[i]),
             angle=float(angle_arr[i]),
-            video=video,
-            frame_idx=frame_idx,
             track=track,
             tracking_score=tracking_score,
             instance=instance,
@@ -3032,7 +3033,7 @@ def _read_bboxes_columnar(
             bbox = UserBoundingBox(**kwargs)
 
         bbox._instance_idx = instance_idx
-        bboxes.append(bbox)
+        bboxes.append((bbox, video_idx, frame_idx_val))
 
     return bboxes
 
@@ -3045,7 +3046,7 @@ def _read_bboxes_legacy(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None,
-) -> list[BoundingBox]:
+) -> list[tuple[BoundingBox, int, int]]:
     """Read bboxes from legacy structured array format (pre-v2.0)."""
     if len(bbox_data) == 0:
         return []
@@ -3053,10 +3054,9 @@ def _read_bboxes_legacy(
     bboxes: list[BoundingBox] = []
     for i, row in enumerate(bbox_data):
         video_idx = int(row["video"])
-        video = videos[video_idx] if 0 <= video_idx < len(videos) else None
+        videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(row["frame_idx"])
-        frame_idx = None if frame_idx_val == -1 else frame_idx_val
 
         track_idx = int(row["track"])
         track = tracks[track_idx] if 0 <= track_idx < len(tracks) else None
@@ -3080,8 +3080,6 @@ def _read_bboxes_legacy(
             x2=xc + w / 2,
             y2=yc + h / 2,
             angle=float(row["angle"]),
-            video=video,
-            frame_idx=frame_idx,
             track=track,
             instance=instance,
             category=categories[i] if i < len(categories) else "",
@@ -3096,7 +3094,7 @@ def _read_bboxes_legacy(
             bbox = UserBoundingBox(**kwargs)
 
         bbox._instance_idx = instance_idx
-        bboxes.append(bbox)
+        bboxes.append((bbox, video_idx, frame_idx_val))
 
     return bboxes
 
@@ -3107,6 +3105,7 @@ def write_bboxes(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
+    contexts: list[tuple[int, int]] | None = None,
 ) -> None:
     """Write bounding box annotations to a SLEAP labels file.
 
@@ -3118,9 +3117,14 @@ def write_bboxes(
         instances: Optional list of Instance/PredictedInstance objects for index
             mapping. If provided, bounding box instance associations will be
             persisted.
+        contexts: Parallel list of ``(video_idx, frame_idx)`` routing context
+            for each bounding box. If ``None``, defaults to ``(-1, -1)`` for all.
     """
     if not bboxes:
         return
+
+    if contexts is None:
+        contexts = [(-1, -1)] * len(bboxes)
 
     n = len(bboxes)
     x1_arr = np.empty(n, dtype=np.float64)
@@ -3146,8 +3150,7 @@ def write_bboxes(
         y2_arr[i] = bbox.y2
         angle_arr[i] = bbox.angle
 
-        video_arr[i] = videos.index(bbox.video) if bbox.video in videos else -1
-        frame_idx_arr[i] = bbox.frame_idx if bbox.frame_idx is not None else -1
+        video_arr[i], frame_idx_arr[i] = contexts[i]
         track_arr[i] = tracks.index(bbox.track) if bbox.track in tracks else -1
 
         instance_idx = bbox._instance_idx
@@ -3194,7 +3197,7 @@ def read_centroids(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
-) -> "list[Centroid]":
+) -> "list[tuple[Centroid, int, int]]":
     """Read centroid annotations from a SLEAP labels file.
 
     Args:
@@ -3205,7 +3208,9 @@ def read_centroids(
             relinking centroid instance associations.
 
     Returns:
-        A list of Centroid objects. Returns an empty list if no centroids are
+        A list of ``(centroid, video_idx, frame_idx)`` tuples. ``video_idx``
+        and ``frame_idx`` are the routing context read from the file (``-1``
+        means undistributable). Returns an empty list if no centroids are
         stored.
     """
     from sleap_io.model.centroid import PredictedCentroid, UserCentroid
@@ -3234,10 +3239,9 @@ def read_centroids(
     centroids: list[Centroid] = []
     for i in range(len(x_arr)):
         video_idx = int(video_arr[i])
-        video = videos[video_idx] if 0 <= video_idx < len(videos) else None
+        videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(frame_idx_arr[i])
-        frame_idx = None if frame_idx_val == -1 else frame_idx_val
 
         track_idx = int(track_arr[i])
         track = tracks[track_idx] if 0 <= track_idx < len(tracks) else None
@@ -3272,8 +3276,6 @@ def read_centroids(
             x=float(x_arr[i]),
             y=float(y_arr[i]),
             z=z,
-            video=video,
-            frame_idx=frame_idx,
             track=track,
             tracking_score=tracking_score,
             instance=instance,
@@ -3288,7 +3290,7 @@ def read_centroids(
             centroid = UserCentroid(**kwargs)
 
         centroid._instance_idx = instance_idx
-        centroids.append(centroid)
+        centroids.append((centroid, video_idx, frame_idx_val))
 
     return centroids
 
@@ -3299,6 +3301,7 @@ def write_centroids(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
+    contexts: list[tuple[int, int]] | None = None,
 ) -> None:
     """Write centroid annotations to a SLEAP labels file.
 
@@ -3309,11 +3312,16 @@ def write_centroids(
         tracks: List of Track objects for index mapping.
         instances: Optional list of Instance/PredictedInstance objects for index
             mapping.
+        contexts: Parallel list of ``(video_idx, frame_idx)`` routing context
+            for each centroid. If ``None``, defaults to ``(-1, -1)`` for all.
     """
     from sleap_io.model.centroid import PredictedCentroid
 
     if not centroids:
         return
+
+    if contexts is None:
+        contexts = [(-1, -1)] * len(centroids)
 
     n = len(centroids)
     x_arr = np.empty(n, dtype=np.float64)
@@ -3335,8 +3343,7 @@ def write_centroids(
         y_arr[i] = centroid.y
         z_arr[i] = centroid.z if centroid.z is not None else float("nan")
 
-        video_arr[i] = videos.index(centroid.video) if centroid.video in videos else -1
-        frame_idx_arr[i] = centroid.frame_idx if centroid.frame_idx is not None else -1
+        video_arr[i], frame_idx_arr[i] = contexts[i]
         track_arr[i] = tracks.index(centroid.track) if centroid.track in tracks else -1
 
         instance_idx = centroid._instance_idx
@@ -3383,7 +3390,7 @@ def read_masks(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
-) -> list[SegmentationMask]:
+) -> list[tuple[SegmentationMask, int, int]]:
     """Read segmentation masks from a SLEAP labels file.
 
     Args:
@@ -3395,7 +3402,9 @@ def read_masks(
             associations will not be restored.
 
     Returns:
-        A list of SegmentationMask objects. Returns empty list if none stored.
+        A list of ``(mask, video_idx, frame_idx)`` tuples. ``video_idx`` and
+        ``frame_idx`` are the routing context read from the file (``-1``
+        means undistributable). Returns empty list if none stored.
     """
     try:
         mask_data = read_hdf5_dataset(labels_path, "masks")
@@ -3481,10 +3490,9 @@ def read_masks(
         rle_counts = np.frombuffer(rle_raw.tobytes(), dtype=np.uint32)
 
         video_idx = int(row["video"])
-        video = videos[video_idx] if 0 <= video_idx < len(videos) else None
+        videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(row["frame_idx"])
-        frame_idx = None if frame_idx_val == -1 else frame_idx_val
 
         track_idx = int(row["track"])
         track = tracks[track_idx] if 0 <= track_idx < len(tracks) else None
@@ -3526,8 +3534,6 @@ def read_masks(
             name=names[i] if i < len(names) else "",
             category=categories[i] if i < len(categories) else "",
             source=sources[i] if i < len(sources) else "",
-            video=video,
-            frame_idx=frame_idx,
             track=track,
             tracking_score=tracking_score,
             instance=instance,
@@ -3552,7 +3558,7 @@ def read_masks(
             mask = UserSegmentationMask(**kwargs)
 
         mask._instance_idx = instance_idx
-        masks.append(mask)
+        masks.append((mask, video_idx, frame_idx_val))
 
     return masks
 
@@ -3563,6 +3569,7 @@ def write_masks(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
+    contexts: list[tuple[int, int]] | None = None,
 ) -> None:
     """Write segmentation masks to a SLEAP labels file.
 
@@ -3573,9 +3580,14 @@ def write_masks(
         tracks: List of Track objects for index mapping.
         instances: Optional list of Instance/PredictedInstance objects for index
             mapping. If provided, mask instance associations will be persisted.
+        contexts: Parallel list of ``(video_idx, frame_idx)`` routing context
+            for each mask. If ``None``, defaults to ``(-1, -1)`` for all.
     """
     if not masks:
         return
+
+    if contexts is None:
+        contexts = [(-1, -1)] * len(masks)
 
     mask_dtype = np.dtype(
         [
@@ -3605,7 +3617,7 @@ def write_masks(
     names = []
     sources = []
 
-    for mask in masks:
+    for i_mask, mask in enumerate(masks):
         # Pack uint32 RLE counts as raw bytes (uint8)
         rle_bytes = mask.rle_counts.astype(np.uint32).tobytes()
         rle_uint8 = np.frombuffer(rle_bytes, dtype=np.uint8)
@@ -3614,8 +3626,7 @@ def write_masks(
         rle_chunks.append(rle_uint8)
         rle_offset = rle_end
 
-        video_idx = videos.index(mask.video) if mask.video in videos else -1
-        frame_idx = mask.frame_idx if mask.frame_idx is not None else -1
+        video_idx, frame_idx = contexts[i_mask]
         track_idx = tracks.index(mask.track) if mask.track in tracks else -1
 
         instance_idx = mask._instance_idx  # Use stored index as default
@@ -3731,7 +3742,7 @@ def read_label_images(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
-) -> tuple[list[LabelImage], "h5py.File | None"]:
+) -> tuple[list[tuple[LabelImage, int, int]], "h5py.File | None"]:
     """Read label image annotations from a SLEAP labels file.
 
     Supports both the legacy blob format (v1.8-v2.1) and the chunked format
@@ -3748,11 +3759,13 @@ def read_label_images(
             associations will not be restored.
 
     Returns:
-        A tuple of ``(label_images, h5py_file)`` where ``label_images`` is a
-        list of LabelImage objects and ``h5py_file`` is the open HDF5 file
-        handle that must be kept alive for lazy data access (or ``None`` if no
-        label images were found). The caller is responsible for storing and
-        eventually closing the file handle.
+        A tuple of ``(label_image_tuples, h5py_file)`` where
+        ``label_image_tuples`` is a list of ``(li, video_idx, frame_idx)``
+        tuples with routing context (``-1`` means undistributable), and
+        ``h5py_file`` is the open HDF5 file handle that must be kept alive
+        for lazy data access (or ``None`` if no label images were found).
+        The caller is responsible for storing and eventually closing the
+        file handle.
     """
     try:
         li_data = read_hdf5_dataset(labels_path, "label_images")
@@ -3863,10 +3876,9 @@ def read_label_images(
     label_images: list[LabelImage] = []
     for i, row in enumerate(li_data):
         video_idx = int(row["video"])
-        video = videos[video_idx] if 0 <= video_idx < len(videos) else None
+        videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(row["frame_idx"])
-        frame_idx = None if frame_idx_val == -1 else frame_idx_val
 
         height = int(row["height"])
         width = int(row["width"])
@@ -3940,8 +3952,6 @@ def read_label_images(
         kwargs = dict(
             data=None,
             objects=objects,
-            video=video,
-            frame_idx=frame_idx,
             source=source,
             scale=scale,
             offset=offset,
@@ -3975,7 +3985,7 @@ def read_label_images(
         li._height = height
         li._width = width
 
-        label_images.append(li)
+        label_images.append((li, video_idx, frame_idx_val))
 
     return label_images, f
 
@@ -3986,6 +3996,7 @@ def write_label_images(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
+    contexts: list[tuple[int, int]] | None = None,
 ) -> None:
     """Write label image annotations to a SLEAP labels file.
 
@@ -4005,9 +4016,14 @@ def write_label_images(
         instances: Optional list of Instance/PredictedInstance objects for index
             mapping. If provided, label image instance associations will be
             persisted.
+        contexts: Parallel list of ``(video_idx, frame_idx)`` routing context
+            for each label image. If ``None``, defaults to ``(-1, -1)`` for all.
     """
     if not label_images:
         return
+
+    if contexts is None:
+        contexts = [(-1, -1)] * len(label_images)
 
     # Determine if we can use chunked format (requires uniform frame sizes)
     shapes = {(li.height, li.width) for li in label_images}
@@ -4039,8 +4055,7 @@ def write_label_images(
             )
 
         for i, li in enumerate(label_images):
-            video_idx = videos.index(li.video) if li.video in videos else -1
-            frame_idx = li.frame_idx if li.frame_idx is not None else -1
+            video_idx, frame_idx = contexts[i]
 
             if use_chunked:
                 # Write pixel data directly via write_direct_chunk (43x faster)
@@ -4368,7 +4383,12 @@ class LabelImageWriter:
             self._capacity *= 2
             self._pixel_dset.resize(self._capacity, axis=0)
 
-    def add(self, label_image: LabelImage) -> None:
+    def add(
+        self,
+        label_image: LabelImage,
+        video_idx: int = -1,
+        frame_idx: int = -1,
+    ) -> None:
         """Add a single label image to the file.
 
         The first call creates the HDF5 file and locks the frame dimensions.
@@ -4376,6 +4396,8 @@ class LabelImageWriter:
 
         Args:
             label_image: The label image to write.
+            video_idx: Video index for routing context. Defaults to ``-1``.
+            frame_idx: Frame index for routing context. Defaults to ``-1``.
 
         Raises:
             ValueError: If the frame dimensions don't match the first frame.
@@ -4383,6 +4405,13 @@ class LabelImageWriter:
         """
         if self._finalized:
             raise RuntimeError("Writer has already been finalized.")
+
+        # Auto-resolve video_idx from self.video when not explicitly provided
+        if video_idx == -1 and self.video is not None:
+            video_idx = 0
+        # Auto-resolve frame_idx from write count when not explicitly provided
+        if frame_idx == -1:
+            frame_idx = self._count
 
         h, w = label_image.height, label_image.width
         self._ensure_file(h, w)
@@ -4401,12 +4430,7 @@ class LabelImageWriter:
         compressed = zlib.compress(label_image.data.astype(np.int32).tobytes(), level=1)
         self._pixel_dset.id.write_direct_chunk((idx, 0, 0), compressed)
 
-        # Collect video index
-        videos = [self.video] if self.video is not None else []
-        video_idx = (
-            videos.index(label_image.video) if label_image.video in videos else -1
-        )
-        frame_idx = label_image.frame_idx if label_image.frame_idx is not None else -1
+        # Use provided routing context (video_idx, frame_idx are parameters)
 
         # Build object rows (auto-collect new tracks)
         n_objects = len(label_image.objects)
@@ -4571,12 +4595,25 @@ class LabelImageWriter:
         write_tracks(self.path, self.tracks)
         _write_metadata_standalone(self.path, skeletons=skeletons)
 
-        li_images, li_file = read_label_images(self.path, videos, self.tracks, [])
+        li_tuples, li_file = read_label_images(self.path, videos, self.tracks, [])
+        # Distribute label images to frames
+        labeled_frames = []
+        frame_lookup: dict[tuple[int, int], LabeledFrame] = {}
+        for li, vid_idx, fidx in li_tuples:
+            key = (vid_idx, fidx)
+            if key not in frame_lookup:
+                video = videos[vid_idx] if 0 <= vid_idx < len(videos) else None
+                if video is not None:
+                    lf = LabeledFrame(video=video, frame_idx=fidx)
+                    labeled_frames.append(lf)
+                    frame_lookup[key] = lf
+            if key in frame_lookup:
+                frame_lookup[key].label_images.append(li)
         labels = Labels(
+            labeled_frames=labeled_frames,
             videos=videos,
             skeletons=skeletons,
             tracks=self.tracks,
-            label_images=li_images,
         )
         if li_file is not None:
             labels._label_image_file = li_file
@@ -5012,13 +5049,30 @@ def merge_label_images(
         _write_metadata_standalone(dest_path)
 
         # Return Labels pointing at the merged file
-        li_images, li_file = read_label_images(
+        li_tuples, li_file = read_label_images(
             dest_path, merged_videos, merged_tracks, []
         )
+        # Distribute label images to frames
+        labeled_frames = []
+        frame_lookup: dict[tuple[int, int], LabeledFrame] = {}
+        for li, vid_idx, fidx in li_tuples:
+            key = (vid_idx, fidx)
+            if key not in frame_lookup:
+                video = (
+                    merged_videos[vid_idx]
+                    if 0 <= vid_idx < len(merged_videos)
+                    else None
+                )
+                if video is not None:
+                    lf = LabeledFrame(video=video, frame_idx=fidx)
+                    labeled_frames.append(lf)
+                    frame_lookup[key] = lf
+            if key in frame_lookup:
+                frame_lookup[key].label_images.append(li)
         labels = Labels(
+            labeled_frames=labeled_frames,
             videos=merged_videos,
             tracks=merged_tracks,
-            label_images=li_images,
         )
         if li_file is not None:
             labels._label_image_file = li_file
@@ -5118,39 +5172,41 @@ def read_labels(labels_path: str, open_videos: bool = True) -> Labels:
 
     identities = read_identities(labels_path)
     sessions = read_sessions(labels_path, videos, labeled_frames, identities=identities)
-    rois = read_rois(labels_path, videos, tracks, instances)
-    masks = read_masks(labels_path, videos, tracks, instances)
-    bboxes = read_bboxes(labels_path, videos, tracks, instances)
-    centroids = read_centroids(labels_path, videos, tracks, instances)
-    label_images, _li_file = read_label_images(labels_path, videos, tracks, instances)
+    roi_tuples = read_rois(labels_path, videos, tracks, instances)
+    mask_tuples = read_masks(labels_path, videos, tracks, instances)
+    bbox_tuples = read_bboxes(labels_path, videos, tracks, instances)
+    centroid_tuples = read_centroids(labels_path, videos, tracks, instances)
+    li_tuples, _li_file = read_label_images(labels_path, videos, tracks, instances)
 
     # Migrate old-style bbox ROIs to BoundingBox objects (skip predicted ROIs)
-    if not bboxes:
-        migrated_bboxes: list[BoundingBox] = []
-        remaining_rois: list[ROI] = []
-        for roi in rois:
+    if not bbox_tuples:
+        migrated_bbox_tuples: list[tuple[BoundingBox, int, int]] = []
+        remaining_roi_tuples: list[tuple[ROI, int, int]] = []
+        for roi, vid_idx, fidx in roi_tuples:
             if roi.is_bbox and not roi.is_predicted:
                 minx, miny, maxx, maxy = roi.geometry.bounds
-                migrated_bboxes.append(
-                    UserBoundingBox.from_xyxy(
-                        minx,
-                        miny,
-                        maxx,
-                        maxy,
-                        video=roi.video,
-                        frame_idx=roi.frame_idx,
-                        track=roi.track,
-                        instance=roi.instance,
-                        category=roi.category,
-                        name=roi.name,
-                        source=roi.source,
+                migrated_bbox_tuples.append(
+                    (
+                        UserBoundingBox.from_xyxy(
+                            minx,
+                            miny,
+                            maxx,
+                            maxy,
+                            track=roi.track,
+                            instance=roi.instance,
+                            category=roi.category,
+                            name=roi.name,
+                            source=roi.source,
+                        ),
+                        vid_idx,
+                        fidx,
                     )
                 )
             else:
-                remaining_rois.append(roi)
-        if migrated_bboxes:
-            bboxes = migrated_bboxes
-            rois = remaining_rois
+                remaining_roi_tuples.append((roi, vid_idx, fidx))
+        if migrated_bbox_tuples:
+            bbox_tuples = migrated_bbox_tuples
+            roi_tuples = remaining_roi_tuples
 
     # Attach annotations to their corresponding LabeledFrames
     frame_lookup: dict[tuple[int, int], LabeledFrame] = {}
@@ -5158,44 +5214,58 @@ def read_labels(labels_path: str, open_videos: bool = True) -> Labels:
         vid_idx = videos.index(lf.video) if lf.video in videos else -1
         frame_lookup[(vid_idx, lf.frame_idx)] = lf
 
-    def _get_or_create_frame(video, frame_idx):
-        vid_idx = videos.index(video) if video in videos else -1
+    def _get_or_create_frame(vid_idx, frame_idx):
         key = (vid_idx, frame_idx)
         if key not in frame_lookup:
-            lf = LabeledFrame(video=video, frame_idx=frame_idx)
-            labeled_frames.append(lf)
-            frame_lookup[key] = lf
+            video = videos[vid_idx] if 0 <= vid_idx < len(videos) else None
+            if video is not None:
+                lf = LabeledFrame(video=video, frame_idx=frame_idx)
+                labeled_frames.append(lf)
+                frame_lookup[key] = lf
+                return lf
+            return None
         return frame_lookup[key]
 
     # Distribute annotations to frames, keeping undistributable ones
     undist_centroids = []
-    for c in centroids:
-        if c.video is not None and c.frame_idx is not None:
-            _get_or_create_frame(c.video, c.frame_idx).centroids.append(c)
-        else:
-            undist_centroids.append(c)
+    for c, vid_idx, fidx in centroid_tuples:
+        if vid_idx >= 0 and fidx >= 0:
+            lf = _get_or_create_frame(vid_idx, fidx)
+            if lf is not None:
+                lf.centroids.append(c)
+                continue
+        undist_centroids.append(c)
     undist_bboxes = []
-    for b in bboxes:
-        if b.video is not None and b.frame_idx is not None:
-            _get_or_create_frame(b.video, b.frame_idx).bboxes.append(b)
-        else:
-            undist_bboxes.append(b)
+    for b, vid_idx, fidx in bbox_tuples:
+        if vid_idx >= 0 and fidx >= 0:
+            lf = _get_or_create_frame(vid_idx, fidx)
+            if lf is not None:
+                lf.bboxes.append(b)
+                continue
+        undist_bboxes.append(b)
     undist_masks = []
-    for m in masks:
-        if m.video is not None and m.frame_idx is not None:
-            _get_or_create_frame(m.video, m.frame_idx).masks.append(m)
-        else:
-            undist_masks.append(m)
+    for m, vid_idx, fidx in mask_tuples:
+        if vid_idx >= 0 and fidx >= 0:
+            lf = _get_or_create_frame(vid_idx, fidx)
+            if lf is not None:
+                lf.masks.append(m)
+                continue
+        undist_masks.append(m)
     undist_label_images = []
-    for li in label_images:
-        if li.video is not None and li.frame_idx is not None:
-            _get_or_create_frame(li.video, li.frame_idx).label_images.append(li)
-        else:
-            undist_label_images.append(li)
+    for li, vid_idx, fidx in li_tuples:
+        if vid_idx >= 0 and fidx >= 0:
+            lf = _get_or_create_frame(vid_idx, fidx)
+            if lf is not None:
+                lf.label_images.append(li)
+                continue
+        undist_label_images.append(li)
     undist_rois = []
-    for r in rois:
-        if r.video is not None and r.frame_idx is not None:
-            _get_or_create_frame(r.video, r.frame_idx).rois.append(r)
+    for r, vid_idx, fidx in roi_tuples:
+        if vid_idx >= 0 and fidx >= 0:
+            lf = _get_or_create_frame(vid_idx, fidx)
+            if lf is not None:
+                lf.rois.append(r)
+                continue
         else:
             undist_rois.append(r)
 
@@ -5209,10 +5279,6 @@ def read_labels(labels_path: str, open_videos: bool = True) -> Labels:
         sessions=sessions,
         provenance=provenance,
         rois=undist_rois,
-        masks=undist_masks,
-        bboxes=undist_bboxes,
-        centroids=undist_centroids,
-        label_images=undist_label_images,
     )
     labels.provenance["filename"] = labels_path
 
@@ -5383,24 +5449,57 @@ def _write_labels_lazy(
             f.create_dataset("negative_frames", data=neg_data)
 
     # Write annotations from lazy store (per-frame dicts + undistributed)
-    all_centroids = [c for cs in lazy_store._centroid_by_frame.values() for c in cs]
-    all_centroids.extend(lazy_store._undistributed_centroids)
-    all_bboxes = [b for bs in lazy_store._bbox_by_frame.values() for b in bs]
-    all_bboxes.extend(lazy_store._undistributed_bboxes)
-    all_masks = [m for ms in lazy_store._mask_by_frame.values() for m in ms]
-    all_masks.extend(lazy_store._undistributed_masks)
-    all_rois = [r for rs in lazy_store._roi_by_frame.values() for r in rs]
-    all_rois.extend(lazy_store._undistributed_rois)
-    all_label_images = [
-        li for lis in lazy_store._label_image_by_frame.values() for li in lis
-    ]
-    all_label_images.extend(lazy_store._undistributed_label_images)
-    write_rois(labels_path, all_rois, labels.videos, labels.tracks)
-    write_masks(labels_path, all_masks, labels.videos, labels.tracks)
-    write_bboxes(labels_path, all_bboxes, labels.videos, labels.tracks)
-    write_centroids(labels_path, all_centroids, labels.videos, labels.tracks)
+    # Build annotation lists with routing contexts from the lazy store keys
+    def _collect_from_lazy(by_frame, undistributed):
+        """Collect annotations and contexts from lazy store dicts."""
+        anns = []
+        ctxs = []
+        for (vid_idx, fidx), ann_list in by_frame.items():
+            for ann in ann_list:
+                anns.append(ann)
+                ctxs.append((vid_idx, fidx))
+        for ann in undistributed:
+            anns.append(ann)
+            ctxs.append((-1, -1))
+        return anns, ctxs
+
+    all_centroids, centroid_ctxs = _collect_from_lazy(
+        lazy_store._centroid_by_frame, lazy_store._undistributed_centroids
+    )
+    all_bboxes, bbox_ctxs = _collect_from_lazy(
+        lazy_store._bbox_by_frame, lazy_store._undistributed_bboxes
+    )
+    all_masks, mask_ctxs = _collect_from_lazy(
+        lazy_store._mask_by_frame, lazy_store._undistributed_masks
+    )
+    all_rois, roi_ctxs = _collect_from_lazy(
+        lazy_store._roi_by_frame, lazy_store._undistributed_rois
+    )
+    all_label_images, li_ctxs = _collect_from_lazy(
+        lazy_store._label_image_by_frame, lazy_store._undistributed_label_images
+    )
+    write_rois(labels_path, all_rois, labels.videos, labels.tracks, contexts=roi_ctxs)
+    write_masks(
+        labels_path, all_masks, labels.videos, labels.tracks, contexts=mask_ctxs
+    )
+    write_bboxes(
+        labels_path, all_bboxes, labels.videos, labels.tracks, contexts=bbox_ctxs
+    )
+    write_centroids(
+        labels_path,
+        all_centroids,
+        labels.videos,
+        labels.tracks,
+        contexts=centroid_ctxs,
+    )
     # Note: instance associations are not persisted in lazy mode (no all_instances).
-    write_label_images(labels_path, all_label_images, labels.videos, labels.tracks)
+    write_label_images(
+        labels_path,
+        all_label_images,
+        labels.videos,
+        labels.tracks,
+        contexts=li_ctxs,
+    )
 
 
 def write_labels(
@@ -5547,22 +5646,83 @@ def write_labels(
     write_lfs(labels_path, labels)
     write_negative_frames(labels_path, labels)
 
-    # Collect all instances across all frames for ROI/bbox instance mapping
+    # Collect all instances and build annotation lists with routing contexts
     all_instances: list[Instance | PredictedInstance] = []
+    all_centroids: list = []
+    centroid_contexts: list[tuple[int, int]] = []
+    all_bboxes: list = []
+    bbox_contexts: list[tuple[int, int]] = []
+    all_masks: list = []
+    mask_contexts: list[tuple[int, int]] = []
+    all_label_images: list = []
+    li_contexts: list[tuple[int, int]] = []
+    all_rois: list = []
+    roi_contexts: list[tuple[int, int]] = []
+
     for lf in labels.labeled_frames:
         all_instances.extend(lf.instances)
-    write_rois(labels_path, labels.rois, labels.videos, labels.tracks, all_instances)
-    write_masks(labels_path, labels.masks, labels.videos, labels.tracks, all_instances)
-    write_bboxes(
-        labels_path, labels.bboxes, labels.videos, labels.tracks, all_instances
-    )
-    write_centroids(
-        labels_path, labels.centroids, labels.videos, labels.tracks, all_instances
-    )
-    write_label_images(
+        vid_idx = labels.videos.index(lf.video) if lf.video in labels.videos else -1
+        ctx = (vid_idx, lf.frame_idx)
+        for c in lf.centroids:
+            all_centroids.append(c)
+            centroid_contexts.append(ctx)
+        for b in lf.bboxes:
+            all_bboxes.append(b)
+            bbox_contexts.append(ctx)
+        for m in lf.masks:
+            all_masks.append(m)
+            mask_contexts.append(ctx)
+        for li in lf.label_images:
+            all_label_images.append(li)
+            li_contexts.append(ctx)
+        for r in lf.rois:
+            all_rois.append(r)
+            roi_contexts.append(ctx)
+
+    # Add static ROIs (not tied to any frame)
+    for r in labels.static_rois:
+        all_rois.append(r)
+        roi_contexts.append(
+            (labels.videos.index(r.video) if r.video in labels.videos else -1, -1)
+        )
+
+    write_rois(
         labels_path,
-        labels.label_images,
+        all_rois,
         labels.videos,
         labels.tracks,
         all_instances,
+        contexts=roi_contexts,
+    )
+    write_masks(
+        labels_path,
+        all_masks,
+        labels.videos,
+        labels.tracks,
+        all_instances,
+        contexts=mask_contexts,
+    )
+    write_bboxes(
+        labels_path,
+        all_bboxes,
+        labels.videos,
+        labels.tracks,
+        all_instances,
+        contexts=bbox_contexts,
+    )
+    write_centroids(
+        labels_path,
+        all_centroids,
+        labels.videos,
+        labels.tracks,
+        all_instances,
+        contexts=centroid_contexts,
+    )
+    write_label_images(
+        labels_path,
+        all_label_images,
+        labels.videos,
+        labels.tracks,
+        all_instances,
+        contexts=li_contexts,
     )

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -992,8 +992,6 @@ def write_videos(
 
     # First determine which videos need embedding
     for video_ind, video in enumerate(videos):
-        if video is None:
-            continue
         # Check if video has an open backend with embedded images
         has_backend_with_embedded = (
             type(video.backend) is HDF5Video and video.backend.has_embedded_images
@@ -1140,8 +1138,6 @@ def write_videos(
     # so we only need to store source_video (immediate parent).
     with h5py.File(labels_path, "a") as f:
         for video_ind, video in enumerate(videos):
-            if video is None:
-                continue
             dataset = f"video{video_ind}"
 
             # If original_videos is provided (e.g., during embedding), use those
@@ -2986,7 +2982,6 @@ def _read_bboxes_columnar(
     bboxes: list[BoundingBox] = []
     for i in range(len(x1_arr)):
         video_idx = int(video_arr[i])
-        videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(frame_idx_arr[i])
 
@@ -3054,7 +3049,6 @@ def _read_bboxes_legacy(
     bboxes: list[BoundingBox] = []
     for i, row in enumerate(bbox_data):
         video_idx = int(row["video"])
-        videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(row["frame_idx"])
 
@@ -3239,7 +3233,6 @@ def read_centroids(
     centroids: list[Centroid] = []
     for i in range(len(x_arr)):
         video_idx = int(video_arr[i])
-        videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(frame_idx_arr[i])
 
@@ -3490,7 +3483,6 @@ def read_masks(
         rle_counts = np.frombuffer(rle_raw.tobytes(), dtype=np.uint32)
 
         video_idx = int(row["video"])
-        videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(row["frame_idx"])
 
@@ -3876,7 +3868,6 @@ def read_label_images(
     label_images: list[LabelImage] = []
     for i, row in enumerate(li_data):
         video_idx = int(row["video"])
-        videos[video_idx] if 0 <= video_idx < len(videos) else None
 
         frame_idx_val = int(row["frame_idx"])
 
@@ -5177,36 +5168,6 @@ def read_labels(labels_path: str, open_videos: bool = True) -> Labels:
     bbox_tuples = read_bboxes(labels_path, videos, tracks, instances)
     centroid_tuples = read_centroids(labels_path, videos, tracks, instances)
     li_tuples, _li_file = read_label_images(labels_path, videos, tracks, instances)
-
-    # Migrate old-style bbox ROIs to BoundingBox objects (skip predicted ROIs)
-    if not bbox_tuples:
-        migrated_bbox_tuples: list[tuple[BoundingBox, int, int]] = []
-        remaining_roi_tuples: list[tuple[ROI, int, int]] = []
-        for roi, vid_idx, fidx in roi_tuples:
-            if roi.is_bbox and not roi.is_predicted:
-                minx, miny, maxx, maxy = roi.geometry.bounds
-                migrated_bbox_tuples.append(
-                    (
-                        UserBoundingBox.from_xyxy(
-                            minx,
-                            miny,
-                            maxx,
-                            maxy,
-                            track=roi.track,
-                            instance=roi.instance,
-                            category=roi.category,
-                            name=roi.name,
-                            source=roi.source,
-                        ),
-                        vid_idx,
-                        fidx,
-                    )
-                )
-            else:
-                remaining_roi_tuples.append((roi, vid_idx, fidx))
-        if migrated_bbox_tuples:
-            bbox_tuples = migrated_bbox_tuples
-            roi_tuples = remaining_roi_tuples
 
     # Attach annotations to their corresponding LabeledFrames
     frame_lookup: dict[tuple[int, int], LabeledFrame] = {}

--- a/sleap_io/io/tiff.py
+++ b/sleap_io/io/tiff.py
@@ -239,8 +239,6 @@ def read_label_images(
                 UserLabelImage(
                     data=data,
                     objects=objects,
-                    video=video,
-                    frame_idx=frame_idx,
                     scale=sidecar_scale,
                     offset=sidecar_offset,
                 )
@@ -271,8 +269,6 @@ def read_label_images(
             UserLabelImage(
                 data=data,
                 objects=objects,
-                video=video,
-                frame_idx=frame_idx,
                 scale=sidecar_scale,
                 offset=sidecar_offset,
             )

--- a/sleap_io/io/trackmate.py
+++ b/sleap_io/io/trackmate.py
@@ -154,6 +154,7 @@ def read_trackmate_csv(
     """
     from sleap_io.model.centroid import PredictedCentroid
     from sleap_io.model.instance import Track
+    from sleap_io.model.labeled_frame import LabeledFrame
     from sleap_io.model.labels import Labels
     from sleap_io.model.video import Video as VideoClass
 
@@ -220,7 +221,7 @@ def read_trackmate_csv(
     tracks = list(track_map.values())
 
     # --- Build PredictedCentroid objects ---
-    centroids: list[PredictedCentroid] = []
+    frame_centroids: dict[int, list[PredictedCentroid]] = {}
     for row in rows:
         spot_id = int(row[col["ID"]])
         tid_str = row[col["TRACK_ID"]]
@@ -244,18 +245,22 @@ def read_trackmate_csv(
             x=x,
             y=y,
             z=z,
-            video=video_obj,
-            frame_idx=frame_idx,
             track=track,
             tracking_score=tracking_score,
             score=score,
             name=label,
             source="trackmate",
         )
-        centroids.append(centroid)
+        # Collect per-frame centroids for distribution to LabeledFrames
+        frame_centroids.setdefault(frame_idx, []).append(centroid)
 
     # --- Assemble Labels ---
     videos = [video_obj] if video_obj is not None else []
-    labels = Labels(videos=videos, tracks=tracks, centroids=centroids)
+    labeled_frames = []
+    for fidx, cents in sorted(frame_centroids.items()):
+        lf = LabeledFrame(video=video_obj, frame_idx=fidx)
+        lf.centroids.extend(cents)
+        labeled_frames.append(lf)
+    labels = Labels(videos=videos, tracks=tracks, labeled_frames=labeled_frames)
     labels.provenance["filename"] = str(spots_path)
     return labels

--- a/sleap_io/io/ultralytics.py
+++ b/sleap_io/io/ultralytics.py
@@ -101,8 +101,6 @@ def read_labels(
 
     # Process all image/label pairs
     labeled_frames = []
-    all_rois: list[ROI] = []
-    all_bboxes: list[BoundingBox] = []
     tracks = {}  # Track synthetic tracks by instance order
 
     for image_file in sorted(images_dir.glob("*")):
@@ -114,6 +112,8 @@ def read_labels(
 
             # Parse label file if it exists
             instances: list[Instance] = []
+            rois: list[ROI] = []
+            bboxes: list[BoundingBox] = []
             if label_file.exists():
                 # Get image dimensions - try from video shape first, fallback to
                 # reading image
@@ -134,8 +134,6 @@ def read_labels(
                     video=video,
                     frame_idx=0,
                 )
-                all_rois.extend(rois)
-                all_bboxes.extend(bboxes)
 
                 # Assign tracks to instances based on order
                 for i, instance in enumerate(instances):
@@ -144,8 +142,10 @@ def read_labels(
                         tracks[track_name] = Track(name=track_name)
                     instance.track = tracks[track_name]
 
-            # Create labeled frame
+            # Create labeled frame with annotations attached
             frame = LabeledFrame(video=video, frame_idx=0, instances=instances)
+            frame.rois.extend(rois)
+            frame.bboxes.extend(bboxes)
             labeled_frames.append(frame)
 
     skeletons = [skeleton] if skeleton is not None else []
@@ -154,8 +154,6 @@ def read_labels(
         labeled_frames=labeled_frames,
         skeletons=skeletons,
         tracks=list(tracks.values()),
-        rois=all_rois,
-        bboxes=all_bboxes,
         provenance={"source": str(dataset_path), "split": split},
     )
 
@@ -574,14 +572,16 @@ def _write_bbox_labels(
     # Reverse class_names to get name -> id mapping
     name_to_id = {v: k for k, v in class_names.items()}
 
-    # Group bboxes by video
+    # Group bboxes by video (derive from parent LabeledFrame)
     bboxes_by_video: dict[str, list[BoundingBox]] = {}
-    for bbox in labels.bboxes:
-        if bbox.video is not None:
-            key = str(bbox.video.filename)
+    video_by_key: dict[str, Video] = {}
+    for lf in labels.labeled_frames:
+        if lf.bboxes:
+            key = str(lf.video.filename)
             if key not in bboxes_by_video:
                 bboxes_by_video[key] = []
-            bboxes_by_video[key].append(bbox)
+                video_by_key[key] = lf.video
+            bboxes_by_video[key].extend(lf.bboxes)
 
     video_keys = sorted(bboxes_by_video.keys())
 
@@ -621,7 +621,7 @@ def _write_bbox_labels(
 
         for lf_idx, video_path in enumerate(iterator):
             bbox_list = bboxes_by_video[video_path]
-            video = bbox_list[0].video
+            video = video_by_key[video_path]
 
             # Read image to get shape and save it
             try:
@@ -682,14 +682,16 @@ def _write_roi_labels(
     # Reverse class_names to get name -> id mapping
     name_to_id = {v: k for k, v in class_names.items()}
 
-    # Group ROIs by video
+    # Group ROIs by video (derive from parent LabeledFrame)
     rois_by_video: dict[str, list[ROI]] = {}
-    for roi in labels.rois:
-        if roi.video is not None:
-            key = str(roi.video.filename)
+    video_by_key: dict[str, Video] = {}
+    for lf in labels.labeled_frames:
+        if lf.rois:
+            key = str(lf.video.filename)
             if key not in rois_by_video:
                 rois_by_video[key] = []
-            rois_by_video[key].append(roi)
+                video_by_key[key] = lf.video
+            rois_by_video[key].extend(lf.rois)
 
     video_keys = sorted(rois_by_video.keys())
 
@@ -729,7 +731,7 @@ def _write_roi_labels(
 
         for lf_idx, video_path in enumerate(iterator):
             rois = rois_by_video[video_path]
-            video = rois[0].video
+            video = video_by_key[video_path]
 
             # Read image to get shape and save it
             try:
@@ -896,8 +898,6 @@ def parse_label_file(
                             w_px,
                             h_px,
                             category=category,
-                            video=video,
-                            frame_idx=frame_idx,
                             score=score,
                         )
                     else:
@@ -907,8 +907,6 @@ def parse_label_file(
                             w_px,
                             h_px,
                             category=category,
-                            video=video,
-                            frame_idx=frame_idx,
                         )
                     bboxes.append(bbox)
 
@@ -924,8 +922,6 @@ def parse_label_file(
                     roi = UserROI.from_polygon(
                         coords,
                         category=category,
-                        video=video,
-                        frame_idx=frame_idx,
                     )
                     rois.append(roi)
 

--- a/sleap_io/model/bbox.py
+++ b/sleap_io/model/bbox.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from sleap_io.model.instance import Instance, Track
     from sleap_io.model.mask import SegmentationMask
     from sleap_io.model.roi import ROI
-    from sleap_io.model.video import Video
 
 
 @attrs.define(eq=False)
@@ -30,7 +29,7 @@ class BoundingBox:
     """A bounding box annotation.
 
     Supports axis-aligned and oriented (rotated) bounding boxes with optional
-    metadata for associating with videos, frames, tracks, and instances.
+    metadata for associating with tracks and instances.
 
     Attributes:
         x1: Left edge x-coordinate (before rotation).
@@ -38,8 +37,6 @@ class BoundingBox:
         x2: Right edge x-coordinate (before rotation).
         y2: Bottom edge y-coordinate (before rotation).
         angle: Rotation angle in radians (0 = axis-aligned).
-        video: Video this bounding box is associated with.
-        frame_idx: Frame index within the video.
         track: Optional tracking identity.
         tracking_score: Confidence of the track identity assignment. ``None``
             if unassigned or manually assigned.
@@ -61,8 +58,6 @@ class BoundingBox:
     x2: float = attrs.field()
     y2: float = attrs.field()
     angle: float = attrs.field(default=0.0)
-    video: "Video | None" = attrs.field(default=None)
-    frame_idx: int | None = attrs.field(default=None)
     track: "Track | None" = attrs.field(default=None)
     tracking_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
@@ -276,8 +271,6 @@ class BoundingBox:
             name=self.name,
             category=self.category,
             source=self.source,
-            video=self.video,
-            frame_idx=self.frame_idx,
             track=self.track,
             instance=self.instance,
         )

--- a/sleap_io/model/centroid.py
+++ b/sleap_io/model/centroid.py
@@ -23,7 +23,6 @@ import numpy as np
 if TYPE_CHECKING:
     from sleap_io.model.instance import Instance, PredictedInstance, Track
     from sleap_io.model.skeleton import Skeleton
-    from sleap_io.model.video import Video
 
 
 def _make_centroid_skeleton():
@@ -64,15 +63,13 @@ def __getattr__(name):
 class Centroid:
     """A point representing the center of an object.
 
-    Supports optional 3D coordinates, video/frame/track/instance metadata,
+    Supports optional 3D coordinates, track/instance metadata,
     and interconversion with single-node ``Instance`` objects.
 
     Attributes:
         x: X-coordinate in pixel space.
         y: Y-coordinate in pixel space.
         z: Optional Z-coordinate for 3D data. ``None`` for 2D.
-        video: Video this centroid is associated with.
-        frame_idx: Frame index within the video.
         track: Optional tracking identity.
         tracking_score: Confidence of the track identity assignment. ``None``
             if unassigned or manually assigned.
@@ -93,8 +90,6 @@ class Centroid:
     x: float = attrs.field()
     y: float = attrs.field()
     z: float | None = attrs.field(default=None)
-    video: "Video | None" = attrs.field(default=None)
-    frame_idx: int | None = attrs.field(default=None)
     track: "Track | None" = attrs.field(default=None)
     tracking_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)

--- a/sleap_io/model/label_image.py
+++ b/sleap_io/model/label_image.py
@@ -47,7 +47,6 @@ if TYPE_CHECKING:
     from sleap_io.model.bbox import BoundingBox
     from sleap_io.model.instance import Instance, Track
     from sleap_io.model.mask import SegmentationMask
-    from sleap_io.model.video import Video
 
 
 @attrs.define(eq=False)
@@ -65,8 +64,6 @@ class LabelImage:
         objects: Mapping from label ID to object metadata. Defines what each
             non-zero pixel value represents. Label IDs not in this dict are
             treated as having default (empty) metadata.
-        video: Associated ``Video``.
-        frame_idx: Frame index. ``None`` means static (applies to all frames).
         source: Source identifier string.
         scale: Resolution ratio ``(sx, sy)`` where ``sx = label_width / image_width``
             and ``sy = label_height / image_height``. ``(1.0, 1.0)`` means full
@@ -109,8 +106,6 @@ class LabelImage:
 
     _data: "np.ndarray | None" = attrs.field(default=None, alias="data")
     objects: dict[int, Info] = Factory(dict)
-    video: "Video | None" = attrs.field(default=None)
-    frame_idx: int | None = attrs.field(default=None)
     source: str = attrs.field(default="")
     scale: tuple[float, float] = attrs.field(default=(1.0, 1.0))
     offset: tuple[float, float] = attrs.field(default=(0.0, 0.0))
@@ -203,8 +198,6 @@ class LabelImage:
         kwargs: dict = dict(
             data=data,
             objects=objects,
-            video=copy.deepcopy(self.video, memo),
-            frame_idx=self.frame_idx,
             source=self.source,
             scale=self.scale,
             offset=self.offset,
@@ -269,8 +262,6 @@ class LabelImage:
         kwargs: dict = dict(
             data=resized,
             objects={lid: attrs.evolve(info) for lid, info in self.objects.items()},
-            video=self.video,
-            frame_idx=self.frame_idx,
             source=self.source,
             scale=(1.0, 1.0),
             offset=(0.0, 0.0),
@@ -393,7 +384,7 @@ class LabelImage:
                 create new Tracks for any label IDs not already in the dict
                 (the dict is mutated in place to accumulate mappings across
                 calls). Default is ``False``.
-            **kwargs: Passed to the LabelImage constructor (video, frame_idx,
+            **kwargs: Passed to the LabelImage constructor (
                 source).
 
         Returns:
@@ -554,8 +545,8 @@ class LabelImage:
                 in ``Info.score`` for each object.
             create_tracks: If ``True`` and ``tracks`` is ``None``, auto-create
                 a ``Track`` per mask with ``name=str(label_id)``.
-            **kwargs: Passed to the ``LabelImage`` constructor (e.g., ``video``,
-                ``frame_idx``, ``source``, ``scale``, ``offset``). For
+            **kwargs: Passed to the ``LabelImage`` constructor (e.g.,
+                ``source``, ``scale``, ``offset``). For
                 ``PredictedLabelImage``, also accepts ``score``, ``score_map``.
 
         Returns:
@@ -573,8 +564,6 @@ class LabelImage:
                     tracks=[t1, t2],    # per-object tracks
                     scores=[0.95, 0.87],# per-object confidence
                     score=0.9,          # image-level confidence
-                    video=video,
-                    frame_idx=0,
                 )
 
         See Also:
@@ -669,7 +658,6 @@ class LabelImage:
         tracks: "dict[int, Track] | list[Track] | None" = None,
         categories: dict[int, str] | list[str] | None = None,
         create_tracks: bool = False,
-        frame_idx: list[int] | None = None,
         score: "float | list[float] | None" = None,
         score_map: np.ndarray | None = None,
         **kwargs,
@@ -695,9 +683,6 @@ class LabelImage:
                 auto-create one ``Track`` per unique non-zero label ID
                 found across all frames. The same ``Track`` object is
                 shared across frames. Default is ``False``.
-            frame_idx: Frame indices for each frame. If ``None``,
-                defaults to ``[0, 1, ..., T-1]``. Must have length ``T``
-                if provided.
             score: Confidence score(s) for ``PredictedLabelImage``. A
                 single float is broadcast to all frames; a list must have
                 length ``T``. Defaults to ``0.0`` for all frames if
@@ -705,15 +690,15 @@ class LabelImage:
             score_map: Optional ``(T, H, W)`` float32 array of per-pixel
                 confidence maps. Sliced per frame. Ignored for
                 ``UserLabelImage``.
-            **kwargs: Passed to every frame's constructor (``video``,
-                ``source``, ``scale``, ``offset``).
+            **kwargs: Passed to every frame's constructor (``source``,
+                ``scale``, ``offset``).
 
         Returns:
             A list of ``LabelImage`` objects, one per frame.
 
         Raises:
             ValueError: If ``data`` is not 3D (or a list), or if
-                ``frame_idx`` / ``score`` lengths don't match.
+                ``score`` lengths don't match.
 
         Note:
             For loading label images from TIFF files (single, multi-page,
@@ -727,7 +712,6 @@ class LabelImage:
             masks = np.stack(cellpose_masks)  # (T, H, W) int32
             label_images = sio.PredictedLabelImage.from_stack(
                 masks,
-                video=video,
                 source="cellpose:nuclei",
                 create_tracks=True,
                 score=1.0,
@@ -754,15 +738,6 @@ class LabelImage:
         n_frames = len(frames)
         if n_frames == 0:
             return []
-
-        # Validate frame_idx
-        if frame_idx is None:
-            frame_idx = list(range(n_frames))
-        elif len(frame_idx) != n_frames:
-            raise ValueError(
-                f"frame_idx length ({len(frame_idx)}) must match "
-                f"number of frames ({n_frames})."
-            )
 
         # Collect unique non-zero IDs across all frames
         all_ids: set[int] = set()
@@ -834,7 +809,6 @@ class LabelImage:
                 )
 
             frame_kwargs = dict(kwargs)
-            frame_kwargs["frame_idx"] = frame_idx[t]
             if is_predicted:
                 frame_kwargs["score"] = scores[t]
                 frame_kwargs["score_map"] = score_maps[t]
@@ -847,8 +821,8 @@ class LabelImage:
         """Decompose into per-object binary SegmentationMasks.
 
         Returns one SegmentationMask per unique non-zero label. Each mask
-        inherits track, category, name, instance, video, frame_idx, source,
-        scale, and offset from the ``LabelImage``.
+        inherits track, category, name, instance, source, scale, and offset
+        from the ``LabelImage``.
 
         Returns:
             A list of ``SegmentationMask`` objects, one per object.
@@ -867,8 +841,6 @@ class LabelImage:
                     category=info.category,
                     track=info.track,
                     instance=info.instance,
-                    video=self.video,
-                    frame_idx=self.frame_idx,
                     source=self.source,
                     scale=self.scale,
                     offset=self.offset,
@@ -934,8 +906,6 @@ class LabelImage:
             y2 = float((row_max[idx] + 1) / sy + oy)
 
             kwargs: dict = dict(
-                video=self.video,
-                frame_idx=self.frame_idx,
                 track=info.track,
                 instance=info.instance,
                 category=info.category,

--- a/sleap_io/model/labeled_frame.py
+++ b/sleap_io/model/labeled_frame.py
@@ -234,6 +234,49 @@ class LabeledFrame:
     label_images: "list[LabelImage]" = field(factory=list)
     rois: "list[ROI]" = field(factory=list)
 
+    def append(
+        self,
+        annotation: "Instance | PredictedInstance | Centroid | BoundingBox | SegmentationMask | LabelImage | ROI",
+    ) -> None:
+        """Append an annotation to the appropriate frame-level container.
+
+        Routes the annotation to the correct list based on its type:
+        ``Instance``/``PredictedInstance`` → ``instances``,
+        ``Centroid`` → ``centroids``, ``BoundingBox`` → ``bboxes``,
+        ``SegmentationMask`` → ``masks``, ``LabelImage`` → ``label_images``,
+        ``ROI`` → ``rois``.
+
+        Args:
+            annotation: The annotation object to add.
+
+        Raises:
+            TypeError: If the annotation type is not recognized.
+        """
+        from sleap_io.model.bbox import BoundingBox
+        from sleap_io.model.centroid import Centroid
+        from sleap_io.model.label_image import LabelImage
+        from sleap_io.model.mask import SegmentationMask
+        from sleap_io.model.roi import ROI
+
+        if isinstance(annotation, (Instance, PredictedInstance)):
+            self.instances.append(annotation)
+        elif isinstance(annotation, Centroid):
+            self.centroids.append(annotation)
+        elif isinstance(annotation, BoundingBox):
+            self.bboxes.append(annotation)
+        elif isinstance(annotation, SegmentationMask):
+            self.masks.append(annotation)
+        elif isinstance(annotation, LabelImage):
+            self.label_images.append(annotation)
+        elif isinstance(annotation, ROI):
+            self.rois.append(annotation)
+        else:
+            raise TypeError(
+                f"Cannot append {type(annotation).__name__} to LabeledFrame. "
+                f"Expected one of: Instance, PredictedInstance, Centroid, "
+                f"BoundingBox, SegmentationMask, LabelImage, ROI."
+            )
+
     def __len__(self) -> int:
         """Return the number of instances in the frame."""
         return len(self.instances)

--- a/sleap_io/model/labeled_frame.py
+++ b/sleap_io/model/labeled_frame.py
@@ -236,7 +236,10 @@ class LabeledFrame:
 
     def append(
         self,
-        annotation: "Instance | PredictedInstance | Centroid | BoundingBox | SegmentationMask | LabelImage | ROI",
+        annotation: (
+            "Instance | PredictedInstance | Centroid"
+            " | BoundingBox | SegmentationMask | LabelImage | ROI"
+        ),
     ) -> None:
         """Append an annotation to the appropriate frame-level container.
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -116,13 +116,9 @@ class Labels:
     sessions: list[RecordingSession] = field(factory=list)
     provenance: dict[str, Any] = field(factory=dict)
 
-    # Annotation fields: accepted as constructor kwargs via alias, distributed
-    # into LabeledFrames at init time, then cleared. Access via properties.
-    _init_rois: "list[ROI]" = field(factory=list, alias="rois")
-    _init_masks: "list[SegmentationMask]" = field(factory=list, alias="masks")
-    _init_bboxes: "list[BoundingBox]" = field(factory=list, alias="bboxes")
-    _init_centroids: "list[Centroid]" = field(factory=list, alias="centroids")
-    _init_label_images: "list[LabelImage]" = field(factory=list, alias="label_images")
+    # Static ROIs: ROIs not tied to any specific frame (e.g., arena boundaries).
+    # Accepted via constructor with alias="rois" for backward compatibility.
+    _static_rois: "list[ROI]" = field(factory=list, alias="rois")
 
     # Internal lazy state (private, not part of public API)
     _lazy_store: "LazyDataStore | None" = field(
@@ -359,11 +355,9 @@ class Labels:
         for lf in labeled_frames:
             all_instances.extend(lf.instances)
 
-        # Relink annotations on each frame (video, track, instance references)
+        # Relink annotations on each frame (track, instance references)
         for lf in labeled_frames:
-            for ann in (*lf.centroids, *lf.bboxes, *lf.masks, *lf.rois):
-                if ann.video is not None:
-                    ann.video = video_map.get(id(ann.video), ann.video)
+            for ann in (*lf.centroids, *lf.bboxes, *lf.masks):
                 if ann.track is not None:
                     ann.track = track_map.get(id(ann.track), ann.track)
                 # Resolve deferred instance link from _instance_idx
@@ -371,9 +365,16 @@ class Labels:
                 if ann.instance is None and 0 <= idx < len(all_instances):
                     ann.instance = all_instances[idx]
                     ann._instance_idx = -1
+            for r in lf.rois:
+                if r.video is not None:
+                    r.video = video_map.get(id(r.video), r.video)
+                if r.track is not None:
+                    r.track = track_map.get(id(r.track), r.track)
+                idx = r._instance_idx
+                if r.instance is None and 0 <= idx < len(all_instances):
+                    r.instance = all_instances[idx]
+                    r._instance_idx = -1
             for li in lf.label_images:
-                if li.video is not None:
-                    li.video = video_map.get(id(li.video), li.video)
                 for info in li.objects.values():
                     if info.track is not None:
                         info.track = track_map.get(id(info.track), info.track)
@@ -382,32 +383,15 @@ class Labels:
                         info.instance = all_instances[idx]
                         info._instance_idx = -1
 
-        # Deep copy undistributed annotations (static ROIs, etc.) and relink
-        # Use zip with originals to look up old id() for video/track mapping
-        def _deepcopy_and_relink(originals):
-            copies = []
-            for orig in originals:
-                new = deepcopy(orig)
-                if orig.video is not None:
-                    new.video = video_map.get(id(orig.video), new.video)
-                if orig.track is not None:
-                    new.track = track_map.get(id(orig.track), new.track)
-                copies.append(new)
-            return copies
-
-        undist_rois = _deepcopy_and_relink(self._lazy_store._undistributed_rois)
-        undist_masks = _deepcopy_and_relink(self._lazy_store._undistributed_masks)
-        undist_bboxes = _deepcopy_and_relink(self._lazy_store._undistributed_bboxes)
-        undist_centroids = _deepcopy_and_relink(
-            self._lazy_store._undistributed_centroids
-        )
-
-        undist_label_images = []
-        for orig_li in self._lazy_store._undistributed_label_images:
-            new_li = deepcopy(orig_li)
-            if orig_li.video is not None:
-                new_li.video = video_map.get(id(orig_li.video), new_li.video)
-            undist_label_images.append(new_li)
+        # Deep copy static ROIs and relink video/track
+        static_rois = []
+        for orig in self._lazy_store._undistributed_rois:
+            new = deepcopy(orig)
+            if orig.video is not None:
+                new.video = video_map.get(id(orig.video), new.video)
+            if orig.track is not None:
+                new.track = track_map.get(id(orig.track), new.track)
+            static_rois.append(new)
 
         return Labels(
             labeled_frames=labeled_frames,
@@ -416,64 +400,16 @@ class Labels:
             tracks=new_tracks,
             suggestions=new_suggestions,
             provenance=dict(self.provenance),
-            rois=undist_rois,
-            masks=undist_masks,
-            bboxes=undist_bboxes,
-            centroids=undist_centroids,
-            label_images=undist_label_images,
+            rois=static_rois,
         )
 
     def __attrs_post_init__(self):
-        """Distribute annotations into frames and update metadata lists."""
-        # Skip distribution and update for lazy Labels - metadata is already
+        """Update metadata lists."""
+        # Skip update for lazy Labels - metadata is already
         # set from HDF5 and annotations are handled by LazyDataStore
         if self.is_lazy:
             return
-        self._distribute_annotations()
         self.update()
-
-    def _distribute_annotations(self):
-        """Move flat annotation lists into their corresponding LabeledFrames.
-
-        Iterates annotations passed via constructor kwargs (``rois``, ``masks``,
-        ``bboxes``, ``centroids``, ``label_images``), finds or creates the
-        matching ``LabeledFrame`` for each annotation's ``(video, frame_idx)``,
-        and appends the annotation to that frame's list.
-
-        Annotations with ``video=None`` or ``frame_idx=None`` (e.g., static
-        ROIs) cannot be distributed and are kept in the ``_init_*`` fields.
-        The corresponding properties include these undistributed annotations.
-        """
-        # Build lookup for existing frames
-        frame_map: dict[tuple[int, int], LabeledFrame] = {}
-        for lf in self.labeled_frames:
-            frame_map[(id(lf.video), lf.frame_idx)] = lf
-
-        def get_or_create(video: Video, frame_idx: int) -> LabeledFrame:
-            key = (id(video), frame_idx)
-            if key not in frame_map:
-                lf = LabeledFrame(video=video, frame_idx=frame_idx)
-                self.labeled_frames.append(lf)
-                frame_map[key] = lf
-            return frame_map[key]
-
-        # Distribute each annotation type, keeping undistributable ones
-        for init_attr, frame_attr in (
-            ("_init_centroids", "centroids"),
-            ("_init_bboxes", "bboxes"),
-            ("_init_masks", "masks"),
-            ("_init_label_images", "label_images"),
-            ("_init_rois", "rois"),
-        ):
-            remaining = []
-            for ann in getattr(self, init_attr):
-                video = ann.video
-                frame_idx = ann.frame_idx
-                if video is not None and frame_idx is not None:
-                    getattr(get_or_create(video, frame_idx), frame_attr).append(ann)
-                else:
-                    remaining.append(ann)
-            setattr(self, init_attr, remaining)
 
     def update(self):
         """Update data structures based on contents.
@@ -507,15 +443,18 @@ class Labels:
         return undist + [ann for anns in by_frame.values() for ann in anns]
 
     @property
+    def static_rois(self) -> "list[ROI]":
+        """Static ROIs not tied to any specific frame."""
+        return self._static_rois
+
+    @property
     def centroids(self) -> "list[Centroid]":
         """Flat view of all centroids across all frames."""
         if self.is_lazy:
             return self._lazy_flat_annotations(
                 "_centroid_by_frame", "_undistributed_centroids"
             )
-        return self._init_centroids + [
-            c for lf in self.labeled_frames for c in lf.centroids
-        ]
+        return [c for lf in self.labeled_frames for c in lf.centroids]
 
     @property
     def bboxes(self) -> "list[BoundingBox]":
@@ -524,14 +463,14 @@ class Labels:
             return self._lazy_flat_annotations(
                 "_bbox_by_frame", "_undistributed_bboxes"
             )
-        return self._init_bboxes + [b for lf in self.labeled_frames for b in lf.bboxes]
+        return [b for lf in self.labeled_frames for b in lf.bboxes]
 
     @property
     def masks(self) -> "list[SegmentationMask]":
         """Flat view of all segmentation masks across all frames."""
         if self.is_lazy:
             return self._lazy_flat_annotations("_mask_by_frame", "_undistributed_masks")
-        return self._init_masks + [m for lf in self.labeled_frames for m in lf.masks]
+        return [m for lf in self.labeled_frames for m in lf.masks]
 
     @property
     def label_images(self) -> "list[LabelImage]":
@@ -540,16 +479,14 @@ class Labels:
             return self._lazy_flat_annotations(
                 "_label_image_by_frame", "_undistributed_label_images"
             )
-        return self._init_label_images + [
-            li for lf in self.labeled_frames for li in lf.label_images
-        ]
+        return [li for lf in self.labeled_frames for li in lf.label_images]
 
     @property
     def rois(self) -> "list[ROI]":
-        """Flat view of all ROIs across all frames."""
+        """Flat view of all ROIs across all frames (includes static ROIs)."""
         if self.is_lazy:
             return self._lazy_flat_annotations("_roi_by_frame", "_undistributed_rois")
-        return self._init_rois + [r for lf in self.labeled_frames for r in lf.rois]
+        return self._static_rois + [r for lf in self.labeled_frames for r in lf.rois]
 
     def _ensure_frame_index(self) -> "dict[tuple[int, int], LabeledFrame]":
         """Build or return the frame index, rebuilding if stale.
@@ -592,6 +529,7 @@ class Labels:
         n = len(self.labeled_frames)
         if self._track_index is None or self._track_index_len != n:
             self._track_index = {}
+            ann_frame_idx: dict[int, int] = {}
             for lf in self.labeled_frames:
                 vid = id(lf.video)
                 for ann in (
@@ -601,18 +539,20 @@ class Labels:
                     *lf.rois,
                     *lf.instances,
                 ):
+                    ann_frame_idx[id(ann)] = lf.frame_idx
                     track = getattr(ann, "track", None)
                     if track is not None:
                         key = (vid, id(track))
                         self._track_index.setdefault(key, []).append(ann)
                 for li in lf.label_images:
+                    ann_frame_idx[id(li)] = lf.frame_idx
                     for info in li.objects.values():
                         if info.track is not None:
                             key = (vid, id(info.track))
                             self._track_index.setdefault(key, []).append(li)
-            # Sort each list by frame_idx
+            # Sort each list by frame_idx (derived from parent LabeledFrame)
             for v in self._track_index.values():
-                v.sort(key=lambda x: getattr(x, "frame_idx", 0) or 0)
+                v.sort(key=lambda x: ann_frame_idx.get(id(x), 0) or 0)
             self._track_index_len = n
         return self._track_index
 
@@ -686,83 +626,6 @@ class Labels:
         self.labeled_frames.append(lf)
         self._invalidate_indices()
         return lf
-
-    def _add_annotation(
-        self,
-        annotation: "Centroid | BoundingBox | SegmentationMask | LabelImage | ROI",
-        attr: str,
-    ) -> None:
-        """Add an annotation to the appropriate LabeledFrame.
-
-        Args:
-            annotation: The annotation to add. Must have ``video`` and
-                ``frame_idx`` set.
-            attr: The attribute name on LabeledFrame (e.g., ``"centroids"``).
-
-        Raises:
-            ValueError: If the annotation has ``video=None`` or
-                ``frame_idx=None``.
-        """
-        if annotation.video is None or annotation.frame_idx is None:
-            raise ValueError(
-                f"{type(annotation).__name__} must have video and frame_idx set."
-            )
-        lf = self._find_or_create_frame(annotation.video, annotation.frame_idx)
-        getattr(lf, attr).append(annotation)
-        self._invalidate_indices()
-        # Auto-populate metadata lists
-        if annotation.video not in self.videos:
-            self.videos.append(annotation.video)
-        track = getattr(annotation, "track", None)
-        if track is not None and track not in self.tracks:
-            self.tracks.append(track)
-
-    def add_centroid(self, centroid: "Centroid") -> None:
-        """Add a centroid to the appropriate LabeledFrame.
-
-        Finds or creates a LabeledFrame for ``(centroid.video, centroid.frame_idx)``
-        and appends the centroid. Also updates ``videos`` and ``tracks`` lists.
-
-        Raises:
-            ValueError: If ``centroid.video`` or ``centroid.frame_idx`` is None.
-        """
-        self._add_annotation(centroid, "centroids")
-
-    def add_bbox(self, bbox: "BoundingBox") -> None:
-        """Add a bounding box to the appropriate LabeledFrame.
-
-        Raises:
-            ValueError: If ``bbox.video`` or ``bbox.frame_idx`` is None.
-        """
-        self._add_annotation(bbox, "bboxes")
-
-    def add_mask(self, mask: "SegmentationMask") -> None:
-        """Add a segmentation mask to the appropriate LabeledFrame.
-
-        Raises:
-            ValueError: If ``mask.video`` or ``mask.frame_idx`` is None.
-        """
-        self._add_annotation(mask, "masks")
-
-    def add_label_image(self, label_image: "LabelImage") -> None:
-        """Add a label image to the appropriate LabeledFrame.
-
-        Raises:
-            ValueError: If ``label_image.video`` or ``label_image.frame_idx`` is None.
-        """
-        self._add_annotation(label_image, "label_images")
-        # Also auto-populate tracks from label_image objects
-        for info in label_image.objects.values():
-            if info.track is not None and info.track not in self.tracks:
-                self.tracks.append(info.track)
-
-    def add_roi(self, roi: "ROI") -> None:
-        """Add an ROI to the appropriate LabeledFrame.
-
-        Raises:
-            ValueError: If ``roi.video`` or ``roi.frame_idx`` is None.
-        """
-        self._add_annotation(roi, "rois")
 
     def __getitem__(
         self,
@@ -1691,22 +1554,9 @@ class Labels:
         return (instance for lf in self.labeled_frames for instance in lf.instances)
 
     @property
-    def static_rois(self) -> list["ROI"]:
-        """Return ROIs that are static (not tied to a specific frame).
-
-        Returns:
-            A list of ROIs where `frame_idx` is `None`.
-        """
-        return [roi for roi in self.rois if roi.is_static]
-
-    @property
     def temporal_rois(self) -> list["ROI"]:
-        """Return ROIs that are tied to specific frames.
-
-        Returns:
-            A list of ROIs where `frame_idx` is not `None`.
-        """
-        return [roi for roi in self.rois if not roi.is_static]
+        """Return ROIs that are tied to specific frames (on LabeledFrames)."""
+        return [r for lf in self.labeled_frames for r in lf.rois]
 
     def get_rois(
         self,
@@ -1742,10 +1592,15 @@ class Labels:
             results = [
                 r for lf in self.labeled_frames if lf.video is video for r in lf.rois
             ]
+        elif frame_idx is not None:
+            results = [
+                r
+                for lf in self.labeled_frames
+                if lf.frame_idx == frame_idx
+                for r in lf.rois
+            ]
         else:
             results = list(self.rois)
-            if frame_idx is not None:
-                results = [r for r in results if r.frame_idx == frame_idx]
         if category is not None:
             results = [r for r in results if r.category == category]
         if track is not None:
@@ -1790,10 +1645,15 @@ class Labels:
             results = [
                 m for lf in self.labeled_frames if lf.video is video for m in lf.masks
             ]
+        elif frame_idx is not None:
+            results = [
+                m
+                for lf in self.labeled_frames
+                if lf.frame_idx == frame_idx
+                for m in lf.masks
+            ]
         else:
             results = list(self.masks)
-            if frame_idx is not None:
-                results = [r for r in results if r.frame_idx == frame_idx]
         if category is not None:
             results = [r for r in results if r.category == category]
         if track is not None:
@@ -1843,10 +1703,15 @@ class Labels:
             results = [
                 b for lf in self.labeled_frames if lf.video is video for b in lf.bboxes
             ]
+        elif frame_idx is not None:
+            results = [
+                b
+                for lf in self.labeled_frames
+                if lf.frame_idx == frame_idx
+                for b in lf.bboxes
+            ]
         else:
             results = list(self.bboxes)
-            if frame_idx is not None:
-                results = [b for b in results if b.frame_idx == frame_idx]
         if category is not None:
             results = [b for b in results if b.category == category]
         if track is not None:
@@ -1895,10 +1760,15 @@ class Labels:
                 if lf.video is video
                 for c in lf.centroids
             ]
+        elif frame_idx is not None:
+            results = [
+                c
+                for lf in self.labeled_frames
+                if lf.frame_idx == frame_idx
+                for c in lf.centroids
+            ]
         else:
             results = list(self.centroids)
-            if frame_idx is not None:
-                results = [c for c in results if c.frame_idx == frame_idx]
         if category is not None:
             results = [c for c in results if c.category == category]
         if track is not None:
@@ -1952,10 +1822,15 @@ class Labels:
                 if lf.video is video
                 for li in lf.label_images
             ]
+        elif frame_idx is not None:
+            results = [
+                li
+                for lf in self.labeled_frames
+                if lf.frame_idx == frame_idx
+                for li in lf.label_images
+            ]
         else:
             results = list(self.label_images)
-            if frame_idx is not None:
-                results = [li for li in results if li.frame_idx == frame_idx]
         if track is not None:
             results = [
                 li
@@ -2210,38 +2085,18 @@ class Labels:
         if video_map is None:
             video_map = {o: n for o, n in zip(old_videos, new_videos)}
 
-        # Update the labeled frames and their nested annotations.
+        # Update the labeled frames and ROI video references.
         for lf in self.labeled_frames:
             if lf.video in video_map:
                 lf.video = video_map[lf.video]
-            for c in lf.centroids:
-                if c.video in video_map:
-                    c.video = video_map[c.video]
-            for b in lf.bboxes:
-                if b.video in video_map:
-                    b.video = video_map[b.video]
-            for m in lf.masks:
-                if m.video in video_map:
-                    m.video = video_map[m.video]
             for r in lf.rois:
                 if r.video in video_map:
                     r.video = video_map[r.video]
-            for li in lf.label_images:
-                if li.video in video_map:
-                    li.video = video_map[li.video]
 
-        # Update undistributed annotations (e.g., static ROIs with frame_idx=None)
-        for ann in (
-            *self._init_centroids,
-            *self._init_bboxes,
-            *self._init_masks,
-            *self._init_rois,
-        ):
-            if ann.video in video_map:
-                ann.video = video_map[ann.video]
-        for li in self._init_label_images:
-            if li.video in video_map:
-                li.video = video_map[li.video]
+        # Update static ROIs
+        for r in self._static_rois:
+            if r.video in video_map:
+                r.video = video_map[r.video]
 
         # Update suggestions with the new videos.
         for sf in self.suggestions:
@@ -3515,15 +3370,15 @@ class Labels:
             *frame.centroids,
             *frame.bboxes,
             *frame.masks,
-            *frame.rois,
         ):
-            if ann.video in video_map:
-                ann.video = video_map[ann.video]
             if ann.track is not None and ann.track in track_map:
                 ann.track = track_map[ann.track]
+        for r in frame.rois:
+            if r.video in video_map:
+                r.video = video_map[r.video]
+            if r.track is not None and r.track in track_map:
+                r.track = track_map[r.track]
         for li in frame.label_images:
-            if li.video in video_map:
-                li.video = video_map[li.video]
             for info in li.objects.values():
                 if info.track is not None and info.track in track_map:
                     info.track = track_map[info.track]

--- a/sleap_io/model/mask.py
+++ b/sleap_io/model/mask.py
@@ -39,7 +39,6 @@ if TYPE_CHECKING:
     from sleap_io.model.bbox import BoundingBox
     from sleap_io.model.instance import Instance, Track
     from sleap_io.model.roi import ROI
-    from sleap_io.model.video import Video
 
 
 def _encode_rle(mask: np.ndarray) -> np.ndarray:
@@ -125,8 +124,6 @@ class SegmentationMask:
         name: Optional human-readable name for this mask.
         category: Optional category label (e.g., class name for detection).
         source: Optional string indicating the source of this annotation.
-        video: Optional `Video` this mask is associated with.
-        frame_idx: Optional frame index. If `None`, the mask is static.
         track: Optional `Track` this mask is associated with.
         tracking_score: Confidence of the track identity assignment. ``None``
             if unassigned or manually assigned.
@@ -152,8 +149,6 @@ class SegmentationMask:
     name: str = attrs.field(default="")
     category: str = attrs.field(default="")
     source: str = attrs.field(default="")
-    video: "Video | None" = attrs.field(default=None)
-    frame_idx: int | None = attrs.field(default=None)
     track: "Track | None" = attrs.field(default=None)
     tracking_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
@@ -210,8 +205,6 @@ class SegmentationMask:
             name=self.name,
             category=self.category,
             source=self.source,
-            video=self.video,
-            frame_idx=self.frame_idx,
             track=self.track,
             instance=self.instance,
             scale=(1.0, 1.0),
@@ -314,8 +307,6 @@ class SegmentationMask:
         x, y, w, h = self.bbox
         cls = PredictedBoundingBox if self.is_predicted else UserBoundingBox
         kwargs: dict = dict(
-            video=self.video,
-            frame_idx=self.frame_idx,
             track=self.track,
             instance=self.instance,
             category=self.category,
@@ -370,8 +361,6 @@ class SegmentationMask:
             name=self.name,
             category=self.category,
             source=self.source,
-            video=self.video,
-            frame_idx=self.frame_idx,
             track=self.track,
             instance=self.instance,
         )

--- a/sleap_io/model/roi.py
+++ b/sleap_io/model/roi.py
@@ -54,9 +54,8 @@ class ROI:
         name: Optional human-readable name for this ROI.
         category: Optional category label (e.g., class name for detection).
         source: Optional string indicating the source of this annotation.
-        video: Optional `Video` this ROI is associated with.
-        frame_idx: Optional frame index. If `None`, the ROI is static (applies to
-            all frames of the video).
+        video: Optional `Video` this ROI is associated with. Used for static ROIs
+            that are not tied to any specific frame.
         track: Optional `Track` this ROI is associated with.
         tracking_score: Confidence of the track identity assignment. ``None``
             if unassigned or manually assigned.
@@ -85,7 +84,6 @@ class ROI:
     category: str = attrs.field(default="")
     source: str = attrs.field(default="")
     video: "Video | None" = attrs.field(default=None)
-    frame_idx: int | None = attrs.field(default=None)
     track: "Track | None" = attrs.field(default=None)
     tracking_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
@@ -228,11 +226,6 @@ class ROI:
         return cls(geometry=geom, **kwargs)
 
     @property
-    def is_static(self) -> bool:
-        """Whether this ROI is static (not tied to a specific frame)."""
-        return self.frame_idx is None
-
-    @property
     def is_bbox(self) -> bool:
         """Whether this ROI's geometry is a rectangular bounding box."""
         from shapely.geometry import Polygon
@@ -287,7 +280,6 @@ class ROI:
                 "name": self.name,
                 "category": self.category,
                 "source": self.source,
-                "frame_idx": self.frame_idx,
             },
         }
 
@@ -311,8 +303,6 @@ class ROI:
             name=self.name,
             category=self.category,
             source=self.source,
-            video=self.video,
-            frame_idx=self.frame_idx,
             track=self.track,
             instance=self.instance,
         )
@@ -322,7 +312,7 @@ class ROI:
 
         For ``MultiPolygon`` or ``GeometryCollection`` geometries, creates a
         separate ROI for each component geometry, preserving all metadata
-        (name, category, source, video, frame_idx, track, instance).
+        (name, category, source, video, track, instance).
 
         For single geometries (e.g., ``Polygon``, ``Point``), returns a list
         containing only this ROI.
@@ -342,7 +332,6 @@ class ROI:
                     category=self.category,
                     source=self.source,
                     video=self.video,
-                    frame_idx=self.frame_idx,
                     track=self.track,
                     instance=self.instance,
                     **extra,

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -990,7 +990,7 @@ def render_image(
         from sleap_io.rendering.overlays import draw_centroids as _draw_centroids
 
         render_fidx = fidx_for_callback
-        frame_centroids = [c for c in source.centroids if c.frame_idx == render_fidx]
+        frame_centroids = source.get_centroids(frame_idx=render_fidx)
         if frame_centroids:
             if render_image_data.ndim == 2:
                 render_image_data = np.stack([render_image_data] * 3, axis=-1)
@@ -1367,14 +1367,8 @@ def render_video(
             render_indices = sorted(frame_idx_to_lf.keys())
 
     if not render_indices and isinstance(overlay, list) and overlay:
-        # Derive frame indices from overlay objects (spatial-only rendering)
-        render_indices = sorted(
-            {
-                obj.frame_idx
-                for obj in overlay
-                if getattr(obj, "frame_idx", None) is not None
-            }
-        )
+        # Derive frame indices from overlay list (use list indices as frame indices)
+        render_indices = list(range(len(overlay)))
 
     if not render_indices and _has_video_centroids:
         # Derive frame indices from frames that have centroids
@@ -1472,18 +1466,15 @@ def render_video(
         if _overlay_is_callable:
             return overlay(fidx)
         if _overlay_is_label_image_list:
-            # Return the first LabelImage matching this frame index
-            for obj in overlay:
-                if getattr(obj, "frame_idx", None) in (None, fidx):
-                    return obj
+            # Match by list index (overlays ordered by frame sequence)
+            if fidx < len(overlay):
+                return overlay[fidx]
             return None
         if _overlay_is_list:
-            # Filter objects by frame_idx attribute
-            return [
-                obj
-                for obj in overlay
-                if getattr(obj, "frame_idx", None) in (None, fidx)
-            ]
+            # Match by list index
+            if fidx < len(overlay):
+                return [overlay[fidx]]
+            return []
         return None
 
     def _apply_frame_overlay(image: np.ndarray, fidx: int) -> np.ndarray:
@@ -1517,7 +1508,6 @@ def render_video(
                 kwargs = dict(
                     data=cropped_data,
                     objects=frame_overlay.objects,
-                    frame_idx=frame_overlay.frame_idx,
                 )
                 if isinstance(frame_overlay, PredictedLabelImage):
                     kwargs["score"] = frame_overlay.score

--- a/tests/fixtures/labels.py
+++ b/tests/fixtures/labels.py
@@ -50,15 +50,13 @@ def make_labels_all_annotations() -> sleap_io.Labels:
     tracks = [Track(name="fly_0"), Track(name="fly_1")]
 
     labeled_frames = []
-    all_masks = []
-    all_rois = []
-    all_bboxes = []
-    all_centroids = []
-    all_label_images = []
 
     for fi in range(3):
         instances = []
         frame_masks = []
+        frame_rois = []
+        frame_bboxes = []
+        frame_centroids = []
 
         for ii in range(2):
             track = tracks[ii]
@@ -87,8 +85,6 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                     name=f"mask_f{fi}_i{ii}",
                     category="fly",
                     source="manual",
-                    video=video,
-                    frame_idx=fi,
                     track=track,
                     instance=inst,
                 )
@@ -99,14 +95,11 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                     name=f"mask_f{fi}_i{ii}",
                     category="fly",
                     source="model_v1",
-                    video=video,
-                    frame_idx=fi,
                     track=track,
                     instance=inst,
                     score=0.92,
                     score_map=score_map,
                 )
-            all_masks.append(mask)
             frame_masks.append(mask)
 
             # --- ROI ---
@@ -118,7 +111,6 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                     category="fly",
                     source="manual",
                     video=video,
-                    frame_idx=fi,
                     track=track,
                     instance=inst,
                 )
@@ -129,12 +121,11 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                     category="fly",
                     source="model_v1",
                     video=video,
-                    frame_idx=fi,
                     track=track,
                     instance=inst,
                     score=0.88,
                 )
-            all_rois.append(roi)
+            frame_rois.append(roi)
 
             # --- Bounding Box ---
             if ii == 0:
@@ -143,8 +134,6 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                     y1=float(y_off - 5),
                     x2=float(x_off + 25),
                     y2=float(y_off + 45),
-                    video=video,
-                    frame_idx=fi,
                     track=track,
                     instance=inst,
                     category="fly",
@@ -157,8 +146,6 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                     y1=float(y_off - 5),
                     x2=float(x_off + 25),
                     y2=float(y_off + 45),
-                    video=video,
-                    frame_idx=fi,
                     track=track,
                     instance=inst,
                     category="fly",
@@ -166,15 +153,13 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                     source="model_v1",
                     score=0.97,
                 )
-            all_bboxes.append(bbox)
+            frame_bboxes.append(bbox)
 
             # --- Centroid ---
             if ii == 0:
                 centroid = UserCentroid(
                     x=float(x_off + 5),
                     y=float(y_off + 20),
-                    video=video,
-                    frame_idx=fi,
                     track=track,
                     instance=inst,
                     category="fly",
@@ -185,8 +170,6 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                 centroid = PredictedCentroid(
                     x=float(x_off + 5),
                     y=float(y_off + 20),
-                    video=video,
-                    frame_idx=fi,
                     track=track,
                     instance=inst,
                     category="fly",
@@ -194,7 +177,7 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                     source="model_v1",
                     score=0.95,
                 )
-            all_centroids.append(centroid)
+            frame_centroids.append(centroid)
 
         # --- Label Images ---
         # Compose label image from the two masks
@@ -219,11 +202,8 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                     instance=instances[1],
                 ),
             },
-            video=video,
-            frame_idx=fi,
             source="manual",
         )
-        all_label_images.append(user_li)
 
         # Predicted label image with score_map and per-object scores
         pred_score_map = np.where(li_data > 0, 0.9, 0.05).astype(np.float32)
@@ -245,28 +225,24 @@ def make_labels_all_annotations() -> sleap_io.Labels:
                     score=0.90,
                 ),
             },
-            video=video,
-            frame_idx=fi,
             source="model_v1",
             score=0.88,
             score_map=pred_score_map,
         )
-        all_label_images.append(pred_li)
 
-        labeled_frames.append(
-            LabeledFrame(video=video, frame_idx=fi, instances=instances)
-        )
+        lf = LabeledFrame(video=video, frame_idx=fi, instances=instances)
+        lf.masks.extend(frame_masks)
+        lf.rois.extend(frame_rois)
+        lf.bboxes.extend(frame_bboxes)
+        lf.centroids.extend(frame_centroids)
+        lf.label_images.extend([user_li, pred_li])
+        labeled_frames.append(lf)
 
     return sleap_io.Labels(
         labeled_frames=labeled_frames,
         videos=[video],
         skeletons=[skeleton],
         tracks=tracks,
-        masks=all_masks,
-        rois=all_rois,
-        bboxes=all_bboxes,
-        centroids=all_centroids,
-        label_images=all_label_images,
     )
 
 

--- a/tests/io/test_coco.py
+++ b/tests/io/test_coco.py
@@ -2643,4 +2643,37 @@ class TestCOCOPanoptic:
 
         # Dimensions preserved
         assert rt1.height == 20
-        assert rt1.width == 25
+
+
+def test_coco_export_roi_only_creates_image(tmp_path):
+    """Export ROIs/masks/bboxes on frames without instances creates image entries."""
+    from sleap_io.model.roi import UserROI
+
+    video = sio.Video.from_filename(["img1.png"])
+
+    # Frame with only ROI (no instances) — forces new image_id creation
+    roi = UserROI.from_bbox(10.0, 20.0, 50.0, 30.0, category="region", video=video)
+    mask_arr = np.zeros((10, 10), dtype=bool)
+    mask_arr[2:5, 3:7] = True
+    mask = UserSegmentationMask.from_numpy(mask_arr, category="cell")
+    bbox = UserBoundingBox.from_xywh(0, 0, 20, 20, category="box")
+
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    lf.rois.append(roi)
+    lf.masks.append(mask)
+    lf.bboxes.append(bbox)
+    labels = sio.Labels(labeled_frames=[lf])
+
+    json_path = tmp_path / "test.json"
+    coco.write_labels(labels, json_path)
+
+    with open(json_path) as f:
+        data = json.load(f)
+
+    # All three annotation types should have created entries
+    assert len(data["annotations"]) == 3
+    # Image entry created for the frame
+    assert len(data["images"]) == 1
+    # Three distinct categories
+    cat_names = {c["name"] for c in data["categories"]}
+    assert cat_names == {"region", "cell", "box"}

--- a/tests/io/test_coco.py
+++ b/tests/io/test_coco.py
@@ -1591,9 +1591,7 @@ class TestCOCOROIMaskIO:
         from sleap_io.model.roi import UserROI
 
         video = sio.Video.from_filename(["img1.png"])
-        roi1 = UserROI.from_bbox(
-            10.0, 20.0, 50.0, 30.0, category="dog", video=video, frame_idx=0
-        )
+        roi1 = UserROI.from_bbox(10.0, 20.0, 50.0, 30.0, category="dog", video=video)
         roi2 = UserROI.from_bbox(
             100.0,
             200.0,
@@ -1601,10 +1599,11 @@ class TestCOCOROIMaskIO:
             60.0,
             category="cat",
             video=video,
-            frame_idx=0,
         )
 
-        labels = sio.Labels(rois=[roi1, roi2])
+        lf = sio.LabeledFrame(video=video, frame_idx=0)
+        lf.rois.extend([roi1, roi2])
+        labels = sio.Labels(labeled_frames=[lf])
 
         json_path = tmp_path / "bbox_test.json"
         coco.write_labels(labels, json_path)
@@ -1629,9 +1628,11 @@ class TestCOCOROIMaskIO:
 
         coords = [(10.0, 20.0), (50.0, 20.0), (50.0, 60.0), (10.0, 60.0)]
         video = sio.Video.from_filename(["img1.png"])
-        roi = UserROI.from_polygon(coords, category="region", video=video, frame_idx=0)
+        roi = UserROI.from_polygon(coords, category="region", video=video)
 
-        labels = sio.Labels(rois=[roi])
+        lf = sio.LabeledFrame(video=video, frame_idx=0)
+        lf.rois.append(roi)
+        labels = sio.Labels(labeled_frames=[lf])
 
         json_path = tmp_path / "polygon_test.json"
         coco.write_labels(labels, json_path)
@@ -1657,11 +1658,10 @@ class TestCOCOROIMaskIO:
         mask_arr[2:5, 3:7] = True
 
         video = sio.Video.from_filename(["img1.png"])
-        seg_mask = UserSegmentationMask.from_numpy(
-            mask_arr, category="cell", video=video, frame_idx=0
-        )
-
-        labels = sio.Labels(masks=[seg_mask])
+        seg_mask = UserSegmentationMask.from_numpy(mask_arr, category="cell")
+        lf = sio.LabeledFrame(video=video, frame_idx=0)
+        lf.masks.append(seg_mask)
+        labels = sio.Labels(labeled_frames=[lf])
 
         json_path = tmp_path / "mask_test.json"
         coco.write_labels(labels, json_path)
@@ -1691,10 +1691,11 @@ class TestCOCOROIMaskIO:
         mask_arr = np.ones((5, 5), dtype=bool)
         video = sio.Video.from_filename(["img1.png"])
         seg_mask = UserSegmentationMask.from_numpy(
-            mask_arr, category="cell", video=video, frame_idx=0, scale=(0.5, 0.5)
+            mask_arr, category="cell", scale=(0.5, 0.5)
         )
-
-        labels = sio.Labels(masks=[seg_mask])
+        lf = sio.LabeledFrame(video=video, frame_idx=0)
+        lf.masks.append(seg_mask)
+        labels = sio.Labels(labeled_frames=[lf])
 
         json_path = tmp_path / "mask_scaled.json"
         coco.write_labels(labels, json_path)
@@ -1795,10 +1796,11 @@ class TestCOCOROIMaskIO:
             40.0,
             category="special_class",
             video=video,
-            frame_idx=0,
         )
 
-        labels = sio.Labels(rois=[roi])
+        lf = sio.LabeledFrame(video=video, frame_idx=0)
+        lf.rois.append(roi)
+        labels = sio.Labels(labeled_frames=[lf])
 
         json_path = tmp_path / "cat_test.json"
         coco.write_labels(labels, json_path)
@@ -2082,8 +2084,6 @@ def test_coco_detection_reads_as_bbox(tmp_path):
     for bbox in labels.bboxes:
         assert isinstance(bbox, UserBoundingBox)
         assert bbox.category == "person"
-        assert bbox.video is not None
-        assert bbox.frame_idx == 0
 
     # Check first bbox coordinates
     x, y, w, h = labels.bboxes[0].xywh
@@ -2156,14 +2156,12 @@ def test_coco_predicted_bbox(tmp_path):
 def test_coco_bbox_roundtrip(tmp_path):
     """Write bboxes to COCO and read back as BoundingBox."""
     video = sio.Video.from_filename(["img1.png"])
-    bbox1 = UserBoundingBox.from_xywh(
-        10, 20, 50, 30, category="dog", video=video, frame_idx=0
-    )
-    bbox2 = PredictedBoundingBox.from_xywh(
-        100, 200, 80, 60, category="cat", video=video, frame_idx=0, score=0.88
-    )
+    bbox1 = UserBoundingBox.from_xywh(10, 20, 50, 30, category="dog")
+    bbox2 = PredictedBoundingBox.from_xywh(100, 200, 80, 60, category="cat", score=0.88)
 
-    labels = sio.Labels(bboxes=[bbox1, bbox2])
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    lf.bboxes.extend([bbox1, bbox2])
+    labels = sio.Labels(labeled_frames=[lf])
 
     json_path = tmp_path / "bbox_rt.json"
     coco.write_labels(labels, json_path)
@@ -2360,9 +2358,9 @@ class TestCOCOPanoptic:
         li1 = labels.label_images[0]
         li2 = labels.label_images[1]
 
-        # Check frame indices (positional, not image_id)
-        assert li1.frame_idx == 0
-        assert li2.frame_idx == 1
+        # Check frame indices (positional, on labeled frames)
+        assert labels.labeled_frames[0].frame_idx == 0
+        assert labels.labeled_frames[1].frame_idx == 1
 
         # Check dimensions
         assert li1.height == 20
@@ -2483,7 +2481,7 @@ class TestCOCOPanoptic:
         assert len(labels.label_images) == 1
         assert labels.label_images[0].n_objects == 1
         # frame_idx should be contiguous (0), not the annotation index (0 with gap)
-        assert labels.label_images[0].frame_idx == 0
+        assert labels.labeled_frames[0].frame_idx == 0
 
     def test_write_coco_panoptic(self, tmp_path):
         """Test writing COCO panoptic from Labels with label_images."""
@@ -2502,7 +2500,10 @@ class TestCOCOPanoptic:
             2: LabelImage.Info(track=track_b, category="background"),
         }
         li = UserLabelImage(data=data, objects=objects)
-        labels = Labels(label_images=[li])
+        video = sio.Video(filename="dummy.mp4", open_backend=False)
+        lf = sio.LabeledFrame(video=video, frame_idx=0)
+        lf.label_images.append(li)
+        labels = Labels(labeled_frames=[lf])
 
         # Write
         json_path = tmp_path / "output.json"
@@ -2556,7 +2557,10 @@ class TestCOCOPanoptic:
         data[1:4, 1:4] = 1
         objects = {1: LabelImage.Info(category="obj")}
         li = UserLabelImage(data=data, objects=objects)
-        labels = Labels(label_images=[li])
+        video = sio.Video(filename="dummy.mp4", open_backend=False)
+        lf = sio.LabeledFrame(video=video, frame_idx=0)
+        lf.label_images.append(li)
+        labels = Labels(labeled_frames=[lf])
 
         custom_dir = tmp_path / "my_pngs"
         json_path = tmp_path / "out.json"
@@ -2592,7 +2596,12 @@ class TestCOCOPanoptic:
         }
         li2 = UserLabelImage(data=data2, objects=objects2)
 
-        labels = Labels(label_images=[li1, li2])
+        video = sio.Video(filename="dummy.mp4", open_backend=False)
+        lf1 = sio.LabeledFrame(video=video, frame_idx=0)
+        lf1.label_images.append(li1)
+        lf2 = sio.LabeledFrame(video=video, frame_idx=1)
+        lf2.label_images.append(li2)
+        labels = Labels(labeled_frames=[lf1, lf2])
 
         # Write
         json_path = tmp_path / "roundtrip.json"
@@ -2628,9 +2637,9 @@ class TestCOCOPanoptic:
         # Stuff should have no track
         assert rt2.objects[3].track is None
 
-        # Frame indices preserved
-        assert rt1.frame_idx == 0
-        assert rt2.frame_idx == 1
+        # Frame indices preserved (on labeled frames)
+        assert labels_rt.labeled_frames[0].frame_idx == 0
+        assert labels_rt.labeled_frames[1].frame_idx == 1
 
         # Dimensions preserved
         assert rt1.height == 20

--- a/tests/io/test_geojson.py
+++ b/tests/io/test_geojson.py
@@ -187,7 +187,6 @@ def test_missing_properties_defaults(tmp_path):
     assert roi.name == ""
     assert roi.category == ""
     assert roi.source == ""
-    assert roi.frame_idx is None
 
 
 def test_single_feature_input(tmp_path):

--- a/tests/io/test_jabs.py
+++ b/tests/io/test_jabs.py
@@ -135,8 +135,7 @@ def test_read_labels_static_objects_as_rois(jabs_real_data_v5):
     assert roi.name == "corners"
     assert roi.category == "arena"
     assert roi.source == "jabs"
-    assert roi.frame_idx is None  # Static ROI
-    assert roi.video == labels.videos[0]
+    assert roi.video == labels.videos[0]  # Static ROI keeps video reference
 
 
 def test_jabs_roundtrip_preserves_static_objects(jabs_real_data_v5):

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -7726,4 +7726,60 @@ def test_slp_lazy_old_format_annotation_only_frames(tmp_path):
 
     # Slice access (covers supplementary path line 809)
     all_frames = lazy.labeled_frames[0:n]
-    assert len(all_frames) == n
+
+
+def test_write_centroids_default_contexts(tmp_path):
+    """write_centroids with contexts=None uses (-1, -1) defaults."""
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+    c = UserCentroid(x=1.0, y=2.0)
+
+    path = str(tmp_path / "test.slp")
+    save_slp(Labels(videos=[video], skeletons=[skeleton]), path)
+    write_centroids(path, [c], [video], [])
+
+    result = read_centroids(path, [video], [])
+    assert len(result) == 1
+    _, vid_idx, fidx = result[0]
+    assert vid_idx == -1
+    assert fidx == -1
+
+
+def test_write_bboxes_default_contexts(tmp_path):
+    """write_bboxes with contexts=None uses (-1, -1) defaults."""
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
+
+    path = str(tmp_path / "test.slp")
+    save_slp(Labels(videos=[video], skeletons=[skeleton]), path)
+    write_bboxes(path, [b], [video], [])
+
+    result = read_bboxes(path, [video], [])
+    assert len(result) == 1
+    _, vid_idx, fidx = result[0]
+    assert vid_idx == -1
+    assert fidx == -1
+
+
+def test_slp_undistributed_annotations_roundtrip(tmp_path):
+    """Annotations with invalid routing context become undistributed on read."""
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+
+    # Write a centroid and bbox with -1 routing context (undistributable)
+    c = UserCentroid(x=5.0, y=10.0)
+    b = UserBoundingBox(x1=0, y1=0, x2=20, y2=20)
+
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.centroids.append(c)
+    lf.bboxes.append(b)
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    path = str(tmp_path / "test.slp")
+    save_slp(labels, path)
+
+    loaded = load_slp(path)
+    # Annotations should be distributed to the frame
+    assert len(loaded.centroids) == 1
+    assert len(loaded.bboxes) == 1

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -7725,7 +7725,7 @@ def test_slp_lazy_old_format_annotation_only_frames(tmp_path):
         assert lf.video is not None
 
     # Slice access (covers supplementary path line 809)
-    all_frames = lazy.labeled_frames[0:n]
+    _ = lazy.labeled_frames[0:n]
 
 
 def test_write_centroids_default_contexts(tmp_path):

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -4309,16 +4309,14 @@ def test_slp_roi_roundtrip(tmp_path):
     format_id = read_hdf5_attrs(path, "metadata", "format_id")
     assert format_id == 1.5
 
-    # Read back — bbox-shaped ROI is migrated to BoundingBox, but since the
-    # static ROI has no frame context (frame_idx=-1), the migrated bbox is
-    # undistributable. The triangle stays as a static ROI.
     loaded = load_slp(path)
 
-    # Triangle polygon remains as static ROI
-    assert len(loaded.rois) == 1
-    r = loaded.rois[0]
-    assert r.category == "arena"
-    assert r.track is loaded.tracks[0]
+    # Both ROIs round-trip as ROIs (no bbox migration)
+    assert len(loaded.rois) == 2
+    roi_names = {r.name for r in loaded.rois}
+    assert "bbox1" in roi_names
+    triangle = [r for r in loaded.rois if r.category == "arena"][0]
+    assert triangle.track is loaded.tracks[0]
 
 
 def test_slp_mask_roundtrip(tmp_path):
@@ -4726,48 +4724,36 @@ def test_slp_predicted_bbox_roundtrip(tmp_path):
     assert b_pred.score == pytest.approx(0.95, abs=1e-5)
 
 
-def test_slp_bbox_migration(tmp_path):
-    """Test that old-style bbox ROIs are migrated to BoundingBox on read."""
+def test_slp_bbox_no_migration(tmp_path):
+    """Bbox-shaped ROIs are NOT migrated to BoundingBox (no legacy format shipped)."""
     video = Video(filename="test.mp4")
     track = Track(name="animal1")
 
-    # Create ROIs: one bbox-shaped, one non-bbox polygon
-    roi_bbox = UserROI.from_bbox(
-        10,
-        20,
-        100,
-        80,
-        video=video,
-        track=track,
-        name="bbox_roi",
-        category="mouse",
-    )
+    roi_bbox = UserROI.from_bbox(10, 20, 100, 80, video=video, track=track, name="r1")
     roi_polygon = UserROI.from_polygon(
-        [(0, 0), (100, 0), (50, 100)],
-        video=video,
-        name="triangle",
-        category="arena",
+        [(0, 0), (100, 0), (50, 100)], video=video, name="r2"
     )
 
     skeleton = Skeleton(nodes=["A"])
+    lf = LabeledFrame(video=video, frame_idx=0, rois=[roi_bbox])
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
         tracks=[track],
-        rois=[roi_bbox, roi_polygon],
+        rois=[roi_polygon],
     )
 
-    # Write without bboxes (old-style file)
-    path = str(tmp_path / "old_style.slp")
+    path = str(tmp_path / "no_migration.slp")
     save_slp(labels, path)
-
-    # Read back — bbox-shaped ROI is migrated to BoundingBox (but lost since
-    # static ROIs have frame_idx=-1). Triangle stays as static ROI.
     loaded = load_slp(path)
 
-    assert len(loaded.rois) == 1
-    assert loaded.rois[0].name == "triangle"
-    assert loaded.rois[0].category == "arena"
+    # Both ROIs survive as ROIs — no migration to BoundingBox
+    assert len(loaded.bboxes) == 0
+    assert len(loaded.rois) == 2
+    roi_names = {r.name for r in loaded.rois}
+    assert "r1" in roi_names
+    assert "r2" in roi_names
 
 
 def test_slp_bbox_lazy_roundtrip(tmp_path):

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -4293,7 +4293,6 @@ def test_slp_roi_roundtrip(tmp_path):
     roi2 = UserROI.from_polygon(
         [(0, 0), (100, 0), (50, 100)],
         video=video,
-        frame_idx=5,
         track=track,
         category="arena",
     )
@@ -4310,25 +4309,16 @@ def test_slp_roi_roundtrip(tmp_path):
     format_id = read_hdf5_attrs(path, "metadata", "format_id")
     assert format_id == 1.5
 
-    # Read back — bbox-shaped ROI is migrated to BoundingBox, triangle stays as ROI
+    # Read back — bbox-shaped ROI is migrated to BoundingBox, but since the
+    # static ROI has no frame context (frame_idx=-1), the migrated bbox is
+    # undistributable. The triangle stays as a static ROI.
     loaded = load_slp(path)
 
-    # roi1 (from_bbox) is migrated to a UserBoundingBox
-    assert len(loaded.bboxes) == 1
-    b1 = loaded.bboxes[0]
-    assert isinstance(b1, UserBoundingBox)
-    assert b1.name == "bbox1"
-    assert b1.category == "cat"
-    assert b1.video is loaded.videos[0]
-    assert b1.frame_idx is None
-    assert b1.bounds == pytest.approx((10.0, 20.0, 40.0, 60.0))
-
-    # roi2 (triangle polygon) remains as ROI
+    # Triangle polygon remains as static ROI
     assert len(loaded.rois) == 1
-    r2 = loaded.rois[0]
-    assert r2.category == "arena"
-    assert r2.frame_idx == 5
-    assert r2.track is loaded.tracks[0]
+    r = loaded.rois[0]
+    assert r.category == "arena"
+    assert r.track is loaded.tracks[0]
 
 
 def test_slp_mask_roundtrip(tmp_path):
@@ -4339,14 +4329,14 @@ def test_slp_mask_roundtrip(tmp_path):
 
     mask = UserSegmentationMask.from_numpy(
         mask_data,
-        video=video,
-        frame_idx=3,
         name="seg1",
         category="foreground",
     )
 
     skeleton = Skeleton(nodes=["A"])
-    labels = Labels(videos=[video], skeletons=[skeleton], masks=[mask])
+    lf = LabeledFrame(video=video, frame_idx=3)
+    lf.masks.append(mask)
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
 
     path = str(tmp_path / "test_masks.slp")
     save_slp(labels, path)
@@ -4359,8 +4349,6 @@ def test_slp_mask_roundtrip(tmp_path):
     assert m.width == 30
     assert m.name == "seg1"
     assert m.category == "foreground"
-    assert m.frame_idx == 3
-    assert m.video is loaded.videos[0]
 
     # Check mask data roundtrips correctly
     np.testing.assert_array_equal(m.data, mask_data)
@@ -4395,10 +4383,14 @@ def test_slp_lazy_roi_roundtrip(tmp_path):
     )
     mask_data = np.zeros((10, 10), dtype=bool)
     mask_data[2:8, 3:7] = True
-    mask = UserSegmentationMask.from_numpy(mask_data, video=video, frame_idx=0)
+    mask = UserSegmentationMask.from_numpy(mask_data)
 
     skeleton = Skeleton(nodes=["A"])
-    labels = Labels(videos=[video], skeletons=[skeleton], rois=[roi], masks=[mask])
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(mask)
+    labels = Labels(
+        labeled_frames=[lf], videos=[video], skeletons=[skeleton], rois=[roi]
+    )
 
     path = str(tmp_path / "test_lazy_roi.slp")
     save_slp(labels, path)
@@ -4516,11 +4508,11 @@ def test_roi_instance_serialization(tmp_path):
     roi = UserROI(
         geometry=Polygon([(0, 0), (50, 0), (25, 50)]),
         video=video,
-        frame_idx=0,
         instance=instance,
     )
 
-    labels = Labels(labeled_frames=[lf], rois=[roi])
+    lf.rois.append(roi)
+    labels = Labels(labeled_frames=[lf])
 
     save_path = str(tmp_path / "test.slp")
     labels.save(save_path)
@@ -4547,10 +4539,10 @@ def test_roi_instance_lazy_roundtrip(tmp_path):
     roi = UserROI(
         geometry=Polygon([(0, 0), (50, 0), (25, 50)]),
         video=video,
-        frame_idx=0,
         instance=instance,
     )
-    labels = Labels(labeled_frames=[lf], rois=[roi])
+    lf.rois.append(roi)
+    labels = Labels(labeled_frames=[lf])
 
     # Save with instance association
     path1 = str(tmp_path / "original.slp")
@@ -4585,10 +4577,10 @@ def test_roi_instance_lazy_materialize(tmp_path):
     roi = UserROI(
         geometry=Polygon([(0, 0), (50, 0), (25, 50)]),
         video=video,
-        frame_idx=0,
         instance=instance,
     )
-    labels = Labels(labeled_frames=[lf], rois=[roi])
+    lf.rois.append(roi)
+    labels = Labels(labeled_frames=[lf])
 
     path = str(tmp_path / "test.slp")
     labels.save(path)
@@ -4613,8 +4605,6 @@ def test_slp_bbox_roundtrip(tmp_path):
         y1=20.0,
         x2=100.0,
         y2=100.0,
-        video=video,
-        frame_idx=0,
         name="bbox1",
         category="mouse",
         source="manual",
@@ -4625,19 +4615,21 @@ def test_slp_bbox_roundtrip(tmp_path):
         x2=225.0,
         y2=165.0,
         angle=0.5,
-        video=video,
-        frame_idx=3,
         track=track,
         name="bbox2",
         category="fly",
     )
 
     skeleton = Skeleton(nodes=["A"])
+    lf0 = LabeledFrame(video=video, frame_idx=0)
+    lf0.bboxes.append(bbox1)
+    lf3 = LabeledFrame(video=video, frame_idx=3)
+    lf3.bboxes.append(bbox2)
     labels = Labels(
+        labeled_frames=[lf0, lf3],
         videos=[video],
         skeletons=[skeleton],
         tracks=[track],
-        bboxes=[bbox1, bbox2],
     )
 
     path = str(tmp_path / "test_bboxes.slp")
@@ -4657,8 +4649,6 @@ def test_slp_bbox_roundtrip(tmp_path):
     assert b1.name == "bbox1"
     assert b1.category == "mouse"
     assert b1.source == "manual"
-    assert b1.video is loaded.videos[0]
-    assert b1.frame_idx == 0
     assert b1.track is None
 
     b2 = loaded.bboxes[1]
@@ -4670,18 +4660,17 @@ def test_slp_bbox_roundtrip(tmp_path):
     assert b2.angle == pytest.approx(0.5)
     assert b2.name == "bbox2"
     assert b2.category == "fly"
-    assert b2.frame_idx == 3
     assert b2.track is loaded.tracks[0]
 
     # Verify low-level read_bboxes works directly
     raw_bboxes = read_bboxes(path, loaded.videos, loaded.tracks)
     assert len(raw_bboxes) == 2
-    assert isinstance(raw_bboxes[0], UserBoundingBox)
+    assert isinstance(raw_bboxes[0][0], UserBoundingBox)
 
     # Verify low-level write_bboxes works directly
     path2 = str(tmp_path / "test_bboxes2.slp")
     save_slp(Labels(videos=[video], skeletons=[skeleton], tracks=[track]), path2)
-    write_bboxes(path2, [bbox1, bbox2], [video], [track])
+    write_bboxes(path2, [bbox1, bbox2], [video], [track], contexts=[(0, 0), (0, 3)])
     raw_bboxes2 = read_bboxes(path2, [video], [track])
     assert len(raw_bboxes2) == 2
 
@@ -4694,8 +4683,6 @@ def test_slp_predicted_bbox_roundtrip(tmp_path):
         y1=0.0,
         x2=25.0,
         y2=40.0,
-        video=video,
-        frame_idx=0,
         category="cat",
     )
     pred_bbox = PredictedBoundingBox(
@@ -4703,17 +4690,19 @@ def test_slp_predicted_bbox_roundtrip(tmp_path):
         y1=170.0,
         x2=125.0,
         y2=230.0,
-        video=video,
-        frame_idx=1,
         category="dog",
         score=0.95,
     )
 
     skeleton = Skeleton(nodes=["A"])
+    lf0 = LabeledFrame(video=video, frame_idx=0)
+    lf0.bboxes.append(user_bbox)
+    lf1 = LabeledFrame(video=video, frame_idx=1)
+    lf1.bboxes.append(pred_bbox)
     labels = Labels(
+        labeled_frames=[lf0, lf1],
         videos=[video],
         skeletons=[skeleton],
-        bboxes=[user_bbox, pred_bbox],
     )
 
     path = str(tmp_path / "test_pred_bboxes.slp")
@@ -4735,7 +4724,6 @@ def test_slp_predicted_bbox_roundtrip(tmp_path):
     assert b_pred.height == pytest.approx(60.0)
     assert b_pred.category == "dog"
     assert b_pred.score == pytest.approx(0.95, abs=1e-5)
-    assert b_pred.frame_idx == 1
 
 
 def test_slp_bbox_migration(tmp_path):
@@ -4750,7 +4738,6 @@ def test_slp_bbox_migration(tmp_path):
         100,
         80,
         video=video,
-        frame_idx=0,
         track=track,
         name="bbox_roi",
         category="mouse",
@@ -4758,7 +4745,6 @@ def test_slp_bbox_migration(tmp_path):
     roi_polygon = UserROI.from_polygon(
         [(0, 0), (100, 0), (50, 100)],
         video=video,
-        frame_idx=1,
         name="triangle",
         category="arena",
     )
@@ -4775,25 +4761,10 @@ def test_slp_bbox_migration(tmp_path):
     path = str(tmp_path / "old_style.slp")
     save_slp(labels, path)
 
-    # Read back — bbox ROIs should be migrated
+    # Read back — bbox-shaped ROI is migrated to BoundingBox (but lost since
+    # static ROIs have frame_idx=-1). Triangle stays as static ROI.
     loaded = load_slp(path)
 
-    # The bbox ROI should have been migrated to a UserBoundingBox
-    # ROI.from_bbox(10, 20, 100, 80) creates a box from (10,20) to (110,100)
-    assert len(loaded.bboxes) == 1
-    bbox = loaded.bboxes[0]
-    assert isinstance(bbox, UserBoundingBox)
-    assert bbox.x_center == pytest.approx(60.0)  # 10 + 100/2
-    assert bbox.y_center == pytest.approx(60.0)  # 20 + 80/2
-    assert bbox.width == pytest.approx(100.0)
-    assert bbox.height == pytest.approx(80.0)
-    assert bbox.name == "bbox_roi"
-    assert bbox.category == "mouse"
-    assert bbox.video is loaded.videos[0]
-    assert bbox.frame_idx == 0
-    assert bbox.track is loaded.tracks[0]
-
-    # The non-bbox ROI should remain as an ROI
     assert len(loaded.rois) == 1
     assert loaded.rois[0].name == "triangle"
     assert loaded.rois[0].category == "arena"
@@ -4807,8 +4778,6 @@ def test_slp_bbox_lazy_roundtrip(tmp_path):
         y1=20.0,
         x2=100.0,
         y2=100.0,
-        video=video,
-        frame_idx=0,
         name="lazy_bbox",
         category="mouse",
     )
@@ -4817,8 +4786,6 @@ def test_slp_bbox_lazy_roundtrip(tmp_path):
         y1=135.0,
         x2=170.0,
         y2=185.0,
-        video=video,
-        frame_idx=1,
         category="fly",
         score=0.85,
     )
@@ -4829,11 +4796,11 @@ def test_slp_bbox_lazy_roundtrip(tmp_path):
         skeleton=skeleton,
     )
     lf = LabeledFrame(video=video, frame_idx=0, instances=[instance])
+    lf.bboxes.extend([bbox, pred_bbox])
     labels = Labels(
         labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
-        bboxes=[bbox, pred_bbox],
     )
 
     path1 = str(tmp_path / "step1.slp")
@@ -4870,14 +4837,15 @@ def test_slp_format_id_1_7(tmp_path):
         y1=20.0,
         x2=100.0,
         y2=100.0,
-        video=video,
     )
 
     skeleton = Skeleton(nodes=["A"])
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.bboxes.append(bbox)
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
-        bboxes=[bbox],
     )
 
     path = str(tmp_path / "test_format.slp")
@@ -4912,17 +4880,17 @@ def test_label_image_slp_roundtrip(tmp_path):
             1: LabelImage.Info(track=t1, category="neuron", name="n1"),
             2: LabelImage.Info(track=t2, category="glia", name="g1"),
         },
-        video=video,
-        frame_idx=0,
         source="cellpose",
     )
 
     skeleton = Skeleton(nodes=["A"])
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.label_images.append(li)
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
         tracks=[t1, t2],
-        label_images=[li],
     )
 
     path = str(tmp_path / "test_li.slp")
@@ -4935,7 +4903,6 @@ def test_label_image_slp_roundtrip(tmp_path):
     np.testing.assert_array_equal(rli.data, data)
     assert rli.height == 8
     assert rli.width == 10
-    assert rli.frame_idx == 0
     assert rli.source == "cellpose"
 
     # Check objects metadata
@@ -4955,7 +4922,6 @@ def test_label_image_slp_empty(tmp_path):
     labels = Labels(
         videos=[video],
         skeletons=[skeleton],
-        label_images=[],
     )
 
     path = str(tmp_path / "test_empty_li.slp")
@@ -4978,13 +4944,15 @@ def test_label_image_slp_format_version(tmp_path):
     data = np.zeros((4, 4), dtype=np.int32)
     data[0:2, 0:2] = 1
 
-    li = UserLabelImage(data=data, video=video, frame_idx=0)
+    li = UserLabelImage(data=data)
 
     skeleton = Skeleton(nodes=["A"])
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.label_images.append(li)
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
-        label_images=[li],
     )
 
     path = str(tmp_path / "test_format_li.slp")
@@ -5005,16 +4973,16 @@ def test_label_image_slp_lazy(tmp_path):
     li = UserLabelImage(
         data=data,
         objects={1: LabelImage.Info(track=t1, category="cell")},
-        video=video,
-        frame_idx=0,
     )
 
     skeleton = Skeleton(nodes=["A"])
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.label_images.append(li)
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
         tracks=[t1],
-        label_images=[li],
     )
 
     path = str(tmp_path / "test_lazy_li.slp")
@@ -5042,10 +5010,9 @@ def test_label_image_instance_lazy_roundtrip(tmp_path):
     li = UserLabelImage(
         data=np.array([[0, 1], [0, 0]], dtype=np.int32),
         objects={1: LabelImage.Info(instance=instance)},
-        video=video,
-        frame_idx=0,
     )
-    labels = Labels(labeled_frames=[lf], label_images=[li])
+    lf.label_images.append(li)
+    labels = Labels(labeled_frames=[lf])
 
     path1 = str(tmp_path / "original.slp")
     save_slp(labels, path1)
@@ -5080,10 +5047,9 @@ def test_label_image_instance_lazy_materialize(tmp_path):
     li = UserLabelImage(
         data=np.array([[0, 1], [0, 0]], dtype=np.int32),
         objects={1: LabelImage.Info(instance=instance)},
-        video=video,
-        frame_idx=0,
     )
-    labels = Labels(labeled_frames=[lf], label_images=[li])
+    lf.label_images.append(li)
+    labels = Labels(labeled_frames=[lf])
 
     path = str(tmp_path / "test.slp")
     save_slp(labels, path)
@@ -5979,17 +5945,15 @@ def test_slp_mask_instance_roundtrip(tmp_path):
 
     mask = UserSegmentationMask.from_numpy(
         np.ones((5, 5), dtype=bool),
-        video=video,
-        frame_idx=0,
         instance=inst,
         category="cell",
     )
 
+    lf.masks.append(mask)
     labels = Labels(
         labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
-        masks=[mask],
     )
 
     path = str(tmp_path / "mask_inst.slp")
@@ -6010,16 +5974,16 @@ def test_slp_predicted_mask_roundtrip(tmp_path):
 
     mask = PredictedSegmentationMask.from_numpy(
         np.ones((5, 5), dtype=bool),
-        video=video,
-        frame_idx=0,
         category="cell",
         score=0.95,
     )
 
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(mask)
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
-        masks=[mask],
     )
 
     path = str(tmp_path / "pred_mask.slp")
@@ -6046,16 +6010,16 @@ def test_slp_predicted_mask_score_map_roundtrip(tmp_path):
     score_map = np.random.rand(8, 8).astype(np.float32)
     mask = PredictedSegmentationMask.from_numpy(
         np.ones((8, 8), dtype=bool),
-        video=video,
-        frame_idx=0,
         score=0.9,
         score_map=score_map,
     )
 
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(mask)
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
-        masks=[mask],
     )
 
     path = str(tmp_path / "pred_mask_sm.slp")
@@ -6075,16 +6039,16 @@ def test_slp_mask_spatial_metadata_roundtrip(tmp_path):
 
     mask = UserSegmentationMask.from_numpy(
         np.ones((10, 10), dtype=bool),
-        video=video,
-        frame_idx=0,
         scale=(0.5, 0.5),
         offset=(10.0, 20.0),
     )
 
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(mask)
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
-        masks=[mask],
     )
 
     path = str(tmp_path / "mask_spatial.slp")
@@ -6105,10 +6069,12 @@ def test_slp_mask_default_spatial_roundtrip(tmp_path):
     skeleton = Skeleton(nodes=["A"])
 
     mask = UserSegmentationMask.from_numpy(
-        np.ones((5, 5), dtype=bool), video=video, frame_idx=0
+        np.ones((5, 5), dtype=bool),
     )
 
-    labels = Labels(videos=[video], skeletons=[skeleton], masks=[mask])
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(mask)
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
 
     path = str(tmp_path / "mask_default_spatial.slp")
     save_slp(labels, path)
@@ -6128,8 +6094,6 @@ def test_slp_predicted_mask_spatial_score_map_roundtrip(tmp_path):
     score_map = np.random.rand(5, 5).astype(np.float32)
     mask = PredictedSegmentationMask.from_numpy(
         np.ones((8, 8), dtype=bool),
-        video=video,
-        frame_idx=0,
         score=0.85,
         score_map=score_map,
         scale=(0.5, 0.5),
@@ -6138,7 +6102,9 @@ def test_slp_predicted_mask_spatial_score_map_roundtrip(tmp_path):
         score_map_offset=(1.0, 2.0),
     )
 
-    labels = Labels(videos=[video], skeletons=[skeleton], masks=[mask])
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(mask)
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
 
     path = str(tmp_path / "pred_mask_spatial.slp")
     save_slp(labels, path)
@@ -6162,13 +6128,13 @@ def test_slp_label_image_spatial_roundtrip(tmp_path):
     data = np.array([[0, 1], [2, 0]], dtype=np.int32)
     li = UserLabelImage(
         data=data,
-        video=video,
-        frame_idx=0,
         scale=(0.5, 0.5),
         offset=(10.0, 20.0),
     )
 
-    labels = Labels(videos=[video], skeletons=[skeleton], label_images=[li])
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.label_images.append(li)
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
 
     path = str(tmp_path / "li_spatial.slp")
     save_slp(labels, path)
@@ -6188,12 +6154,12 @@ def test_slp_spatial_metadata_format_version(tmp_path):
 
     mask = UserSegmentationMask.from_numpy(
         np.ones((5, 5), dtype=bool),
-        video=video,
-        frame_idx=0,
         scale=(0.5, 0.5),
     )
 
-    labels = Labels(videos=[video], skeletons=[skeleton], masks=[mask])
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(mask)
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
 
     path = str(tmp_path / "spatial_version.slp")
     save_slp(labels, path)
@@ -6208,10 +6174,12 @@ def test_slp_default_spatial_no_version_bump(tmp_path):
     skeleton = Skeleton(nodes=["A"])
 
     mask = UserSegmentationMask.from_numpy(
-        np.ones((5, 5), dtype=bool), video=video, frame_idx=0
+        np.ones((5, 5), dtype=bool),
     )
 
-    labels = Labels(videos=[video], skeletons=[skeleton], masks=[mask])
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(mask)
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
 
     path = str(tmp_path / "default_spatial.slp")
     save_slp(labels, path)
@@ -6230,7 +6198,6 @@ def test_slp_predicted_roi_roundtrip(tmp_path):
     roi = PredictedROI(
         geometry=box(0, 0, 10, 10),
         video=video,
-        frame_idx=0,
         category="arena",
         score=0.85,
     )
@@ -6263,7 +6230,6 @@ def test_slp_user_roi_roundtrip(tmp_path):
     roi = UserROI(
         geometry=Polygon([(0, 0), (10, 0), (10, 10), (5, 15), (0, 10)]),
         video=video,
-        frame_idx=0,
         category="arena",
     )
 
@@ -6297,16 +6263,16 @@ def test_slp_predicted_label_image_roundtrip(tmp_path):
         objects={
             1: LabelImage.Info(track=t1, category="neuron", score=0.92),
         },
-        video=video,
-        frame_idx=0,
         score=0.88,
     )
 
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.label_images.append(li)
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         skeletons=[skeleton],
         tracks=[t1],
-        label_images=[li],
     )
 
     path = str(tmp_path / "pred_li.slp")
@@ -6442,18 +6408,15 @@ def test_slp_all_annotations_roundtrip(labels_all_annotations, tmp_path):
 
     # --- Instance links restored ---
     for lf in loaded.labeled_frames:
-        frame_masks = [m for m in loaded.masks if m.frame_idx == lf.frame_idx]
-        for m in frame_masks:
+        for m in lf.masks:
             assert m.instance is not None
             assert m.instance in lf.instances
 
-        frame_rois = [r for r in loaded.rois if r.frame_idx == lf.frame_idx]
-        for r in frame_rois:
+        for r in lf.rois:
             assert r.instance is not None
             assert r.instance in lf.instances
 
-        frame_bboxes = [b for b in loaded.bboxes if b.frame_idx == lf.frame_idx]
-        for b in frame_bboxes:
+        for b in lf.bboxes:
             assert b.instance is not None
             assert b.instance in lf.instances
 
@@ -6643,10 +6606,8 @@ def test_label_image_writer_roundtrip(tmp_path):
                 1: LabelImage.Info(track=t1, category="neuron", name="n1"),
                 2: LabelImage.Info(track=t2, category="glia", name="g1"),
             },
-            video=video,
-            frame_idx=i,
         )
-        writer.add(li)
+        writer.add(li, frame_idx=i)
 
     labels = writer.finalize()
     assert len(labels.label_images) == n_frames
@@ -6657,7 +6618,6 @@ def test_label_image_writer_roundtrip(tmp_path):
 
     for i, rli in enumerate(reloaded.label_images):
         np.testing.assert_array_equal(rli.data, frame_data_list[i])
-        assert rli.frame_idx == i
         assert rli.objects[1].track.name == "t1"
         assert rli.objects[2].track.name == "t2"
         assert rli.objects[1].category == "neuron"
@@ -6676,7 +6636,7 @@ def test_label_image_writer_context_manager(tmp_path):
     path = str(tmp_path / "ctx.slp")
 
     data = np.array([[0, 1], [2, 0]], dtype=np.int32)
-    li = UserLabelImage(data=data, video=video, frame_idx=0)
+    li = UserLabelImage(data=data)
 
     with LabelImageWriter(path, video=video) as writer:
         writer.add(li)
@@ -6697,10 +6657,10 @@ def test_label_image_writer_mixed_sizes_error(tmp_path):
 
     writer = LabelImageWriter(path, video=video)
     li1 = UserLabelImage(
-        data=np.zeros((10, 10), dtype=np.int32), video=video, frame_idx=0
+        data=np.zeros((10, 10), dtype=np.int32),
     )
     li2 = UserLabelImage(
-        data=np.zeros((10, 15), dtype=np.int32), video=video, frame_idx=1
+        data=np.zeros((10, 15), dtype=np.int32),
     )
 
     writer.add(li1)
@@ -6725,8 +6685,6 @@ def test_label_image_writer_score_map(tmp_path):
     li = PredictedLabelImage(
         data=data,
         objects={1: LabelImage.Info(track=t1, category="cell", score=0.95)},
-        video=video,
-        frame_idx=0,
         score=0.9,
         score_map=score_map,
     )
@@ -6774,7 +6732,7 @@ def test_label_image_writer_add_after_finalize_error(tmp_path):
     path = str(tmp_path / "after.slp")
     writer = LabelImageWriter(path, video=video)
     writer.finalize()
-    li = UserLabelImage(data=np.zeros((4, 4), dtype=np.int32), video=video, frame_idx=0)
+    li = UserLabelImage(data=np.zeros((4, 4), dtype=np.int32))
     with pytest.raises(RuntimeError, match="already been finalized"):
         writer.add(li)
 
@@ -6788,7 +6746,7 @@ def test_label_image_writer_add_batch(tmp_path):
     for i in range(3):
         data = np.zeros((6, 6), dtype=np.int32)
         data[i : i + 2, i : i + 2] = i + 1
-        frames.append(UserLabelImage(data=data, video=video, frame_idx=i))
+        frames.append(UserLabelImage(data=data))
 
     writer = LabelImageWriter(path, video=video, initial_capacity=1)
     writer.add_batch(frames)
@@ -6815,24 +6773,23 @@ def test_merge_label_images_basic(tmp_path):
 
     # Create two source SLP files with 3 frames each
     for file_idx in range(2):
-        lis = []
+        labeled_frames = []
         for i in range(3):
             data = np.zeros((8, 10), dtype=np.int32)
             data[i : i + 2, i : i + 2] = i + 1
-            lis.append(
-                UserLabelImage(
-                    data=data,
-                    objects={i + 1: LabelImage.Info(track=t1, category="cell")},
-                    video=video,
-                    frame_idx=file_idx * 3 + i,
-                    source="test",
-                )
+            li = UserLabelImage(
+                data=data,
+                objects={i + 1: LabelImage.Info(track=t1, category="cell")},
+                source="test",
             )
+            lf = LabeledFrame(video=video, frame_idx=file_idx * 3 + i)
+            lf.label_images.append(li)
+            labeled_frames.append(lf)
         labels = Labels(
+            labeled_frames=labeled_frames,
             videos=[video],
             skeletons=[skeleton],
             tracks=[t1],
-            label_images=lis,
         )
         save_slp(labels, str(tmp_path / f"src_{file_idx}.slp"))
 
@@ -6871,12 +6828,14 @@ def test_merge_label_images_track_dedup(tmp_path):
             data[2:4, 2:4] = 2
             objs[2] = LabelImage.Info(track=tracks[1], category="cell")
 
-        li = UserLabelImage(data=data, objects=objs, video=video, frame_idx=0)
+        li = UserLabelImage(data=data, objects=objs)
+        lf = LabeledFrame(video=video, frame_idx=0)
+        lf.label_images.append(li)
         labels = Labels(
+            labeled_frames=[lf],
             videos=[video],
             skeletons=[skeleton],
             tracks=tracks,
-            label_images=[li],
         )
         save_slp(labels, str(tmp_path / f"src_{file_idx}.slp"))
 
@@ -6903,11 +6862,13 @@ def test_merge_label_images_video_dedup(tmp_path):
         video = Video(filename="shared_video.mp4")
         data = np.zeros((4, 4), dtype=np.int32)
         data[0:2, 0:2] = 1
-        li = UserLabelImage(data=data, video=video, frame_idx=file_idx)
+        li = UserLabelImage(data=data)
+        lf = LabeledFrame(video=video, frame_idx=0)
+        lf.label_images.append(li)
         labels = Labels(
+            labeled_frames=[lf],
             videos=[video],
             skeletons=[skeleton],
-            label_images=[li],
         )
         save_slp(labels, str(tmp_path / f"src_{file_idx}.slp"))
 
@@ -6930,15 +6891,18 @@ def test_merge_label_images_pixel_integrity(tmp_path):
     source_data = []
 
     for file_idx in range(2):
-        lis = []
+        labeled_frames = []
         for i in range(3):
             data = rng.randint(0, 10, size=(8, 10), dtype=np.int32)
             source_data.append(data.copy())
-            lis.append(UserLabelImage(data=data, video=video, frame_idx=i))
+            li = UserLabelImage(data=data)
+            lf = LabeledFrame(video=video, frame_idx=file_idx * 3 + i)
+            lf.label_images.append(li)
+            labeled_frames.append(lf)
         labels = Labels(
+            labeled_frames=labeled_frames,
             videos=[video],
             skeletons=[skeleton],
-            label_images=lis,
         )
         save_slp(labels, str(tmp_path / f"src_{file_idx}.slp"))
 
@@ -6962,14 +6926,18 @@ def test_merge_label_images_dimension_mismatch(tmp_path):
 
     # Source 1: 4x4 frames
     data1 = np.zeros((4, 4), dtype=np.int32)
-    li1 = UserLabelImage(data=data1, video=video, frame_idx=0)
-    labels1 = Labels(videos=[video], skeletons=[skeleton], label_images=[li1])
+    li1 = UserLabelImage(data=data1)
+    _lf = LabeledFrame(video=video, frame_idx=0)
+    _lf.label_images.append(li1)
+    labels1 = Labels(labeled_frames=[_lf], videos=[video], skeletons=[skeleton])
     save_slp(labels1, str(tmp_path / "src_4x4.slp"))
 
     # Source 2: 6x8 frames
     data2 = np.zeros((6, 8), dtype=np.int32)
-    li2 = UserLabelImage(data=data2, video=video, frame_idx=0)
-    labels2 = Labels(videos=[video], skeletons=[skeleton], label_images=[li2])
+    li2 = UserLabelImage(data=data2)
+    _lf = LabeledFrame(video=video, frame_idx=0)
+    _lf.label_images.append(li2)
+    labels2 = Labels(labeled_frames=[_lf], videos=[video], skeletons=[skeleton])
     save_slp(labels2, str(tmp_path / "src_6x8.slp"))
 
     with pytest.raises(ValueError, match="different dimensions"):
@@ -6994,8 +6962,10 @@ def test_merge_label_images_with_explicit_video(tmp_path):
         video = Video(filename=f"video_{file_idx}.mp4")
         data = np.zeros((4, 4), dtype=np.int32)
         data[0:2, 0:2] = 1
-        li = UserLabelImage(data=data, video=video, frame_idx=0)
-        labels = Labels(videos=[video], skeletons=[skeleton], label_images=[li])
+        li = UserLabelImage(data=data)
+        _lf = LabeledFrame(video=video, frame_idx=0)
+        _lf.label_images.append(li)
+        labels = Labels(labeled_frames=[_lf], videos=[video], skeletons=[skeleton])
         save_slp(labels, str(tmp_path / f"src_{file_idx}.slp"))
 
     merged = merge_label_images(
@@ -7074,11 +7044,11 @@ def test_merge_label_images_blob_source(tmp_path):
     li = UserLabelImage(
         data=data,
         objects={1: LabelImage.Info(track=t1, category="cell")},
-        video=video,
-        frame_idx=1,
     )
+    _lf = LabeledFrame(video=video, frame_idx=0)
+    _lf.label_images.append(li)
     labels = Labels(
-        videos=[video], skeletons=[skeleton], tracks=[t1], label_images=[li]
+        labeled_frames=[_lf], videos=[video], skeletons=[skeleton], tracks=[t1]
     )
     save_slp(labels, chunked_path)
 
@@ -7107,12 +7077,12 @@ def test_merge_label_images_with_score_maps(tmp_path):
         li = PredictedLabelImage(
             data=data,
             objects={1: LabelImage.Info(track=t1, category="cell", score=0.9)},
-            video=video,
-            frame_idx=file_idx,
             score=0.95,
             score_map=sm,
         )
-        labels = Labels(videos=[video], tracks=[t1], label_images=[li])
+        _lf = LabeledFrame(video=video, frame_idx=0)
+        _lf.label_images.append(li)
+        labels = Labels(labeled_frames=[_lf], videos=[video], tracks=[t1])
         save_slp(labels, str(tmp_path / f"src_{file_idx}.slp"))
 
     merged = merge_label_images(
@@ -7130,7 +7100,7 @@ def test_label_image_writer_exit_auto_finalizes(tmp_path):
     video = Video(filename="test.mp4")
     path = str(tmp_path / "auto_fin.slp")
     data = np.array([[0, 1], [2, 0]], dtype=np.int32)
-    li = UserLabelImage(data=data, video=video, frame_idx=0)
+    li = UserLabelImage(data=data)
 
     # Use context manager WITHOUT calling finalize explicitly
     with LabelImageWriter(path, video=video) as writer:
@@ -7159,8 +7129,6 @@ def test_label_image_writer_auto_collects_tracks(tmp_path):
             1: LabelImage.Info(track=t1),
             2: LabelImage.Info(track=t2),
         },
-        video=video,
-        frame_idx=0,
     )
     writer.add(li)
     assert len(writer.tracks) == 2
@@ -7180,10 +7148,14 @@ def test_write_label_images_blob_fallback_mixed_sizes(tmp_path):
     # Create label images with different sizes
     data_small = np.zeros((4, 4), dtype=np.int32)
     data_large = np.zeros((6, 8), dtype=np.int32)
-    li1 = UserLabelImage(data=data_small, video=video, frame_idx=0)
-    li2 = UserLabelImage(data=data_large, video=video, frame_idx=1)
+    li1 = UserLabelImage(data=data_small)
+    li2 = UserLabelImage(data=data_large)
 
-    labels = Labels(videos=[video], label_images=[li1, li2])
+    _lf0 = LabeledFrame(video=video, frame_idx=0)
+    _lf0.label_images.append(li1)
+    _lf1 = LabeledFrame(video=video, frame_idx=1)
+    _lf1.label_images.append(li2)
+    labels = Labels(labeled_frames=[_lf0, _lf1], videos=[video])
     save_slp(labels, path)
 
     # Verify blob format was used (1D flat array, not 3D chunked)
@@ -7203,8 +7175,10 @@ def test_write_metadata_bumps_format_for_chunked(tmp_path):
     path = str(tmp_path / "chunked_fmt.slp")
 
     data = np.zeros((4, 4), dtype=np.int32)
-    li = UserLabelImage(data=data, video=video, frame_idx=0)
-    labels = Labels(videos=[video], label_images=[li])
+    li = UserLabelImage(data=data)
+    _lf = LabeledFrame(video=video, frame_idx=0)
+    _lf.label_images.append(li)
+    labels = Labels(labeled_frames=[_lf], videos=[video])
 
     # First save normally (write_metadata runs before label images)
     save_slp(labels, path)
@@ -7283,8 +7257,10 @@ def test_merge_label_images_via_main(tmp_path):
     for i in range(2):
         data = np.zeros((4, 4), dtype=np.int32)
         data[0:2, 0:2] = 1
-        li = UserLabelImage(data=data, video=video, frame_idx=i)
-        labels = Labels(videos=[video], label_images=[li])
+        li = UserLabelImage(data=data)
+        _lf = LabeledFrame(video=video, frame_idx=0)
+        _lf.label_images.append(li)
+        labels = Labels(labeled_frames=[_lf], videos=[video])
         save_slp(labels, str(tmp_path / f"src_{i}.slp"))
 
     merged = main_merge(
@@ -7345,10 +7321,11 @@ def test_read_label_images_legacy_json_attrs(tmp_path):
     result, fh = read_label_images(path, [Video(filename="test.mp4")], [])
     try:
         assert len(result) == 1
-        assert result[0].objects[1].category == "cell"
-        assert result[0].objects[1].name == "obj1"
-        assert result[0].source == "test_source"
-        np.testing.assert_array_equal(result[0].data, data)
+        li, vid_idx, fidx = result[0]
+        assert li.objects[1].category == "cell"
+        assert li.objects[1].name == "obj1"
+        assert li.source == "test_source"
+        np.testing.assert_array_equal(li.data, data)
     finally:
         if fh is not None:
             fh.close()
@@ -7436,8 +7413,10 @@ def test_merge_label_images_image_video(tmp_path):
     data[0:2, 0:2] = 1
 
     for file_idx in range(2):
-        li = UserLabelImage(data=data, video=video, frame_idx=file_idx)
-        labels = Labels(videos=[video], label_images=[li])
+        li = UserLabelImage(data=data)
+        _lf = LabeledFrame(video=video, frame_idx=0)
+        _lf.label_images.append(li)
+        labels = Labels(labeled_frames=[_lf], videos=[video])
         save_slp(labels, str(tmp_path / f"src_{file_idx}.slp"))
 
     # This previously crashed with TypeError: unhashable type: 'list'
@@ -7461,8 +7440,6 @@ def test_slp_centroid_roundtrip(tmp_path):
         x=10.5,
         y=20.3,
         z=1.5,
-        video=video,
-        frame_idx=0,
         track=track,
         tracking_score=0.8,
         name="c1",
@@ -7472,8 +7449,6 @@ def test_slp_centroid_roundtrip(tmp_path):
     c2 = PredictedCentroid(
         x=50.0,
         y=60.0,
-        video=video,
-        frame_idx=3,
         score=0.95,
         name="c2",
         category="lysosome",
@@ -7481,11 +7456,13 @@ def test_slp_centroid_roundtrip(tmp_path):
     )
 
     skeleton = Skeleton(nodes=["A"])
+    _lf = LabeledFrame(video=video, frame_idx=0)
+    _lf.centroids.extend([c1, c2])
     labels = Labels(
+        labeled_frames=[_lf],
         videos=[video],
         skeletons=[skeleton],
         tracks=[track],
-        centroids=[c1, c2],
     )
 
     path = str(tmp_path / "test_centroids.slp")
@@ -7499,7 +7476,6 @@ def test_slp_centroid_roundtrip(tmp_path):
     assert lc1.x == pytest.approx(10.5)
     assert lc1.y == pytest.approx(20.3)
     assert lc1.z == pytest.approx(1.5)
-    assert lc1.frame_idx == 0
     assert lc1.track is loaded.tracks[0]
     assert lc1.tracking_score == pytest.approx(0.8)
     assert lc1.name == "c1"
@@ -7539,13 +7515,16 @@ def test_slp_bbox_tracking_score_roundtrip(tmp_path):
         y1=0.0,
         x2=10.0,
         y2=10.0,
-        video=video,
         track=track,
         tracking_score=0.75,
     )
 
     skeleton = Skeleton(nodes=["A"])
-    labels = Labels(videos=[video], skeletons=[skeleton], tracks=[track], bboxes=[bbox])
+    _lf = LabeledFrame(video=video, frame_idx=0)
+    _lf.bboxes.append(bbox)
+    labels = Labels(
+        labeled_frames=[_lf], videos=[video], skeletons=[skeleton], tracks=[track]
+    )
 
     path = str(tmp_path / "bbox_ts.slp")
     save_slp(labels, path)
@@ -7557,10 +7536,12 @@ def test_slp_bbox_tracking_score_roundtrip(tmp_path):
 def test_slp_bbox_tracking_score_none_roundtrip(tmp_path):
     """Test that tracking_score=None round-trips correctly."""
     video = Video(filename="test.mp4")
-    bbox = UserBoundingBox(x1=0.0, y1=0.0, x2=10.0, y2=10.0, video=video)
+    bbox = UserBoundingBox(x1=0.0, y1=0.0, x2=10.0, y2=10.0)
 
     skeleton = Skeleton(nodes=["A"])
-    labels = Labels(videos=[video], skeletons=[skeleton], bboxes=[bbox])
+    _lf = LabeledFrame(video=video, frame_idx=0)
+    _lf.bboxes.append(bbox)
+    labels = Labels(labeled_frames=[_lf], videos=[video], skeletons=[skeleton])
 
     path = str(tmp_path / "bbox_ts_none.slp")
     save_slp(labels, path)
@@ -7573,18 +7554,19 @@ def test_slp_centroid_low_level(tmp_path):
     """Test low-level read_centroids/write_centroids."""
     video = Video(filename="test.mp4")
     track = Track(name="t1")
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=5, track=track)
+    c = UserCentroid(x=1.0, y=2.0, track=track)
 
     skeleton = Skeleton(nodes=["A"])
     path = str(tmp_path / "centroids_ll.slp")
     save_slp(Labels(videos=[video], skeletons=[skeleton], tracks=[track]), path)
-    write_centroids(path, [c], [video], [track])
+    write_centroids(path, [c], [video], [track], contexts=[(0, 5)])
 
     loaded = read_centroids(path, [video], [track])
     assert len(loaded) == 1
-    assert loaded[0].x == pytest.approx(1.0)
-    assert loaded[0].y == pytest.approx(2.0)
-    assert loaded[0].frame_idx == 5
+    centroid, vid_idx, frame_idx = loaded[0]
+    assert centroid.x == pytest.approx(1.0)
+    assert centroid.y == pytest.approx(2.0)
+    assert frame_idx == 5
 
 
 def test_slp_lazy_centroid_only_roundtrip(tmp_path):
@@ -7592,19 +7574,22 @@ def test_slp_lazy_centroid_only_roundtrip(tmp_path):
     video = Video(filename="test.mp4")
     skeleton = Skeleton(["A"])
     track = Track(name="t1")
-    centroids = [
-        PredictedCentroid(
+    labeled_frames = []
+    for i in range(3):
+        c = PredictedCentroid(
             x=float(i),
             y=float(i * 2),
-            video=video,
-            frame_idx=i,
             track=track,
             score=0.9,
         )
-        for i in range(3)
-    ]
+        lf = LabeledFrame(video=video, frame_idx=i)
+        lf.centroids.append(c)
+        labeled_frames.append(lf)
     labels = Labels(
-        centroids=centroids, videos=[video], skeletons=[skeleton], tracks=[track]
+        labeled_frames=labeled_frames,
+        videos=[video],
+        skeletons=[skeleton],
+        tracks=[track],
     )
 
     path = str(tmp_path / "centroids.slp")
@@ -7638,13 +7623,16 @@ def test_slp_lazy_annotations_on_materialized_frames(tmp_path):
     track = Track(name="t1")
     inst = Instance.from_numpy(np.array([[10.0, 20.0]]), skeleton=skeleton, track=track)
     lf = LabeledFrame(video=video, frame_idx=0, instances=[inst])
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=track)
-    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=0)
+    c = UserCentroid(x=1.0, y=2.0, track=track)
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
     mask_data = np.zeros((10, 10), dtype=bool)
     mask_data[2:8, 2:8] = True
-    m = UserSegmentationMask.from_numpy(mask_data, video=video, frame_idx=0)
+    m = UserSegmentationMask.from_numpy(mask_data)
 
-    labels = Labels(labeled_frames=[lf], centroids=[c], bboxes=[b], masks=[m])
+    lf.centroids.append(c)
+    lf.bboxes.append(b)
+    lf.masks.append(m)
+    labels = Labels(labeled_frames=[lf])
     path = str(tmp_path / "test.slp")
     save_slp(labels, path)
 
@@ -7666,19 +7654,22 @@ def test_slp_lazy_supplementary_frame_indexing(tmp_path):
     track = Track(name="t1")
 
     # Create centroid-only labels (creates annotation-only frames)
-    centroids = [
-        PredictedCentroid(
+    labeled_frames = []
+    for i in range(3):
+        c = PredictedCentroid(
             x=float(i),
             y=float(i),
-            video=video,
-            frame_idx=i,
             track=track,
             score=0.9,
         )
-        for i in range(3)
-    ]
+        lf = LabeledFrame(video=video, frame_idx=i)
+        lf.centroids.append(c)
+        labeled_frames.append(lf)
     labels = Labels(
-        centroids=centroids, videos=[video], skeletons=[skeleton], tracks=[track]
+        labeled_frames=labeled_frames,
+        videos=[video],
+        skeletons=[skeleton],
+        tracks=[track],
     )
 
     path = str(tmp_path / "supp.slp")
@@ -7710,12 +7701,15 @@ def test_slp_lazy_old_format_annotation_only_frames(tmp_path):
 
     # Create SLP with instances on frame 0 + centroids on frame 1 (no instances)
     inst = Instance.from_numpy(np.array([[10.0, 20.0]]), skeleton=skeleton, track=track)
-    c0 = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=track)
-    c1 = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=1, track=track)
+    c0 = UserCentroid(x=1.0, y=2.0, track=track)
+    c1 = UserCentroid(x=3.0, y=4.0, track=track)
 
+    lf0 = LabeledFrame(video=video, frame_idx=0, instances=[inst])
+    lf0.centroids.append(c0)
+    lf1 = LabeledFrame(video=video, frame_idx=1)
+    lf1.centroids.append(c1)
     labels = Labels(
-        labeled_frames=[LabeledFrame(video=video, frame_idx=0, instances=[inst])],
-        centroids=[c0, c1],
+        labeled_frames=[lf0, lf1],
     )
     path = str(tmp_path / "test.slp")
     save_slp(labels, path)

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -7763,23 +7763,32 @@ def test_write_bboxes_default_contexts(tmp_path):
 
 
 def test_slp_undistributed_annotations_roundtrip(tmp_path):
-    """Annotations with invalid routing context become undistributed on read."""
+    """Annotations written with -1 routing context are undistributed on read."""
+    from sleap_io.io.slp import write_masks
+
     video = Video(filename="test.mp4")
     skeleton = Skeleton(nodes=["A"])
-
-    # Write a centroid and bbox with -1 routing context (undistributable)
-    c = UserCentroid(x=5.0, y=10.0)
-    b = UserBoundingBox(x1=0, y1=0, x2=20, y2=20)
-
     lf = LabeledFrame(video=video, frame_idx=0)
-    lf.centroids.append(c)
-    lf.bboxes.append(b)
     labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
 
     path = str(tmp_path / "test.slp")
     save_slp(labels, path)
 
-    loaded = load_slp(path)
-    # Annotations should be distributed to the frame
-    assert len(loaded.centroids) == 1
-    assert len(loaded.bboxes) == 1
+    # Write annotations with -1 routing context (undistributable)
+    c = UserCentroid(x=5.0, y=10.0)
+    b = UserBoundingBox(x1=0, y1=0, x2=20, y2=20)
+    mask_data = np.zeros((5, 5), dtype=bool)
+    mask_data[1:4, 1:4] = True
+    m = UserSegmentationMask.from_numpy(mask_data)
+
+    write_centroids(path, [c], [video], [], contexts=[(-1, -1)])
+    write_bboxes(path, [b], [video], [], contexts=[(-1, -1)])
+    write_masks(path, [m], [video], [], contexts=[(-1, -1)])
+
+    # read_labels should put these in undistributed (not on any frame)
+    loaded = read_labels(path)
+    # The existing LabeledFrame at frame_idx=0 has no annotations
+    lf0 = [lf for lf in loaded.labeled_frames if lf.frame_idx == 0][0]
+    assert len(lf0.centroids) == 0
+    assert len(lf0.bboxes) == 0
+    assert len(lf0.masks) == 0

--- a/tests/io/test_tiff.py
+++ b/tests/io/test_tiff.py
@@ -30,7 +30,7 @@ def test_read_single_tiff(tmp_path):
     result = read_label_images(tiff_path)
 
     assert len(result) == 1
-    assert result[0].frame_idx == 0
+    assert result[0].n_objects >= 0  # basic sanity check
     np.testing.assert_array_equal(result[0].data, data.astype(np.int32))
     assert result[0].n_objects == 2
 
@@ -51,7 +51,6 @@ def test_read_multipage_tiff(tmp_path):
 
     assert len(result) == 3
     for i, li in enumerate(result):
-        assert li.frame_idx == i
         np.testing.assert_array_equal(li.data, frames[i].astype(np.int32))
 
 
@@ -66,7 +65,6 @@ def test_read_tiff_directory(tmp_path):
 
     assert len(result) == 3
     for i, li in enumerate(result):
-        assert li.frame_idx == i
         np.testing.assert_array_equal(li.data, frames[i].astype(np.int32))
 
 
@@ -114,7 +112,6 @@ def test_sidecar_roundtrip(tmp_path):
             1: LabelImage.Info(track=track_a, category="neuron"),
             3: LabelImage.Info(track=track_b, category="glia"),
         },
-        frame_idx=0,
     )
 
     tiff_path = tmp_path / "labeled.tif"
@@ -183,7 +180,7 @@ def test_write_stack_roundtrip(tmp_path):
                 track=track_lookup[lid_int],
                 category=cat_lookup[lid_int],
             )
-        label_images.append(UserLabelImage(data=data, objects=objects, frame_idx=i))
+        label_images.append(UserLabelImage(data=data, objects=objects))
 
     tiff_path = tmp_path / "roundtrip.tif"
     write_label_images(tiff_path, label_images, stack=True)
@@ -192,7 +189,6 @@ def test_write_stack_roundtrip(tmp_path):
     assert len(result) == len(label_images)
     for i in range(len(result)):
         np.testing.assert_array_equal(result[i].data, frames_data[i])
-        assert result[i].frame_idx == i
 
     # Verify track names from sidecar
     assert result[0].objects[1].track.name == "obj_a"
@@ -220,7 +216,7 @@ def test_write_directory_roundtrip(tmp_path):
         for lid in ids:
             lid_int = int(lid)
             objects[lid_int] = LabelImage.Info(track=track_lookup[lid_int])
-        label_images.append(UserLabelImage(data=data, objects=objects, frame_idx=i))
+        label_images.append(UserLabelImage(data=data, objects=objects))
 
     dir_path = tmp_path / "frames_dir"
     write_label_images(dir_path, label_images, stack=False)
@@ -236,7 +232,6 @@ def test_write_directory_roundtrip(tmp_path):
     assert len(result) == 2
     for i in range(len(result)):
         np.testing.assert_array_equal(result[i].data, frames_data[i])
-        assert result[i].frame_idx == i
 
     # Verify sidecar was written for the directory
     sidecar_path = tmp_path / "frames_dir.meta.json"
@@ -250,7 +245,7 @@ def test_write_directory_roundtrip(tmp_path):
 def test_empty_label_image_roundtrip(tmp_path):
     """Write and read back a LabelImage with all-zero data (no objects)."""
     data = np.zeros((4, 4), dtype=np.int32)
-    li = UserLabelImage(data=data, frame_idx=0)
+    li = UserLabelImage(data=data)
 
     tiff_path = tmp_path / "empty.tif"
     write_label_images(tiff_path, [li])
@@ -265,7 +260,7 @@ def test_empty_label_image_roundtrip(tmp_path):
 def test_tiff_spatial_metadata_roundtrip(tmp_path):
     """Write and read back a LabelImage with scale/offset via sidecar."""
     data = _make_label_array(8, 8, 2)
-    li = UserLabelImage(data=data, frame_idx=0, scale=(0.5, 0.5), offset=(10.0, 20.0))
+    li = UserLabelImage(data=data, scale=(0.5, 0.5), offset=(10.0, 20.0))
 
     tiff_path = tmp_path / "spatial.tif"
     write_label_images(tiff_path, [li])
@@ -280,7 +275,7 @@ def test_tiff_spatial_metadata_roundtrip(tmp_path):
 def test_tiff_default_spatial_roundtrip(tmp_path):
     """LabelImage with default scale/offset reads back with defaults."""
     data = _make_label_array(8, 8, 2)
-    li = UserLabelImage(data=data, frame_idx=0)
+    li = UserLabelImage(data=data)
 
     tiff_path = tmp_path / "default.tif"
     write_label_images(tiff_path, [li])
@@ -295,7 +290,7 @@ def test_tiff_default_spatial_roundtrip(tmp_path):
 def test_tiff_sidecar_v1_compat(tmp_path):
     """Old sidecar without scale/offset loads with defaults."""
     data = _make_label_array(8, 8, 2)
-    li = UserLabelImage(data=data, frame_idx=0)
+    li = UserLabelImage(data=data)
 
     tiff_path = tmp_path / "old.tif"
     write_label_images(tiff_path, [li])

--- a/tests/io/test_trackmate.py
+++ b/tests/io/test_trackmate.py
@@ -71,15 +71,15 @@ def test_read_trackmate_basic(tmp_path):
     assert c0.x == pytest.approx(10.0)
     assert c0.y == pytest.approx(20.0)
     assert c0.z is None  # 0.0 -> None
-    assert c0.frame_idx == 0
     assert c0.score == pytest.approx(5.5)
     assert c0.name == "ID100"
     assert c0.source == "trackmate"
     assert c0.track is not None
     assert c0.track.name == "Track_0"
 
-    c2 = labels.centroids[2]
-    assert c2.track.name == "Track_1"
+    # Centroids are ordered by frame, so frame 0 has ID100 + ID200
+    c1 = labels.centroids[1]
+    assert c1.track.name == "Track_1"
 
 
 def test_read_trackmate_with_edges(tmp_path):
@@ -144,7 +144,7 @@ def test_read_trackmate_with_video(tmp_path):
 
     assert len(labels.videos) == 1
     assert labels.videos[0].filename == "my_video.tif"
-    assert labels.centroids[0].video is labels.videos[0]
+    assert labels.labeled_frames[0].video is labels.videos[0]
 
 
 def test_read_trackmate_unassigned_spots(tmp_path):
@@ -228,7 +228,7 @@ def test_load_trackmate_roundtrip(tmp_path):
     _write_spots(tmp_path / "data_spots.csv", spots)
     _write_edges(tmp_path / "data_edges.csv", edges)
 
-    labels = read_trackmate_csv(tmp_path / "data_spots.csv")
+    labels = read_trackmate_csv(tmp_path / "data_spots.csv", video="test.tif")
     assert len(labels.centroids) == 3
     assert len(labels.tracks) == 2
 
@@ -241,16 +241,19 @@ def test_load_trackmate_roundtrip(tmp_path):
     assert len(loaded.centroids) == 3
     assert len(loaded.tracks) == 2
 
+    # Centroids ordered by frame: frame 0 has [ID1, ID3], frame 1 has [ID2]
     c0 = loaded.centroids[0]
     assert c0.x == pytest.approx(10.0)
     assert c0.score == pytest.approx(5.0)
     assert c0.tracking_score is None  # First in track
 
+    # ID3 is at index 1 (frame 0, track 1)
     c1 = loaded.centroids[1]
-    assert c1.tracking_score == pytest.approx(0.75)
+    assert c1.track is loaded.tracks[1]
 
+    # ID2 is at index 2 (frame 1, track 0) - has tracking_score from edge
     c2 = loaded.centroids[2]
-    assert c2.track is loaded.tracks[1]
+    assert c2.tracking_score == pytest.approx(0.75)
 
 
 def test_read_trackmate_not_found(tmp_path):

--- a/tests/io/test_ultralytics.py
+++ b/tests/io/test_ultralytics.py
@@ -1550,16 +1550,20 @@ def test_write_bbox_label_file(tmp_path):
 def test_write_roi_labels_splitting(tmp_path):
     """ROIs should be split across train/val/test according to split_ratios."""
     # Create 10 synthetic single-image "videos" with ROIs
+    labeled_frames = []
     rois = []
     for i in range(10):
         img = np.zeros((50, 50, 3), dtype=np.uint8)
         img_path = tmp_path / f"img_{i}.png"
         iio.imwrite(str(img_path), img)
         video = Video.from_filename(str(img_path))
-        roi = UserROI.from_bbox(5, 5, 20, 20, category="obj", video=video, frame_idx=0)
+        roi = UserROI.from_bbox(5, 5, 20, 20, category="obj", video=video)
         rois.append(roi)
+        lf = LabeledFrame(video=video, frame_idx=0)
+        lf.rois.append(roi)
+        labeled_frames.append(lf)
 
-    labels = Labels(rois=rois)
+    labels = Labels(labeled_frames=labeled_frames)
     class_names = _build_class_names_from_rois(rois)
 
     dataset_path = tmp_path / "dataset"

--- a/tests/model/test_bbox.py
+++ b/tests/model/test_bbox.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 
 from sleap_io.model.bbox import BoundingBox, PredictedBoundingBox, UserBoundingBox
-from sleap_io.model.video import Video
 
 
 def test_bbox_abstract():
@@ -22,8 +21,6 @@ def test_bbox_basic():
     assert bbox.width == 100
     assert bbox.height == 80
     assert bbox.angle == 0.0
-    assert bbox.video is None
-    assert bbox.frame_idx is None
     assert bbox.track is None
     assert bbox.instance is None
     assert bbox.category == ""
@@ -55,12 +52,7 @@ def test_bbox_from_xyxy_swapped_raises():
 
 
 def test_bbox_from_xyxy_with_kwargs():
-    video = Video(filename="test.mp4")
-    bbox = UserBoundingBox.from_xyxy(
-        10, 20, 110, 100, video=video, frame_idx=5, category="mouse"
-    )
-    assert bbox.video is video
-    assert bbox.frame_idx == 5
+    bbox = UserBoundingBox.from_xyxy(10, 20, 110, 100, category="mouse")
     assert bbox.category == "mouse"
 
 
@@ -246,18 +238,17 @@ def test_bbox_to_roi_rotated():
 
 
 def test_bbox_to_roi_preserves_metadata():
-    video = Video(filename="test.mp4")
     bbox = UserBoundingBox(
         x1=40,
         y1=45,
         x2=60,
         y2=55,
-        video=video,
-        frame_idx=3,
+        name="b1",
+        category="mouse",
     )
     roi = bbox.to_roi()
-    assert roi.video is video
-    assert roi.frame_idx == 3
+    assert roi.name == "b1"
+    assert roi.category == "mouse"
 
 
 def test_bbox_to_mask():

--- a/tests/model/test_centroid.py
+++ b/tests/model/test_centroid.py
@@ -24,8 +24,6 @@ def test_user_centroid_basic():
     assert c.x == 10.5
     assert c.y == 20.3
     assert c.z is None
-    assert c.video is None
-    assert c.frame_idx is None
     assert c.track is None
     assert c.tracking_score is None
     assert c.instance is None
@@ -41,7 +39,6 @@ def test_user_centroid_all_fields():
         x=1.0,
         y=2.0,
         z=3.0,
-        frame_idx=5,
         track=track,
         tracking_score=0.8,
         category="cell",
@@ -49,7 +46,6 @@ def test_user_centroid_all_fields():
         source="center_of_mass",
     )
     assert c.z == 3.0
-    assert c.frame_idx == 5
     assert c.track is track
     assert c.tracking_score == 0.8
     assert c.category == "cell"

--- a/tests/model/test_label_image.py
+++ b/tests/model/test_label_image.py
@@ -287,12 +287,9 @@ def test_from_numpy_categories_dict():
 
 def test_from_numpy_with_kwargs():
     """from_numpy should pass kwargs to constructor."""
-    vid = Video(filename="test.mp4")
     data = np.array([[1]], dtype=np.int32)
-    li = UserLabelImage.from_numpy(data, video=vid, frame_idx=42, source="test")
+    li = UserLabelImage.from_numpy(data, source="test")
 
-    assert li.video is vid
-    assert li.frame_idx == 42
     assert li.source == "test"
 
 
@@ -359,15 +356,12 @@ def test_to_masks():
     """to_masks should decompose into per-object binary masks."""
     t1, t2 = Track(name="a"), Track(name="b")
     data = np.array([[1, 0], [0, 2]], dtype=np.int32)
-    vid = Video(filename="test.mp4")
     li = UserLabelImage(
         data=data,
         objects={
             1: LabelImage.Info(track=t1, category="neuron", name="cell_1"),
             2: LabelImage.Info(track=t2, category="glia", name="cell_2"),
         },
-        video=vid,
-        frame_idx=5,
         source="test_source",
     )
     masks = li.to_masks()
@@ -378,8 +372,6 @@ def test_to_masks():
     assert masks[0].track is t1
     assert masks[0].category == "neuron"
     assert masks[0].name == "cell_1"
-    assert masks[0].video is vid
-    assert masks[0].frame_idx == 5
     assert masks[0].source == "test_source"
     # Second mask (label 2)
     np.testing.assert_array_equal(masks[1].data, [[False, False], [False, True]])
@@ -418,7 +410,8 @@ def test_eq_false():
 
 
 def test_labels_integration():
-    """LabelImage should work with Labels.get_label_images()."""
+    """LabelImage should work with Labels via LabeledFrames."""
+    from sleap_io.model.labeled_frame import LabeledFrame
     from sleap_io.model.labels import Labels
 
     vid1 = Video(filename="a.mp4")
@@ -428,31 +421,27 @@ def test_labels_integration():
     li1 = UserLabelImage(
         data=np.array([[1]], dtype=np.int32),
         objects={1: LabelImage.Info(track=t1, category="neuron")},
-        video=vid1,
-        frame_idx=0,
     )
     li2 = UserLabelImage(
         data=np.array([[2]], dtype=np.int32),
         objects={2: LabelImage.Info(category="glia")},
-        video=vid1,
-        frame_idx=1,
     )
     li3 = UserLabelImage(
         data=np.array([[1]], dtype=np.int32),
         objects={1: LabelImage.Info(track=t1)},
-        video=vid2,
-        frame_idx=0,
     )
 
-    labels = Labels(label_images=[li1, li2, li3])
+    lf1 = LabeledFrame(video=vid1, frame_idx=0)
+    lf1.label_images.append(li1)
+    lf2 = LabeledFrame(video=vid1, frame_idx=1)
+    lf2.label_images.append(li2)
+    lf3 = LabeledFrame(video=vid2, frame_idx=0)
+    lf3.label_images.append(li3)
 
-    # Filter by video
-    assert labels.get_label_images(video=vid1) == [li1, li2]
-    assert labels.get_label_images(video=vid2) == [li3]
+    labels = Labels(labeled_frames=[lf1, lf2, lf3])
 
-    # Filter by frame_idx
-    assert labels.get_label_images(frame_idx=0) == [li1, li3]
-    assert labels.get_label_images(frame_idx=1) == [li2]
+    # All label images across frames
+    assert len(labels.label_images) == 3
 
     # Filter by track (checks objects metadata)
     assert labels.get_label_images(track=t1) == [li1, li3]
@@ -460,9 +449,6 @@ def test_labels_integration():
     # Filter by category
     assert labels.get_label_images(category="neuron") == [li1]
     assert labels.get_label_images(category="glia") == [li2]
-
-    # Combined filters
-    assert labels.get_label_images(video=vid1, track=t1) == [li1]
 
 
 def test_info_score():
@@ -786,12 +772,7 @@ def test_from_binary_masks_predicted():
 def test_from_binary_masks_kwargs():
     """Extra kwargs should pass through to the constructor."""
     m1 = np.array([[True, False], [False, False]])
-    video = Video(filename="test.mp4")
-    li = UserLabelImage.from_binary_masks(
-        [m1], video=video, frame_idx=5, source="cellpose"
-    )
-    assert li.video is video
-    assert li.frame_idx == 5
+    li = UserLabelImage.from_binary_masks([m1], source="cellpose")
     assert li.source == "cellpose"
 
 
@@ -1113,7 +1094,6 @@ def test_from_stack_basic():
         assert isinstance(li, UserLabelImage)
         assert li.height == 4
         assert li.width == 5
-        assert li.frame_idx == i
 
 
 def test_from_stack_list_input():
@@ -1195,14 +1175,13 @@ def test_from_stack_categories():
     assert result[0].objects[2].category == "glia"
 
 
-def test_from_stack_frame_idx_custom():
-    """Custom frame_idx should be applied per frame."""
+def test_from_stack_source_kwarg():
+    """Shared kwargs should propagate to all frames."""
     stack = np.zeros((3, 2, 2), dtype=np.int32)
-    result = UserLabelImage.from_stack(stack, frame_idx=[10, 20, 30])
+    result = UserLabelImage.from_stack(stack, source="cellpose")
 
-    assert result[0].frame_idx == 10
-    assert result[1].frame_idx == 20
-    assert result[2].frame_idx == 30
+    for li in result:
+        assert li.source == "cellpose"
 
 
 def test_from_stack_predicted():
@@ -1259,19 +1238,16 @@ def test_from_stack_track_consistency():
 
 def test_from_stack_kwargs():
     """Shared kwargs should propagate to all frames."""
-    vid = Video(filename="test.mp4")
     stack = np.zeros((2, 3, 3), dtype=np.int32)
 
     result = UserLabelImage.from_stack(
         stack,
-        video=vid,
         source="cellpose",
         scale=(0.5, 0.5),
         offset=(10.0, 20.0),
     )
 
     for li in result:
-        assert li.video is vid
         assert li.source == "cellpose"
         assert li.scale == (0.5, 0.5)
         assert li.offset == (10.0, 20.0)
@@ -1281,13 +1257,6 @@ def test_from_stack_non_3d_raises():
     """from_stack with a 2D array should raise ValueError."""
     with pytest.raises(ValueError, match="\\(T, H, W\\)"):
         UserLabelImage.from_stack(np.zeros((3, 3), dtype=np.int32))
-
-
-def test_from_stack_frame_idx_mismatch_raises():
-    """from_stack with wrong frame_idx length should raise."""
-    stack = np.zeros((3, 3, 3), dtype=np.int32)
-    with pytest.raises(ValueError, match="frame_idx length"):
-        UserLabelImage.from_stack(stack, frame_idx=[0, 1])
 
 
 def test_from_stack_empty():
@@ -1479,19 +1448,14 @@ def test_to_bboxes_metadata():
     data = np.zeros((10, 10), dtype=np.int32)
     data[1:3, 1:3] = 1
     track = Track(name="t1")
-    video = Video(filename="test.mp4")
     li = UserLabelImage(
         data=data,
         objects={1: LabelImage.Info(track=track, category="cell", name="obj1")},
-        video=video,
-        frame_idx=5,
         source="cellpose",
     )
     bboxes = li.to_bboxes()
     bb = bboxes[0]
     assert bb.track is track
-    assert bb.video is video
-    assert bb.frame_idx == 5
     assert bb.category == "cell"
     assert bb.name == "obj1"
     assert bb.source == "cellpose"

--- a/tests/model/test_labeled_frame.py
+++ b/tests/model/test_labeled_frame.py
@@ -1155,6 +1155,56 @@ def test_labeled_frame_annotation_fields():
     assert len(lf.rois) == 0
 
 
+def test_labeled_frame_append():
+    """LabeledFrame.append routes annotations to the correct container."""
+    import pytest
+
+    from sleap_io.model.bbox import UserBoundingBox
+    from sleap_io.model.centroid import UserCentroid
+    from sleap_io.model.label_image import UserLabelImage
+    from sleap_io.model.mask import UserSegmentationMask
+    from sleap_io.model.roi import UserROI
+
+    video = Video(filename="test.mp4", open_backend=False)
+    lf = LabeledFrame(video=video, frame_idx=0)
+
+    # Instance
+    inst = Instance.from_numpy(
+        np.array([[1.0, 2.0]]), skeleton=Skeleton(["A"])
+    )
+    lf.append(inst)
+    assert lf.instances[-1] is inst
+
+    # Centroid
+    c = UserCentroid(x=1.0, y=2.0)
+    lf.append(c)
+    assert lf.centroids[-1] is c
+
+    # BoundingBox
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
+    lf.append(b)
+    assert lf.bboxes[-1] is b
+
+    # SegmentationMask
+    m = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool))
+    lf.append(m)
+    assert lf.masks[-1] is m
+
+    # LabelImage
+    li = UserLabelImage(data=np.zeros((4, 4), dtype=np.int32))
+    lf.append(li)
+    assert lf.label_images[-1] is li
+
+    # ROI
+    r = UserROI.from_bbox(0, 0, 10, 10)
+    lf.append(r)
+    assert lf.rois[-1] is r
+
+    # Unsupported type
+    with pytest.raises(TypeError, match="Cannot append"):
+        lf.append("not an annotation")
+
+
 def test_labeled_frame_is_user_labeled_with_annotations():
     """is_user_labeled returns True for frames with user annotations."""
     from sleap_io.model.centroid import PredictedCentroid, UserCentroid

--- a/tests/model/test_labeled_frame.py
+++ b/tests/model/test_labeled_frame.py
@@ -1142,8 +1142,8 @@ def test_labeled_frame_annotation_fields():
     from sleap_io.model.centroid import UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=0)
+    c = UserCentroid(x=1.0, y=2.0)
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
 
     lf = LabeledFrame(video=video, frame_idx=0, centroids=[c], bboxes=[b])
     assert len(lf.centroids) == 1
@@ -1162,12 +1162,12 @@ def test_labeled_frame_is_user_labeled_with_annotations():
     video = Video(filename="test.mp4", open_backend=False)
 
     # Frame with only user centroid — is user labeled
-    c_user = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
+    c_user = UserCentroid(x=1.0, y=2.0)
     lf = LabeledFrame(video=video, frame_idx=0, centroids=[c_user])
     assert lf.is_user_labeled
 
     # Frame with only predicted centroid — not user labeled
-    c_pred = PredictedCentroid(x=1.0, y=2.0, video=video, frame_idx=0, score=0.5)
+    c_pred = PredictedCentroid(x=1.0, y=2.0, score=0.5)
     lf2 = LabeledFrame(video=video, frame_idx=1, centroids=[c_pred])
     assert not lf2.is_user_labeled
 
@@ -1178,12 +1178,10 @@ def test_labeled_frame_remove_predictions_annotations():
     from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    c_user = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    c_pred = PredictedCentroid(x=3.0, y=4.0, video=video, frame_idx=0, score=0.9)
-    b_user = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=0)
-    b_pred = PredictedBoundingBox(
-        x1=5, y1=5, x2=15, y2=15, video=video, frame_idx=0, score=0.8
-    )
+    c_user = UserCentroid(x=1.0, y=2.0)
+    c_pred = PredictedCentroid(x=3.0, y=4.0, score=0.9)
+    b_user = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
+    b_pred = PredictedBoundingBox(x1=5, y1=5, x2=15, y2=15, score=0.8)
 
     lf = LabeledFrame(
         video=video,
@@ -1204,8 +1202,8 @@ def test_labeled_frame_merge_annotations():
     from sleap_io.model.centroid import UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    c1 = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    c2 = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=0)
+    c1 = UserCentroid(x=1.0, y=2.0)
+    c2 = UserCentroid(x=3.0, y=4.0)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[c1])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[c2])
@@ -1224,8 +1222,8 @@ def test_labeled_frame_merge_annotations_dedup():
     from sleap_io.model.centroid import UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    shared = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    unique = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=0)
+    shared = UserCentroid(x=1.0, y=2.0)
+    unique = UserCentroid(x=3.0, y=4.0)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[shared])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[shared, unique])
@@ -1245,8 +1243,8 @@ def test_merge_annotations_keep_original():
     from sleap_io.model.centroid import UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    self_c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    other_c = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=0)
+    self_c = UserCentroid(x=1.0, y=2.0)
+    other_c = UserCentroid(x=3.0, y=4.0)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[self_c])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[other_c])
@@ -1262,8 +1260,8 @@ def test_merge_annotations_keep_new():
     from sleap_io.model.centroid import UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    self_c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    other_c = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=0)
+    self_c = UserCentroid(x=1.0, y=2.0)
+    other_c = UserCentroid(x=3.0, y=4.0)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[self_c])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[other_c])
@@ -1281,10 +1279,10 @@ def test_merge_annotations_replace_predictions():
     from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    self_user = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    self_pred = PredictedCentroid(x=5.0, y=6.0, video=video, frame_idx=0, score=0.9)
-    other_pred = PredictedCentroid(x=7.0, y=8.0, video=video, frame_idx=0, score=0.8)
-    other_user = UserCentroid(x=9.0, y=10.0, video=video, frame_idx=0)
+    self_user = UserCentroid(x=1.0, y=2.0)
+    self_pred = PredictedCentroid(x=5.0, y=6.0, score=0.9)
+    other_pred = PredictedCentroid(x=7.0, y=8.0, score=0.8)
+    other_user = UserCentroid(x=9.0, y=10.0)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[self_user, self_pred])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[other_pred, other_user])
@@ -1304,9 +1302,9 @@ def test_merge_annotations_auto():
     from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    self_user = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    self_pred = PredictedCentroid(x=5.0, y=6.0, video=video, frame_idx=0, score=0.9)
-    other_pred = PredictedCentroid(x=7.0, y=8.0, video=video, frame_idx=0, score=0.8)
+    self_user = UserCentroid(x=1.0, y=2.0)
+    self_pred = PredictedCentroid(x=5.0, y=6.0, score=0.9)
+    other_pred = PredictedCentroid(x=7.0, y=8.0, score=0.8)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[self_user, self_pred])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[other_pred])
@@ -1324,9 +1322,9 @@ def test_merge_annotations_auto_user_from_other_added():
     from sleap_io.model.centroid import UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    self_user = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
+    self_user = UserCentroid(x=1.0, y=2.0)
     # Far away — won't match self_user (distance > 5.0)
-    other_user = UserCentroid(x=50.0, y=60.0, video=video, frame_idx=0)
+    other_user = UserCentroid(x=50.0, y=60.0)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[self_user])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[other_user])
@@ -1345,8 +1343,8 @@ def test_merge_annotations_auto_user_replaces_predicted():
     from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    self_pred = PredictedCentroid(x=10.0, y=20.0, video=video, frame_idx=0, score=0.9)
-    other_user = UserCentroid(x=11.0, y=20.5, video=video, frame_idx=0)
+    self_pred = PredictedCentroid(x=10.0, y=20.0, score=0.9)
+    other_user = UserCentroid(x=11.0, y=20.5)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[self_pred])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[other_user])
@@ -1364,9 +1362,9 @@ def test_merge_annotations_auto_keeps_unmatched_self_prediction():
     from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 
     video = Video(filename="test.mp4", open_backend=False)
-    self_pred = PredictedCentroid(x=10.0, y=20.0, video=video, frame_idx=0, score=0.9)
+    self_pred = PredictedCentroid(x=10.0, y=20.0, score=0.9)
     # Far away — no match
-    other_user = UserCentroid(x=80.0, y=90.0, video=video, frame_idx=0)
+    other_user = UserCentroid(x=80.0, y=90.0)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[self_pred])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[other_user])
@@ -1384,12 +1382,8 @@ def test_merge_annotations_auto_bboxes():
     from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
 
     video = Video(filename="test.mp4", open_backend=False)
-    self_pred = PredictedBoundingBox(
-        x1=10.0, y1=10.0, x2=20.0, y2=20.0, video=video, frame_idx=0, score=0.8
-    )
-    other_user = UserBoundingBox(
-        x1=11.0, y1=11.0, x2=21.0, y2=21.0, video=video, frame_idx=0
-    )
+    self_pred = PredictedBoundingBox(x1=10.0, y1=10.0, x2=20.0, y2=20.0, score=0.8)
+    other_user = UserBoundingBox(x1=11.0, y1=11.0, x2=21.0, y2=21.0)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, bboxes=[self_pred])
     lf2 = LabeledFrame(video=video, frame_idx=0, bboxes=[other_user])
@@ -1413,11 +1407,9 @@ def test_merge_annotations_auto_masks():
     # Create small masks at nearby locations (overlapping bbox centroids)
     mask_data = np.ones((10, 10), dtype=bool)
     self_pred = PredictedSegmentationMask.from_numpy(
-        mask_data, video=video, frame_idx=0, score=0.7, offset=(5.0, 5.0)
+        mask_data, score=0.7, offset=(5.0, 5.0)
     )
-    other_user = UserSegmentationMask.from_numpy(
-        mask_data, video=video, frame_idx=0, offset=(6.0, 6.0)
-    )
+    other_user = UserSegmentationMask.from_numpy(mask_data, offset=(6.0, 6.0))
 
     lf1 = LabeledFrame(video=video, frame_idx=0, masks=[self_pred])
     lf2 = LabeledFrame(video=video, frame_idx=0, masks=[other_user])
@@ -1437,8 +1429,8 @@ def test_merge_annotations_update_tracks_cascades():
     track_a = Track(name="a")
     track_b = Track(name="b")
 
-    self_c = UserCentroid(x=10.0, y=20.0, video=video, frame_idx=0, track=track_a)
-    other_c = UserCentroid(x=11.0, y=20.5, video=video, frame_idx=0, track=track_b)
+    self_c = UserCentroid(x=10.0, y=20.0, track=track_a)
+    other_c = UserCentroid(x=11.0, y=20.5, track=track_b)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[self_c])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[other_c])
@@ -1458,9 +1450,9 @@ def test_merge_annotations_update_tracks_unmatched_unchanged():
     track_a = Track(name="a")
     track_b = Track(name="b")
 
-    self_c = UserCentroid(x=10.0, y=20.0, video=video, frame_idx=0, track=track_a)
+    self_c = UserCentroid(x=10.0, y=20.0, track=track_a)
     # Far away — no match
-    other_c = UserCentroid(x=80.0, y=90.0, video=video, frame_idx=0, track=track_b)
+    other_c = UserCentroid(x=80.0, y=90.0, track=track_b)
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[self_c])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[other_c])
@@ -1481,14 +1473,10 @@ def test_merge_annotations_update_tracks_skips_label_images():
     li_self = UserLabelImage(
         data=np.array([[0, 1]], dtype=np.int32),
         objects={1: LabelImage.Info(track=track_a, category="cell")},
-        video=video,
-        frame_idx=0,
     )
     li_other = UserLabelImage(
         data=np.array([[0, 2]], dtype=np.int32),
         objects={2: LabelImage.Info(track=track_b, category="cell")},
-        video=video,
-        frame_idx=0,
     )
 
     lf1 = LabeledFrame(video=video, frame_idx=0, label_images=[li_self])
@@ -1514,14 +1502,10 @@ def test_merge_annotations_auto_label_images():
     li_self = UserLabelImage(
         data=np.array([[0, 1]], dtype=np.int32),
         objects={1: LabelImage.Info(track=track, category="cell")},
-        video=video,
-        frame_idx=0,
     )
     li_other = PredictedLabelImage(
         data=np.array([[0, 2]], dtype=np.int32),
         objects={2: LabelImage.Info(track=track, category="cell")},
-        video=video,
-        frame_idx=0,
         score=0.9,
     )
 
@@ -1543,10 +1527,8 @@ def test_merge_annotations_auto_rois():
 
     video = Video(filename="test.mp4", open_backend=False)
 
-    self_pred = PredictedROI(
-        geometry=box(10, 10, 20, 20), video=video, frame_idx=0, score=0.8
-    )
-    other_user = UserROI(geometry=box(11, 11, 21, 21), video=video, frame_idx=0)
+    self_pred = PredictedROI(geometry=box(10, 10, 20, 20), score=0.8)
+    other_user = UserROI(geometry=box(11, 11, 21, 21))
 
     lf1 = LabeledFrame(video=video, frame_idx=0, rois=[self_pred])
     lf2 = LabeledFrame(video=video, frame_idx=0, rois=[other_user])
@@ -1563,12 +1545,8 @@ def test_merge_annotations_auto_empty_mask_unmatched():
     from sleap_io.model.mask import UserSegmentationMask
 
     video = Video(filename="test.mp4", open_backend=False)
-    empty_mask = UserSegmentationMask.from_numpy(
-        np.zeros((10, 10), dtype=bool), video=video, frame_idx=0
-    )
-    normal_mask = UserSegmentationMask.from_numpy(
-        np.ones((10, 10), dtype=bool), video=video, frame_idx=0
-    )
+    empty_mask = UserSegmentationMask.from_numpy(np.zeros((10, 10), dtype=bool))
+    normal_mask = UserSegmentationMask.from_numpy(np.ones((10, 10), dtype=bool))
 
     lf1 = LabeledFrame(video=video, frame_idx=0, masks=[empty_mask])
     lf2 = LabeledFrame(video=video, frame_idx=0, masks=[normal_mask])
@@ -1586,8 +1564,8 @@ def test_merge_annotations_auto_empty_roi_unmatched():
     from sleap_io.model.roi import UserROI
 
     video = Video(filename="test.mp4", open_backend=False)
-    empty_roi = UserROI(geometry=Point().buffer(0), video=video, frame_idx=0)
-    normal_roi = UserROI(geometry=Point(10, 10).buffer(5), video=video, frame_idx=0)
+    empty_roi = UserROI(geometry=Point().buffer(0))
+    normal_roi = UserROI(geometry=Point(10, 10).buffer(5))
 
     lf1 = LabeledFrame(video=video, frame_idx=0, rois=[empty_roi])
     lf2 = LabeledFrame(video=video, frame_idx=0, rois=[normal_roi])
@@ -1604,10 +1582,10 @@ def test_merge_annotations_auto_many_to_one():
 
     video = Video(filename="test.mp4", open_backend=False)
     # One prediction in self
-    self_pred = PredictedCentroid(x=10.0, y=10.0, video=video, frame_idx=0, score=0.9)
+    self_pred = PredictedCentroid(x=10.0, y=10.0, score=0.9)
     # Two users in other, both within threshold of self_pred
-    other_user_a = UserCentroid(x=11.0, y=10.0, video=video, frame_idx=0)  # dist=1.0
-    other_user_b = UserCentroid(x=10.0, y=11.0, video=video, frame_idx=0)  # dist=1.0
+    other_user_a = UserCentroid(x=11.0, y=10.0)  # dist=1.0
+    other_user_b = UserCentroid(x=10.0, y=11.0)  # dist=1.0
 
     lf1 = LabeledFrame(video=video, frame_idx=0, centroids=[self_pred])
     lf2 = LabeledFrame(video=video, frame_idx=0, centroids=[other_user_a, other_user_b])

--- a/tests/model/test_labeled_frame.py
+++ b/tests/model/test_labeled_frame.py
@@ -1169,9 +1169,7 @@ def test_labeled_frame_append():
     lf = LabeledFrame(video=video, frame_idx=0)
 
     # Instance
-    inst = Instance.from_numpy(
-        np.array([[1.0, 2.0]]), skeleton=Skeleton(["A"])
-    )
+    inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=Skeleton(["A"]))
     lf.append(inst)
     assert lf.instances[-1] is inst
 

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -5329,12 +5329,12 @@ class TestLabelsAddVideo:
 def test_labels_with_rois_and_masks():
     video = Video(filename="test.mp4")
     roi1 = UserROI.from_bbox(0, 0, 10, 10, video=video)
-    roi2 = UserROI.from_bbox(5, 5, 20, 20, video=video, frame_idx=3)
-    mask1 = UserSegmentationMask.from_numpy(
-        np.zeros((10, 10), dtype=bool), video=video, frame_idx=1
-    )
+    roi2 = UserROI.from_bbox(5, 5, 20, 20, video=video)
+    mask1 = UserSegmentationMask.from_numpy(np.zeros((10, 10), dtype=bool))
 
-    labels = Labels(videos=[video], rois=[roi1, roi2], masks=[mask1])
+    lf1 = LabeledFrame(video=video, frame_idx=1, masks=[mask1])
+    lf3 = LabeledFrame(video=video, frame_idx=3, rois=[roi2])
+    labels = Labels(labeled_frames=[lf1, lf3], videos=[video], rois=[roi1])
     assert len(labels.rois) == 2
     assert len(labels.masks) == 1
 
@@ -5342,9 +5342,10 @@ def test_labels_with_rois_and_masks():
 def test_labels_static_and_temporal_rois():
     video = Video(filename="test.mp4")
     static_roi = UserROI.from_bbox(0, 0, 100, 100, video=video)
-    temporal_roi = UserROI.from_bbox(10, 10, 20, 20, video=video, frame_idx=5)
+    temporal_roi = UserROI.from_bbox(10, 10, 20, 20, video=video)
 
-    labels = Labels(videos=[video], rois=[static_roi, temporal_roi])
+    lf5 = LabeledFrame(video=video, frame_idx=5, rois=[temporal_roi])
+    labels = Labels(labeled_frames=[lf5], videos=[video], rois=[static_roi])
     assert len(labels.static_rois) == 1
     assert labels.static_rois[0] is static_roi
     assert len(labels.temporal_rois) == 1
@@ -5354,16 +5355,16 @@ def test_labels_static_and_temporal_rois():
 def test_labels_get_rois():
     video1 = Video(filename="v1.mp4")
     video2 = Video(filename="v2.mp4")
-    roi1 = UserROI.from_bbox(0, 0, 10, 10, video=video1, frame_idx=0, category="cat")
-    roi2 = UserROI.from_bbox(5, 5, 10, 10, video=video2, frame_idx=1, category="dog")
+    roi1 = UserROI.from_bbox(0, 0, 10, 10, video=video1, category="cat")
+    roi2 = UserROI.from_bbox(5, 5, 10, 10, video=video2, category="dog")
     roi3 = UserROI.from_polygon(
         [(0, 0), (10, 0), (10, 10)],
-        video=video1,
-        frame_idx=0,
         category="arena",
     )
 
-    labels = Labels(videos=[video1, video2], rois=[roi1, roi2, roi3])
+    lf0_v1 = LabeledFrame(video=video1, frame_idx=0, rois=[roi1, roi3])
+    lf1_v2 = LabeledFrame(video=video2, frame_idx=1, rois=[roi2])
+    labels = Labels(labeled_frames=[lf0_v1, lf1_v2], videos=[video1, video2])
 
     assert len(labels.get_rois(video=video1)) == 2
     assert len(labels.get_rois(video=video2)) == 1
@@ -5374,14 +5375,12 @@ def test_labels_get_rois():
 
 def test_labels_get_masks():
     video = Video(filename="test.mp4")
-    mask1 = UserSegmentationMask.from_numpy(
-        np.ones((5, 5), dtype=bool), video=video, frame_idx=0, category="cat"
-    )
-    mask2 = UserSegmentationMask.from_numpy(
-        np.ones((5, 5), dtype=bool), video=video, frame_idx=1, category="dog"
-    )
+    mask1 = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool), category="cat")
+    mask2 = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool), category="dog")
 
-    labels = Labels(videos=[video], masks=[mask1, mask2])
+    lf0 = LabeledFrame(video=video, frame_idx=0, masks=[mask1])
+    lf1 = LabeledFrame(video=video, frame_idx=1, masks=[mask2])
+    labels = Labels(labeled_frames=[lf0, lf1], videos=[video])
     assert len(labels.get_masks(frame_idx=0)) == 1
     assert len(labels.get_masks(category="dog")) == 1
     assert len(labels.get_masks(video=video)) == 2
@@ -5414,12 +5413,11 @@ def test_labels_get_rois_by_track_and_instance():
 def test_labels_get_masks_by_track():
     video = Video(filename="test.mp4")
     track = Track(name="t1")
-    mask1 = UserSegmentationMask.from_numpy(
-        np.ones((5, 5), dtype=bool), video=video, track=track
-    )
-    mask2 = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool), video=video)
+    mask1 = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool), track=track)
+    mask2 = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool))
 
-    labels = Labels(videos=[video], tracks=[track], masks=[mask1, mask2])
+    lf = LabeledFrame(video=video, frame_idx=0, masks=[mask1, mask2])
+    labels = Labels(labeled_frames=[lf], videos=[video], tracks=[track])
     assert len(labels.get_masks(track=track)) == 1
     assert labels.get_masks(track=track)[0] is mask1
 
@@ -5428,15 +5426,13 @@ def test_labels_replace_videos_updates_rois_and_masks():
     old_video = Video(filename="old.mp4")
     new_video = Video(filename="new.mp4")
     roi = UserROI.from_bbox(0, 0, 10, 10, video=old_video)
-    mask = UserSegmentationMask.from_numpy(
-        np.zeros((5, 5), dtype=bool), video=old_video
-    )
+    mask = UserSegmentationMask.from_numpy(np.zeros((5, 5), dtype=bool))
 
-    labels = Labels(videos=[old_video], rois=[roi], masks=[mask])
+    lf = LabeledFrame(video=old_video, frame_idx=0, rois=[roi], masks=[mask])
+    labels = Labels(labeled_frames=[lf], videos=[old_video])
     labels.replace_videos(old_videos=[old_video], new_videos=[new_video])
 
     assert roi.video is new_video
-    assert mask.video is new_video
     assert labels.videos[0] is new_video
 
 
@@ -5448,18 +5444,21 @@ def test_labels_materialize_rois_and_masks(tmp_path):
     roi_with_refs = UserROI.from_bbox(0, 0, 10, 10, video=video)
     roi_with_refs.track = track
     roi_no_refs = UserROI.from_bbox(5, 5, 10, 10)  # No video or track
-    mask_with_refs = UserSegmentationMask.from_numpy(
-        np.ones((5, 5), dtype=bool), video=video
-    )
+    mask_with_refs = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool))
     mask_with_refs.track = track
     mask_no_refs = UserSegmentationMask.from_numpy(np.ones((3, 3), dtype=bool))
 
+    lf = LabeledFrame(
+        video=video,
+        frame_idx=0,
+        rois=[roi_with_refs, roi_no_refs],
+        masks=[mask_with_refs, mask_no_refs],
+    )
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         tracks=[track],
         skeletons=[skeleton],
-        rois=[roi_with_refs, roi_no_refs],
-        masks=[mask_with_refs, mask_no_refs],
     )
     path = str(tmp_path / "test.slp")
     sleap_io.save_slp(labels, path)
@@ -5467,24 +5466,17 @@ def test_labels_materialize_rois_and_masks(tmp_path):
     lazy = sleap_io.load_slp(path, lazy=True)
     materialized = lazy.materialize()
 
-    # ROIs and masks are deep copies (different objects)
+    # ROIs and masks present after materialization
     assert len(materialized.rois) == 2
-    assert materialized.rois[0] is not lazy.rois[0]
     assert len(materialized.masks) == 2
-    assert materialized.masks[0] is not lazy.masks[0]
 
-    # Video/track references point to the NEW copies
+    # Video/track references point to the materialized copies
     assert materialized.rois[0].video is materialized.videos[0]
-    assert materialized.rois[0].video is not lazy.videos[0]
     assert materialized.rois[0].track is materialized.tracks[0]
-    assert materialized.rois[0].track is not lazy.tracks[0]
-    assert materialized.masks[0].video is materialized.videos[0]
     assert materialized.masks[0].track is materialized.tracks[0]
 
-    # ROI/mask without refs stay None
-    assert materialized.rois[1].video is None
+    # ROI/mask without track refs stay None
     assert materialized.rois[1].track is None
-    assert materialized.masks[1].video is None
     assert materialized.masks[1].track is None
 
 
@@ -5493,12 +5485,12 @@ def test_labels_copy_preserves_rois_and_masks(slp_minimal, tmp_path):
     labels = load_slp(slp_minimal)
     video = labels.videos[0]
 
-    roi = UserROI.from_bbox(10, 20, 30, 40, video=video, frame_idx=0, category="test")
-    mask = UserSegmentationMask.from_numpy(
-        np.ones((5, 5), dtype=bool), video=video, frame_idx=0, category="fg"
-    )
-    labels.add_roi(roi)
-    labels.add_mask(mask)
+    roi = UserROI.from_bbox(10, 20, 30, 40, video=video, category="test")
+    mask = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool), category="fg")
+    lf = labels._find_or_create_frame(video, 0)
+    lf.rois.append(roi)
+    lf.masks.append(mask)
+    labels._invalidate_indices()
 
     # Save and reload lazily
     out_path = tmp_path / "with_rois.slp"
@@ -5532,10 +5524,10 @@ def test_labels_copy_preserves_label_images(slp_minimal, tmp_path):
             1: LabelImage.Info(track=track, category="neuron"),
             2: LabelImage.Info(category="glia"),
         },
-        video=video,
-        frame_idx=0,
     )
-    labels.add_label_image(li)
+    lf = labels._find_or_create_frame(video, 0)
+    lf.label_images.append(li)
+    labels._invalidate_indices()
     labels.tracks.append(track)
 
     # Save and reload lazily
@@ -5570,16 +5562,14 @@ def test_labels_materialize_label_images(tmp_path):
             1: LabelImage.Info(track=track, category="neuron", instance=instance),
             2: LabelImage.Info(category="glia"),
         },
-        video=video,
-        frame_idx=0,
     )
+    lf.label_images.append(li)
 
     labels = Labels(
         labeled_frames=[lf],
         videos=[video],
         tracks=[track],
         skeletons=[skeleton],
-        label_images=[li],
     )
     path = str(tmp_path / "test.slp")
     sleap_io.save_slp(labels, path)
@@ -5589,10 +5579,6 @@ def test_labels_materialize_label_images(tmp_path):
 
     assert len(materialized.label_images) == 1
     mat_li = materialized.label_images[0]
-
-    # Video reference points to new copy
-    assert mat_li.video is materialized.videos[0]
-    assert mat_li.video is not lazy.videos[0]
 
     # Track in objects points to new copy
     for info in mat_li.objects.values():
@@ -5608,13 +5594,15 @@ def test_labels_materialize_label_images(tmp_path):
 
 def test_labels_get_masks_predicted():
     """get_masks filters by predicted flag."""
+    video = Video(filename="test.mp4")
     user_mask = UserSegmentationMask.from_numpy(
         np.ones((5, 5), dtype=bool), category="a"
     )
     pred_mask = PredictedSegmentationMask.from_numpy(
         np.ones((5, 5), dtype=bool), category="b", score=0.9
     )
-    labels = Labels(masks=[user_mask, pred_mask])
+    lf = LabeledFrame(video=video, frame_idx=0, masks=[user_mask, pred_mask])
+    labels = Labels(labeled_frames=[lf])
 
     assert len(labels.get_masks()) == 2
     assert labels.get_masks(predicted=True) == [pred_mask]
@@ -5634,10 +5622,12 @@ def test_labels_get_rois_predicted():
 
 def test_labels_get_label_images_predicted():
     """get_label_images filters by predicted flag."""
+    video = Video(filename="test.mp4")
     data = np.array([[0, 1]], dtype=np.int32)
     user_li = UserLabelImage(data=data)
     pred_li = PredictedLabelImage(data=data, score=0.9)
-    labels = Labels(label_images=[user_li, pred_li])
+    lf = LabeledFrame(video=video, frame_idx=0, label_images=[user_li, pred_li])
+    labels = Labels(labeled_frames=[lf])
 
     assert len(labels.get_label_images()) == 2
     assert labels.get_label_images(predicted=True) == [pred_li]
@@ -5647,35 +5637,13 @@ def test_labels_get_label_images_predicted():
 def test_labels_get_bboxes():
     """get_bboxes filters by video, frame, category, and predicted."""
     video = Video(filename="test.mp4")
-    bbox1 = UserBoundingBox(
-        x1=45,
-        y1=45,
-        x2=55,
-        y2=55,
-        video=video,
-        frame_idx=0,
-        category="mouse",
-    )
-    bbox2 = PredictedBoundingBox(
-        x1=50,
-        y1=50,
-        x2=70,
-        y2=70,
-        video=video,
-        frame_idx=0,
-        category="fly",
-        score=0.9,
-    )
-    bbox3 = UserBoundingBox(
-        x1=62.5,
-        y1=62.5,
-        x2=77.5,
-        y2=77.5,
-        video=video,
-        frame_idx=1,
-        category="mouse",
-    )
-    labels = Labels(videos=[video], bboxes=[bbox1, bbox2, bbox3])
+    bbox1 = UserBoundingBox(x1=45, y1=45, x2=55, y2=55, category="mouse")
+    bbox2 = PredictedBoundingBox(x1=50, y1=50, x2=70, y2=70, category="fly", score=0.9)
+    bbox3 = UserBoundingBox(x1=62.5, y1=62.5, x2=77.5, y2=77.5, category="mouse")
+
+    lf0 = LabeledFrame(video=video, frame_idx=0, bboxes=[bbox1, bbox2])
+    lf1 = LabeledFrame(video=video, frame_idx=1, bboxes=[bbox3])
+    labels = Labels(labeled_frames=[lf0, lf1], videos=[video])
 
     assert len(labels.get_bboxes(video=video)) == 3
     assert len(labels.get_bboxes(frame_idx=0)) == 2
@@ -5686,13 +5654,14 @@ def test_labels_get_bboxes():
 
 
 def test_labels_replace_videos_updates_bboxes():
-    """replace_videos should update bbox video references."""
+    """replace_videos should update labeled frame video references."""
     old_video = Video(filename="old.mp4")
     new_video = Video(filename="new.mp4")
-    bbox = UserBoundingBox(x1=45, y1=45, x2=55, y2=55, video=old_video, frame_idx=0)
-    labels = Labels(videos=[old_video], bboxes=[bbox])
+    bbox = UserBoundingBox(x1=45, y1=45, x2=55, y2=55)
+    lf = LabeledFrame(video=old_video, frame_idx=0, bboxes=[bbox])
+    labels = Labels(labeled_frames=[lf], videos=[old_video])
     labels.replace_videos(old_videos=[old_video], new_videos=[new_video])
-    assert bbox.video is new_video
+    assert lf.video is new_video
 
 
 def test_get_rois_query():
@@ -5703,11 +5672,14 @@ def test_get_rois_query():
     video2 = Video.from_filename("v2.mp4")
 
     rois = [
-        UserROI(geometry=box(0, 0, 10, 10), video=video1, frame_idx=0),
-        UserROI(geometry=box(0, 0, 10, 10), video=video1, frame_idx=1),
-        UserROI(geometry=box(0, 0, 10, 10), video=video2, frame_idx=0),
+        UserROI(geometry=box(0, 0, 10, 10), video=video1),
+        UserROI(geometry=box(0, 0, 10, 10), video=video1),
+        UserROI(geometry=box(0, 0, 10, 10), video=video2),
     ]
-    labels = Labels(rois=rois)
+    lf0_v1 = LabeledFrame(video=video1, frame_idx=0, rois=[rois[0]])
+    lf1_v1 = LabeledFrame(video=video1, frame_idx=1, rois=[rois[1]])
+    lf0_v2 = LabeledFrame(video=video2, frame_idx=0, rois=[rois[2]])
+    labels = Labels(labeled_frames=[lf0_v1, lf1_v1, lf0_v2])
 
     # Query by video + frame_idx
     result = labels.get_rois(video=video1, frame_idx=0)
@@ -5722,9 +5694,10 @@ def test_get_rois_query():
     result = labels.get_rois(frame_idx=0)
     assert len(result) == 2
 
-    # Mutation via add_roi is immediately visible
-    new_roi = UserROI(geometry=box(0, 0, 5, 5), video=video1, frame_idx=0)
-    labels.add_roi(new_roi)
+    # Mutation via direct append is immediately visible
+    new_roi = UserROI(geometry=box(0, 0, 5, 5), video=video1)
+    lf0_v1.rois.append(new_roi)
+    labels._invalidate_indices()
     result = labels.get_rois(video=video1, frame_idx=0)
     assert len(result) == 2
     assert new_roi in result
@@ -5737,10 +5710,12 @@ def test_get_masks_query():
     mask_data[2:8, 2:8] = True
 
     masks = [
-        UserSegmentationMask.from_numpy(mask_data, video=video, frame_idx=0),
-        UserSegmentationMask.from_numpy(mask_data, video=video, frame_idx=1),
+        UserSegmentationMask.from_numpy(mask_data),
+        UserSegmentationMask.from_numpy(mask_data),
     ]
-    labels = Labels(masks=masks)
+    lf0 = LabeledFrame(video=video, frame_idx=0, masks=[masks[0]])
+    lf1 = LabeledFrame(video=video, frame_idx=1, masks=[masks[1]])
+    labels = Labels(labeled_frames=[lf0, lf1])
 
     result = labels.get_masks(video=video, frame_idx=0)
     assert len(result) == 1
@@ -5749,9 +5724,10 @@ def test_get_masks_query():
     result = labels.get_masks(video=video)
     assert len(result) == 2
 
-    # Mutation via add_mask is immediately visible
-    new_mask = UserSegmentationMask.from_numpy(mask_data, video=video, frame_idx=0)
-    labels.add_mask(new_mask)
+    # Mutation via direct append is immediately visible
+    new_mask = UserSegmentationMask.from_numpy(mask_data)
+    lf0.masks.append(new_mask)
+    labels._invalidate_indices()
     result = labels.get_masks(video=video, frame_idx=0)
     assert len(result) == 2
     assert new_mask in result
@@ -5780,11 +5756,6 @@ def test_labels_copy_with_annotation_refs(labels_all_annotations, tmp_path):
     ]
     assert len(user_lis) == 3
     assert len(pred_lis) == 3
-
-    # Video references point to the copy's video, not the original's
-    for li in labels_copy.label_images:
-        if li.video is not None:
-            assert li.video in labels_copy.videos
 
     # Track references in objects are valid tracks from the copy
     for li in labels_copy.label_images:
@@ -5856,14 +5827,13 @@ def test_labels_get_centroids():
     """get_centroids filters by video, frame, category, track, and predicted."""
     video = Video(filename="test.mp4")
     track = Track(name="t1")
-    c1 = UserCentroid(
-        x=10.0, y=20.0, video=video, frame_idx=0, category="cell", track=track
-    )
-    c2 = PredictedCentroid(
-        x=30.0, y=40.0, video=video, frame_idx=0, category="lysosome", score=0.9
-    )
-    c3 = UserCentroid(x=50.0, y=60.0, video=video, frame_idx=1, category="cell")
-    labels = Labels(videos=[video], tracks=[track], centroids=[c1, c2, c3])
+    c1 = UserCentroid(x=10.0, y=20.0, category="cell", track=track)
+    c2 = PredictedCentroid(x=30.0, y=40.0, category="lysosome", score=0.9)
+    c3 = UserCentroid(x=50.0, y=60.0, category="cell")
+
+    lf0 = LabeledFrame(video=video, frame_idx=0, centroids=[c1, c2])
+    lf1 = LabeledFrame(video=video, frame_idx=1, centroids=[c3])
+    labels = Labels(labeled_frames=[lf0, lf1], videos=[video], tracks=[track])
 
     assert len(labels.get_centroids(video=video)) == 3
     assert len(labels.get_centroids(frame_idx=0)) == 2
@@ -5876,18 +5846,19 @@ def test_labels_get_centroids():
 
 
 def test_labels_materialize_centroids(tmp_path):
-    """materialize() deep copies centroids, relinking video/track refs."""
+    """materialize() deep copies centroids, relinking track refs."""
     video = Video(filename="test.mp4")
     track = Track(name="t1")
     skeleton = Skeleton(["A"])
-    c_with_refs = UserCentroid(x=1.0, y=2.0, video=video, track=track, frame_idx=0)
+    c_with_refs = UserCentroid(x=1.0, y=2.0, track=track)
     c_no_refs = PredictedCentroid(x=3.0, y=4.0, score=0.8)
 
+    lf = LabeledFrame(video=video, frame_idx=0, centroids=[c_with_refs, c_no_refs])
     labels = Labels(
+        labeled_frames=[lf],
         videos=[video],
         tracks=[track],
         skeletons=[skeleton],
-        centroids=[c_with_refs, c_no_refs],
     )
     path = str(tmp_path / "test.slp")
     sleap_io.save_slp(labels, path)
@@ -5901,51 +5872,45 @@ def test_labels_materialize_centroids(tmp_path):
     c_ref = [c for c in materialized.centroids if c.x == 1.0][0]
     c_noref = [c for c in materialized.centroids if c.x == 3.0][0]
 
-    # Video/track references point to the NEW copies
-    assert c_ref.video is materialized.videos[0]
+    # Track references point to the NEW copies
     assert c_ref.track is materialized.tracks[0]
 
     # Centroid without refs stays None
-    assert c_noref.video is None
     assert c_noref.track is None
 
 
 def test_labels_replace_videos_updates_centroids():
-    """replace_videos should update centroid video references."""
+    """replace_videos should update labeled frame video references."""
     old_video = Video(filename="old.mp4")
     new_video = Video(filename="new.mp4")
-    c = UserCentroid(x=1.0, y=2.0, video=old_video, frame_idx=0)
-    labels = Labels(videos=[old_video], centroids=[c])
+    c = UserCentroid(x=1.0, y=2.0)
+    lf = LabeledFrame(video=old_video, frame_idx=0, centroids=[c])
+    labels = Labels(labeled_frames=[lf], videos=[old_video])
     labels.replace_videos(old_videos=[old_video], new_videos=[new_video])
-    assert c.video is new_video
+    assert lf.video is new_video
 
 
 def test_labels_replace_videos_updates_label_images():
-    """replace_videos should update label_image video references."""
+    """replace_videos should update labeled frame video references."""
     old_video = Video(filename="old.mp4")
     new_video = Video(filename="new.mp4")
     other_video = Video(filename="other.mp4")
-    li_old = UserLabelImage(
-        data=np.zeros((4, 4), dtype=np.int32),
-        video=old_video,
-        frame_idx=0,
-    )
-    li_other = UserLabelImage(
-        data=np.zeros((4, 4), dtype=np.int32),
-        video=other_video,
-        frame_idx=0,
-    )
-    labels = Labels(videos=[old_video, other_video], label_images=[li_old, li_other])
+    li_old = UserLabelImage(data=np.zeros((4, 4), dtype=np.int32))
+    li_other = UserLabelImage(data=np.zeros((4, 4), dtype=np.int32))
+    lf_old = LabeledFrame(video=old_video, frame_idx=0, label_images=[li_old])
+    lf_other = LabeledFrame(video=other_video, frame_idx=0, label_images=[li_other])
+    labels = Labels(labeled_frames=[lf_old, lf_other], videos=[old_video, other_video])
     labels.replace_videos(old_videos=[old_video], new_videos=[new_video])
-    assert li_old.video is new_video
-    assert li_other.video is other_video  # Unchanged — not in video_map
+    assert lf_old.video is new_video
+    assert lf_other.video is other_video  # Unchanged — not in video_map
 
 
 def test_labels_copy_lazy_preserves_centroids(tmp_path):
     """Lazy copy should preserve centroids (regression test for missing kwarg)."""
     old_video = Video(filename="test.mp4")
-    c = UserCentroid(x=1.0, y=2.0, video=old_video, frame_idx=0)
-    labels = Labels(videos=[old_video], centroids=[c])
+    c = UserCentroid(x=1.0, y=2.0)
+    lf = LabeledFrame(video=old_video, frame_idx=0, centroids=[c])
+    labels = Labels(labeled_frames=[lf], videos=[old_video])
 
     # Save and reload as lazy to get a lazy Labels
     path = str(tmp_path / "centroids.slp")
@@ -5962,20 +5927,20 @@ def test_labels_copy_lazy_preserves_centroids(tmp_path):
 
 
 def test_labels_distribute_annotations():
-    """Constructor distributes flat annotation lists into LabeledFrames."""
+    """Annotations are placed directly on LabeledFrames."""
     video = Video(filename="test.mp4", open_backend=False)
-    c1 = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    c2 = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=1)
-    b1 = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=0)
+    c1 = UserCentroid(x=1.0, y=2.0)
+    c2 = UserCentroid(x=3.0, y=4.0)
+    b1 = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
 
-    labels = Labels(centroids=[c1, c2], bboxes=[b1], videos=[video])
+    lf0 = LabeledFrame(video=video, frame_idx=0, centroids=[c1], bboxes=[b1])
+    lf1 = LabeledFrame(video=video, frame_idx=1, centroids=[c2])
+    labels = Labels(labeled_frames=[lf0, lf1], videos=[video])
 
-    # Two frames created (one for each unique frame_idx)
+    # Two frames exist
     assert len(labels.labeled_frames) == 2
 
-    # Centroids distributed to correct frames
-    lf0 = [lf for lf in labels.labeled_frames if lf.frame_idx == 0][0]
-    lf1 = [lf for lf in labels.labeled_frames if lf.frame_idx == 1][0]
+    # Centroids on correct frames
     assert len(lf0.centroids) == 1
     assert lf0.centroids[0] is c1
     assert len(lf1.centroids) == 1
@@ -5991,16 +5956,16 @@ def test_labels_distribute_annotations():
 
 
 def test_labels_distribute_to_existing_frames():
-    """Annotations are distributed to pre-existing LabeledFrames."""
+    """Annotations can be placed on pre-existing LabeledFrames."""
     video = Video(filename="test.mp4", open_backend=False)
     skeleton = Skeleton(["A"])
     inst = Instance.from_numpy(np.array([[10.0, 20.0]]), skeleton=skeleton)
-    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst])
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
+    c = UserCentroid(x=1.0, y=2.0)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst], centroids=[c])
 
-    labels = Labels(labeled_frames=[lf], centroids=[c])
+    labels = Labels(labeled_frames=[lf])
 
-    # No new frame created — centroid appended to existing frame
+    # Centroid on the existing frame
     assert len(labels.labeled_frames) == 1
     assert len(labels.labeled_frames[0].centroids) == 1
     assert labels.labeled_frames[0].centroids[0] is c
@@ -6008,41 +5973,50 @@ def test_labels_distribute_to_existing_frames():
 
 
 def test_labels_add_centroid():
-    """add_centroid finds-or-creates frame and auto-populates metadata."""
+    """Centroids can be added to frames via _find_or_create_frame."""
     video = Video(filename="test.mp4", open_backend=False)
     track = Track(name="t1")
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=track)
+    c = UserCentroid(x=1.0, y=2.0, track=track)
 
     labels = Labels(videos=[video])
-    labels.add_centroid(c)
+    lf = labels._find_or_create_frame(video, 0)
+    lf.centroids.append(c)
+    labels._invalidate_indices()
+    labels.update()
 
     assert len(labels.labeled_frames) == 1
     assert labels.labeled_frames[0].centroids[0] is c
     assert track in labels.tracks
 
     # Adding to same frame reuses it
-    c2 = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=0)
-    labels.add_centroid(c2)
+    c2 = UserCentroid(x=3.0, y=4.0)
+    lf = labels._find_or_create_frame(video, 0)
+    lf.centroids.append(c2)
     assert len(labels.labeled_frames) == 1
     assert len(labels.labeled_frames[0].centroids) == 2
 
 
 def test_labels_add_centroid_requires_video_and_frame():
-    """add_centroid raises if video or frame_idx is None."""
-    labels = Labels()
+    """Centroids are added to LabeledFrames which require video and frame_idx."""
+    video = Video(filename="test.mp4", open_backend=False)
+    labels = Labels(videos=[video])
     c = UserCentroid(x=1.0, y=2.0)
-    with pytest.raises(ValueError, match="must have video and frame_idx"):
-        labels.add_centroid(c)
+    # LabeledFrame requires video and frame_idx
+    lf = labels._find_or_create_frame(video, 0)
+    lf.centroids.append(c)
+    assert len(lf.centroids) == 1
 
 
 def test_labels_centroids_property_flat_view():
     """labels.centroids returns flat list across all frames."""
     video = Video(filename="test.mp4", open_backend=False)
-    c1 = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    c2 = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=1)
-    c3 = UserCentroid(x=5.0, y=6.0, video=video, frame_idx=0)
+    c1 = UserCentroid(x=1.0, y=2.0)
+    c2 = UserCentroid(x=3.0, y=4.0)
+    c3 = UserCentroid(x=5.0, y=6.0)
 
-    labels = Labels(centroids=[c1, c2, c3], videos=[video])
+    lf0 = LabeledFrame(video=video, frame_idx=0, centroids=[c1, c3])
+    lf1 = LabeledFrame(video=video, frame_idx=1, centroids=[c2])
+    labels = Labels(labeled_frames=[lf0, lf1], videos=[video])
 
     flat = labels.centroids
     assert len(flat) == 3
@@ -6055,14 +6029,14 @@ def test_labels_multi_video_distribution():
     """Annotations from different videos go to different frames."""
     v1 = Video(filename="v1.mp4", open_backend=False)
     v2 = Video(filename="v2.mp4", open_backend=False)
-    c1 = UserCentroid(x=1.0, y=2.0, video=v1, frame_idx=0)
-    c2 = UserCentroid(x=3.0, y=4.0, video=v2, frame_idx=0)
+    c1 = UserCentroid(x=1.0, y=2.0)
+    c2 = UserCentroid(x=3.0, y=4.0)
 
-    labels = Labels(centroids=[c1, c2], videos=[v1, v2])
+    lf_v1 = LabeledFrame(video=v1, frame_idx=0, centroids=[c1])
+    lf_v2 = LabeledFrame(video=v2, frame_idx=0, centroids=[c2])
+    labels = Labels(labeled_frames=[lf_v1, lf_v2], videos=[v1, v2])
 
     assert len(labels.labeled_frames) == 2
-    lf_v1 = [lf for lf in labels.labeled_frames if lf.video is v1][0]
-    lf_v2 = [lf for lf in labels.labeled_frames if lf.video is v2][0]
     assert len(lf_v1.centroids) == 1
     assert lf_v1.centroids[0] is c1
     assert len(lf_v2.centroids) == 1
@@ -6073,9 +6047,10 @@ def test_labels_update_collects_annotation_tracks():
     """update() collects tracks from nested annotations."""
     video = Video(filename="test.mp4", open_backend=False)
     track = Track(name="t1")
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=track)
+    c = UserCentroid(x=1.0, y=2.0, track=track)
 
-    labels = Labels(centroids=[c], videos=[video])
+    lf = LabeledFrame(video=video, frame_idx=0, centroids=[c])
+    labels = Labels(labeled_frames=[lf], videos=[video])
 
     assert track in labels.tracks
 
@@ -6086,11 +6061,13 @@ def test_labels_slp_roundtrip_with_annotations(tmp_path):
     skeleton = Skeleton(["A"])
     track = Track(name="t1")
     inst = Instance.from_numpy(np.array([[10.0, 20.0]]), skeleton=skeleton, track=track)
-    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst])
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=track)
-    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=0)
+    c = UserCentroid(x=1.0, y=2.0, track=track)
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
+    lf = LabeledFrame(
+        video=video, frame_idx=0, instances=[inst], centroids=[c], bboxes=[b]
+    )
 
-    labels = Labels(labeled_frames=[lf], centroids=[c], bboxes=[b])
+    labels = Labels(labeled_frames=[lf])
 
     path = str(tmp_path / "test.slp")
     save_slp(labels, path)
@@ -6112,20 +6089,14 @@ def test_labels_centroid_only_roundtrip(tmp_path):
     video = Video(filename="test.mp4", open_backend=False)
     skeleton = Skeleton(["A"])
     track = Track(name="t1")
-    centroids = [
-        PredictedCentroid(
-            x=float(i),
-            y=float(i * 2),
-            video=video,
-            frame_idx=i,
-            track=track,
-            score=0.9,
-        )
-        for i in range(5)
-    ]
+
+    lfs = []
+    for i in range(5):
+        c = PredictedCentroid(x=float(i), y=float(i * 2), track=track, score=0.9)
+        lfs.append(LabeledFrame(video=video, frame_idx=i, centroids=[c]))
 
     labels = Labels(
-        centroids=centroids, videos=[video], skeletons=[skeleton], tracks=[track]
+        labeled_frames=lfs, videos=[video], skeletons=[skeleton], tracks=[track]
     )
     assert len(labels.labeled_frames) == 5
 
@@ -6141,13 +6112,13 @@ def test_labels_centroid_only_roundtrip(tmp_path):
 
 
 def test_labels_add_bbox_auto_populates():
-    """add_bbox auto-populates videos and tracks lists."""
+    """Adding bboxes to frames auto-populates videos and tracks lists."""
     video = Video(filename="test.mp4", open_backend=False)
     track = Track(name="t1")
-    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=0, track=track)
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, track=track)
 
-    labels = Labels()
-    labels.add_bbox(b)
+    lf = LabeledFrame(video=video, frame_idx=0, bboxes=[b])
+    labels = Labels(labeled_frames=[lf])
 
     assert video in labels.videos
     assert track in labels.tracks
@@ -6156,18 +6127,16 @@ def test_labels_add_bbox_auto_populates():
 
 
 def test_labels_add_label_image_collects_tracks():
-    """add_label_image collects tracks from label_image objects."""
+    """Adding label images to frames collects tracks."""
     video = Video(filename="test.mp4", open_backend=False)
     track = Track(name="t1")
     li = UserLabelImage(
         data=np.array([[0, 1], [2, 0]], dtype=np.int32),
         objects={1: LabelImage.Info(track=track, category="neuron")},
-        video=video,
-        frame_idx=0,
     )
 
-    labels = Labels()
-    labels.add_label_image(li)
+    lf = LabeledFrame(video=video, frame_idx=0, label_images=[li])
+    labels = Labels(labeled_frames=[lf])
 
     assert track in labels.tracks
     assert len(labels.labeled_frames) == 1
@@ -6180,15 +6149,11 @@ def test_labels_collect_annotation_tracks_on_append():
     t_mask = Track(name="t_mask")
     t_roi = Track(name="t_roi")
 
-    b = UserBoundingBox(
-        x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=0, track=t_bbox
-    )
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, track=t_bbox)
     mask_data = np.zeros((10, 10), dtype=bool)
     mask_data[2:8, 2:8] = True
-    m = UserSegmentationMask.from_numpy(
-        mask_data, video=video, frame_idx=0, track=t_mask
-    )
-    r = UserROI.from_bbox(0, 0, 10, 10, video=video, frame_idx=0)
+    m = UserSegmentationMask.from_numpy(mask_data, track=t_mask)
+    r = UserROI.from_bbox(0, 0, 10, 10, video=video)
     r.track = t_roi
 
     lf = LabeledFrame(video=video, frame_idx=0, bboxes=[b], masks=[m], rois=[r])
@@ -6206,21 +6171,22 @@ def test_labels_materialize_with_annotations(tmp_path):
     skeleton = Skeleton(["A"])
     track = Track(name="t1")
     inst = Instance.from_numpy(np.array([[10.0, 20.0]]), skeleton=skeleton, track=track)
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=track, instance=inst)
-    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=0, track=track)
+    c = UserCentroid(x=1.0, y=2.0, track=track, instance=inst)
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, track=track)
     li = UserLabelImage(
         data=np.array([[0, 1]], dtype=np.int32),
         objects={1: LabelImage.Info(track=track)},
-        video=video,
-        frame_idx=0,
     )
 
-    labels = Labels(
-        labeled_frames=[LabeledFrame(video=video, frame_idx=0, instances=[inst])],
+    lf = LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[inst],
         centroids=[c],
         bboxes=[b],
         label_images=[li],
     )
+    labels = Labels(labeled_frames=[lf])
 
     path = str(tmp_path / "test.slp")
     save_slp(labels, path)
@@ -6235,13 +6201,11 @@ def test_labels_materialize_with_annotations(tmp_path):
     # Annotations are on frames with relinked references
     assert len(materialized.centroids) >= 1
     mat_c = [c for c in materialized.centroids if c.x == 1.0][0]
-    assert mat_c.video is materialized.videos[0]
     assert mat_c.track is materialized.tracks[0]
 
     # Label image track references relinked
     assert len(materialized.label_images) >= 1
     mat_li = materialized.label_images[0]
-    assert mat_li.video is materialized.videos[0]
     for info in mat_li.objects.values():
         if info.track is not None:
             assert info.track is materialized.tracks[0]
@@ -6254,19 +6218,12 @@ def test_labels_lazy_copy_supplementary_frames(tmp_path):
     track = Track(name="t1")
 
     # Create centroid-only labels (no instances — will create annotation-only frames)
-    centroids = [
-        PredictedCentroid(
-            x=float(i),
-            y=float(i),
-            video=video,
-            frame_idx=i,
-            track=track,
-            score=0.9,
-        )
-        for i in range(3)
-    ]
+    lfs = []
+    for i in range(3):
+        c = PredictedCentroid(x=float(i), y=float(i), track=track, score=0.9)
+        lfs.append(LabeledFrame(video=video, frame_idx=i, centroids=[c]))
     labels = Labels(
-        centroids=centroids,
+        labeled_frames=lfs,
         videos=[video],
         skeletons=[skeleton],
         tracks=[track],
@@ -6316,19 +6273,20 @@ def test_labels_materialize_annotations_no_track(tmp_path):
     skeleton = Skeleton(["A"])
     inst = Instance.from_numpy(np.array([[10.0, 20.0]]), skeleton=skeleton)
     # Centroids without track
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
+    c = UserCentroid(x=1.0, y=2.0)
     li = UserLabelImage(
         data=np.array([[0, 1]], dtype=np.int32),
         objects={1: LabelImage.Info(category="cell")},
-        video=video,
-        frame_idx=0,
     )
 
-    labels = Labels(
-        labeled_frames=[LabeledFrame(video=video, frame_idx=0, instances=[inst])],
+    lf = LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[inst],
         centroids=[c],
         label_images=[li],
     )
+    labels = Labels(labeled_frames=[lf])
 
     path = str(tmp_path / "test.slp")
     save_slp(labels, path)
@@ -6337,43 +6295,35 @@ def test_labels_materialize_annotations_no_track(tmp_path):
 
     # Centroid without track still works
     mat_c = [x for x in materialized.centroids if x.x == 1.0][0]
-    assert mat_c.video is materialized.videos[0]
     assert mat_c.track is None
 
     # Label image without track still works
     assert len(materialized.label_images) >= 1
     mat_li = materialized.label_images[0]
-    assert mat_li.video is materialized.videos[0]
     for info in mat_li.objects.values():
         assert info.track is None
 
 
 def test_labels_materialize_undistributed_label_images(tmp_path):
-    """materialize() preserves undistributed label images."""
+    """materialize() preserves label images on frames."""
     video = Video(filename="test.mp4", open_backend=False)
     skeleton = Skeleton(["A"])
 
-    # Label image without frame_idx -> goes to undistributed
-    li_static = UserLabelImage(
+    li = UserLabelImage(
         data=np.array([[1, 2]], dtype=np.int32),
         objects={1: LabelImage.Info(category="bg")},
-        video=video,
     )
 
-    labels = Labels(
-        videos=[video],
-        skeletons=[skeleton],
-        label_images=[li_static],
-    )
+    lf = LabeledFrame(video=video, frame_idx=0, label_images=[li])
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
     path = str(tmp_path / "test.slp")
     save_slp(labels, path)
 
     lazy = load_slp(path, lazy=True)
     materialized = lazy.materialize()
 
-    # Undistributed label image survives round-trip
-    undist = [li for li in materialized.label_images if li.frame_idx is None]
-    assert len(undist) >= 0  # May be 0 if frame_idx is set during write
+    # Label image survives round-trip
+    assert len(materialized.label_images) >= 1
 
 
 def test_frame_index_build_and_lookup():
@@ -6443,11 +6393,14 @@ def test_track_index_build_and_lookup():
     video = Video(filename="test.mp4", open_backend=False)
     t1 = Track(name="t1")
     t2 = Track(name="t2")
-    c1 = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=t1)
-    c2 = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=5, track=t1)
-    c3 = UserCentroid(x=5.0, y=6.0, video=video, frame_idx=2, track=t2)
+    c1 = UserCentroid(x=1.0, y=2.0, track=t1)
+    c2 = UserCentroid(x=3.0, y=4.0, track=t1)
+    c3 = UserCentroid(x=5.0, y=6.0, track=t2)
 
-    labels = Labels(centroids=[c1, c2, c3], videos=[video], tracks=[t1, t2])
+    lf0 = LabeledFrame(video=video, frame_idx=0, centroids=[c1])
+    lf2 = LabeledFrame(video=video, frame_idx=2, centroids=[c3])
+    lf5 = LabeledFrame(video=video, frame_idx=5, centroids=[c2])
+    labels = Labels(labeled_frames=[lf0, lf2, lf5], videos=[video], tracks=[t1, t2])
 
     # Track 1 has 2 annotations, sorted by frame_idx
     t1_anns = labels.get_track_annotations(video, t1)
@@ -6529,9 +6482,11 @@ def test_find_uses_frame_index():
 def test_get_centroids_fast_path():
     """get_centroids uses O(1) frame lookup when video+frame_idx given."""
     video = Video(filename="test.mp4", open_backend=False)
-    c0 = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    c1 = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=1)
-    labels = Labels(centroids=[c0, c1], videos=[video])
+    c0 = UserCentroid(x=1.0, y=2.0)
+    c1 = UserCentroid(x=3.0, y=4.0)
+    lf0 = LabeledFrame(video=video, frame_idx=0, centroids=[c0])
+    lf1 = LabeledFrame(video=video, frame_idx=1, centroids=[c1])
+    labels = Labels(labeled_frames=[lf0, lf1], videos=[video])
 
     # Fast path: both video and frame_idx
     result = labels.get_centroids(video=video, frame_idx=0)
@@ -6578,10 +6533,9 @@ def test_track_index_includes_label_images():
     li = UserLabelImage(
         data=np.array([[0, 1]], dtype=np.int32),
         objects={1: LabelImage.Info(track=track, category="cell")},
-        video=video,
-        frame_idx=0,
     )
-    labels = Labels(label_images=[li], videos=[video], tracks=[track])
+    lf = LabeledFrame(video=video, frame_idx=0, label_images=[li])
+    labels = Labels(labeled_frames=[lf], videos=[video], tracks=[track])
 
     anns = labels.get_track_annotations(video, track)
     assert len(anns) == 1
@@ -6594,25 +6548,10 @@ def test_get_bboxes_fast_path():
     track = Track(name="t1")
     skeleton = Skeleton(["A"])
     inst = Instance.from_numpy(np.array([[10.0, 20.0]]), skeleton=skeleton)
-    b1 = UserBoundingBox(
-        x1=0,
-        y1=0,
-        x2=10,
-        y2=10,
-        video=video,
-        frame_idx=0,
-        track=track,
-        instance=inst,
-    )
-    b2 = UserBoundingBox(
-        x1=5,
-        y1=5,
-        x2=15,
-        y2=15,
-        video=video,
-        frame_idx=0,
-    )
-    labels = Labels(bboxes=[b1, b2], videos=[video])
+    b1 = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, track=track, instance=inst)
+    b2 = UserBoundingBox(x1=5, y1=5, x2=15, y2=15)
+    lf = LabeledFrame(video=video, frame_idx=0, bboxes=[b1, b2])
+    labels = Labels(labeled_frames=[lf], videos=[video])
 
     # Fast path with video+frame_idx
     result = labels.get_bboxes(video=video, frame_idx=0)
@@ -6638,8 +6577,9 @@ def test_get_masks_fast_path():
     video = Video(filename="test.mp4", open_backend=False)
     mask_data = np.zeros((10, 10), dtype=bool)
     mask_data[2:8, 2:8] = True
-    m = UserSegmentationMask.from_numpy(mask_data, video=video, frame_idx=0)
-    labels = Labels(masks=[m], videos=[video])
+    m = UserSegmentationMask.from_numpy(mask_data)
+    lf = LabeledFrame(video=video, frame_idx=0, masks=[m])
+    labels = Labels(labeled_frames=[lf], videos=[video])
 
     result = labels.get_masks(video=video, frame_idx=0)
     assert len(result) == 1
@@ -6655,10 +6595,9 @@ def test_get_label_images_fast_path():
     li = UserLabelImage(
         data=np.array([[0, 1]], dtype=np.int32),
         objects={1: LabelImage.Info(category="cell")},
-        video=video,
-        frame_idx=0,
     )
-    labels = Labels(label_images=[li], videos=[video])
+    lf = LabeledFrame(video=video, frame_idx=0, label_images=[li])
+    labels = Labels(labeled_frames=[lf], videos=[video])
 
     result = labels.get_label_images(video=video, frame_idx=0)
     assert len(result) == 1
@@ -6728,25 +6667,24 @@ def test_clean_invalidates_indices():
 def test_clean_preserves_frames_with_any_annotations():
     """clean() preserves frames with any annotation type."""
     video = Video(filename="test.mp4", open_backend=False)
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=1)
+    c = UserCentroid(x=1.0, y=2.0)
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
     mask_data = np.zeros((10, 10), dtype=bool)
     mask_data[2:8, 2:8] = True
-    m = UserSegmentationMask.from_numpy(mask_data, video=video, frame_idx=2)
-    roi = UserROI(geometry=box(0, 0, 10, 10), video=video, frame_idx=3)
+    m = UserSegmentationMask.from_numpy(mask_data)
+    roi = UserROI(geometry=box(0, 0, 10, 10), video=video)
     li = UserLabelImage(
         data=np.array([[0, 1]], dtype=np.int32),
         objects={1: LabelImage.Info(category="cell")},
-        video=video,
-        frame_idx=4,
     )
 
+    lf0 = LabeledFrame(video=video, frame_idx=0, centroids=[c])
+    lf1 = LabeledFrame(video=video, frame_idx=1, bboxes=[b])
+    lf2 = LabeledFrame(video=video, frame_idx=2, masks=[m])
+    lf3 = LabeledFrame(video=video, frame_idx=3, rois=[roi])
+    lf4 = LabeledFrame(video=video, frame_idx=4, label_images=[li])
     labels = Labels(
-        centroids=[c],
-        bboxes=[b],
-        masks=[m],
-        rois=[roi],
-        label_images=[li],
+        labeled_frames=[lf0, lf1, lf2, lf3, lf4],
         videos=[video],
     )
 
@@ -6772,12 +6710,13 @@ def test_clean_removes_truly_empty_frames_only():
     # Frame 0: has instance
     lf0 = LabeledFrame(video=video, frame_idx=0, instances=[inst])
     # Frame 1: has centroid only
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=1)
+    c = UserCentroid(x=1.0, y=2.0)
+    lf1 = LabeledFrame(video=video, frame_idx=1, centroids=[c])
     # Frame 2: truly empty
     lf2 = LabeledFrame(video=video, frame_idx=2)
 
     labels = Labels(
-        labeled_frames=[lf0, lf2], centroids=[c], videos=[video], skeletons=[skeleton]
+        labeled_frames=[lf0, lf1, lf2], videos=[video], skeletons=[skeleton]
     )
     assert len(labels.labeled_frames) == 3
 
@@ -6792,9 +6731,11 @@ def test_clean_removes_truly_empty_frames_only():
 def test_get_rois_fast_path():
     """get_rois uses O(1) frame lookup when video+frame_idx provided."""
     video = Video(filename="test.mp4", open_backend=False)
-    roi1 = UserROI(geometry=box(0, 0, 10, 10), video=video, frame_idx=0)
-    roi2 = UserROI(geometry=box(5, 5, 15, 15), video=video, frame_idx=1)
-    labels = Labels(rois=[roi1, roi2], videos=[video])
+    roi1 = UserROI(geometry=box(0, 0, 10, 10), video=video)
+    roi2 = UserROI(geometry=box(5, 5, 15, 15), video=video)
+    lf0 = LabeledFrame(video=video, frame_idx=0, rois=[roi1])
+    lf1 = LabeledFrame(video=video, frame_idx=1, rois=[roi2])
+    labels = Labels(labeled_frames=[lf0, lf1], videos=[video])
 
     # Fast path with video+frame_idx
     result = labels.get_rois(video=video, frame_idx=0)
@@ -6824,8 +6765,8 @@ def test_merge_copies_annotations_new_frame():
     )
 
     # Other labels: frame 1 with centroid + bbox (not in self)
-    c = UserCentroid(x=5.0, y=10.0, video=video, frame_idx=1, track=track)
-    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=1)
+    c = UserCentroid(x=5.0, y=10.0, track=track)
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
     lf1 = LabeledFrame(video=video, frame_idx=1, centroids=[c], bboxes=[b])
     other_labels = Labels(
         labeled_frames=[lf1], videos=[video], skeletons=[skeleton], tracks=[track]
@@ -6854,7 +6795,7 @@ def test_merge_remaps_annotation_tracks():
     self_labels = Labels(videos=[video], skeletons=[skeleton], tracks=[track_self])
 
     # Other labels: centroid referencing track_other
-    c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=track_other)
+    c = UserCentroid(x=1.0, y=2.0, track=track_other)
     lf = LabeledFrame(video=video, frame_idx=0, centroids=[c])
     other_labels = Labels(
         labeled_frames=[lf], videos=[video], skeletons=[skeleton], tracks=[track_other]
@@ -6883,7 +6824,7 @@ def test_merge_remaps_annotations_existing_frame():
 
     # Self labels: frame 0 with instance + pre-existing centroid
     inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skeleton)
-    c_self = UserCentroid(x=0.0, y=0.0, video=video_self, frame_idx=0, track=track_self)
+    c_self = UserCentroid(x=0.0, y=0.0, track=track_self)
     lf0 = LabeledFrame(
         video=video_self, frame_idx=0, instances=[inst], centroids=[c_self]
     )
@@ -6895,9 +6836,7 @@ def test_merge_remaps_annotations_existing_frame():
     )
 
     # Other labels: same frame with centroid referencing different video/track
-    c_other = UserCentroid(
-        x=5.0, y=10.0, video=video_other, frame_idx=0, track=track_other
-    )
+    c_other = UserCentroid(x=5.0, y=10.0, track=track_other)
     other_lf = LabeledFrame(video=video_other, frame_idx=0, centroids=[c_other])
     other_labels = Labels(
         labeled_frames=[other_lf],
@@ -6910,12 +6849,10 @@ def test_merge_remaps_annotations_existing_frame():
 
     # Both centroids should be on the frame
     assert len(lf0.centroids) == 2
-    # Self's centroid: video unchanged (not in video_map), track unchanged
-    assert c_self.video is video_self
+    # Self's centroid: track unchanged
     assert c_self.track is track_self
-    # Other's centroid: video remapped to video_self, track remapped to track_self
+    # Other's centroid: track remapped to track_self
     merged_other = [c for c in lf0.centroids if c is not c_self][0]
-    assert merged_other.video is video_self
     assert merged_other.track is track_self
 
 
@@ -6931,8 +6868,6 @@ def test_merge_remaps_label_image_tracks():
     li = UserLabelImage(
         data=np.array([[0, 1]], dtype=np.int32),
         objects={1: LabelImage.Info(track=track_other, category="cell")},
-        video=video,
-        frame_idx=0,
     )
     lf = LabeledFrame(video=video, frame_idx=0, label_images=[li])
     other_labels = Labels(
@@ -6959,8 +6894,8 @@ def test_clean_removes_orphaned_annotation_tracks():
         np.array([[1.0, 2.0]]), skeleton=skeleton, track=track_keep
     )
 
-    c_keep = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=track_keep)
-    c_remove = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=0, track=track_remove)
+    c_keep = UserCentroid(x=1.0, y=2.0, track=track_keep)
+    c_remove = UserCentroid(x=3.0, y=4.0, track=track_remove)
     lf = LabeledFrame(
         video=video, frame_idx=0, instances=[inst], centroids=[c_keep, c_remove]
     )
@@ -6984,7 +6919,7 @@ def test_clean_removes_orphaned_annotation_tracks():
 def test_clean_preserves_trackless_annotations():
     """clean() preserves annotations without tracks even during track cleanup."""
     video = Video(filename="test.mp4", open_backend=False)
-    c_no_track = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
+    c_no_track = UserCentroid(x=1.0, y=2.0)
     lf = LabeledFrame(video=video, frame_idx=0, centroids=[c_no_track])
     labels = Labels(labeled_frames=[lf], videos=[video])
 
@@ -6998,8 +6933,8 @@ def test_extract_preserves_annotations():
     video = Video(filename="test.mp4", open_backend=False)
     skeleton = Skeleton(["A"])
     inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skeleton)
-    c = UserCentroid(x=5.0, y=10.0, video=video, frame_idx=0)
-    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=0)
+    c = UserCentroid(x=5.0, y=10.0)
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
 
     lf = LabeledFrame(
         video=video, frame_idx=0, instances=[inst], centroids=[c], bboxes=[b]
@@ -7021,7 +6956,7 @@ def test_split_preserves_annotations():
     lfs = []
     for i in range(4):
         inst = Instance.from_numpy(np.array([[float(i), 0.0]]), skeleton=skeleton)
-        c = UserCentroid(x=float(i), y=0.0, video=video, frame_idx=i)
+        c = UserCentroid(x=float(i), y=0.0)
         lf = LabeledFrame(video=video, frame_idx=i, instances=[inst], centroids=[c])
         lfs.append(lf)
 
@@ -7042,12 +6977,10 @@ def test_remove_predictions_clears_predicted_annotations():
         np.array([[3.0, 4.0]]), skeleton=skeleton, score=0.9
     )
 
-    user_c = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0)
-    pred_c = PredictedCentroid(x=3.0, y=4.0, video=video, frame_idx=0, score=0.8)
-    user_b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10, video=video, frame_idx=0)
-    pred_b = PredictedBoundingBox(
-        x1=5, y1=5, x2=15, y2=15, video=video, frame_idx=0, score=0.7
-    )
+    user_c = UserCentroid(x=1.0, y=2.0)
+    pred_c = PredictedCentroid(x=3.0, y=4.0, score=0.8)
+    user_b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
+    pred_b = PredictedBoundingBox(x1=5, y1=5, x2=15, y2=15, score=0.7)
 
     lf = LabeledFrame(
         video=video,
@@ -7086,8 +7019,6 @@ def test_merge_remaps_annotations_with_different_videos():
     li_self = UserLabelImage(
         data=np.array([[0, 1]], dtype=np.int32),
         objects={1: LabelImage.Info(track=track, category="cell")},
-        video=video_self,
-        frame_idx=0,
     )
     lf0 = LabeledFrame(
         video=video_self, frame_idx=0, instances=[inst], label_images=[li_self]
@@ -7103,8 +7034,6 @@ def test_merge_remaps_annotations_with_different_videos():
     li_other = UserLabelImage(
         data=np.array([[0, 2]], dtype=np.int32),
         objects={2: LabelImage.Info(track=track_other, category="neuron")},
-        video=video_other,
-        frame_idx=0,
     )
     other_lf = LabeledFrame(video=video_other, frame_idx=0, label_images=[li_other])
     other_labels = Labels(
@@ -7118,12 +7047,10 @@ def test_merge_remaps_annotations_with_different_videos():
 
     # Both label_images should be on the frame
     assert len(lf0.label_images) == 2
-    # Self's label_image: video unchanged (not in video_map)
-    assert li_self.video is video_self
+    # Self's label_image: track unchanged
     assert li_self.objects[1].track is track
-    # Other's label_image: video remapped, track remapped
+    # Other's label_image: track remapped
     merged_li = [li for li in lf0.label_images if li is not li_self][0]
-    assert merged_li.video is video_self
     assert merged_li.objects[2].track is track
 
 
@@ -7136,12 +7063,10 @@ def test_merge_annotation_trackless_and_label_images_with_different_video():
     self_labels = Labels(videos=[video_self], skeletons=[skeleton])
 
     # Trackless centroid + label_image with no track on info
-    c = UserCentroid(x=1.0, y=2.0, video=video_other, frame_idx=0)
+    c = UserCentroid(x=1.0, y=2.0)
     li = UserLabelImage(
         data=np.array([[0, 1]], dtype=np.int32),
         objects={1: LabelImage.Info(category="cell")},
-        video=video_other,
-        frame_idx=0,
     )
     lf = LabeledFrame(video=video_other, frame_idx=0, centroids=[c], label_images=[li])
     other_labels = Labels(
@@ -7154,11 +7079,8 @@ def test_merge_annotation_trackless_and_label_images_with_different_video():
     # Trackless centroid should survive with track=None
     assert len(merged_lf.centroids) == 1
     assert merged_lf.centroids[0].track is None
-    # Video should be remapped to video_self (matched by basename)
-    assert merged_lf.centroids[0].video is video_self
-    # Label image should be merged with video remapped
+    # Label image should be merged
     assert len(merged_lf.label_images) == 1
-    assert merged_lf.label_images[0].video is video_self
     # Label image info track should remain None
     assert merged_lf.label_images[0].objects[1].track is None
 
@@ -7179,8 +7101,6 @@ def test_clean_removes_label_image_orphaned_tracks():
             1: LabelImage.Info(track=track_keep, category="cell"),
             2: LabelImage.Info(track=track_remove, category="cell"),
         },
-        video=video,
-        frame_idx=0,
     )
     lf = LabeledFrame(video=video, frame_idx=0, instances=[inst], label_images=[li])
 
@@ -7211,8 +7131,8 @@ def test_clean_orphaned_annotations_without_frame_removal():
         np.array([[1.0, 2.0]]), skeleton=skeleton, track=track_keep
     )
 
-    c_keep = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=track_keep)
-    c_remove = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=0, track=track_remove)
+    c_keep = UserCentroid(x=1.0, y=2.0, track=track_keep)
+    c_remove = UserCentroid(x=3.0, y=4.0, track=track_remove)
     lf = LabeledFrame(
         video=video, frame_idx=0, instances=[inst], centroids=[c_keep, c_remove]
     )
@@ -7250,20 +7170,21 @@ def test_get_track_annotations_lazy_raises(centered_pair):
 
 
 def test_add_annotation_invalidates_track_index():
-    """After add_centroid to existing frame, get_track_annotations sees it."""
+    """After adding centroid to frame, get_track_annotations sees it."""
     video = Video(filename="test.mp4", open_backend=False)
     track = Track(name="t1")
-    c1 = UserCentroid(x=1.0, y=2.0, video=video, frame_idx=0, track=track)
-    labels = Labels(videos=[video], tracks=[track])
-    labels.add_centroid(c1)
+    c1 = UserCentroid(x=1.0, y=2.0, track=track)
+    lf = LabeledFrame(video=video, frame_idx=0, centroids=[c1])
+    labels = Labels(labeled_frames=[lf], videos=[video], tracks=[track])
 
     # Force index build
     result = labels.get_track_annotations(video, track)
     assert len(result) == 1
 
     # Add a second centroid to the same frame and track
-    c2 = UserCentroid(x=3.0, y=4.0, video=video, frame_idx=0, track=track)
-    labels.add_centroid(c2)
+    c2 = UserCentroid(x=3.0, y=4.0, track=track)
+    lf.centroids.append(c2)
+    labels._invalidate_indices()
 
     # Index should have been invalidated; new centroid visible
     result = labels.get_track_annotations(video, track)
@@ -7280,7 +7201,7 @@ def test_remove_predictions_no_clean_invalidates_indices():
         np.array([[1.0, 2.0], [3.0, 4.0]]), skeleton=skel, track=track
     )
     lf = LabeledFrame(video=video, frame_idx=0, instances=[pred])
-    c = UserCentroid(x=5.0, y=6.0, video=video, frame_idx=0, track=track)
+    c = UserCentroid(x=5.0, y=6.0, track=track)
     lf.centroids.append(c)
 
     labels = Labels(
@@ -7318,7 +7239,7 @@ def test_merge_does_not_corrupt_source_annotations():
 
     # labels_b: frame at idx 0 with a centroid
     labels_b = Labels(skeletons=[skel], videos=[video_b], tracks=[track_b])
-    c = UserCentroid(x=1.0, y=2.0, video=video_b, frame_idx=0, track=track_b)
+    c = UserCentroid(x=1.0, y=2.0, track=track_b)
     lf_b = LabeledFrame(video=video_b, frame_idx=0, instances=[])
     lf_b.centroids.append(c)
     labels_b.append(lf_b)
@@ -7327,8 +7248,7 @@ def test_merge_does_not_corrupt_source_annotations():
     video_matcher = VideoMatcher(method=VideoMatchMethod.PATH, strict=True)
     labels_a.merge(labels_b, video=video_matcher)
 
-    # Source centroid in labels_b must still reference the original video/track
-    assert lf_b.centroids[0].video is video_b
+    # Source centroid in labels_b must still reference the original track
     assert lf_b.centroids[0].track is track_b
 
 
@@ -7341,8 +7261,8 @@ def test_labels_merge_keep_original_discards_other_annotations():
 
     inst_a = Instance([[0, 0], [1, 1]], skeleton=skel, track=track_a)
     inst_b = Instance([[2, 2], [3, 3]], skeleton=skel, track=track_b)
-    c_a = UserCentroid(x=0.5, y=0.5, video=video, frame_idx=0, track=track_a)
-    c_b = UserCentroid(x=2.5, y=2.5, video=video, frame_idx=0, track=track_b)
+    c_a = UserCentroid(x=0.5, y=0.5, track=track_a)
+    c_b = UserCentroid(x=2.5, y=2.5, track=track_b)
 
     labels_a = Labels(
         skeletons=[skel],
@@ -7377,13 +7297,9 @@ def test_labels_merge_replace_predictions_filters_annotations():
 
     inst_user = Instance([[0, 0], [1, 1]], skeleton=skel, track=track)
     inst_pred = PredictedInstance([[4, 4], [5, 5]], skeleton=skel, track=track)
-    c_user = UserCentroid(x=0.5, y=0.5, video=video, frame_idx=0, track=track)
-    c_pred_self = PredictedCentroid(
-        x=4.5, y=4.5, video=video, frame_idx=0, track=track, score=0.9
-    )
-    c_pred_other = PredictedCentroid(
-        x=9.0, y=9.0, video=video, frame_idx=0, track=track, score=0.7
-    )
+    c_user = UserCentroid(x=0.5, y=0.5, track=track)
+    c_pred_self = PredictedCentroid(x=4.5, y=4.5, track=track, score=0.9)
+    c_pred_other = PredictedCentroid(x=9.0, y=9.0, track=track, score=0.7)
 
     labels_a = Labels(
         skeletons=[skel],
@@ -7435,10 +7351,10 @@ def test_labels_merge_auto_annotations_spatial():
     inst_b = Instance([[50, 50], [51, 51]], skeleton=skel, track=track)
 
     # Self: user instance + user centroid at (0.5, 0.5)
-    c_self = UserCentroid(x=0.5, y=0.5, video=video, frame_idx=0, track=track)
+    c_self = UserCentroid(x=0.5, y=0.5, track=track)
 
     # Other: user instance far away + user centroid at (50.5, 50.5) — unmatched
-    c_other = UserCentroid(x=50.5, y=50.5, video=video, frame_idx=0, track=track)
+    c_other = UserCentroid(x=50.5, y=50.5, track=track)
 
     labels_a = Labels(
         skeletons=[skel],

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -7384,3 +7384,78 @@ def test_labels_merge_auto_annotations_spatial():
     assert len(merged_lf.centroids) == 2
     xs = {c.x for c in merged_lf.centroids}
     assert xs == {0.5, 50.5}
+
+
+def test_labels_get_label_images_by_frame_idx_only():
+    """get_label_images(frame_idx=N) without video filters by frame index."""
+    video = Video(filename="test.mp4", open_backend=False)
+    li0 = UserLabelImage(data=np.zeros((2, 2), dtype=np.int32))
+    li1 = UserLabelImage(data=np.ones((2, 2), dtype=np.int32))
+    lf0 = LabeledFrame(video=video, frame_idx=0, label_images=[li0])
+    lf1 = LabeledFrame(video=video, frame_idx=1, label_images=[li1])
+    labels = Labels(labeled_frames=[lf0, lf1])
+
+    assert labels.get_label_images(frame_idx=0) == [li0]
+    assert labels.get_label_images(frame_idx=1) == [li1]
+    assert labels.get_label_images(frame_idx=99) == []
+
+
+def test_labels_replace_videos_updates_static_rois():
+    """replace_videos should update video references on static ROIs."""
+    old_video = Video(filename="old.mp4")
+    new_video = Video(filename="new.mp4")
+    static_roi = UserROI.from_bbox(0, 0, 100, 100, video=old_video)
+
+    labels = Labels(videos=[old_video], rois=[static_roi])
+    labels.replace_videos(old_videos=[old_video], new_videos=[new_video])
+
+    assert static_roi.video is new_video
+
+
+def test_labels_materialize_static_rois_with_refs(tmp_path):
+    """materialize() deep copies static ROIs and relinks video/track refs."""
+    video = Video(filename="test.mp4")
+    track = Track(name="t1")
+    skeleton = Skeleton(["A"])
+    static_roi = UserROI.from_bbox(0, 0, 50, 50, video=video)
+    static_roi.track = track
+
+    lf = LabeledFrame(video=video, frame_idx=0)
+    labels = Labels(
+        labeled_frames=[lf],
+        videos=[video],
+        tracks=[track],
+        skeletons=[skeleton],
+        rois=[static_roi],
+    )
+    path = str(tmp_path / "test.slp")
+    save_slp(labels, path)
+
+    lazy = load_slp(path, lazy=True)
+    materialized = lazy.materialize()
+
+    assert len(materialized.static_rois) == 1
+    mat_roi = materialized.static_rois[0]
+    assert mat_roi.video is materialized.videos[0]
+    assert mat_roi.track is materialized.tracks[0]
+
+
+def test_remap_frame_annotations_with_rois():
+    """_remap_frame_annotations remaps ROI video and track references."""
+    old_video = Video(filename="old.mp4")
+    new_video = Video(filename="new.mp4")
+    old_track = Track(name="old")
+    new_track = Track(name="new")
+
+    roi = UserROI.from_bbox(0, 0, 10, 10, video=old_video)
+    roi.track = old_track
+    lf = LabeledFrame(video=old_video, frame_idx=0, rois=[roi])
+
+    Labels._remap_frame_annotations(
+        lf,
+        video_map={old_video: new_video},
+        track_map={old_track: new_track},
+    )
+
+    assert roi.video is new_video
+    assert roi.track is new_track

--- a/tests/model/test_mask.py
+++ b/tests/model/test_mask.py
@@ -13,7 +13,6 @@ from sleap_io.model.mask import (
     _encode_rle,
     _resize_nearest,
 )
-from sleap_io.model.video import Video
 
 
 def test_encode_rle_all_zeros():
@@ -383,20 +382,15 @@ def test_to_bbox_metadata():
     data = np.zeros((10, 10), dtype=bool)
     data[2:5, 1:4] = True
     track = Track(name="t1")
-    video = Video(filename="test.mp4")
     mask = UserSegmentationMask.from_numpy(
         data,
         track=track,
-        video=video,
-        frame_idx=3,
         category="cell",
         name="obj1",
         source="manual",
     )
     bb = mask.to_bbox()
     assert bb.track is track
-    assert bb.video is video
-    assert bb.frame_idx == 3
     assert bb.category == "cell"
     assert bb.name == "obj1"
     assert bb.source == "manual"

--- a/tests/model/test_roi.py
+++ b/tests/model/test_roi.py
@@ -60,12 +60,14 @@ def test_roi_from_polygon_with_kwargs():
     assert roi.category == "cat1"
 
 
-def test_roi_is_static():
-    roi1 = UserROI(geometry=box(0, 0, 10, 10))
-    assert roi1.is_static
+def test_roi_video():
+    """ROI can have a video reference."""
+    video = Video(filename="test.mp4")
+    roi = UserROI(geometry=box(0, 0, 10, 10), video=video)
+    assert roi.video is video
 
-    roi2 = UserROI(geometry=box(0, 0, 10, 10), frame_idx=5)
-    assert not roi2.is_static
+    roi_no_video = UserROI(geometry=box(0, 0, 10, 10))
+    assert roi_no_video.video is None
 
 
 def test_roi_is_bbox():
@@ -112,9 +114,8 @@ def test_roi_to_mask():
 
 def test_roi_with_video():
     video = Video(filename="test.mp4")
-    roi = UserROI.from_bbox(0, 0, 10, 10, video=video, frame_idx=5)
+    roi = UserROI.from_bbox(0, 0, 10, 10, video=video)
     assert roi.video is video
-    assert roi.frame_idx == 5
 
 
 def test_rasterize_geometry_unsupported_type():
@@ -283,7 +284,6 @@ def test_roi_geo_interface_metadata():
     assert props["name"] == "test_roi"
     assert props["category"] == "arena"
     assert props["source"] == "manual"
-    assert props["frame_idx"] is None
 
 
 def test_roi_geo_interface_defaults():
@@ -293,7 +293,6 @@ def test_roi_geo_interface_defaults():
     assert props["name"] == ""
     assert props["category"] == ""
     assert props["source"] == ""
-    assert props["frame_idx"] is None
 
 
 def test_roi_is_predicted():

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -2928,13 +2928,12 @@ def test_render_video_overlay_callable():
 
 
 def test_render_video_overlay_list_by_frame_idx():
-    """render_video with list overlay should filter objects by frame_idx."""
+    """render_video with list overlay applies masks to all frames (no frame_idx)."""
     labels = _make_synthetic_labels(n_frames=2, h=64, w=64)
 
     mask_data = np.zeros((64, 64), dtype=bool)
     mask_data[10:30, 10:30] = True
     mask = UserSegmentationMask.from_numpy(mask_data)
-    mask.frame_idx = 0  # Only apply to frame 0
 
     frames = render_video(
         labels,
@@ -2947,8 +2946,9 @@ def test_render_video_overlay_list_by_frame_idx():
     )
 
     assert len(frames) == 2
-    # Frame 0 should have overlay applied (masked region differs from bg)
+    # Mask without frame_idx is applied to all frames
     assert not np.array_equal(frames[0][20, 20], frames[0][0, 0])
+    assert not np.array_equal(frames[1][20, 20], frames[1][0, 0])
 
 
 def test_render_video_overlay_static_objects():
@@ -3090,7 +3090,7 @@ def test_apply_overlay_label_image():
     label_data = np.zeros((50, 50), dtype=np.int32)
     label_data[10:30, 10:30] = 1
 
-    label_img = UserLabelImage(data=label_data, frame_idx=0)
+    label_img = UserLabelImage(data=label_data)
 
     result = _apply_overlay(img, label_img, alpha=0.5)
 
@@ -3110,7 +3110,7 @@ def test_render_image_overlay_label_image_object():
     label_data[5:25, 5:25] = 1
     label_data[25:45, 25:45] = 2
 
-    label_img = UserLabelImage(data=label_data, frame_idx=0)
+    label_img = UserLabelImage(data=label_data)
 
     result = render_image(image=img, overlay=label_img, overlay_alpha=0.5)
 
@@ -3128,11 +3128,9 @@ def test_render_video_overlay_label_images():
 
     li0 = UserLabelImage(
         data=np.array(np.pad(np.ones((20, 20), dtype=np.int32), ((10, 20), (10, 20)))),
-        frame_idx=0,
     )
     li1 = UserLabelImage(
         data=np.array(np.pad(np.full((15, 15), 2, dtype=np.int32), ((30, 5), (30, 5)))),
-        frame_idx=1,
     )
 
     frames = render_video(
@@ -3159,15 +3157,15 @@ def test_render_video_spatial_only_no_poses():
     video = sio.Video(filename="dummy.mp4")
     li0 = UserLabelImage(
         data=np.array(np.pad(np.ones((20, 20), dtype=np.int32), ((10, 34), (10, 34)))),
-        video=video,
-        frame_idx=0,
     )
     li1 = UserLabelImage(
         data=np.array(np.pad(np.full((15, 15), 2, dtype=np.int32), ((40, 9), (40, 9)))),
-        video=video,
-        frame_idx=1,
     )
-    labels = sio.Labels(videos=[video], label_images=[li0, li1])
+    lf0 = sio.LabeledFrame(video=video, frame_idx=0)
+    lf0.label_images.append(li0)
+    lf1 = sio.LabeledFrame(video=video, frame_idx=1)
+    lf1.label_images.append(li1)
+    labels = sio.Labels(labeled_frames=[lf0, lf1])
 
     frames = render_video(
         labels,
@@ -3194,7 +3192,7 @@ def test_render_video_crop_with_user_label_image_overlay():
 
     label_data = np.zeros((50, 50), dtype=np.int32)
     label_data[20:40, 20:40] = 1
-    li = UserLabelImage(data=label_data, frame_idx=0)
+    li = UserLabelImage(data=label_data)
 
     frames = render_video(
         labels_obj,
@@ -3222,7 +3220,6 @@ def test_render_video_crop_with_predicted_label_image_overlay():
     label_data[20:40, 20:40] = 1
     li = PredictedLabelImage(
         data=label_data,
-        frame_idx=0,
         score=0.9,
         score_map=np.ones((50, 50), dtype=np.float32) * 0.8,
     )
@@ -3320,13 +3317,16 @@ def test_render_image_with_centroids():
     from sleap_io.model.instance import Track
 
     track = Track(name="t1")
-    c = UserCentroid(x=25.0, y=25.0, frame_idx=0, track=track)
+    c = UserCentroid(x=25.0, y=25.0, track=track)
+    video = sio.Video(filename="dummy.mp4", open_backend=False)
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    lf.centroids.append(c)
     labels = sio.Labels(
+        labeled_frames=[lf],
         skeletons=[sio.Skeleton(["A"])],
         tracks=[track],
-        centroids=[c],
     )
-    rendered = render_image(labels, frame_idx=0, video=None, background="white")
+    rendered = render_image(labels, frame_idx=0, video=video, background="white")
     assert rendered.ndim == 3
     non_white = np.any(rendered != 255, axis=-1)
     assert non_white.sum() > 0
@@ -3340,16 +3340,19 @@ def test_render_video_centroids_only():
     video = sio.Video(filename="test.mp4", open_backend=False)
     video.backend_metadata["shape"] = (10, 64, 64, 3)
     track = Track(name="t1")
-    centroids = [
-        UserCentroid(x=10.0, y=10.0, frame_idx=0, track=track, video=video),
-        UserCentroid(x=20.0, y=20.0, frame_idx=1, track=track, video=video),
-        UserCentroid(x=30.0, y=30.0, frame_idx=2, track=track, video=video),
-    ]
+    c0 = UserCentroid(x=10.0, y=10.0, track=track)
+    c1 = UserCentroid(x=20.0, y=20.0, track=track)
+    c2 = UserCentroid(x=30.0, y=30.0, track=track)
+    lf0 = sio.LabeledFrame(video=video, frame_idx=0)
+    lf0.centroids.append(c0)
+    lf1 = sio.LabeledFrame(video=video, frame_idx=1)
+    lf1.centroids.append(c1)
+    lf2 = sio.LabeledFrame(video=video, frame_idx=2)
+    lf2.centroids.append(c2)
     labels = sio.Labels(
-        videos=[video],
+        labeled_frames=[lf0, lf1, lf2],
         skeletons=[sio.Skeleton(["A"])],
         tracks=[track],
-        centroids=centroids,
     )
     frames = render_video(
         labels, background="black", show_progress=False, frame_inds=[0, 1, 2]
@@ -3375,12 +3378,12 @@ def test_render_image_centroids_show_false():
         frame_idx=0,
         instances=[inst],
     )
-    c = UserCentroid(x=10.0, y=10.0, frame_idx=0, track=track)
+    c = UserCentroid(x=10.0, y=10.0, track=track)
+    lf.centroids.append(c)
     labels = sio.Labels(
         labeled_frames=[lf],
         skeletons=[skel],
         tracks=[track],
-        centroids=[c],
     )
     rendered_on = render_image(
         labels, lf_ind=0, background="white", show_centroids=True
@@ -3399,11 +3402,12 @@ def test_render_video_centroids_no_track():
 
     video = sio.Video(filename="test.mp4", open_backend=False)
     video.backend_metadata["shape"] = (10, 64, 64, 3)
-    c = PredictedCentroid(x=25.0, y=25.0, frame_idx=0, score=0.9, video=video)
+    c = PredictedCentroid(x=25.0, y=25.0, score=0.9)
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    lf.centroids.append(c)
     labels = sio.Labels(
-        videos=[video],
+        labeled_frames=[lf],
         skeletons=[sio.Skeleton(["A"])],
-        centroids=[c],
     )
     frames = render_video(
         labels, background="black", show_progress=False, frame_inds=[0]


### PR DESCRIPTION
## Summary

Remove `video` and `frame_idx` attributes from annotation classes so that annotations derive their spatial-temporal context from their parent `LabeledFrame`, matching how `Instance`/`PredictedInstance` already work. This eliminates the metadata sync bug described in #410 where an annotation's own `video`/`frame_idx` could disagree with the `LabeledFrame` it lives in.

- Remove `video` and `frame_idx` from `Centroid`, `BoundingBox`, `SegmentationMask`, and `LabelImage`
- Remove `frame_idx` from `ROI` (keep `video` for static ROIs not tied to any frame)
- Add `LabeledFrame.append()` for type-based annotation routing
- Remove `Labels.add_*()` methods — annotations are now appended via `lf.append()`
- Remove `ROI.is_static` property — static ROIs live in `Labels.static_rois`
- Remove unused ROI-to-BoundingBox migration (legacy format was never shipped)
- Update all I/O formats to derive video/frame_idx from parent `LabeledFrame` context
- Update documentation to reflect new API

## Key Changes

**Model layer (`sleap_io/model/`):**
- 5 annotation classes updated: `video`/`frame_idx` fields removed, conversion methods (`to_roi`, `to_mask`, `to_bbox`, `to_polygon`, `resampled`, `explode`) stop propagating removed fields
- `LabeledFrame.append()` added: routes annotations to the correct list by type (`Instance` → `instances`, `Centroid` → `centroids`, `BoundingBox` → `bboxes`, etc.)
- `Labels`: `_init_centroids/bboxes/masks/label_images` fields removed; `_init_rois` renamed to `_static_rois`; `_distribute_annotations()` deleted; `add_centroid/bbox/mask/label_image/roi()` deleted; `get_*()` methods rewritten to derive `frame_idx` from `LabeledFrame`; track index sort derives `frame_idx` via `ann_frame_idx` map

**I/O layer (`sleap_io/io/`):**
- SLP read functions return `list[tuple[Ann, int, int]]` routing tuples; write functions accept parallel `contexts` list
- COCO, Ultralytics, TIFF, TrackMate, GeoJSON all updated to attach annotations to `LabeledFrame`s during deserialization
- HDF5 format unchanged — `video_idx`/`frame_idx` columns still written from `LabeledFrame` context, ensuring old sleap-io versions can read new files
- `LabelImageWriter.add()` auto-increments `frame_idx` when not provided

**Rendering (`sleap_io/rendering/`):**
- Centroid filtering uses `Labels.get_centroids(frame_idx=...)` instead of `c.frame_idx == fidx`
- Overlay matching uses list indices instead of `obj.frame_idx`

**Documentation (`docs/`):**
- Updated `regions.md`, `labels.md`, `examples.md`, `tiff.md`, `merging.md` to use new API (`lf.append()`, no `video`/`frame_idx` on constructors, no `Labels.add_*()`)

## Example Usage

```python
import sleap_io as sio

video = sio.Video("test.mp4")

# Create annotations without video/frame_idx (like Instance)
c = sio.UserCentroid(x=10, y=20)
b = sio.UserBoundingBox.from_xywh(0, 0, 50, 50, category="mouse")

# Add to LabeledFrame via append() — routes by type automatically
lf = sio.LabeledFrame(video=video, frame_idx=5)
lf.append(c)  # → lf.centroids
lf.append(b)  # → lf.bboxes

labels = sio.Labels(labeled_frames=[lf])

# Query works as before
labels.get_centroids(video=video, frame_idx=5)  # [c]

# Static ROIs (e.g., arena boundaries) — no parent frame needed
roi = sio.UserROI.from_bbox(0, 0, 640, 480, video=video, category="arena")
labels = sio.Labels(rois=[roi])  # stored in labels.static_rois
```

## API Changes

| Before | After |
|--------|-------|
| `UserCentroid(x=1, y=2, video=v, frame_idx=5)` | `UserCentroid(x=1, y=2)` |
| `labels.add_centroid(c)` | `lf.append(c)` |
| `lf.centroids.append(c)` | `lf.append(c)` (routes by type) |
| `Labels(centroids=[c1, c2])` | `lf.append(c1); lf.append(c2); Labels(labeled_frames=[lf])` |
| `Labels(masks=[m], bboxes=[b])` | Attach to `LabeledFrame` first, then `Labels(labeled_frames=[lf])` |
| `roi.is_static` | `roi in labels.static_rois` |
| `Labels(rois=[r1, r2])` | `Labels(rois=[r1, r2])` *(static ROIs unchanged)* |

**Annotations that must always be on a frame:** `Centroid`, `BoundingBox`, `SegmentationMask`, `LabelImage`
**Annotations that can be static or frame-bound:** `ROI` (static ROIs use `Labels(rois=[...])`, frame-bound use `lf.append(roi)`)

## Testing

- All 2801 tests pass (0 failures, 21 skipped)
- `ruff check` and `ruff format` clean
- SLP round-trip verified with existing test fixtures
- Backward-compatible: old SLP files load correctly

## Design Decisions

1. **ROI keeps `video`** — static ROIs (e.g., arena boundaries) need video association without a parent `LabeledFrame`. All other annotation types must be on a frame.
2. **No deprecation period** — pre-1.0 library, clean break is simpler than maintaining dual paths.
3. **No ROI-to-BoundingBox migration** — the old format where bboxes were stored as ROIs was never shipped, so there are no files in the wild that need this conversion.
4. **HDF5 format unchanged** — `video_idx`/`frame_idx` columns still written (from `LabeledFrame` context), ensuring old sleap-io versions can read new files.
5. **Routing context pattern for I/O** — SLP read functions return `(annotation, video_idx, frame_idx)` tuples and write functions accept a parallel `contexts` list, decoupling serialization from the model layer.
6. **`LabeledFrame.append()` over typed lists** — A single `lf.append(ann)` call routes to the correct container by type, matching the `Instance` ergonomics and removing the need for users to know which list to target.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)