### PR TITLE
docs(v0.7.0): v0.7.0 feature coverage across cli, examples, and model

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -449,6 +449,12 @@ sio convert labels.slp -o annotations.json --to coco
 
 # Convert COCO to SLEAP
 sio convert annotations.json -o labels.slp --from coco
+
+# Convert TrackMate spot data to SLEAP (auto-detected from headers)
+sio convert spots.csv -o labels.slp
+
+# Explicit TrackMate import (skips content sniffing)
+sio convert spots.csv -o labels.slp --from trackmate
 ```
 
 ### Options
@@ -468,7 +474,7 @@ sio convert annotations.json -o labels.slp --from coco
 
 ### Supported Formats
 
-**Input formats:** `slp`, `nwb`, `coco`, `labelstudio`, `alphatracker`, `jabs`, `dlc`, `csv`, `ultralytics`, `leap`
+**Input formats:** `slp`, `nwb`, `coco`, `labelstudio`, `alphatracker`, `jabs`, `dlc`, `csv`, `trackmate`, `ultralytics`, `leap`
 
 **Output formats:** `slp`, `nwb`, `coco`, `labelstudio`, `jabs`, `ultralytics`, `csv`, `analysis_h5`
 
@@ -481,9 +487,11 @@ The CLI automatically detects formats from file extensions:
 | `.slp` | SLEAP | SLEAP |
 | `.nwb` | NWB | NWB |
 | `.mat` | LEAP | - |
-| `.csv` | DeepLabCut | CSV |
+| `.csv` | TrackMate or DeepLabCut (auto-detected from headers) | CSV |
 | `.h5` / `.hdf5` | (ambiguous) | Analysis HDF5 |
 | Directory with `data.yaml` | Ultralytics | Ultralytics |
+
+For `.csv` inputs, the CLI first sniffs the file header: TrackMate spots exports are detected via their `LABEL,ID,TRACK_ID,...` schema, otherwise DeepLabCut multi-index headers are matched, and everything else falls back to the generic `csv` reader. Pass `--from trackmate` or `--from dlc` to bypass sniffing.
 
 **Ambiguous extensions** (`.json`, `.h5`) require explicit `--from`:
 
@@ -1739,6 +1747,8 @@ sio render <input> --lf <index> [-o <output>] [options]
 
 **Image mode**: Renders a single frame to a PNG image. Use `--lf` or `--frame`.
 
+**Overlay-only mode**: Render segmentation overlays on external images without a labels file. Pass `--images` with a TIFF stack or directory of TIFFs plus `--overlay` to drop straight into rendering, bypassing the labels requirement. See [Segmentation Overlays](#segmentation-overlays) below.
+
 ### Basic Usage
 
 ```bash
@@ -1760,6 +1770,12 @@ sio render predictions.slp --lf 0               # -> predictions.lf=0.png
 # Render without source video (solid background)
 sio render predictions.slp --background black
 sio render predictions.slp --background "#333"
+
+# Overlay a segmentation mask on rendered poses
+sio render predictions.slp --overlay masks.tif --overlay-alpha 0.4
+
+# Overlay-only mode: render masks on images without a labels file
+sio render --images frames/ --overlay masks.tif -o output.mp4
 ```
 
 ### Options Reference
@@ -1768,9 +1784,11 @@ sio render predictions.slp --background "#333"
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `-i, --input` | (required) | Input labels file (can also pass as positional argument) |
+| `-i, --input` | (required in video/image mode) | Input labels file (can also pass as positional argument). Not required when `--images` + `--overlay` are used (overlay-only mode). |
 | `-o, --output` | auto | Output path. Default: `{input}.viz.mp4` for video, `{input}.lf={N}.png` for image |
 | `--background` | video | Background mode: `video` (load frames) or a color (e.g., `black`, `#333`) |
+| `--images` | none | Image source for overlay-only mode (no labels file needed): TIFF stack or directory of TIFFs |
+| `--images-stack` / `--no-images-stack` | auto | Force 3-D TIFF interpretation: `--images-stack` treats the file as a frame stack, `--no-images-stack` as a single image. Default auto-detects based on last dim (3 or 4 → single image, otherwise → stack). |
 
 #### Frame Selection Options
 
@@ -1805,6 +1823,26 @@ sio render predictions.slp --background "#333"
 | `--alpha` | 1.0 | Pose overlay transparency (0.0-1.0) |
 | `--no-nodes` | false | Hide node markers |
 | `--no-edges` | false | Hide skeleton edges |
