### PR TITLE
fix: Preserve LabelImage lazy reads across Labels GC

### DIFF
--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -164,7 +164,16 @@ class Labels:
             object.__setattr__(self, key, value)
 
     def close(self) -> None:
-        """Close open file handles held for lazy label image data."""
+        """Close open file handles held for lazy label image data.
+
+        This forcibly closes the HDF5 file. Any ``LabelImage`` objects from
+        this ``Labels`` whose ``.data`` has not yet been materialized will
+        fail on subsequent ``.data`` access. For normal cleanup, prefer
+        letting garbage collection release the handle: ``Labels.__del__``
+        drops the reference without forcibly closing, so ``LabelImage``
+        objects that outlive this ``Labels`` keep working via HDF5's own
+        reference counting on dataset identifiers.
+        """
         if self._label_image_file is not None:
             try:
                 self._label_image_file.close()
@@ -173,8 +182,25 @@ class Labels:
             self._label_image_file = None
 
     def __del__(self) -> None:
-        """Release resources on garbage collection."""
-        self.close()
+        """Release our reference to the lazy label-image file on GC.
+
+        We intentionally do NOT call ``close()`` here. Forcibly closing the
+        HDF5 file on GC breaks ``LabelImage`` objects that outlive this
+        ``Labels`` — e.g. ``li = sio.load_slp("x.slp")[0].label_images[0]``,
+        where the anonymous ``Labels`` is GC'd after the expression finishes
+        but ``li`` is still held. By merely dropping our Python reference,
+        the HDF5 file stays open (h5py's C-level refcount holds it open
+        while ``Dataset`` identifiers captured by lazy loaders are alive)
+        and closes cleanly once the last consumer is also released.
+        """
+        # Drop our reference; do not forcibly close. See `close()` for the
+        # explicit-close variant.
+        try:
+            self._label_image_file = None
+        except AttributeError:
+            # Can fire during interpreter teardown on partially-constructed
+            # attrs instances; nothing to release.
+            pass
 
     @property
     def is_lazy(self) -> bool:

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -195,12 +195,7 @@ class Labels:
         """
         # Drop our reference; do not forcibly close. See `close()` for the
         # explicit-close variant.
-        try:
-            self._label_image_file = None
-        except AttributeError:
-            # Can fire during interpreter teardown on partially-constructed
-            # attrs instances; nothing to release.
-            pass
+        self._label_image_file = None
 
     @property
     def is_lazy(self) -> bool:

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -5181,11 +5181,11 @@ def test_iterate_label_images_after_anonymous_load(tmp_path):
 
     path, expected = _make_slp_with_label_image(tmp_path)
 
-    datas = [li.data for li in load_slp(path)[0].label_images]
+    data_arrays = [li.data for li in load_slp(path)[0].label_images]
     gc.collect()
 
-    assert len(datas) == 1
-    np.testing.assert_array_equal(datas[0], expected)
+    assert len(data_arrays) == 1
+    np.testing.assert_array_equal(data_arrays[0], expected)
 
 
 # -- h5wasm compatibility tests --

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -5053,6 +5053,141 @@ def test_label_image_instance_lazy_materialize(tmp_path):
     assert materialized.label_images[0].objects[1]._instance_idx == -1
 
 
+# -- LabelImage lifetime regression tests --
+# These guard against a class of bugs where the HDF5 file backing lazy
+# LabelImage.data is closed while LabelImage objects still reference it.
+
+
+def _make_slp_with_label_image(tmp_path, path_name="lazy.slp"):
+    """Helper: write a small labels.slp with one LabelImage and return path."""
+    video = Video(filename="test.mp4")
+    data = np.zeros((8, 8), dtype=np.int32)
+    data[2:5, 2:5] = 1
+    data[5:7, 5:7] = 2
+    li = UserLabelImage(
+        data=data,
+        objects={
+            1: LabelImage.Info(category="cell"),
+            2: LabelImage.Info(category="cell"),
+        },
+    )
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.label_images.append(li)
+    labels = Labels(labeled_frames=[lf], videos=[video])
+    path = str(tmp_path / path_name)
+    save_slp(labels, path)
+    return path, data
+
+
+def test_label_image_data_survives_anonymous_labels_gc(tmp_path):
+    """``sio.load_slp(...)[0].label_images[0].data`` works.
+
+    Regression: the anonymous ``Labels`` returned by ``load_slp`` is GC'd at
+    the end of the expression. Before the fix, ``Labels.__del__`` forcibly
+    closed the HDF5 file, invalidating the lazy loader's Dataset references
+    and raising ``RuntimeError: Unable to synchronously get dataspace``.
+    """
+    import gc
+
+    path, expected = _make_slp_with_label_image(tmp_path)
+
+    li = load_slp(path)[0].label_images[0]
+    # Force any deferred cleanup of the anonymous Labels object.
+    gc.collect()
+
+    # Lazy load should succeed.
+    np.testing.assert_array_equal(li.data, expected)
+
+
+def test_label_image_data_survives_function_return(tmp_path):
+    """LabelImage returned from a function outlives the function's local Labels."""
+    import gc
+
+    path, expected = _make_slp_with_label_image(tmp_path)
+
+    def get_li(p):
+        labels = load_slp(p)
+        return labels[0].label_images[0]
+
+    li = get_li(path)
+    gc.collect()
+    np.testing.assert_array_equal(li.data, expected)
+
+
+def test_multiple_labels_open_simultaneously(tmp_path):
+    """Loading the same file into two Labels and accessing both works."""
+    path, expected = _make_slp_with_label_image(tmp_path)
+
+    labels_a = load_slp(path)
+    labels_b = load_slp(path)
+    li_a = labels_a[0].label_images[0]
+    li_b = labels_b[0].label_images[0]
+
+    np.testing.assert_array_equal(li_a.data, expected)
+    np.testing.assert_array_equal(li_b.data, expected)
+
+
+def test_dropping_one_labels_does_not_break_another(tmp_path):
+    """Dropping one Labels ref while another still holds its own file is OK."""
+    import gc
+
+    path, expected = _make_slp_with_label_image(tmp_path)
+
+    labels_a = load_slp(path)
+    labels_b = load_slp(path)
+    li_b = labels_b[0].label_images[0]
+
+    # Drop labels_a and force GC. This must not close labels_b's file.
+    del labels_a
+    gc.collect()
+
+    np.testing.assert_array_equal(li_b.data, expected)
+
+
+def test_label_image_survives_labels_dropped_after_li_held(tmp_path):
+    """Holding a LabelImage after dropping its owning Labels still allows reads."""
+    import gc
+
+    path, expected = _make_slp_with_label_image(tmp_path)
+
+    labels = load_slp(path)
+    li = labels[0].label_images[0]
+    del labels
+    gc.collect()
+
+    np.testing.assert_array_equal(li.data, expected)
+
+
+def test_explicit_labels_close_still_invalidates_label_image(tmp_path):
+    """Explicit ``labels.close()`` forcibly closes the file.
+
+    Users who explicitly call ``close()`` opt in to forcibly releasing the
+    file handle; subsequent lazy reads on LabelImage objects from the same
+    Labels must fail (this is the price of the explicit-close contract).
+    """
+    path, _ = _make_slp_with_label_image(tmp_path)
+
+    labels = load_slp(path)
+    li = labels[0].label_images[0]
+    labels.close()
+
+    with pytest.raises(RuntimeError):
+        _ = li.data
+
+
+def test_iterate_label_images_after_anonymous_load(tmp_path):
+    """List-comprehension pattern over anonymous Labels also works."""
+    import gc
+
+    path, expected = _make_slp_with_label_image(tmp_path)
+
+    datas = [li.data for li in load_slp(path)[0].label_images]
+    gc.collect()
+
+    assert len(datas) == 1
+    np.testing.assert_array_equal(datas[0], expected)
+
+
 # -- h5wasm compatibility tests --
 
 

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -5806,8 +5806,14 @@ def test_labels_close_handles_exception():
     assert labels._label_image_file is None
 
 
