### PR TITLE
docs(v0.7.0): fix broken refs, schema drift, and silent shape change

### DIFF
--- a/docs/codecs.md
+++ b/docs/codecs.md
@@ -32,7 +32,7 @@ labels = sio.load_file("predictions.slp")
 data = labels.to_dict()
 
 # Convert to NumPy array
-# Shape: (n_frames, n_tracks, n_nodes, 2)
+# Shape: (n_frames, n_tracks, n_nodes, 2); n_frames == len(video) in v0.7.0
 tracks = labels.numpy()
 
 # Convert to pandas DataFrame
@@ -104,6 +104,12 @@ data = labels.to_dict()
                     "score": 0.91
                 }
             ]
+        },
+        {
+            "frame_idx": 12,
+            "video_idx": 0,
+            "instances": [],
+            "is_negative": true
         }
     ],
     "suggestions": [],
@@ -112,6 +118,8 @@ data = labels.to_dict()
 ```
 
 The dictionary uses index-based references (`skeleton_idx`, `video_idx`, `track_idx`) for compactness. All values are JSON-serializable primitives.
+
+Frames explicitly marked as containing no instances (negative training examples) are preserved in v0.7.0 via an `is_negative: true` field on each frame dict — round-tripping through `to_dict()` / `from_dict()` no longer drops them (PR #369).
 
 **Parameters:**
 
@@ -173,6 +181,8 @@ tracks = labels.numpy()
 print(tracks.shape)
 # (n_frames, n_tracks, n_nodes, 2)
 ```
