### PR TITLE
fix(slp): preserve static ROI video association on lazy round-trip

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -5411,7 +5411,7 @@ def _write_labels_lazy(
 
     # Write annotations from lazy store (per-frame dicts + undistributed)
     # Build annotation lists with routing contexts from the lazy store keys
-    def _collect_from_lazy(by_frame, undistributed):
+    def _collect_from_lazy(by_frame, undistributed, videos):
         """Collect annotations and contexts from lazy store dicts."""
         anns = []
         ctxs = []
@@ -5421,23 +5421,35 @@ def _write_labels_lazy(
                 ctxs.append((vid_idx, fidx))
         for ann in undistributed:
             anns.append(ann)
-            ctxs.append((-1, -1))
+            ann_video = getattr(ann, "video", None)
+            if ann_video is not None:
+                try:
+                    vid_idx = videos.index(ann_video)
+                except ValueError:
+                    vid_idx = -1
+            else:
+                vid_idx = -1
+            ctxs.append((vid_idx, -1))
         return anns, ctxs
 
     all_centroids, centroid_ctxs = _collect_from_lazy(
-        lazy_store._centroid_by_frame, lazy_store._undistributed_centroids
+        lazy_store._centroid_by_frame,
+        lazy_store._undistributed_centroids,
+        labels.videos,
     )
     all_bboxes, bbox_ctxs = _collect_from_lazy(
-        lazy_store._bbox_by_frame, lazy_store._undistributed_bboxes
+        lazy_store._bbox_by_frame, lazy_store._undistributed_bboxes, labels.videos
     )
     all_masks, mask_ctxs = _collect_from_lazy(
-        lazy_store._mask_by_frame, lazy_store._undistributed_masks
+        lazy_store._mask_by_frame, lazy_store._undistributed_masks, labels.videos
     )
     all_rois, roi_ctxs = _collect_from_lazy(
-        lazy_store._roi_by_frame, lazy_store._undistributed_rois
+        lazy_store._roi_by_frame, lazy_store._undistributed_rois, labels.videos
     )
     all_label_images, li_ctxs = _collect_from_lazy(
-        lazy_store._label_image_by_frame, lazy_store._undistributed_label_images
+        lazy_store._label_image_by_frame,
+        lazy_store._undistributed_label_images,
+        labels.videos,
     )
     write_rois(labels_path, all_rois, labels.videos, labels.tracks, contexts=roi_ctxs)
     write_masks(

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -5421,13 +5421,9 @@ def _write_labels_lazy(
                 ctxs.append((vid_idx, fidx))
         for ann in undistributed:
             anns.append(ann)
-            ann_video = getattr(ann, "video", None)
-            if ann_video is not None:
-                try:
-                    vid_idx = videos.index(ann_video)
-                except ValueError:
-                    vid_idx = -1
-            else:
+            try:
+                vid_idx = videos.index(getattr(ann, "video", None))
+            except ValueError:
                 vid_idx = -1
             ctxs.append((vid_idx, -1))
         return anns, ctxs

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1569,6 +1569,18 @@ class Labels:
     ) -> list["ROI"]:
         """Query ROIs by video, frame, category, track, or instance.
 
+        Filtering rule:
+            * When a frame-aware filter (``video`` or ``frame_idx``) is set,
+              only ROIs attached to ``LabeledFrame`` instances are searched. Static
+              ROIs are excluded from these results.
+            * Otherwise (no filter, or only ``category``/``track``/
+              ``instance``/``predicted``), the search runs over ``self.rois``
+              — the union of static + frame-bound ROIs.
+
+        To access static (video-level) ROIs directly, use
+        ``Labels.static_rois``. To access only frame-bound ROIs across all
+        frames, use ``Labels.temporal_rois``.
+
         Args:
             video: If specified, only return ROIs for this video (identity
                 comparison).
@@ -1622,6 +1634,13 @@ class Labels:
     ) -> list["SegmentationMask"]:
         """Query segmentation masks by video, frame, category, track, or instance.
 
+        Filtering rule:
+            * When a frame-aware filter (``video`` or ``frame_idx``) is set,
+              only masks attached to ``LabeledFrame`` instances are searched.
+            * Otherwise (no filter, or only ``category``/``track``/
+              ``instance``/``predicted``), the search runs over
+              ``self.masks``.
+
         Args:
             video: If specified, only return masks for this video (identity
                 comparison).
@@ -1674,6 +1693,13 @@ class Labels:
         predicted: bool | None = None,
     ) -> list["BoundingBox"]:
         """Query bounding boxes by video, frame, category, track, or instance.
+
+        Filtering rule:
+            * When a frame-aware filter (``video`` or ``frame_idx``) is set,
+              only bboxes attached to ``LabeledFrame`` instances are searched.
+            * Otherwise (no filter, or only ``category``/``track``/
+              ``instance``/``predicted``), the search runs over
+              ``self.bboxes``.
 
         Args:
             video: If specified, only return bboxes for this video (identity
@@ -1732,6 +1758,13 @@ class Labels:
         predicted: bool | None = None,
     ) -> list["Centroid"]:
         """Query centroids by video, frame, category, track, or instance.
+
+        Filtering rule:
+            * When a frame-aware filter (``video`` or ``frame_idx``) is set,
+              only centroids attached to ``LabeledFrame`` instances are searched.
+            * Otherwise (no filter, or only ``category``/``track``/
+              ``instance``/``predicted``), the search runs over
+              ``self.centroids``.
 
         Args:
             video: If specified, only return centroids for this video (identity
@@ -1794,6 +1827,12 @@ class Labels:
         with that track. When ``category`` is specified, returns LabelImages
         containing an Info with that category. These filters check the
         ``objects`` metadata without decoding pixel data.
+
+        Filtering rule:
+            * When a frame-aware filter (``video`` or ``frame_idx``) is set,
+              only label images attached to ``LabeledFrame`` instances are searched.
+            * Otherwise (no filter, or only ``track``/``category``/
+              ``predicted``), the search runs over ``self.label_images``.
 
         Args:
             video: If specified, only return label images for this video

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -710,6 +710,26 @@ def test_lazy_write_preserves_static_roi_video(tmp_path):
     assert reread.static_rois[0].category == "arena"
 
 
+def test_lazy_write_static_roi_without_video(tmp_path):
+    """Lazy round-trip must handle ROIs with no video association (fallback)."""
+    video = Video(filename="v.mp4")
+    anchored = UserROI.from_bbox(0, 0, 10, 10, video=video, category="anchored")
+    orphan = UserROI.from_bbox(20, 20, 30, 30, video=None, category="orphan")
+    labels = Labels(videos=[video], rois=[anchored, orphan])
+
+    p1 = tmp_path / "a.slp"
+    p2 = tmp_path / "b.slp"
+    save_file(labels, p1)
+
+    lazy = load_slp(p1, lazy=True)
+    save_file(lazy, p2)
+
+    reread = load_slp(p2)
+    by_category = {r.category: r for r in reread.static_rois}
+    assert by_category["anchored"].video is reread.videos[0]
+    assert by_category["orphan"].video is None
+
+
 def test_lazy_write_preserves_static_roi_video_multi(tmp_path):
     """Lazy round-trip must pick the correct video index for multi-video labels."""
     video_a = Video(filename="a.mp4")

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -690,6 +690,26 @@ def test_negative_frames_materialize(tmp_path):
     assert len(eager_labels.negative_frames) == 1
 
 
+def test_lazy_write_preserves_static_roi_video(tmp_path):
+    """Lazy round-trip must preserve video association on static ROIs."""
+    video = Video(filename="v.mp4")
+    roi = UserROI.from_bbox(0, 0, 100, 100, video=video, category="arena")
+    labels = Labels(videos=[video], rois=[roi])
+
+    p1 = tmp_path / "a.slp"
+    p2 = tmp_path / "b.slp"
+    save_file(labels, p1)
+
+    lazy = load_slp(p1, lazy=True)
+    save_file(lazy, p2)
+
+    reread = load_slp(p2)
+    assert len(reread.static_rois) == 1
+    assert reread.static_rois[0].video is not None
+    assert reread.static_rois[0].video.filename == "v.mp4"
+    assert reread.static_rois[0].category == "arena"
+
+
 def test_write_sessions(slp_multiview, tmp_path):
     labels = read_labels(slp_multiview)
     sessions = labels.sessions

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -710,6 +710,31 @@ def test_lazy_write_preserves_static_roi_video(tmp_path):
     assert reread.static_rois[0].category == "arena"
 
 
+def test_lazy_write_preserves_static_roi_video_multi(tmp_path):
+    """Lazy round-trip must pick the correct video index for multi-video labels."""
+    video_a = Video(filename="a.mp4")
+    video_b = Video(filename="b.mp4")
+    video_c = Video(filename="c.mp4")
+    roi_b = UserROI.from_bbox(0, 0, 50, 50, video=video_b, category="arena_b")
+    roi_c = UserROI.from_bbox(10, 10, 60, 60, video=video_c, category="arena_c")
+    labels = Labels(videos=[video_a, video_b, video_c], rois=[roi_b, roi_c])
+
+    p1 = tmp_path / "a.slp"
+    p2 = tmp_path / "b.slp"
+    save_file(labels, p1)
+
+    lazy = load_slp(p1, lazy=True)
+    save_file(lazy, p2)
+
+    reread = load_slp(p2)
+    assert len(reread.static_rois) == 2
+    by_category = {r.category: r for r in reread.static_rois}
+    assert by_category["arena_b"].video is reread.videos[1]
+    assert by_category["arena_b"].video.filename == "b.mp4"
+    assert by_category["arena_c"].video is reread.videos[2]
+    assert by_category["arena_c"].video.filename == "c.mp4"
+
+
 def test_write_sessions(slp_multiview, tmp_path):
     labels = read_labels(slp_multiview)
     sessions = labels.sessions


### PR DESCRIPTION
## Summary

Fixes #413.

- **Bug fix**: `_write_labels_lazy` was silently dropping the video association on static ROIs (`UserROI`/`PredictedROI` attached to a `Video` but no `LabeledFrame`) on a lazy read → lazy write round-trip. The nested `_collect_from_lazy` helper hardcoded `(-1, -1)` for every undistributed annotation, so the saved file recorded `video=-1` and the ROI deserialized with `video=None` on re-read.
- **Doc clarity**: `Labels.get_rois` and its four sibling `get_*` methods follow an implicit filtering rule (frame-aware filters walk `labeled_frames`; bare/category/track/instance/predicted filters walk the flat container) that was only readable from control flow. Documented it on all five methods, with cross-references to `Labels.static_rois` and `Labels.temporal_rois` on `get_rois`.

## Key Changes

### `sleap_io/io/slp.py` — `_collect_from_lazy`
- Accept the parent `videos` list as a third argument.
- For each undistributed annotation, look up `videos.index(ann.video)` (via `getattr(ann, "video", None)`) and emit `(vid_idx, -1)` instead of always `(-1, -1)`.
- All five call sites in `_write_labels_lazy` now pass `labels.videos`.

In practice only `_undistributed_rois` carries a `.video` after #411, but the uniform code path is symmetric and future-proof.

### `sleap_io/model/labels.py` — `get_*` docstrings
- `get_rois`, `get_masks`, `get_bboxes`, `get_centroids`, `get_label_images` now spell out the filtering rule explicitly.
- `get_rois` additionally points readers at `Labels.static_rois` and `Labels.temporal_rois` for direct access.
- No behavior change.

### `tests/io/test_slp.py`
- `test_lazy_write_preserves_static_roi_video` — single-video regression test for the original bug. Verified to fail on `main` and pass with the fix.
- `test_lazy_write_preserves_static_roi_video_multi` — three-video variant with static ROIs on `videos[1]` and `videos[2]`. Asserts each ROI rehydrates to the correct `Video` by identity + `filename`. Guards against a regression where the index lookup defaults to `0` or `-1` instead of picking the right index.

## Example Usage

```python
import sleap_io as sio

video = sio.Video(filename="v.mp4")
roi = sio.UserROI.from_bbox(0, 0, 100, 100, video=video, category="arena")
labels = sio.Labels(videos=[video], rois=[roi])

sio.save_file(labels, "out.slp")
loaded_lazy = sio.load_slp("out.slp", lazy=True)
sio.save_file(loaded_lazy, "out2.slp")  # lazy write path

reread = sio.load_slp("out2.slp")
assert reread.static_rois[0].video is not None  # now passes
```

## API Changes

None. Internal helper `_collect_from_lazy` (nested inside `_write_labels_lazy`) gained a third argument; not part of the public API. Docstring additions only.

## Testing

- `pytest tests/io/test_slp.py` — passes including both new regression tests.
- `pytest tests/model/test_labels.py` — 243 passed.
- Single-video test verified failing against `main` (`AssertionError: assert None is not None`) and passing on this branch.
- `ruff format` and `ruff check` clean.

## Design Decisions

- **Uniform `_collect_from_lazy` over an ROI-only inline fix.** The issue suggested both. Funneling all five undistributed lists through the same lookup keeps the helper symmetric, costs nothing for the (currently empty) non-ROI lists, and avoids a future regression if any other annotation type ever gains its own `.video` attribute again.
- **`getattr(ann, "video", None)` rather than an `isinstance(ann, ROI)` branch.** Avoids importing `ROI` into the helper and stays type-agnostic.
- **Identity-based `videos.index(...)`.** `Video` is defined with `@attrs.define(eq=False)`, so `list.index` falls back to `object.__eq__` — matching the "identity comparison" semantics the `get_rois` docstring advertises. Two `Video` objects with the same `filename` will not collapse.
- **Multi-video test to discriminate index bugs.** The single-video test would still pass if the fix hardcoded `vid_idx = 0`. The multi-video test pins ROIs to `videos[1]` and `videos[2]` and asserts identity with the reloaded videos, so a "pick index 0" or "pick index -1" regression fails loudly.
- **Docstring filter-rule wording matches the JS port discussion in [sleap-io.js#94](https://github.com/talmolab/sleap-io.js/pull/94).** That PR caught and removed an asymmetric `getRois({video})` workaround that injected static ROIs into a frame-walking branch; explicit Python docs prevent the same drift in either library.

## Tracking checklist (from #413)

- [x] Issue 1 fix in `_write_labels_lazy`
- [x] Issue 1 regression test in `tests/io/test_slp.py` (single- and multi-video variants)
- [x] Issue 2 docstring updates on `get_rois` and siblings
- [ ] Cross-verify after fix: round-trip a static ROI between Python and sleap-io.js via lazy write (manual post-merge step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)