-def test_labels_del_calls_close():
-    """Labels.__del__() calls close()."""
+def test_labels_del_drops_reference_without_force_close():
+    """Labels.__del__() drops the file reference but does NOT forcibly close.
+
+    Forcibly closing on GC would invalidate LabelImage lazy loaders whose
+    h5py Dataset references rely on the file staying open. By just dropping
+    the reference, h5py's own C-level refcounting keeps the file open as
+    long as any Dataset (held by a LabelImage closure) still uses it.
+    """
     labels = Labels()
 
     class FakeFile:
@@ -5820,7 +5826,10 @@ def test_labels_del_calls_close():
     fake = FakeFile()
     labels._label_image_file = fake
     labels.__del__()
-    assert fake.closed
+    # Reference is dropped
+    assert labels._label_image_file is None
+    # But the file was NOT forcibly closed
+    assert not fake.closed
 
 
 def test_labels_get_centroids():


### PR DESCRIPTION
## Summary
- `Labels.__del__` forcibly closed the HDF5 file on every GC cycle, breaking `LabelImage.data` access in any pattern where a `LabelImage` outlived its anonymous owning `Labels` (e.g. chained `sio.load_slp("x.slp")[0].label_images[0]`).
- Changed `__del__` to drop the Python reference without forcibly closing. h5py's own C-level refcount keeps the HDF5 file open until the last lazy `LabelImage` closure is also released, then closes it cleanly.
- `Labels.close()` still forcibly closes for users who opt in — its contract is unchanged.

