### PR TITLE
fix: Add TrackMate CLI convert support and format docs

### DIFF
--- a/docs/formats/index.md
+++ b/docs/formats/index.md
@@ -641,6 +641,7 @@ Different formats have varying capabilities:
 | Label Studio | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | CSV (.csv) | ✅ | ✅ | ❌ | ✅** | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | DeepLabCut | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| [TrackMate](trackmate.md) (.csv) | ✅ | ❌ | ✅******* | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | AlphaTracker | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ |
 | LEAP (.mat) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | COCO (.json) | ✅ | ✅ | ❌ | ✅ | ✅*** | ❌ | ✅ | ✅ | ✅ | ❌ |
@@ -655,6 +656,7 @@ Different formats have varying capabilities:
 ****COCO panoptic tracks for "thing" segments only
 *****TIFF tracks via `.meta.json` sidecar
 ******Ultralytics segmentation polygons stored as ROIs
+*******TrackMate auto-detects sibling `.tif`/`.tiff` video files
 
 ## See Also
 

--- a/docs/formats/trackmate.md
+++ b/docs/formats/trackmate.md
@@ -1,0 +1,91 @@
+# TrackMate CSV Format
+
+[TrackMate](https://imagej.net/plugins/trackmate/) is an ImageJ/Fiji plugin for
+single-particle tracking in microscopy images. It exports tracking results as a
+set of CSV files. sleap-io reads these exports and converts spot detections into
+[`PredictedCentroid`][sleap_io.PredictedCentroid] objects with track assignments.
+
+## File Structure
+
+TrackMate exports three CSV files per video, sharing a common prefix:
+
+| File | Description | Required |
+|------|-------------|----------|
+| `*_spots.csv` | Individual spot detections with coordinates, quality score, and track assignment | **Yes** |
+| `*_edges.csv` | Frame-to-frame linkages with assignment cost | No (provides `tracking_score`) |
+| `*_tracks.csv` | Track-level summary statistics | No (not used) |
+
+All CSV files have **4 header rows** (field names, descriptions, abbreviations,
+units) followed by data rows.
+
+## Auto-Detection
+
+sleap-io automatically detects TrackMate CSV files by checking for the column
+signature `LABEL, ID, TRACK_ID, QUALITY, POSITION_X, POSITION_Y` in the first
+row. When loading a spots file:
+
+- The sibling `*_edges.csv` is auto-detected (by replacing `_spots` with
+  `_edges` in the filename) and used to populate `tracking_score` on each
+  centroid.
+- A sibling `.tif` / `.tiff` video file is auto-detected (by stripping `_spots`
+  from the stem) and associated with the loaded data.
+
+## Data Mapping
+
+| TrackMate field | sleap-io field |
+|-----------------|----------------|
+| `POSITION_X`, `POSITION_Y` | `PredictedCentroid.x`, `.y` |
+| `POSITION_Z` | `PredictedCentroid.z` (`None` if 0.0) |
+| `QUALITY` | `PredictedCentroid.score` |
+| `LINK_COST` (edges) | `PredictedCentroid.tracking_score` |
+| `TRACK_ID` | `Track` (named `Track_<id>`) |
+| `LABEL` | `PredictedCentroid.name` |
+| `FRAME` | `LabeledFrame.frame_idx` |
+
+## Reading
+
+```python
+import sleap_io as sio
+
+# Load from spots CSV (edges and video auto-detected)
+labels = sio.load_trackmate("experiment_spots.csv")
+
+# Auto-detection via load_file
+labels = sio.load_file("experiment_spots.csv")
+
+# With explicit video path
+labels = sio.load_trackmate("experiment_spots.csv", video="experiment.tif")
+```
+
+## CLI
+
+TrackMate CSV files can be converted to other formats via the `sio convert`
+command. The format is auto-detected from CSV content:
+
+```bash
+# Auto-detected from CSV content
+sio convert experiment_spots.csv -o experiment.slp
+
+# Explicit format
+sio convert experiment_spots.csv -o experiment.slp --from trackmate
+
+# Convert to NWB
+sio convert experiment_spots.csv -o experiment.nwb --from trackmate
+```
+
+## API
+
+::: sleap_io.io.main.load_trackmate
+    options:
+      heading_level: 3
+      show_root_toc_entry: false
+
+::: sleap_io.io.trackmate.read_trackmate_csv
+    options:
+      heading_level: 3
+      show_root_toc_entry: false
+
+::: sleap_io.io.trackmate.is_trackmate_file
+    options:
+      heading_level: 3
+      show_root_toc_entry: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -172,5 +172,6 @@ nav:
       - CSV Format: formats/csv.md
       - Analysis HDF5: formats/analysis_h5.md
       - TIFF: formats/tiff.md
+      - TrackMate: formats/trackmate.md
     - CLI: cli.md
     - Full API: reference/

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -102,6 +102,7 @@ INPUT_FORMATS = [
     "jabs",
     "dlc",
     "csv",
+    "trackmate",
     "ultralytics",
     "leap",
 ]
@@ -124,7 +125,6 @@ EXTENSION_TO_FORMAT = {
     ".slp": "slp",
     ".nwb": "nwb",
     ".mat": "leap",
-    ".csv": "dlc",
 }
 
 # Output extension to format mapping
@@ -1746,6 +1746,16 @@ def _infer_input_format(path: Path) -> str | None:
             return "ultralytics"
         return None
 
+    # CSV requires content-based detection (trackmate vs dlc vs generic)
+    if suffix == ".csv":
+        from sleap_io.io import dlc, trackmate
+
+        if trackmate.is_trackmate_file(str(path)):
+            return "trackmate"
+        elif dlc.is_dlc_file(str(path)):
+            return "dlc"
+        return "csv"
+
     # Check unambiguous extensions
     if suffix in EXTENSION_TO_FORMAT:
         return EXTENSION_TO_FORMAT[suffix]
@@ -1870,7 +1880,8 @@ def convert(
     but can be explicitly specified using --from and --to.
 
     [bold]Supported input formats:[/]
-    slp, nwb, coco, labelstudio, alphatracker, jabs, dlc, ultralytics, leap
+    slp, nwb, coco, labelstudio, alphatracker, jabs, dlc, csv,
+    trackmate, ultralytics, leap
 
     [bold]Supported output formats:[/]
     slp, nwb, coco, labelstudio, jabs, ultralytics, csv, analysis_h5

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -1766,6 +1766,91 @@ def test_infer_input_format_unknown_extension(tmp_path):
     assert result is None
 
 
+def test_infer_input_format_trackmate_csv(tmp_path):
+    """Test _infer_input_format detects TrackMate CSV from content."""
+    from sleap_io.io.cli import _infer_input_format
+
+    spots = tmp_path / "data_spots.csv"
+    spots.write_text(
+        "LABEL,ID,TRACK_ID,QUALITY,POSITION_X,POSITION_Y,POSITION_Z,"
+        "POSITION_T,FRAME,RADIUS,VISIBILITY\n"
+        "Label,Spot ID,Track ID,Quality,X,Y,Z,T,Frame,Radius,Visibility\n"
+        "Label,Spot ID,Track ID,Quality,X,Y,Z,T,Frame,R,Visibility\n"
+        ",,,(quality),(pixel),(pixel),(pixel),(frame),,(pixel),\n"
+        "ID0,0,0,5.0,10.0,20.0,0.0,0.0,0,11.5,1\n"
+    )
+    assert _infer_input_format(spots) == "trackmate"
+
+
+def test_infer_input_format_dlc_csv(tmp_path):
+    """Test _infer_input_format detects DLC CSV from content."""
+    from sleap_io.io.cli import _infer_input_format
+
+    dlc_file = tmp_path / "data.csv"
+    dlc_file.write_text(
+        "scorer,DLC_resnet50,DLC_resnet50,DLC_resnet50\n"
+        "bodyparts,nose,nose,nose\n"
+        "coords,x,y,likelihood\n"
+        "0,100.0,200.0,0.99\n"
+    )
+    assert _infer_input_format(dlc_file) == "dlc"
+
+
+def test_infer_input_format_generic_csv(tmp_path):
+    """Test _infer_input_format falls back to generic CSV."""
+    from sleap_io.io.cli import _infer_input_format
+
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("frame,x,y\n0,10.0,20.0\n")
+    assert _infer_input_format(csv_file) == "csv"
+
+
+def test_convert_trackmate_to_csv(tmp_path):
+    """Test converting a TrackMate CSV to SLEAP CSV via auto-detection."""
+    spots = tmp_path / "data_spots.csv"
+    spots.write_text(
+        "LABEL,ID,TRACK_ID,QUALITY,POSITION_X,POSITION_Y,POSITION_Z,"
+        "POSITION_T,FRAME,RADIUS,VISIBILITY\n"
+        "Label,Spot ID,Track ID,Quality,X,Y,Z,T,Frame,Radius,Visibility\n"
+        "Label,Spot ID,Track ID,Quality,X,Y,Z,T,Frame,R,Visibility\n"
+        ",,,(quality),(pixel),(pixel),(pixel),(frame),,(pixel),\n"
+        "ID0,0,0,5.0,10.0,20.0,0.0,0.0,0,11.5,1\n"
+        "ID1,1,0,4.0,12.0,22.0,0.0,1.0,1,11.5,1\n"
+    )
+    output = tmp_path / "output.csv"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["convert", str(spots), "-o", str(output), "--from", "trackmate"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "trackmate" in result.output.lower()
+    assert output.exists()
+
+
+def test_convert_trackmate_explicit_from(tmp_path):
+    """Test converting a TrackMate CSV with explicit --from trackmate."""
+    spots = tmp_path / "data_spots.csv"
+    spots.write_text(
+        "LABEL,ID,TRACK_ID,QUALITY,POSITION_X,POSITION_Y,POSITION_Z,"
+        "POSITION_T,FRAME,RADIUS,VISIBILITY\n"
+        "Label,Spot ID,Track ID,Quality,X,Y,Z,T,Frame,Radius,Visibility\n"
+        "Label,Spot ID,Track ID,Quality,X,Y,Z,T,Frame,R,Visibility\n"
+        ",,,(quality),(pixel),(pixel),(pixel),(frame),,(pixel),\n"
+        "ID0,0,0,5.0,10.0,20.0,0.0,0.0,0,11.5,1\n"
+    )
+    output = tmp_path / "output.csv"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["convert", str(spots), "-o", str(output), "--from", "trackmate"],
+    )
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+
+
 def test_infer_output_format_directory(tmp_path):
     """Test _infer_output_format returns ultralytics for directories."""
     from sleap_io.io.cli import _infer_output_format


### PR DESCRIPTION
## Summary

- Registers `trackmate` as an input format in the CLI `convert` command
- Adds content-based CSV auto-detection to `_infer_input_format()` so `.csv` files are correctly identified as TrackMate, DLC, or generic CSV (previously hardcoded to DLC)
- Creates `docs/formats/trackmate.md` format reference page
- Adds TrackMate to the format capabilities table in `docs/formats/index.md`

## Key Changes

- **`sleap_io/io/cli.py`**: Added `"trackmate"` to `INPUT_FORMATS`, replaced the `.csv` → `"dlc"` hardcoding in `EXTENSION_TO_FORMAT` with content-based detection in `_infer_input_format()` (mirrors `load_file()` logic), updated convert docstring
- **`docs/formats/trackmate.md`**: New format reference covering file structure, auto-detection, data mapping, reading examples, CLI usage, and API docs
- **`docs/formats/index.md`**: Added TrackMate row to capabilities table
- **`mkdocs.yml`**: Added nav entry for TrackMate docs
- **`tests/io/test_cli.py`**: 5 new tests for format inference (TrackMate, DLC, generic CSV) and end-to-end convert

## Test plan

- [x] All 500 existing tests pass (`pytest tests/io/test_trackmate.py tests/io/test_cli.py`)
- [x] `sio convert --help` shows `trackmate` in supported input formats
- [x] Content-based CSV detection correctly identifies TrackMate, DLC, and generic CSV files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)