+
+#### Overlay Options
+
+See [Segmentation Overlays](#segmentation-overlays) for end-to-end examples.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--overlay` | none | Segmentation overlay: TIFF file (2-D label image or 3-D stack) or directory of TIFF label images |
+| `--overlay-alpha` | 0.3 | Overlay opacity (0.0–1.0) |
+| `--overlay-palette` | distinct | Color palette for overlay labels |
+| `--overlay-outline` / `--no-overlay-outline` | off | Draw outlines around segmented regions |
+| `--overlay-outline-width` | 1 | Outline width in pixels |
+| `--overlay-outline-color` | (darkened fill) | Outline color (e.g., `white`, `#ff0000`, `255,0,0`) |
+
+#### Discovery Options
+
+| Option | Description |
+|--------|-------------|
+| `--list-colors` | Print available named colors and exit |
+| `--list-palettes` | Print available color palettes and exit |
 
 #### Crop Options (Single Image Only)
 
@@ -1981,6 +2019,38 @@ sio render predictions.slp --no-nodes
 # Show only nodes (no skeleton edges)
 sio render predictions.slp --no-edges
 ```
+
+### Segmentation Overlays
+
+`sio render` can composite segmentation masks over poses or over bare images. Overlays accept a TIFF stack (one frame per plane) or a directory of per-frame TIFF label images, and each integer label is colored via `--overlay-palette`.
+
+```bash
+# Segmentation overlay from a TIFF stack on top of pose predictions
+sio render predictions.slp --overlay masks.tif --overlay-alpha 0.4
+
+# Overlay from a directory of per-frame TIFFs
+sio render predictions.slp --overlay masks/
+
+# Single-frame PNG with overlay and outlines
+sio render predictions.slp --lf 0 --overlay masks.tif \
+    --overlay-outline --overlay-outline-color white
+
+# Overlay-only mode: no labels file, just images + masks
+sio render --images frames/ --overlay masks.tif -o output.mp4
+
+# Overlay-only with a TIFF stack of images
+sio render --images frames.tif --overlay masks/ --overlay-outline -o output.mp4
+
+# Tweak outline thickness and palette
+sio render predictions.slp --overlay masks.tif \
+    --overlay-palette tableau10 \
+    --overlay-outline --overlay-outline-width 2
+```
+
+!!! tip "Discovering palettes"
+    Use `sio render --list-palettes` to print all supported palette names (for both pose and overlay coloring) or `sio render --list-colors` for the named-color table used by `--background`, `--overlay-outline-color`, and similar options.
+
+See [Rendering → Segmentation Overlays](rendering.md#segmentation-overlays) for Python API equivalents.
 
 ### Multi-Video Labels
 
@@ -2168,6 +2238,7 @@ This creates:
 - **HDF5Video** (embedded videos in `.slp` files): Reencoded using Python path
 - **ImageVideo** (image sequences): Skipped (cannot be reencoded to video)
 - **TiffVideo** (TIFF stacks): Skipped (cannot be reencoded to video)
+- **SeqVideo** (Norpix `.seq` files): Reencoded using the Python path (falls back when ffmpeg cannot open the source)
 
 This is particularly useful for:
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -174,7 +174,7 @@ inst = centroid.to_instance()
 
 # Convenience accessors on full pose Instances
 xy = pose_instance.centroid_xy        # (x, y) tuple
-c2 = pose_instance.to_centroid()      # shortcut for from_instance(..., method="centroid")
+c2 = pose_instance.to_centroid()      # shortcut for Centroid.from_instance(pose_instance)
 ```
 
 Import TrackMate `*_spots.csv` exports straight into a `Labels` object — either with the explicit loader or by letting `sio.load_file` auto-detect the format from the CSV header:

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -105,6 +105,230 @@ assert xy_score == 3  # x, y, and confidence score
 !!! note "See also"
     [`Labels.numpy`](model/labels.md#sleap_io.Labels.numpy): Full documentation of array conversion options
 
+## Annotation types
+
+Each new v0.7.0 annotation type (bounding boxes, centroids, identities, and 3-D instances) has a `User*` variant for ground-truth annotations and a `Predicted*` variant carrying confidence scores. All of them live inside [`LabeledFrame`][sleap_io.LabeledFrame] and are appended with the same type-dispatching [`LabeledFrame.append`][sleap_io.LabeledFrame.append].
+
+### Bounding box detections
+
+Create, inspect, and convert `BoundingBox` annotations for detection and tracking workflows.
+
+```python title="bbox_basics.py" linenums="1"
+import sleap_io as sio
+
+# Construct from corners or from top-left + size
+bbox = sio.UserBoundingBox(x1=10, y1=20, x2=100, y2=200, category="mouse")
+bbox = sio.UserBoundingBox.from_xywh(10, 20, 90, 180)  # same box
+
+# Query geometric properties
+bbox.xyxy         # (10.0, 20.0, 100.0, 200.0)
+bbox.xywh         # (10.0, 20.0, 90.0, 180.0)
+bbox.area         # 16200.0
+bbox.centroid_xy  # (55.0, 110.0)
+
+# Predictions carry a score (and optional tracking_score)
+pred_bbox = sio.PredictedBoundingBox(
+    x1=10, y1=20, x2=100, y2=200, score=0.95, tracking_score=0.88,
+)
+
+# Convert to related annotation types
+roi = bbox.to_roi()
+mask = bbox.to_mask(height=480, width=640)
+```
+
+Attach a box to a frame and save it into SLP (format v2.0+) — bboxes also round-trip through COCO detection, Ultralytics detection, GeoJSON, and JABS when the dataset carries the metadata those formats require.
+
+```python title="bbox_save.py" linenums="1"
+import sleap_io as sio
+
+video = sio.Video.from_filename("clip.mp4", open=False)
+lf = sio.LabeledFrame(video=video, frame_idx=0)
+lf.append(sio.UserBoundingBox(x1=10, y1=20, x2=100, y2=200, category="mouse"))
+
+labels = sio.Labels(labeled_frames=[lf], videos=[video])
+labels.save("boxes.slp")
+```
+
+!!! note "See also"
+    - [Regions: Bounding boxes](model/regions.md#bounding-boxes) — full API and metadata fields
+    - [Formats: COCO](formats/index.md#coco-format-json) and [Ultralytics](formats/index.md#ultralytics-yolo-format) for detection round-trips
+
+### Centroid tracking and TrackMate import
+
+`Centroid` annotations are lightweight `(x, y)` points used by TrackMate, SORT, ByteTrack, and similar trackers. They interconvert with full pose [`Instance`][sleap_io.Instance] objects.
+
+```python title="centroid_basics.py" linenums="1"
+import sleap_io as sio
+
+track = sio.Track(name="mouse_A")
+
+# User and predicted variants
+c = sio.UserCentroid(x=100.5, y=200.3, track=track)
+p = sio.PredictedCentroid(x=50.0, y=60.0, score=0.95, source="trackmate")
+
+# Convert a pose Instance into a single-point centroid
+centroid = sio.Centroid.from_instance(pose_instance, method="center_of_mass")
+
+# And back: produces a single-node Instance on CENTROID_SKELETON
+inst = centroid.to_instance()
+
+# Convenience accessors on full pose Instances
+xy = pose_instance.centroid_xy        # (x, y) tuple
+c2 = pose_instance.to_centroid()      # shortcut for from_instance(..., method="centroid")
+```
+
+Import TrackMate `*_spots.csv` exports straight into a `Labels` object — either with the explicit loader or by letting `sio.load_file` auto-detect the format from the CSV header:
+
+```python title="load_trackmate.py" linenums="1"
+import sleap_io as sio
+
+# Explicit loader (use when you also want to pass edges or other options)
+labels = sio.load_trackmate("spots.csv", video="experiment.tif")
+
+# Auto-detect from CSV headers (falls back to DLC and generic CSV readers)
+labels = sio.load_file("spots.csv")
+
+print(len(labels.centroids), "centroid detections")
+```
+
+!!! note "See also"
+    - [Regions: Centroids](model/regions.md#centroids) — full API
+    - [Formats: TrackMate](formats/trackmate.md) — spots/edges/tracks CSV layout
+
+### Cross-session identity and 3-D instances
+
+[`Identity`][sleap_io.Identity] identifies the same animal across multiple recording sessions, distinct from per-video [`Track`][sleap_io.Track]. [`Instance3D`][sleap_io.Instance3D] / [`PredictedInstance3D`][sleap_io.PredictedInstance3D] carry structured triangulated keypoints, and [`InstanceGroup`][sleap_io.InstanceGroup] ties multi-view 2-D instances together with their 3-D reconstruction.
+
+```python title="identity_and_3d.py" linenums="1"
+import numpy as np
+import sleap_io as sio
+
+skel = sio.Skeleton(nodes=["head", "tail"], edges=[("head", "tail")])
+
+# Persistent per-animal identity (color is free-form and optional)
+mouse_a = sio.Identity(name="mouse_A", color="#e6194b")
+
+# 3-D keypoint storage, aligned to a skeleton
+pts = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+inst_3d = sio.Instance3D(points=pts, skeleton=skel)
+pred_3d = sio.PredictedInstance3D(
+    points=pts, skeleton=skel, point_scores=np.array([0.9, 0.8]),
+)
+
+# Group per-camera 2-D detections with the reconstructed 3-D instance
+cam1 = sio.Camera(name="cam1")
+cam2 = sio.Camera(name="cam2")
+inst_2d_cam1 = sio.Instance.from_numpy(np.zeros((2, 2)), skeleton=skel)
+inst_2d_cam2 = sio.Instance.from_numpy(np.zeros((2, 2)), skeleton=skel)
+group = sio.InstanceGroup(
+    instance_by_camera={cam1: inst_2d_cam1, cam2: inst_2d_cam2},
+    instance_3d=inst_3d,
+    identity=mouse_a,
+)
+
+# Identities and recording sessions hang off Labels directly
+labels = sio.Labels(identities=[mouse_a])
+```
+
+Identities and `Instance3D` both persist into SLP format v1.9+, so round-tripping between sleap-io and sleap-io.js / luc3d is lossless.
+
+!!! note "See also"
+    [3D model](model/3d.md): `Camera`, `CameraGroup`, `RecordingSession`, `FrameGroup`, `InstanceGroup`, `Identity`, `Instance3D`.
+
+### Reading and writing GeoJSON ROIs
+
+ROIs are serializable to the `movement`-compatible GeoJSON format used by Shapely, GeoPandas, QGIS, and QuPath. Each ROI also implements the Python [`__geo_interface__`](https://gist.github.com/sgillies/2217756) protocol so it plugs straight into any `geopandas.GeoDataFrame`.
+
+```python title="geojson_rois.py" linenums="1"
+import sleap_io as sio
+
+labels = sio.load_slp("labels.slp")
+
+# Dump every ROI (static and frame-level) to GeoJSON
+sio.save_geojson(labels.rois, "regions.geojson")
+
+# Load an externally drawn region set
+rois = sio.load_geojson("regions.geojson")
+first = rois[0]
+first.__geo_interface__   # standard GeoJSON Feature dict
+
+# Universal loader auto-detects the .geojson extension
+labels = sio.load_file("regions.geojson")
+```
+
+!!! note "See also"
+    - [Formats: GeoJSON](formats/index.md#geojson-format-geojson) — schema and movement-library interop
+    - [Regions: Static vs. temporal ROIs](model/regions.md#static-vs-temporal-rois)
+
+### Adding annotations to frames (type dispatch)
+
+`LabeledFrame.append()` routes each annotation to the correct per-type list based on its runtime type. The same method handles every annotation kind — you never have to touch `lf.bboxes`, `lf.centroids`, etc. by hand for appends.
+
+```python title="frame_append_dispatch.py" linenums="1"
+import numpy as np
+import sleap_io as sio
+from shapely.geometry import box
+
+skel = sio.Skeleton(nodes=["head"], edges=[])
+video = sio.Video.from_filename("clip.mp4", open=False)
+lf = sio.LabeledFrame(video=video, frame_idx=0)
+
+# Each append() routes by type:
+lf.append(sio.Instance.from_numpy(np.zeros((1, 2)), skeleton=skel))  # → lf.instances
+lf.append(sio.UserBoundingBox(x1=0, y1=0, x2=10, y2=10))             # → lf.bboxes
+lf.append(sio.UserCentroid(x=5, y=5))                                # → lf.centroids
+lf.append(sio.UserSegmentationMask.from_numpy(np.zeros((8, 8), bool)))  # → lf.masks
+lf.append(sio.UserLabelImage.from_numpy(np.zeros((8, 8), int)))      # → lf.label_images
+lf.append(sio.UserROI(geometry=box(0, 0, 10, 10)))                   # → lf.rois
+
+# Per-frame accessors are plain lists you can iterate or index:
+print(len(lf.instances), len(lf.bboxes), len(lf.centroids))
+print(len(lf.masks), len(lf.label_images), len(lf.rois))
+
+# Flat read-only views across the whole Labels object
+labels = sio.Labels(labeled_frames=[lf], videos=[video])
+labels.bboxes      # every bbox across every frame
+labels.centroids   # every centroid across every frame
+labels.static_rois # video-level ROIs (separate from frame-level lf.rois)
+```
+
+!!! note "See also"
+    [Regions → Working with annotations in frames](model/regions.md#working-with-annotations-in-frames) for more context on the flat-vs-nested views.
+
+### Fast O(1) frame and track lookups
+
+[`Labels.get_frame`][sleap_io.Labels.get_frame] and [`Labels.get_track_annotations`][sleap_io.Labels.get_track_annotations] replace O(n) linear scans with O(1) dictionary lookups backed by lazy indices. Use them when iterating over large datasets or cross-referencing by frame / track.
+
+```python title="fast_lookups.py" linenums="1"
+import sleap_io as sio
+
+labels = sio.load_slp("predictions.slp")
+video = labels.videos[0]
+track = labels.tracks[0]
+
+# O(1) frame lookup (returns None if the frame is missing)
+lf = labels.get_frame(video, frame_idx=42)
+if lf is not None:
+    print(len(lf.instances), "instances on frame 42")
+
+# O(1) per-track annotation view (sorted by frame_idx)
+annotations = labels.get_track_annotations(video, track)
+for ann in annotations[:5]:
+    print(ann.frame_idx, type(ann).__name__)
+
+# Existing convenience methods now use the same indices internally
+labels.find(video, frame_idx=42)                    # O(1)
+labels.get_centroids(video=video, frame_idx=0)      # O(1)
+labels.get_bboxes(video=video, frame_idx=0)         # O(1)
+
+# If you mutate labels.labeled_frames in place, force a rebuild
+labels.labeled_frames.append(sio.LabeledFrame(video=video, frame_idx=99))
+labels.reindex()
+```
+
+!!! tip "When to call `reindex()`"
+    The indices rebuild automatically when you use the public `Labels` APIs. You only need `reindex()` after mutating `labels.labeled_frames` or the annotation lists in place (which bypasses the invalidation hooks).
+
 ## Format conversion
 
 ### Load and save in different formats
@@ -700,6 +924,27 @@ last_frame = video[-1]
     - [`sio.load_video`](formats/#sleap_io.load_video): Video loading function
     - [`Video`](model/video.md#sleap_io.Video): Video class documentation
 
+### Norpix `.seq` video
+
+Load Norpix StreamPix `.seq` files the same way as any other video. The Norpix backend exposes per-frame timestamps and an auto-computed FPS derived from the timestamp stream, which is handy for high-speed behavioral recordings where the header FPS is often wrong.
+
+```python title="read_seq.py" linenums="1"
+import sleap_io as sio
+
+video = sio.load_video("recording.seq")
+frame = video[0]
+
+# Inspect backend-specific metadata
+seq = video.backend
+print(seq.fps)              # auto-computed from per-frame timestamps
+print(seq.get_timestamps()[0])  # seconds-since-epoch of the first frame
+```
+
+Supported codecs: raw mono, raw RGB, JPEG, and PNG. The `sio show` CLI prints Norpix-specific header info (codec, bit depth, description, FPS), and `sio reencode recording.seq -o recording.mp4` converts to MP4 via the Python path.
+
+!!! note "See also"
+    [Video backends](model/video.md#backends) — how `SeqVideo` fits alongside `MediaVideo`, `HDF5Video`, `ImageVideo`, and `TiffVideo`.
+
 ### Re-encode video
 
 Fix video seeking issues by re-encoding with optimal settings.
@@ -1013,6 +1258,45 @@ print(f"Merged: {len(merged.label_images)} total frames")
     - [Merging: Label images](merging.md#merging-label-images): Full merge documentation
     - [`merge_label_images`](model/regions.md#sleap_io.merge_label_images): API reference
 
+### Parallel segmentation pipeline
+
+Combine the streaming writer and the zero-decompression merger to build a parallel batch segmentation pipeline. Each worker streams its own shard with [`LabelImageWriter`][sleap_io.LabelImageWriter], and a final [`merge_label_images`][sleap_io.merge_label_images] call concatenates the shards without decompressing a single pixel.
+
+```python title="parallel_segmentation.py" linenums="1"
+import sleap_io as sio
+
+def run_shard(video_path: str, frame_range: range, shard_path: str) -> None:
+    """Segment a frame range and stream the results to one SLP shard."""
+    video = sio.load_video(video_path)
+    with sio.LabelImageWriter(shard_path, video=video) as writer:
+        for frame_idx in frame_range:
+            mask = run_segmentation(video[frame_idx])   # (H, W) int32
+            li = sio.PredictedLabelImage.from_numpy(
+                mask, source="cellpose:nuclei", score=1.0,
+            )
+            writer.add(li)
+
+# Launch one worker per shard (e.g., with multiprocessing, joblib, or a job
+# scheduler) so every worker streams to its own file.
+run_shard("microscopy.tif", range(0, 500), "shard_0.slp")
+run_shard("microscopy.tif", range(500, 1000), "shard_1.slp")
+run_shard("microscopy.tif", range(1000, 1500), "shard_2.slp")
+
+# Concatenate the shards into the final dataset in O(shards), without
+# decompressing any pixel chunks.
+merged = sio.merge_label_images(
+    ["shard_0.slp", "shard_1.slp", "shard_2.slp"],
+    "all_frames.slp",
+)
+print(f"Merged: {len(merged.label_images)} frames")
+```
+
+!!! tip "Why this is fast"
+    Workers run in parallel and produce contiguous SLP shards that each hold only
+    one frame's worth of compressed data in memory at a time. `merge_label_images`
+    then copies compressed HDF5 chunks byte-for-byte between files — no
+    decompression, no conflict resolution, no Python-level object reconstruction.
+
 ## Rendering
 
 Create videos and images with pose overlays for visualization and publication.
@@ -1036,6 +1320,50 @@ sio.render_image(labels[0], "frame.png")
 sio render -i predictions.slp -o output.mp4
 sio render -i predictions.slp --preset preview
 sio render -i predictions.slp --lf 0  # Single frame
+```
+
+### Segmentation overlay rendering
+
+Render pose predictions on top of a segmentation mask (or render masks on bare images, no labels file needed). The overlay pipeline accepts 2-D label images, 3-D label stacks, or a directory of per-frame TIFFs.
+
+```python title="segmentation_overlay.py" linenums="1"
+import numpy as np
+import sleap_io as sio
+
+labels = sio.load_slp("predictions.slp")
+lf = labels[0]
+
+# Overlay a (H, W) integer label image on a single labeled frame
+label_mask = np.load("frame0_mask.npy")  # (H, W) int
+img = sio.render_image(
+    lf,
+    overlay=label_mask,
+    overlay_alpha=0.4,
+    overlay_outline=True,
+)
+
+# Overlay-only mode (no poses) — renders masks on an arbitrary image
+frame = sio.load_video("clip.mp4")[0]
+masked = sio.render_image(image=frame, overlay=label_mask)
+
+# Video rendering with a 3-D label stack (one mask per frame)
+stack = np.load("masks_stack.npy")  # (T, H, W) int
+sio.render_video(labels, "overlay.mp4", overlay=stack)
+
+# Standalone draw_* helpers compose overlays manually onto any image
+canvas = frame.copy()
+sio.draw_label_image(canvas, label_mask, alpha=0.4, outline=True)
+sio.draw_bboxes(canvas, lf.bboxes)
+sio.draw_masks(canvas, [m for m in lf.masks])
+sio.draw_rois(canvas, lf.rois, fill_alpha=0.3)
+```
+
+```bash title="CLI"
+# Overlay segmentation on rendered poses
+sio render predictions.slp --overlay masks.tif --overlay-alpha 0.4
+
+# Overlay-only mode: no labels file needed
+sio render --images frames/ --overlay masks.tif -o output.mp4
 ```
 
 !!! note "See also"

--- a/docs/formats/tiff.md
+++ b/docs/formats/tiff.md
@@ -100,19 +100,30 @@ label_images = sio.PredictedLabelImage.from_stack(
 sio.save_label_images("cellpose_masks.tif", label_images)
 
 # Or save as SLP (preserves tracks, categories, and provenance)
-labeled_frames = [
-    sio.LabeledFrame(video=video, frame_idx=i, label_images=[li])
-    for i, li in enumerate(label_images)
-]
+labeled_frames = []
+for i, li in enumerate(label_images):
+    lf = sio.LabeledFrame(video=video, frame_idx=i)
+    lf.append(li)  # dispatches to lf.label_images
+    labeled_frames.append(lf)
 labels = sio.Labels(labeled_frames=labeled_frames, videos=[video])
 labels.provenance["segmentation_model"] = "cellpose"
 labels.provenance["cellpose_diameter"] = 25
 labels.save("cellpose_masks.slp")
 ```
 
+`lf.append(li)` is the idiomatic way to attach a `LabelImage` to a frame — it routes the annotation onto `lf.label_images` via the type-dispatched [`LabeledFrame.append`][sleap_io.LabeledFrame.append]. Constructing `LabeledFrame(..., label_images=[li])` directly is still supported.
+
 The `from_stack()` method ensures that the same `Track` object is shared across
 frames for a given label ID, which is essential for consistent tracking and
 downstream analysis.
+
+!!! tip "TIFF → SLP follow-ups"
+    - [`sio.normalize_label_ids`][sleap_io.normalize_label_ids] rewrites per-frame label IDs so they are globally consistent across a stack — essential when upstream segmentation assigns different IDs in different frames (e.g., Cellpose without tracking). See [Regions → Normalizing label IDs](../model/regions.md#normalizing-label-ids).
+    - [`sio.merge_label_images`][sleap_io.merge_label_images] concatenates multiple chunked SLP files (e.g., parallel batch segmentation shards) via zero-decompression HDF5 chunk copies. See [Examples → Parallel segmentation pipeline](../examples.md#parallel-segmentation-pipeline).
+    - [`sio.LabelImageWriter`][sleap_io.LabelImageWriter] streams `LabelImage` frames one at a time into SLP with constant memory — ideal for TIFF-stack pipelines that don't fit in memory. See [Regions → Streaming writes](../model/regions.md#streaming-writes).
+
+!!! note "See also"
+    [Formats → COCO Panoptic segmentation](index.md#coco-panoptic-segmentation) — the COCO Panoptic reader/writer uses the same `LabelImage` model, so the same post-processing helpers apply.
 
 ## API
 

--- a/docs/model/3d.md
+++ b/docs/model/3d.md
@@ -155,6 +155,25 @@ Key properties:
 - `score` — optional confidence score for the match.
 - `identity` — optional `Identity` for this group (which animal).
 
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skel = sio.Skeleton(nodes=["head", "tail"], edges=[("head", "tail")])
+>>> cam1, cam2 = sio.Camera(name="cam1"), sio.Camera(name="cam2")
+>>> inst_2d_cam1 = sio.Instance.from_numpy(np.array([[10, 20], [30, 40]]), skeleton=skel)
+>>> inst_2d_cam2 = sio.Instance.from_numpy(np.array([[12, 22], [32, 42]]), skeleton=skel)
+>>> inst_3d = sio.Instance3D(points=np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]), skeleton=skel)
+>>> mouse_a = sio.Identity(name="mouse_A", color="#e6194b")
+>>> group = sio.InstanceGroup(
+...     instance_by_camera={cam1: inst_2d_cam1, cam2: inst_2d_cam2},
+...     instance_3d=inst_3d,
+...     identity=mouse_a,
+... )
+>>> print(len(group.instances), "matched instances")
+>>> print(group.identity.name)
+
+```
+
 ---
 
 ## Identity
@@ -171,6 +190,18 @@ Key properties:
 
 Identities are stored at the top level on [`Labels.identities`](labels.md) and referenced by `InstanceGroup.identity`.
 
+```pycon
+>>> import sleap_io as sio
+>>> mouse_a = sio.Identity(name="mouse_A", color="#e6194b")
+>>> mouse_b = sio.Identity(name="mouse_B", color="#3cb44b")
+>>> labels = sio.Labels(identities=[mouse_a, mouse_b])
+>>> print([ident.name for ident in labels.identities])
+
+```
+
+!!! note "SLP persistence"
+    `Identity` and [`Instance3D`](#instance3d) persist into SLP format v1.9+, so round-tripping between sleap-io and sleap-io.js / luc3d is lossless.
+
 ---
 
 ## Instance3D
@@ -186,6 +217,22 @@ Key properties:
 - `is_empty` — whether all keypoints are missing.
 
 `PredictedInstance3D` extends `Instance3D` with per-keypoint confidence scores in the `point_scores` field.
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skel = sio.Skeleton(nodes=["head", "tail"], edges=[("head", "tail")])
+>>> pts = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+>>> inst_3d = sio.Instance3D(points=pts, skeleton=skel)
+>>> print(inst_3d.n_visible, inst_3d.is_empty)
+>>> pred_3d = sio.PredictedInstance3D(
+...     points=pts, skeleton=skel, point_scores=np.array([0.9, 0.8]),
+... )
+>>> print(pred_3d.point_scores)
+
+```
+
+Both `Instance3D` and `PredictedInstance3D` serialize into SLP v1.9+.
 
 ---
 

--- a/docs/model/index.md
+++ b/docs/model/index.md
@@ -96,7 +96,24 @@ classDiagram
     }
     class InstanceGroup:::threed {
         +instance_by_camera
+        +Instance3D instance_3d
+        +Identity identity
+    }
+    class Identity:::threed {
+        +str name
+        +str color
+    }
+    class Instance3D:::threed {
         +ndarray points
+        +Skeleton skeleton
+    }
+    class PredictedInstance3D:::threed {
+        +ndarray point_scores
+    }
+
+    class LabelImageWriter:::labels {
+        +str filename
+        +add()
     }
 
     class ROI:::regions {
@@ -176,6 +193,11 @@ classDiagram
     FrameGroup "1" *-- "0..*" InstanceGroup
     InstanceGroup --> Instance
     InstanceGroup --> Camera
+    InstanceGroup --> Instance3D
+    InstanceGroup --> Identity
+    Instance3D --> Skeleton : uses
+    Instance3D <|-- PredictedInstance3D
+    Labels --> Identity
 
     Centroid <|-- UserCentroid
     Centroid <|-- PredictedCentroid
@@ -188,6 +210,8 @@ classDiagram
     LabelImage <|-- UserLabelImage
     LabelImage <|-- PredictedLabelImage
     LabelImage --> SegmentationMask : to_masks()
+    LabelImage --> BoundingBox : to_bboxes()
+    LabelImageWriter --> LabelImage : streams
     LabeledFrame --> Centroid
     LabeledFrame --> BoundingBox
     LabeledFrame --> ROI
@@ -222,6 +246,9 @@ classDiagram
 | [`RecordingSession`](3d.md) | [3D](3d.md) | Multi-camera recording linking cameras to videos |
 | [`FrameGroup`](3d.md) | [3D](3d.md) | Matched labeled frames across views at one time point |
 | [`InstanceGroup`](3d.md) | [3D](3d.md) | Same animal matched across cameras, with optional 3D points |
+| [`Identity`](3d.md#identity) | [3D](3d.md) | Cross-session persistent animal identity (distinct from per-video `Track`) |
+| [`Instance3D`](3d.md#instance3d) | [3D](3d.md) | Structured triangulated 3D keypoint storage |
+| [`PredictedInstance3D`](3d.md#instance3d) | [3D](3d.md) | Model-predicted 3D keypoints with per-point scores |
 | [`Centroid`](regions.md) | [Regions](regions.md) | Abstract base centroid point annotation |
 | [`UserCentroid`](regions.md) | [Regions](regions.md) | Human-annotated centroid |
 | [`PredictedCentroid`](regions.md) | [Regions](regions.md) | Model-predicted centroid with score |
@@ -237,6 +264,7 @@ classDiagram
 | [`UserLabelImage`](regions.md) | [Regions](regions.md) | Human-annotated label image |
 | [`PredictedLabelImage`](regions.md) | [Regions](regions.md) | Model-predicted label image with score |
 | [`LabelImage`](regions.md) | [Regions](regions.md) | Dense integer label image for instance segmentation |
+| [`LabelImageWriter`](regions.md#streaming-writes) | [Regions](regions.md) | Streaming writer for chunked label image SLP files |
 
 !!! tip "Hands-on examples"
 

--- a/docs/model/poses.md
+++ b/docs/model/poses.md
@@ -178,6 +178,29 @@ Create an instance with no visible points (all coordinates are unset):
     [`LabeledFrame`](labels.md#labeled-frames) and [`Labels`](labels.md#labels).
     See the [Labels & Frames](labels.md) page for the full picture.
 
+### Centroid integration
+
+A pose `Instance` can be summarized as a single point without losing its metadata. [`Instance.centroid_xy`][sleap_io.Instance.centroid_xy] returns the `(x, y)` of the visible landmarks, and [`Instance.to_centroid()`][sleap_io.Instance.to_centroid] produces a full [`UserCentroid`][sleap_io.UserCentroid] (or [`PredictedCentroid`][sleap_io.PredictedCentroid] for a `PredictedInstance`) carrying the same track, category, and confidence metadata.
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "thorax", "abdomen"])
+>>> inst = sio.Instance.from_numpy(
+...     np.array([[10, 20], [30, 40], [50, 60]]),
+...     skeleton=skeleton,
+... )
+>>> print(inst.centroid_xy)       # (mean_x, mean_y) of the visible points
+>>> c = inst.to_centroid()
+>>> print(type(c).__name__, c.xy)
+
+```
+
+Centroids can be turned back into single-node instances with
+[`Centroid.to_instance`][sleap_io.Centroid.to_instance], so the two
+representations are fully interchangeable. See
+[Regions → Centroids](regions.md#centroids) for the full data model.
+
 ---
 
 ## Predicted instances
@@ -233,6 +256,9 @@ as belonging to the same individual.
     `Track` objects are compared by **identity** (not by name). Two different
     `Track("mouse")` objects are considered distinct: this allows multiple
     tracks with the same display name if needed.
+
+!!! tip "Track vs. Identity"
+    `Track` is a **per-video** temporal trajectory — it links instances in consecutive frames of the same recording and disappears when the tracker loses its target. [`Identity`](3d.md#identity) is a **cross-session** persistent label for the same animal across recordings, sessions, and multi-view setups. In multi-view workflows, multiple per-camera `Track`s typically map to a single `Identity` through [`InstanceGroup.identity`](3d.md#instance-group).
 
 ---
 

--- a/docs/model/regions.md
+++ b/docs/model/regions.md
@@ -42,24 +42,27 @@ properties. The four geometry types can be converted between each other
 ## Working with annotations in frames
 
 Since annotations are nested in [`LabeledFrame`](labels.md), you add them
-directly to a frame's annotation lists.
+directly to a frame's annotation lists. [`LabeledFrame.append`][sleap_io.LabeledFrame.append] dispatches on the runtime type of the annotation and pushes it onto the correct per-type list — you never have to touch `lf.instances`, `lf.bboxes`, `lf.centroids`, `lf.masks`, `lf.label_images`, or `lf.rois` directly.
 
 ```pycon
+>>> import numpy as np
 >>> import sleap_io as sio
+>>> from shapely.geometry import box
 >>> video = sio.Video("test.mp4", open_backend=False)
 >>> lf = sio.LabeledFrame(video=video, frame_idx=0)
->>> bbox = sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60)
->>> lf.append(bbox)
->>> centroid = sio.UserCentroid(x=100, y=200)
->>> lf.append(centroid)
+>>> lf.append(sio.UserBoundingBox(x1=10, y1=20, x2=50, y2=60))  # → lf.bboxes
+>>> lf.append(sio.UserCentroid(x=100, y=200))                    # → lf.centroids
+>>> lf.append(sio.UserSegmentationMask.from_numpy(np.zeros((8, 8), bool)))  # → lf.masks
+>>> lf.append(sio.UserLabelImage.from_numpy(np.zeros((8, 8), int)))         # → lf.label_images
+>>> lf.append(sio.UserROI(geometry=box(0, 0, 10, 10)))            # → lf.rois
 >>> labels = sio.Labels(labeled_frames=[lf])
->>> print(len(labels.centroids))
->>> print(len(labels.bboxes))
+>>> print(len(labels.centroids), len(labels.bboxes))
+>>> print(len(labels.masks), len(labels.label_images), len(labels.rois))
 
 ```
 
 The `labels.centroids`, `labels.bboxes`, `labels.masks`, `labels.label_images`,
-and `labels.rois` properties return flattened views across all frames.
+and `labels.rois` properties return flattened read-only views across all frames. Static, video-level ROIs (with no frame association) live separately on [`Labels.static_rois`][sleap_io.Labels.static_rois] — see [Static vs. temporal ROIs](#static-vs-temporal-rois) below.
 
 ---
 
@@ -72,6 +75,9 @@ pose skeletons are not needed. `Centroid` is abstract — use [`UserCentroid`][s
 
 Centroids support optional 3D coordinates (`z`), interconversion with
 single-node [`Instance`](poses.md) objects, and the same track/instance metadata as other annotation types.
+
+!!! tip "Importing TrackMate detections"
+    `PredictedCentroid(source="trackmate")` is the canonical representation for TrackMate (ImageJ/Fiji) point tracking results. Load spot exports directly with [`sio.load_trackmate`][sleap_io.load_trackmate] or let [`sio.load_file`][sleap_io.load_file] auto-detect the format from the CSV header. See [Formats → TrackMate](../formats/trackmate.md) for the full schema.
 
 ### Direct construction
 
@@ -169,6 +175,9 @@ Every centroid can carry optional metadata:
 | `name`      | `str`              | Human-readable name                          |
 | `source`    | `str`              | How the centroid was computed (e.g., `"center_of_mass"`) |
 
+!!! tip "Rendering"
+    Centroids compose with pose rendering in [`sio.render_image`][sleap_io.render_image] / [`sio.render_video`][sleap_io.render_video] and are listed in [Rendering → Segmentation Overlays](../rendering.md#segmentation-overlays). For standalone canvases, pair [`sio.draw_bboxes`][sleap_io.draw_bboxes] with `Centroid.to_instance()` or use the pose drawing helpers directly.
+
 ---
 
 ## Bounding boxes
@@ -264,10 +273,14 @@ Every bounding box can carry optional metadata:
 | Field       | Type               | Description                                  |
 | ----------- | ------------------ | -------------------------------------------- |
 | `track`     | [`Track`](poses.md) `\| None`    | Tracking identity across frames              |
+| `tracking_score` | `float \| None` | Confidence of track identity assignment    |
 | `instance`  | [`Instance`](poses.md) `\| None` | Linked pose instance                         |
 | `category`  | `str`              | Class label (e.g., `"mouse"`)                |
 | `name`      | `str`              | Human-readable name                          |
 | `source`    | `str`              | Annotation source identifier                 |
+
+!!! tip "Rendering"
+    Use [`sio.draw_bboxes`][sleap_io.draw_bboxes] to composite bounding boxes onto an image, or pass `bboxes` to [`sio.render_image`][sleap_io.render_image] / [`sio.render_video`][sleap_io.render_video]. See [Rendering → Segmentation Overlays](../rendering.md#segmentation-overlays).
 
 ---
 
@@ -282,6 +295,21 @@ rectangle. `ROI` is abstract — use [`UserROI`][sleap_io.UserROI] or [`Predicte
 ### Static vs. temporal ROIs
 
 ROIs can be **static** (applying to all frames of a video) or **frame-bound** (attached to a specific `LabeledFrame`). Static ROIs are stored in `Labels.static_rois` and have a `video` attribute. Frame-bound ROIs are stored on individual `LabeledFrame.rois` lists.
+
+Adding a static ROI to a dataset is a direct list append:
+
+```pycon
+>>> import sleap_io as sio
+>>> from shapely.geometry import box
+>>> video = sio.Video("test.mp4", open_backend=False)
+>>> labels = sio.Labels(videos=[video])
+>>> arena = sio.UserROI(geometry=box(10, 10, 100, 100), video=video)
+>>> labels.static_rois.append(arena)
+>>> print(len(labels.static_rois))
+
+```
+
+Frame-bound ROIs use `LabeledFrame.append(roi)` and participate in the O(1) per-frame accessors (`lf.rois`).
 
 ### From polygon coordinates
 
@@ -395,6 +423,23 @@ predictions. `PredictedROI` adds a `score` field for confidence:
 
 ```
 
+### Metadata fields
+
+Every ROI can carry optional metadata:
+
+| Field       | Type               | Description                                  |
+| ----------- | ------------------ | -------------------------------------------- |
+| `video`     | [`Video`](video.md) `\| None` | Associated video — set for static ROIs, `None` for frame-bound ROIs |
+| `track`     | [`Track`](poses.md) `\| None`    | Tracking identity across frames              |
+| `tracking_score` | `float \| None` | Confidence of track identity assignment    |
+| `instance`  | [`Instance`](poses.md) `\| None` | Linked pose instance                         |
+| `category`  | `str`              | Class label (e.g., `"arena"`)                |
+| `name`      | `str`              | Human-readable name                          |
+| `source`    | `str`              | Annotation source identifier                 |
+
+!!! tip "Rendering"
+    Use [`sio.draw_rois`][sleap_io.draw_rois] to composite ROIs onto an image, or pass them to [`sio.render_image`][sleap_io.render_image]. The ROI stroke/fill colors follow the same palette options as other overlays. See [Rendering → Segmentation Overlays](../rendering.md#segmentation-overlays).
+
 ---
 
 ## Segmentation masks
@@ -499,6 +544,70 @@ and optional `score_map` fields:
 The `score_map` field is an optional dense `float32` array of shape `(H, W)`
 providing pixel-level confidence. It is stored separately in the SLP format
 using zlib compression to avoid bloating files.
+
+### Multi-resolution masks
+
+Segmentation masks stored at lower resolution — e.g., from a model that
+downsamples inputs, or a cropped tile extracted from a larger image — can carry
+spatial metadata so they round-trip losslessly into image-pixel space.
+
+`SegmentationMask.scale` is a `(sx, sy)` scale factor and `offset` is an
+`(x, y)` pixel shift. Together they define the transform
+`image_coord = mask_coord / scale + offset`. Use the `stride=` convenience
+argument to set an isotropic downsample ratio, or pass `offset=` directly:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> half_res = np.zeros((240, 320), dtype=bool)
+>>> half_res[60:120, 80:180] = True
+>>> mask = sio.UserSegmentationMask.from_numpy(half_res, stride=2)
+>>> print(mask.scale)  # (0.5, 0.5) — equivalent to stride=2
+>>> print(mask.bbox)   # bbox is returned in full-image coordinates
+
+```
+
+Crop-space masks (e.g., from a detector that processes `(H, W)` tiles) use the
+`offset=` kwarg — `mask.bbox` then maps back into image-pixel space without any
+extra math on your side:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> crop = np.zeros((50, 50), dtype=bool)
+>>> crop[10:30, 15:40] = True
+>>> mask = sio.UserSegmentationMask.from_numpy(crop, offset=(100.0, 200.0))
+>>> print(mask.offset)
+>>> print(mask.bbox)  # offset + extent → image coordinates
+
+```
+
+Call `mask.resampled(target_height, target_width)` to materialize the mask at a
+new resolution while preserving its spatial metadata for further transforms.
+
+!!! note "Also on `LabelImage`"
+    The same `scale` / `offset` / `resampled()` convention applies to
+    [`LabelImage`](#label-images) — a single `LabelImage` can carry a whole
+    frame's worth of objects at a downsampled resolution, with the object-id
+    metadata mapping back to full-image pixel space via the same transform.
+
+### Metadata fields
+
+Every segmentation mask can carry optional metadata:
+
+| Field            | Type               | Description                                  |
+| ---------------- | ------------------ | -------------------------------------------- |
+| `track`          | [`Track`](poses.md) `\| None`    | Tracking identity across frames              |
+| `tracking_score` | `float \| None`    | Confidence of track identity assignment      |
+| `instance`       | [`Instance`](poses.md) `\| None` | Linked pose instance                         |
+| `scale`          | `tuple[float, float]` | `(sx, sy)` spatial scale (default `(1, 1)`) |
+| `offset`         | `tuple[float, float]` | `(x, y)` pixel offset (default `(0, 0)`)    |
+| `category`       | `str`              | Class label (e.g., `"neuron"`)              |
+| `name`           | `str`              | Human-readable name                          |
+| `source`         | `str`              | Annotation source identifier                 |
+
+!!! tip "Rendering"
+    Use [`sio.draw_masks`][sleap_io.draw_masks] to composite a sequence of segmentation masks onto an image, or include them in [`sio.render_image`][sleap_io.render_image] / [`sio.render_video`][sleap_io.render_video] overlays. See [Rendering → Segmentation Overlays](../rendering.md#segmentation-overlays).
 
 ---
 
@@ -900,6 +1009,9 @@ category string merge into one pixel value per frame:
 ```python
 sio.normalize_label_ids(labels.label_images, by="category")
 ```
+
+!!! tip "Rendering"
+    Use [`sio.draw_label_image`][sleap_io.draw_label_image] to composite a single `LabelImage` onto an arbitrary image, or pass `overlay=label_stack_or_image` to [`sio.render_image`][sleap_io.render_image] / [`sio.render_video`][sleap_io.render_video]. See [Rendering → Segmentation Overlays](../rendering.md#segmentation-overlays) for the full overlay pipeline.
 
 ### Lazy loading
 

--- a/docs/model/video.md
+++ b/docs/model/video.md
@@ -102,6 +102,18 @@ The full list of supported extensions is available via `Video.EXTS`:
 >>> print(sio.Video.EXTS)
 ```
 
+!!! info "Norpix `.seq` extras"
+    The `SeqVideo` backend exposes per-frame timestamps and an auto-computed FPS derived from the timestamp stream (handy when the header FPS is wrong, as is common for high-speed recordings):
+
+    ```python
+    video = sio.load_video("recording.seq")
+    seq = video.backend   # SeqVideo
+    print(seq.fps)                  # auto-computed from timestamps
+    ts = seq.get_timestamps()       # seconds-since-epoch, shape (num_frames,)
+    ```
+
+    `sio show recording.seq` surfaces the Norpix header (codec, bit depth, description, FPS), and `sio reencode recording.seq -o recording.mp4` uses the Python path to transcode.
+
 For media videos, you can choose which reading plugin to use:
 
 ```python

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -797,6 +797,13 @@ sio render --images frames/ --overlay masks.tif -o output.mp4
 
 # Overlay-only with TIFF stack images
 sio render --images frames.tif --overlay masks/ --overlay-outline -o output.mp4
+
+# Color overlay with a specific palette
+sio render -i predictions.slp --overlay masks.tif --overlay-palette tableau10
+
+# Discover palettes and named colors
+sio render --list-palettes
+sio render --list-colors
 ```
 
 ---
@@ -833,22 +840,22 @@ sio render --images frames.tif --overlay masks/ --overlay-outline -o output.mp4
       show_root_heading: true
       heading_level: 3
 
-::: sleap_io.rendering.draw_label_image
+::: sleap_io.draw_label_image
     options:
       show_root_heading: true
       heading_level: 3
 
-::: sleap_io.rendering.draw_masks
+::: sleap_io.draw_masks
     options:
       show_root_heading: true
       heading_level: 3
 
-::: sleap_io.rendering.draw_bboxes
+::: sleap_io.draw_bboxes
     options:
       show_root_heading: true
       heading_level: 3
 
-::: sleap_io.rendering.draw_rois
+::: sleap_io.draw_rois
     options:
       show_root_heading: true
       heading_level: 3


### PR DESCRIPTION
## Summary

- PR 2 of the v0.7.0 docs refresh tracked in `scratch/.../DOCS_AUDIT.md`. PR 1 (#415) fixed demonstrably wrong content; this PR is purely additive documentation of shipped features.
- Adds `sio render --overlay*` flag coverage, TrackMate convert examples, segmentation overlay workflows, multi-resolution mask docs, 3D / Identity pycon examples, and a TIFF → SLP follow-up recipe pointer.

## Key changes

- **`docs/cli.md`**: new Segmentation Overlays subsection (10 overlay/image flags, overlay-only render mode, examples mirrored from `rendering.md`); TrackMate examples + input-format listing + Format Detection table update; SeqVideo entry in the `sio reencode` behavior-by-video-type list.
- **`docs/rendering.md`**: swap API Reference autodoc targets from `sleap_io.rendering.draw_*` to the shorter `sleap_io.draw_*` aliases; add `--overlay-palette` / `--list-colors` / `--list-palettes` to the CLI example block.
- **`docs/examples.md`**: new top-level *Annotation types* section (bounding boxes, centroids + TrackMate, cross-session identity + 3D, GeoJSON ROIs, `LabeledFrame.append` type dispatch, O(1) frame/track lookups) plus new subsections for Norpix `.seq` video, segmentation overlay rendering, and a parallel segmentation pipeline combining `LabelImageWriter` with `merge_label_images`. Every snippet was validated against the current sleap-io API in a REPL.
- **`docs/model/regions.md`**: multi-resolution masks subsection (`scale`/`offset`/`resampled()`/`stride` constructors); new metadata tables for `ROI` and `SegmentationMask` plus `tracking_score` on `BoundingBox`; static-ROI append example; inline `draw_*` rendering tips; Centroid → TrackMate cross-link; extended *Working with annotations in frames* dispatch walkthrough.
- **`docs/model/3d.md`**: live pycon examples for `InstanceGroup`, `Identity`, `Instance3D`, and `PredictedInstance3D`; `Labels(identities=...)` construction example; SLP v1.9 persistence note.
- **`docs/model/poses.md`**: Centroid integration subsection under `Instance` (covers `Instance.centroid_xy` / `Instance.to_centroid()`) and a Track-vs-Identity disambiguation tip on the Track section.
- **`docs/model/index.md`**: Mermaid class diagram extended with `Identity`, `Instance3D`, `PredictedInstance3D`, `LabelImageWriter`, plus the `LabelImage.to_bboxes()` → `BoundingBox` edge; Quick reference table gains rows for the new types.
- **`docs/model/video.md`**: `SeqVideo.get_timestamps()` / auto-FPS callout under Backends.
- **`docs/formats/tiff.md`**: replace the legacy `LabeledFrame(..., label_images=[li])` pattern with `lf.append(li)` in the Cellpose example; add a TIFF → SLP follow-ups tip linking `normalize_label_ids`, `merge_label_images`, and `LabelImageWriter`; add a "See also: COCO Panoptic" pointer.

## Commit layering

1. `docs(cli,rendering): document sio render overlay flags and expose draw_* aliases`
2. `docs(examples): add v0.7.0 annotation type and workflow examples`
3. `docs(model): document v0.7.0 annotation metadata and 3D/multi-view types`
4. `docs(formats/tiff): cross-link label image helpers and append dispatch`

## Test plan

- [x] `uv run mkdocs build` passes with no new broken links or autodoc resolution errors (unique warning set identical to `main` modulo 2 pre-existing "Multiple primary URLs" entries that surface once the poses/regions pages reference symbols also covered by the autogen reference tree).
- [x] Every added pycon / python snippet validated against the current `sleap_io` API in a REPL (bounding box constructors and helpers, centroid conversions, `Identity` / `Instance3D` / `InstanceGroup` construction, `LabeledFrame.append` dispatch, `SegmentationMask` stride / offset / resampled, O(1) lookups, GeoJSON round-trip).
- [x] `docs/cli.md` overlay flag additions cross-checked against `sleap_io/io/cli.py:3307-3382`.
- [x] `rendering.md` autodoc swap verified by confirming `draw_rois` / `draw_masks` / `draw_bboxes` / `draw_label_image` are top-level exports at `sleap_io/__init__.py:71-76` and appear in the rendered rendering page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)