## The bug

```python
li = sio.load_slp("x.slp")[0].label_images[0]
li.data   # RuntimeError: Unable to synchronously get dataspace (identifier is not of specified type)
```

The `Labels` returned by `load_slp` is anonymous, so it's garbage-collected as soon as the expression finishes. The previous `__del__` called `self._label_image_file.close()`, which invalidated every `h5py.Dataset` identifier the lazy loader had captured. The subsequent `.data` access blew up deep inside h5py with a message that gave no hint about object lifetime.

## Root cause

- `LabelImage._lazy_loader` closes over an `h5py.Dataset` — a pointer into an open HDF5 file.
- `h5py.Dataset` does **not** hold a Python refcount on `h5py.File` (verified empirically via `weakref`), but HDF5 internally ref-counts the file at the C level for every live Dataset ID.
- Explicit `file.close()` tears everything down regardless of HDF5's internal refcount. That's what the old `__del__` triggered.

## Fix

`sleap_io/model/labels.py`:
- `Labels.__del__` now just sets `self._label_image_file = None`. It does **not** call `close()`.
- `Labels.close()` is unchanged but now has a docstring note explaining that explicit close invalidates unmaterialized `LabelImage` objects (expected behavior — users opt in).

## Why this correctly closes the file

The file **still** gets closed — verified with `lsof` + `weakref`. It just closes at the right moment:
- No `LabelImage` held → drop `Labels` → Python GC collects `h5py.File` → h5py destructor closes the file immediately.
- `LabelImage` held with lazy data → drop `Labels` → HDF5 keeps the file open via its Dataset-ID refcount → file closes only when the `LabelImage`/closure is also released (or when `.data` materializes and the closure is replaced).

In every case fd count reaches 0; no leak, no stale `File` object.

## Test plan

- [x] Updated `test_labels_del_calls_close` → `test_labels_del_drops_reference_without_force_close` to assert the corrected semantics.
- [x] Added 7 regression tests in `tests/io/test_slp.py`:
  - `test_label_image_data_survives_anonymous_labels_gc` — the exact one-liner repro.
  - `test_label_image_data_survives_function_return` — function returns `LabelImage`, local `Labels` goes out of scope.
  - `test_multiple_labels_open_simultaneously` — two parallel loads of the same file.
  - `test_dropping_one_labels_does_not_break_another` — independent lifetimes.
  - `test_label_image_survives_labels_dropped_after_li_held` — explicit `del labels`.
  - `test_explicit_labels_close_still_invalidates_label_image` — preserves the `close()` contract.
  - `test_iterate_label_images_after_anonymous_load` — list-comprehension pattern.
- [x] Full suite: **2821 passed, 16 skipped** (1 pre-existing unrelated CLI failure on `main`).
- [x] `ruff check` + `ruff format --check` clean.
- [x] Manual stress test (`lsof`): 10 simultaneous `Labels` open, 50 load/drop cycles, deepcopy + source-drop, pickle round-trip, delete `.slp` after drop, overwrite `.slp` while loaded, multiple files concurrent. All fd counts return to 0. No stale `weakref` to `h5py.File` after full drop.

## Design decisions

- **Preserve `Labels.close()` semantics.** Users who call `close()` explicitly are opting into hard cleanup; keeping old behavior avoids a silent behavior change for that path. Only the implicit GC path is relaxed.
- **Don't add back-references from `LabelImage` to `Labels`.** That would create reference cycles and couple lifetimes tighter than necessary. Relying on h5py's existing C-level refcount is sufficient and cleaner.
- **No changes to save/read paths.** The lazy-loader factories in `sleap_io/io/slp.py` already capture `Dataset` objects correctly; they just needed the file to stop being forcibly closed out from under them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)