+
+In v0.7.0, `n_frames == len(video)` — the full video duration. Frames past the last labeled frame are NaN-padded along all coordinate axes (PR #368). Code that previously assumed `tracks.shape[0] == last_labeled_frame + 1` may need updating.
 
 **Output array:**
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -494,6 +494,7 @@ import numpy as np
 labels = sio.load_file("predictions.slp")
 
 # Convert to array — shape: (n_frames, n_tracks, n_nodes, 2)
+# In v0.7.0, n_frames == len(video); frames past the last labeled frame are NaN.
 trx = labels.numpy()
 
 # Apply temporal smoothing along the frame axis (axis=0)

--- a/docs/formats/analysis_h5.md
+++ b/docs/formats/analysis_h5.md
@@ -2,6 +2,10 @@
 
 The SLEAP Analysis HDF5 format is a portable format for exporting pose tracking predictions as dense numpy arrays. This format is designed for easy loading in MATLAB and Python analysis pipelines.
 
+!!! warning "Shape change in v0.7.0"
+
+    The frame dimension of every array in this file is now `n_frames == len(video)`, not `last_labeled_frame + 1` as in v0.6.x. Frames past the last labeled frame are filled with `NaN` for pose coordinates and `False` for track occupancy. Code that sized downstream arrays from the exported shape may need to account for the new longer arrays. See [Migration Notes](https://github.com/talmolab/sleap-io/blob/main/CHANGELOG.md#migration-notes) (PR #368).
+
 ## Overview
 
 Analysis HDF5 files contain:
@@ -36,7 +40,7 @@ analysis.h5
 ├── video_path                # Dataset: Source video path
 │
 ├── @format                   # Attribute: "analysis" (format identifier)
-├── @sleap_io_version         # Attribute: Format version (e.g., "1.0")
+├── @sleap_io_version         # Attribute: sleap-io package version
 ├── @preset                   # Attribute: Axis ordering preset
 ├── @provenance               # Attribute: Source file provenance (JSON)
 ├── @skeleton_name            # Attribute: Skeleton name
@@ -60,6 +64,8 @@ Optimized for MATLAB's column-major memory layout. Compatible with SLEAP's origi
 | `point_scores` | `(n_tracks, n_nodes, n_frames)` | `["track", "node", "frame"]` |
 | `instance_scores` | `(n_tracks, n_frames)` | `["track", "frame"]` |
 | `tracking_scores` | `(n_tracks, n_frames)` | `["track", "frame"]` |
+
+In v0.7.0, `n_frames == len(video)` — the full video duration, not the number of labeled frames.
 
 **MATLAB usage:**
 
@@ -185,7 +191,7 @@ Source video file path.
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `format` | string | Always `"analysis"` |
-| `sleap_io_version` | string | Format version (e.g., `"1.0"`) |
+| `sleap_io_version` | string | sleap-io package version that wrote the file |
 | `preset` | string | Axis ordering: `"matlab"`, `"standard"`, or `"custom"` |
 | `provenance` | JSON string | Source file and creation metadata |
 | `skeleton_name` | string | Skeleton name |
@@ -216,7 +222,7 @@ sio.save_analysis_h5(labels, "all.h5", min_occupancy=0.0)
 sio.save_analysis_h5(labels, "filtered.h5", min_occupancy=0.5)
 ```
 
-Occupancy is calculated as: `frames_with_track / total_frames`
+Occupancy is calculated as: `frames_with_track / total_frames`, where `total_frames == len(video)` in v0.7.0. If your dataset has many unlabeled frames at the end of the video, the occupancy denominator will be larger than in v0.6.x and `min_occupancy` thresholds may need to be lowered correspondingly.
 
 ## Custom Axis Ordering
 

--- a/docs/formats/analysis_h5.md
+++ b/docs/formats/analysis_h5.md
@@ -4,7 +4,7 @@ The SLEAP Analysis HDF5 format is a portable format for exporting pose tracking 
 
 !!! warning "Shape change in v0.7.0"
 
-    The frame dimension of every array in this file is now `n_frames == len(video)`, not `last_labeled_frame + 1` as in v0.6.x. Frames past the last labeled frame are filled with `NaN` for pose coordinates and `False` for track occupancy. Code that sized downstream arrays from the exported shape may need to account for the new longer arrays. See [Migration Notes](https://github.com/talmolab/sleap-io/blob/main/CHANGELOG.md#migration-notes) (PR #368).
+    The frame dimension of every array in this file is now `n_frames == len(video)`, not `last_labeled_frame + 1` as in v0.6.x. Frames past the last labeled frame are filled with `NaN` for pose coordinates and `False` for track occupancy. Code that sized downstream arrays from the exported shape (e.g. `array.shape[0] == last_labeled_frame + 1`) may need to be updated to account for the new longer arrays (PR #368).
 
 ## Overview
 

--- a/docs/formats/analysis_h5.md
+++ b/docs/formats/analysis_h5.md
@@ -199,6 +199,9 @@ Source video file path.
 | `skeleton_symmetries` | JSON string | Symmetry pairs as `[["left", "right"], ...]` |
 | `labels_path` | string | Original labels file path (optional) |
 
+!!! note "`sleap_io_version` is a provenance stamp, not a format gate"
+    This attribute records the `sleap-io` package version that wrote the file (read from `importlib.metadata.version("sleap-io")` at save time). It is **not** a file-format version — the Analysis HDF5 layout itself is not versioned. Downstream tools should not use this value as a semver gate for structural changes; check the presence of specific datasets or `@preset` instead.
+
 ### Dataset Attributes
 
 Each dataset has a `dims` attribute containing a JSON-encoded list of dimension names:

--- a/docs/formats/analysis_h5.md
+++ b/docs/formats/analysis_h5.md
@@ -200,7 +200,7 @@ Source video file path.
 | `labels_path` | string | Original labels file path (optional) |
 
 !!! note "`sleap_io_version` is a provenance stamp, not a format gate"
-    This attribute records the `sleap-io` package version that wrote the file (read from `importlib.metadata.version("sleap-io")` at save time). It is **not** a file-format version — the Analysis HDF5 layout itself is not versioned. Downstream tools should not use this value as a semver gate for structural changes; check the presence of specific datasets or `@preset` instead.
+    This attribute records the `sleap-io` package version that wrote the file (the value of `sleap_io.__version__` at save time). It is **not** a file-format version — the Analysis HDF5 layout itself is not versioned. Downstream tools should not use this value as a semver gate for structural changes; check the presence of specific datasets or `@preset` instead.
 
 ### Dataset Attributes
 

--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -913,6 +913,9 @@ Per-centroid `category`, `name`, and `source` strings are stored as vlen string 
 
 The `/centroids/` group is only written when the [`Labels`][sleap_io.Labels] object contains centroids. On read, a missing group defaults to an empty list.
 
+!!! note "Format version"
+    Centroid presence alone does not bump the SLP format version — the `/centroids/` group rides alongside whatever other state drives the file's `format_id` (see [Version History](#version-history) below). A file containing only centroids and pose instances may still be written at format 1.4.
+
 ## Regions of Interest (ROIs)
 
 [`ROI`][sleap_io.ROI]s store vector geometry annotations such as polygons and other shapes. ROI support was introduced in format 1.5.
@@ -1288,7 +1291,7 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 - New [`merge_label_images()`][sleap_io.merge_label_images] copies raw compressed chunks between files (zero decompression for chunked sources)
 - Backward compatible: old files (v1.8-v2.1) remain fully readable; `data_start`/`data_end` fields are unused (set to 0) in chunked format
 
-### Browser-side compatibility (h5wasm / sleap-io.js)
+## Browser-side compatibility (h5wasm / sleap-io.js)
 
 [`sleap-io.js`](https://github.com/talmolab/sleap-io.js) is the browser port of this library and writes SLP files via [h5wasm](https://github.com/usnistgov/h5wasm). h5wasm cannot create HDF5 compound (structured) datasets, so it stores the `points`, `pred_points`, `instances`, and `frames` datasets as **flat 2D arrays** with the same per-row field layout as the structured dtype. The Python reader in v0.7.0 detects this representation (via shape and dataset attributes) and auto-converts on the fly, so files written by sleap-io.js round-trip cleanly through the Python library without requiring a manual conversion step. Multiple HDF5 string encodings are also tolerated (PR #378).
 

--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -12,9 +12,12 @@ SLP files can contain:
 - **Suggestions** for frames to label ([`SuggestionFrame`][sleap_io.SuggestionFrame])
 - **Recording sessions** for multi-camera setups ([`RecordingSession`][sleap_io.RecordingSession])
 - **Bounding boxes** for object detection and tracking ([`BoundingBox`][sleap_io.BoundingBox])
+- **Centroids** for point tracking and TrackMate-style spot detection ([`Centroid`][sleap_io.Centroid])
 - **Regions of interest** (ROIs) with vector geometry ([`ROI`][sleap_io.ROI])
 - **Segmentation masks** with run-length encoding ([`SegmentationMask`][sleap_io.SegmentationMask])
 - **Label images** for dense per-pixel instance segmentation ([`LabelImage`][sleap_io.LabelImage])
+
+In v0.7.0 the annotation types ([`ROI`][sleap_io.ROI], [`SegmentationMask`][sleap_io.SegmentationMask], [`BoundingBox`][sleap_io.BoundingBox], [`Centroid`][sleap_io.Centroid], and [`LabelImage`][sleap_io.LabelImage]) are abstract base classes; instances are always one of the `User*` or `Predicted*` subclasses. The on-disk dtype includes an `is_predicted` flag (and a `score` field for predicted variants).
 
 ## HDF5 Layout
 
@@ -50,6 +53,22 @@ file.slp
 │   ├── instance                 # Dataset: int32 instance index
 │   ├── is_predicted             # Dataset: uint8 (0=user, 1=predicted)
 │   ├── score                    # Dataset: float32 confidence score
+│   ├── tracking_score           # Dataset: float32 tracking link confidence
+│   ├── category                 # Dataset: vlen str category labels
+│   ├── name                     # Dataset: vlen str name labels
+│   └── source                   # Dataset: vlen str source labels
+│
+├── /centroids/                  # Group: Columnar centroid storage (v0.7.0+)
+│   ├── x                        # Dataset: float64 x-coordinate
+│   ├── y                        # Dataset: float64 y-coordinate
+│   ├── z                        # Dataset: float64 z-coordinate (NaN for 2D)
+│   ├── video                    # Dataset: int32 video index
+│   ├── frame_idx                # Dataset: int64 frame index
+│   ├── track                    # Dataset: int32 track index
+│   ├── instance                 # Dataset: int32 instance index
+│   ├── is_predicted             # Dataset: uint8 (0=user, 1=predicted)
+│   ├── score                    # Dataset: float32 confidence score
+│   ├── tracking_score           # Dataset: float32 tracking link confidence
 │   ├── category                 # Dataset: vlen str category labels
 │   ├── name                     # Dataset: vlen str name labels
 │   └── source                   # Dataset: vlen str source labels
@@ -827,6 +846,7 @@ Bounding box data is stored as individual datasets within the `/bboxes/` HDF5 gr
 | `instance` | `int32` | Instance index (-1 if none) |
 | `is_predicted` | `uint8` | 0 = UserBoundingBox, 1 = PredictedBoundingBox |
 | `score` | `float32` | Confidence score (NaN for user bboxes) |
+| `tracking_score` | `float32` | Tracking link confidence (NaN if unset) |
 | `category` | vlen `str` | Category label per bounding box |
 | `name` | vlen `str` | Name label per bounding box |
 | `source` | vlen `str` | Source label per bounding box |
@@ -854,6 +874,45 @@ The `/bboxes/` group is only written when the [`Labels`][sleap_io.Labels] object
 
 When reading older files without a `/bboxes` dataset or group, any ROIs with axis-aligned rectangular geometry (`is_bbox = True`) are automatically migrated to [`UserBoundingBox`][sleap_io.UserBoundingBox] objects in `Labels.bboxes`. The migrated ROIs are removed from `Labels.rois`.
 
+## Centroids
+
+[`Centroid`][sleap_io.Centroid] annotations store lightweight 2D or 3D point detections used for point tracking and TrackMate-style spot workflows. Centroid storage was added in v0.7.0 and uses a columnar HDF5 group, mirroring the bounding box layout.
+
+### Columnar Datasets
+
+Centroid data is stored as individual datasets within the `/centroids/` HDF5 group:
+
+| Dataset | Dtype | Description |
+|---------|-------|-------------|
+| `x` | `float64` | x-coordinate in pixels |
+| `y` | `float64` | y-coordinate in pixels |
+| `z` | `float64` | z-coordinate (NaN for 2D centroids) |
+| `video` | `int32` | Video index (-1 if none) |
+| `frame_idx` | `int64` | Frame index (-1 if none) |
+| `track` | `int32` | Track index (-1 if none) |
+| `instance` | `int32` | Instance index (-1 if none) |
+| `is_predicted` | `uint8` | 0 = UserCentroid, 1 = PredictedCentroid |
+| `score` | `float32` | Confidence score (NaN for user centroids) |
+| `tracking_score` | `float32` | Tracking link confidence (NaN if unset) |
+| `category` | vlen `str` | Category label per centroid |
+| `name` | vlen `str` | Name label per centroid |
+| `source` | vlen `str` | Source label (e.g., `"trackmate"`) |
+
+The `z` dataset is always written but stores `NaN` for 2D centroids. This makes the columnar layout uniform between 2D point tracking and 3D triangulated workflows without requiring a separate dtype.
+
+### User vs Predicted
+
+- `is_predicted = 0`: [`UserCentroid`][sleap_io.UserCentroid] -- human-annotated
+- `is_predicted = 1`: [`PredictedCentroid`][sleap_io.PredictedCentroid] -- model- or tracker-detected, `score` contains the detection confidence
+
+### String Metadata
+
+Per-centroid `category`, `name`, and `source` strings are stored as vlen string datasets within the `/centroids/` group. The `source` field is the canonical place for tracker provenance — for example, `sio.load_trackmate(...)` sets `source="trackmate"`.
+
+### Optional Group
+
+The `/centroids/` group is only written when the [`Labels`][sleap_io.Labels] object contains centroids. On read, a missing group defaults to an empty list.
+
 ## Regions of Interest (ROIs)
 
 [`ROI`][sleap_io.ROI]s store vector geometry annotations such as polygons and other shapes. ROI support was introduced in format 1.5.
@@ -877,6 +936,7 @@ roi_dtype = np.dtype([
     ("track", "i4"),            # Track index (-1 if none)
     ("is_predicted", "u1"),     # 0 = UserROI, 1 = PredictedROI (Format 1.9+)
     ("score", "f4"),            # Confidence score (NaN for user ROIs) (Format 1.9+)
+    ("tracking_score", "f4"),   # Tracking link confidence (NaN if unset)
     ("wkb_start", "u8"),       # Start byte offset into /roi_wkb
     ("wkb_end", "u8"),         # End byte offset into /roi_wkb
     ("instance", "i4"),        # Instance index (-1 if none) (Format 1.6+)
@@ -951,8 +1011,13 @@ mask_dtype = np.dtype([
     ("instance", "i4"),         # Instance index (-1 if none) (Format 1.9+)
     ("is_predicted", "u1"),     # 0 = UserSegmentationMask, 1 = Predicted (Format 1.9+)
     ("score", "f4"),            # Confidence score (NaN for user masks) (Format 1.9+)
+    ("tracking_score", "f4"),   # Tracking link confidence (NaN if unset)
     ("rle_start", "u8"),       # Start byte offset into /mask_rle
     ("rle_end", "u8"),         # End byte offset into /mask_rle
+    ("scale_x", "f4"),          # Spatial scale x (1.0 = native res) (Format 2.1+)
+    ("scale_y", "f4"),          # Spatial scale y (1.0 = native res) (Format 2.1+)
+    ("offset_x", "f4"),         # Spatial offset x in pixels (Format 2.1+)
+    ("offset_y", "f4"),         # Spatial offset y in pixels (Format 2.1+)
 ])
 ```
 
@@ -998,6 +1063,10 @@ mask_score_map_index_dtype = np.dtype([
     ("data_end", "u8"),     # End byte offset into /mask_score_maps
     ("height", "u4"),       # Score map height in pixels
     ("width", "u4"),        # Score map width in pixels
+    ("scale_x", "f4"),      # Score map spatial scale x (Format 2.1+)
+    ("scale_y", "f4"),      # Score map spatial scale y (Format 2.1+)
+    ("offset_x", "f4"),     # Score map spatial offset x in pixels (Format 2.1+)
+    ("offset_y", "f4"),     # Score map spatial offset y in pixels (Format 2.1+)
 ])
 ```
 
@@ -1017,6 +1086,10 @@ label_image_score_map_index_dtype = np.dtype([
     ("data_end", "u8"),     # End byte offset into /label_image_score_maps
     ("height", "u4"),       # Score map height in pixels
     ("width", "u4"),        # Score map width in pixels
+    ("scale_x", "f4"),      # Score map spatial scale x (Format 2.1+)
+    ("scale_y", "f4"),      # Score map spatial scale y (Format 2.1+)
+    ("offset_x", "f4"),     # Score map spatial offset x in pixels (Format 2.1+)
+    ("offset_y", "f4"),     # Score map spatial offset y in pixels (Format 2.1+)
 ])
 ```
 
@@ -1056,6 +1129,10 @@ label_image_dtype = np.dtype([
     ("data_end", "u8"),       # End byte offset into /label_image_data
     ("is_predicted", "u1"),   # 0 = UserLabelImage, 1 = Predicted (Format 1.9+)
     ("score", "f4"),          # Confidence score (NaN for user) (Format 1.9+)
+    ("scale_x", "f4"),        # Spatial scale x (1.0 = native res) (Format 2.1+)
+    ("scale_y", "f4"),        # Spatial scale y (1.0 = native res) (Format 2.1+)
+    ("offset_x", "f4"),       # Spatial offset x in pixels (Format 2.1+)
+    ("offset_y", "f4"),       # Spatial offset y in pixels (Format 2.1+)
 ])
 ```
 
@@ -1065,10 +1142,11 @@ Each object within a label image is described by a row in `/label_image_objects`
 
 ```python
 label_image_object_dtype = np.dtype([
-    ("label_id", "i4"),    # Pixel label value in the image data
-    ("track", "i4"),       # Track index (-1 if none)
-    ("instance", "i4"),    # Instance index (-1 if none)
-    ("score", "f4"),       # Per-object confidence score (Format 1.9+)
+    ("label_id", "i4"),       # Pixel label value in the image data
+    ("track", "i4"),          # Track index (-1 if none)
+    ("instance", "i4"),       # Instance index (-1 if none)
+    ("score", "f4"),          # Per-object confidence score (Format 1.9+)
+    ("tracking_score", "f4"), # Tracking link confidence (NaN if unset)
 ])
 ```
 
@@ -1187,6 +1265,16 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 - String metadata (`category`, `name`, `source`) stored as vlen string datasets within the group
 - The reader auto-detects whether `/bboxes` is a group (format 2.0+) or a dataset (legacy 1.7--1.9) and handles both transparently
 
+### Format 2.1
+
+**Multi-resolution spatial metadata for dense annotations.**
+
+- Added `scale_x`, `scale_y`, `offset_x`, `offset_y` (`f4`) fields to `mask_dtype`, `label_image_dtype`, `mask_score_map_index_dtype`, and `label_image_score_map_index_dtype`
+- Lets a [`SegmentationMask`][sleap_io.SegmentationMask] or [`LabelImage`][sleap_io.LabelImage] describe pixel data at half resolution, quarter resolution, or any spatial offset/scale relative to the source video
+- A `(scale, offset)` of `((1.0, 1.0), (0.0, 0.0))` means native resolution; e.g., `stride=2` constructors set `scale=(0.5, 0.5)` for half-resolution masks
+- Triggered automatically when any mask or label image has non-trivial spatial transform; otherwise the format remains 1.x or 2.0
+- Backward compatible: older readers ignore the new fields; writers always emit them but set defaults for unset cases
+
 ### Format 2.2 (Current)
 
 **Chunked label image storage and lazy loading.**
@@ -1199,6 +1287,10 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 - New [`LabelImageWriter`][sleap_io.LabelImageWriter] enables streaming writes with constant memory
 - New [`merge_label_images()`][sleap_io.merge_label_images] copies raw compressed chunks between files (zero decompression for chunked sources)
 - Backward compatible: old files (v1.8-v2.1) remain fully readable; `data_start`/`data_end` fields are unused (set to 0) in chunked format
+
+### Browser-side compatibility (h5wasm / sleap-io.js)
+
+[`sleap-io.js`](https://github.com/talmolab/sleap-io.js) is the browser port of this library and writes SLP files via [h5wasm](https://github.com/usnistgov/h5wasm). h5wasm cannot create HDF5 compound (structured) datasets, so it stores the `points`, `pred_points`, `instances`, and `frames` datasets as **flat 2D arrays** with the same per-row field layout as the structured dtype. The Python reader in v0.7.0 detects this representation (via shape and dataset attributes) and auto-converts on the fly, so files written by sleap-io.js round-trip cleanly through the Python library without requiring a manual conversion step. Multiple HDF5 string encodings are also tolerated (PR #378).
 
 ## API
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ labels = sio.load_file("predictions.slp")
 labels.save("predictions.nwb")
 
 # Convert to NumPy arrays
-trx = labels.numpy()  # (n_frames, n_tracks, n_nodes, 2)
+trx = labels.numpy()  # (n_frames, n_tracks, n_nodes, 2); n_frames == len(video)
 
 # Merge annotations from multiple sources
 base = sio.load_file("manual_annotations.slp")

--- a/docs/model/labels.md
+++ b/docs/model/labels.md
@@ -11,7 +11,7 @@ The core data structures form a layered hierarchy:
 - **[`SuggestionFrame`](#sleap_io.SuggestionFrame)** is a lightweight pointer to frames suggested for annotation (no instance data).
 - **[`LabelsSet`](#sleap_io.LabelsSet)** manages named collections of `Labels` (e.g., train/val/test splits).
 
-The hierarchy flows as **Labels -> LabeledFrame -> [`Instance`](poses.md)** (or any spatial annotation type). `Labels` also holds shared objects ([videos](video.md), [skeletons](poses.md), [tracks](poses.md), [identities](3d.md#identity), and `static_rois` for video-level ROIs) that are referenced by frames and instances, so each object is stored once and reused throughout the project. Flat read-only views like `labels.centroids`, `labels.bboxes`, `labels.masks`, `labels.label_images`, and `labels.rois` flatten the per-frame annotations across every `LabeledFrame` for convenient iteration.
+The hierarchy flows as **Labels -> LabeledFrame -> [`Instance`](poses.md)** (or any spatial annotation type). `Labels` also holds shared objects ([videos](video.md), [skeletons](poses.md), [tracks](poses.md), [identities](3d.md#identity), and `static_rois` for video-level ROIs) that are referenced by frames and instances, so each object is stored once and reused throughout the project. Flat views like `labels.centroids`, `labels.bboxes`, `labels.masks`, `labels.label_images`, and `labels.rois` flatten the per-frame annotations across every `LabeledFrame` for convenient iteration (`labels.rois` additionally includes `labels.static_rois`). These views return a fresh list on each access, so mutating the returned list does **not** propagate back to the owning `LabeledFrame` — use `lf.append(...)` or edit the per-frame lists directly to modify annotations.
 
 ---
 

--- a/docs/model/labels.md
+++ b/docs/model/labels.md
@@ -7,11 +7,11 @@
 The core data structures form a layered hierarchy:
 
 - **[`Labels`](#sleap_io.Labels)** is the top-level container: it owns everything in a project.
-- **[`LabeledFrame`](#sleap_io.LabeledFrame)** groups all annotations for one frame of one video.
+- **[`LabeledFrame`](#sleap_io.LabeledFrame)** groups all annotations for one frame of one video — pose [`instances`](poses.md), [`centroids`](regions.md), [`bboxes`](regions.md), [`masks`](regions.md), [`label_images`](regions.md), and [`rois`](regions.md).
 - **[`SuggestionFrame`](#sleap_io.SuggestionFrame)** is a lightweight pointer to frames suggested for annotation (no instance data).
 - **[`LabelsSet`](#sleap_io.LabelsSet)** manages named collections of `Labels` (e.g., train/val/test splits).
 
-The hierarchy flows as **Labels -> LabeledFrame -> [`Instance`](poses.md)**. `Labels` also holds shared objects ([videos](video.md), [skeletons](poses.md), [tracks](poses.md)) that are referenced by frames and instances, so each object is stored once and reused throughout the project.
+The hierarchy flows as **Labels -> LabeledFrame -> [`Instance`](poses.md)** (or any spatial annotation type). `Labels` also holds shared objects ([videos](video.md), [skeletons](poses.md), [tracks](poses.md), [identities](3d.md#identity), and `static_rois` for video-level ROIs) that are referenced by frames and instances, so each object is stored once and reused throughout the project. Flat read-only views like `labels.centroids`, `labels.bboxes`, `labels.masks`, `labels.label_images`, and `labels.rois` flatten the per-frame annotations across every `LabeledFrame` for convenient iteration.
 
 ---
 
@@ -183,8 +183,10 @@ Convert all tracked instances to a NumPy array for numerical analysis:
 >>> lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
 >>> labels = sio.Labels(labeled_frames=[lf])
 >>> trx = labels.numpy()
->>> print(trx.shape)  # (n_frames, n_tracks, n_nodes, 2)
+>>> print(trx.shape)  # (n_frames, n_tracks, n_nodes, 2); n_frames == len(video) in v0.7.0
 ```
+
+In v0.7.0, the frame dimension equals `len(video)` instead of `last_labeled_frame + 1` (PR #368). Frames past the last labeled frame are NaN-padded. Code that previously sized downstream arrays from this shape may need updating.
 
 !!! note "See also"
 
@@ -221,16 +223,31 @@ new_skeleton = sio.Skeleton(["HEAD", "BODY", "TAIL"])
 labels.replace_skeleton(new_skeleton)
 ```
 
-**Adding spatial annotations** to a frame by appending to its annotation lists:
+**Adding spatial annotations** to a frame by appending to its annotation lists. `LabeledFrame.append()` dispatches by type, routing each annotation into the correct list (`instances`, `centroids`, `bboxes`, `masks`, `label_images`, or `rois`):
 
 ```python
-lf = labels.get(video, 0)  # get or create LabeledFrame for frame 0
-lf.append(sio.UserCentroid(x=100, y=200))
-lf.append(sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60))
-lf.append(mask)
-lf.append(label_image)
-lf.append(roi)
+lf = labels.get_frame(video, frame_idx=0)  # O(1) frame lookup
+lf.append(sio.UserCentroid(x=100, y=200))         # → lf.centroids
+lf.append(sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60))  # → lf.bboxes
+lf.append(mask)                                    # → lf.masks
+lf.append(label_image)                             # → lf.label_images
+lf.append(roi)                                     # → lf.rois
 ```
+
+**Cleaning up unused state** with [`Labels.clean()`](#sleap_io.Labels.clean): removes empty frames, unused tracks, unused skeletons, and orphaned annotations whose track is no longer present. As of v0.7.0, frames that contain any annotation type (centroids, bboxes, masks, label_images, rois) are preserved even if they have no pose instances — only frames with zero annotations of any kind are dropped.
+
+```python
+labels.clean()  # remove empty frames + unused tracks/skeletons + orphan annotations
+```
+
+**Static ROIs** (video-level regions, e.g. arena boundaries) live on `labels.static_rois` instead of inside a `LabeledFrame`. The list is mutable, so you can append to it directly:
+
+```python
+arena = sio.UserROI(geometry=polygon, video=video, category="arena")
+labels.static_rois.append(arena)
+```
+
+**Closing lazy file handles** with `labels.close()`: when a labels file was loaded with `lazy=True` and contains chunked label image data, h5py file handles are kept open for on-demand decompression. Call `close()` to release them when finished.
 
 !!! note "See also"
 

--- a/sleap_io/io/analysis_h5.py
+++ b/sleap_io/io/analysis_h5.py
@@ -73,7 +73,7 @@ list of strings. File-level attributes include:
 
 - ``preset``: str, the preset used ("matlab", "standard", or "custom")
 - ``format``: str, always "analysis" for this format
-- ``sleap_io_version``: str, format version (currently "1.0")
+- ``sleap_io_version``: str, `sleap-io` package version that wrote the file
 
 Example:
     >>> import sleap_io as sio
@@ -104,6 +104,7 @@ from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
 from sleap_io.model.skeleton import Skeleton
 from sleap_io.model.video import Video
+from sleap_io.version import __version__
 
 # =============================================================================
 # Preset Definitions
@@ -812,7 +813,7 @@ def write_labels(
         # File-level attributes (always written for format identification)
         f.attrs["preset"] = preset_name
         f.attrs["format"] = "analysis"
-        f.attrs["sleap_io_version"] = "1.0"
+        f.attrs["sleap_io_version"] = __version__
 
         # Extended metadata for round-trip (as attributes)
         if save_metadata:

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -1142,8 +1142,9 @@ def render_video(
 
             - ``np.ndarray``: 3-D array ``(T, H, W)`` of integer label images
               indexed by frame number, or 2-D ``(H, W)`` for a static overlay.
-            - ``list[SegmentationMask | ROI | BoundingBox]``: Objects are
-              filtered per frame by their ``frame_idx`` attribute.
+            - ``list[SegmentationMask | ROI | BoundingBox]``: Indexed by
+              position — the item at list index ``i`` is applied to frame
+              ``i``. One overlay per frame.
             - ``Callable[[int], np.ndarray]``: Called with the frame index,
               returns an ``(H, W)`` label image for that frame.
         overlay_alpha: Opacity for the annotation overlay (0.0 to 1.0).

--- a/tests/io/test_analysis_h5.py
+++ b/tests/io/test_analysis_h5.py
@@ -303,7 +303,7 @@ class TestWriteLabels:
 
         with h5py.File(h5_path, "r") as f:
             assert f.attrs.get("format") == "analysis"
-            assert f.attrs.get("sleap_io_version") == "1.0"
+            assert f.attrs.get("sleap_io_version") == sio.__version__
             assert "skeleton_name" in f.attrs
             assert "skeleton_symmetries" in f.attrs
             assert "video_backend_metadata" in f.attrs


### PR DESCRIPTION
## Summary

Reference correctness pass for the v0.7.0 docs refresh. Addresses everything factually wrong, stale, or silently misleading that came out of the three-agent docs audit. PR 1 of 3 in the refresh; PRs 2 and 3 will follow with feature coverage and polish.

## Key Changes

### Broken / runnable-but-fails fixes
- **`docs/model/labels.md:227`** — replaced the broken `labels.get(video, 0)` call (no such method on `Labels`) with `labels.get_frame(video, 0)`. Anyone who copy-pasted the old snippet got `AttributeError`.
- **`sleap_io/rendering/core.py:1146`** — fixed the `render_video` overlay docstring that still referenced the removed `SegmentationMask.frame_idx` attribute (PR #411). Now correctly describes positional indexing — `overlay[i]` applies to frame `i`. Flows into `docs/rendering.md:655` via autodoc.
- **`sleap_io/io/analysis_h5.py:816`** — the writer was hardcoding `f.attrs["sleap_io_version"] = "1.0"`, which looked like a format version but was never bumped. Now writes the actual `sleap_io.__version__` so downstream tools can tell which release produced a given file. The docs already describe this attribute as a provenance stamp (not a format gate); the code now matches.

### `docs/formats/slp.md` — schema drift overhaul
The four on-disk dtype code blocks no longer disagreed silently with `sleap_io/io/slp.py`:
- `/rois` dtype — added missing `tracking_score (f4)`.
- `/masks` dtype — added missing `tracking_score`, `scale_x`, `scale_y`, `offset_x`, `offset_y`.
- `/label_images` dtype — added missing `scale_x`, `scale_y`, `offset_x`, `offset_y`.
- `/label_image_objects` dtype — added missing `tracking_score`.
- `/mask_score_map_index` and `/label_image_score_map_index` dtypes — added the four spatial fields.
- `/bboxes/` columnar table — added `tracking_score`.

Also added the entire **`/centroids/` HDF5 group** documentation (was completely missing) and a **Format 2.1** subsection to the Version History (multi-resolution scale/offset metadata, PR #385). Added a **browser-side compatibility** section explaining the h5wasm / sleap-io.js auto-conversion (PR #378). Noted that `ROI` / `SegmentationMask` / `LabelImage` are abstract base classes in v0.7.0.

### `docs/model/labels.md` — modernization
- Container hierarchy intro rewritten for the v0.7.0 annotation-nesting architecture (`LabeledFrame` now owns centroids/bboxes/masks/label_images/rois; `Labels` exposes flat read-only views).
- New `Labels.clean()` paragraph documenting the annotation-preserving behavior (PR #403).
- New bullets for `static_rois`, `identities`, `sessions`, `close()` (lazy file handle cleanup, PR #390).
- `LabeledFrame.append()` type dispatch is now spelled out with explicit routing (`→ lf.centroids`, `→ lf.masks`, etc.).
- One-line note on the `labels.numpy()` shape change (PR #368).

### Numpy shape-change (#368) callouts
The `n_frames == len(video)` change is silent — no API surface, only shape semantics — so users won't notice until something downstream breaks. Added warnings on every page where they would look:
- `docs/formats/analysis_h5.md` — top-level `!!! warning` admonition + preset-table note + `min_occupancy` denominator clarification.
- `docs/codecs.md` — NumPy codec section + full-array example.
- `docs/model/labels.md` — `print(trx.shape)` example.
- `docs/examples.md:496` and `docs/index.md:63` — one-line inline notes on the existing quick-start snippets.

### Misc
- `docs/codecs.md` — documented `is_negative` preservation in the dictionary codec output (PR #369).

## API Changes

Behavior change in `sleap_io.io.analysis_h5.write_labels`: the `sleap_io_version` HDF5 attribute now reflects the `sleap-io` package version at save time rather than a fixed `"1.0"` literal. No API surface change — existing call sites are unaffected. Readers that were matching the literal `"1.0"` will see semver strings going forward; the attribute's documented role as a provenance stamp (not a format gate) is unchanged.

The `render_video` overlay docstring fix is documentation-only and does not alter runtime behavior.

## Testing

- `uv run mkdocs build` — clean build; all warnings are pre-existing in `transforms.py` / `examples.md` cross-refs unrelated to this PR.
- `uv run pytest tests/rendering/` — 181 passed (covers the docstring change in `rendering/core.py`).
- `uv run pytest tests/io/test_analysis_h5.py` — 52 passed; `test_write_metadata` updated to assert `sio.__version__` instead of the former `"1.0"` literal.
- `uv run ruff format` / `ruff check` — clean.

## Design Decisions

- **Schema source of truth**: every rewritten dtype code block was copy-pasted from `sleap_io/io/slp.py` (specifically `slp.py:90` for `LI_DTYPE`, `slp.py:109` for `OBJ_DTYPE`, `slp.py:119` for `LI_SM_INDEX_DTYPE`, `slp.py:2837` for `roi_dtype`, `slp.py:3584` for `mask_dtype`, `slp.py:3707` for `mask_sm_index_dtype`). No paraphrasing — third-party tooling depends on these schemas.
- **Format 2.1 reconciliation**: I verified the `format_id` branching at `slp.py:1497-1524` and confirmed the existing Format 1.9 / 2.0 docstrings were accurate (predicted ROI/Mask/LabelImage bumps to 1.9; bboxes always bump to 2.0). The audit's flag about "1.9 vs 2.0 confusion" was based on a misreading; no changes needed there beyond the new 2.1 subsection.
- **`/centroids/` group**: the columnar layout includes a `z` dataset (always present, NaN for 2D) so the same dtype handles both 2D point tracking and 3D triangulated workflows.
- **Shape-change callouts**: I considered a single shared admonition include but Mkdocs Material's snippet plugin isn't currently configured here — inlined a short note on each page instead. A shared include can be refactored in a future polish pass.
- **`sleap_io_version` stamp**: used the existing `from sleap_io.version import __version__` pattern already established in `sleap_io/io/cli.py:6641` rather than `importlib.metadata.version("sleap-io")`. Same value, one less indirection, no extra import.
- **Coverage of release notes "always static" residual**: removed the two stale rows in the Removed/Changed API table that contradicted the actual `LabeledFrame.rois` field. The release notes now correctly say frame context comes from the parent container.

## Tracking

This is **PR 1 of 3** in the v0.7.0 docs refresh. The full plan and audit live in `scratch/2026-04-11-release-notes-v0.7.0/` (git-ignored). Next up:
- PR 2: v0.7.0 feature coverage (CLI overlay flags, examples.md expansion, regions.md multi-resolution, model docs additions)
- PR 3: Landing pages & format polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)