### PR TITLE
fix: Allow render_image(source=lf) for segmentation-only LabeledFrames

### DIFF
--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -870,11 +870,17 @@ def render_image(
     elif isinstance(source, LabeledFrame):
         lf = source
         instances = list(lf.instances)
-        skeleton = instances[0].skeleton if instances else None
-        if skeleton is None:
-            raise ValueError("LabeledFrame has no instances with skeleton")
-        edge_inds = skeleton.edge_inds
-        node_names = [n.name for n in skeleton.nodes]
+        if instances:
+            skeleton = instances[0].skeleton
+            edge_inds = skeleton.edge_inds
+            node_names = [n.name for n in skeleton.nodes]
+        else:
+            # No instances — segmentation/overlay-only mode. Fall through with
+            # empty pose-rendering state so the video frame and any overlay
+            # (masks, label images, ROIs, bboxes) still render. Mirrors the
+            # centroid-only path in the `Labels` branch above.
+            edge_inds = []
+            node_names = []
         fidx_for_callback = lf.frame_idx
         track_indices = None
         n_tracks = 0

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -1177,18 +1177,32 @@ class TestRenderImage:
         assert isinstance(rendered, np.ndarray)
         # Should have some reasonable size based on keypoints
 
-    def test_render_image_labeled_frame_no_skeleton_error(self):
-        """Test render_image with LabeledFrame that has no instances."""
+    def test_render_image_labeled_frame_without_instances(self):
+        """``render_image(source=lf)`` works when the LabeledFrame has no instances.
+
+        Before this was fixed, a bare ``LabeledFrame`` without instances raised
+        ``ValueError("LabeledFrame has no instances with skeleton")``, forcing
+        segmentation-only workflows to pass ``source=None, image=lf.image``.
+        The LabeledFrame source now falls through to empty pose-rendering state
+        (mirroring the centroid-only path in the ``Labels`` branch).
+        """
         from sleap_io.model.labeled_frame import LabeledFrame
         from sleap_io.model.video import Video
         from sleap_io.rendering import render_image
 
-        # Create empty labeled frame
         video = Video(filename="dummy.mp4")
         lf = LabeledFrame(video=video, frame_idx=0, instances=[])
 
-        with pytest.raises(ValueError, match="no instances with skeleton"):
-            render_image(lf, image=np.zeros((100, 100, 3), dtype=np.uint8))
+        # With an explicit image — should render the image as-is.
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        rendered = render_image(lf, image=img)
+        assert isinstance(rendered, np.ndarray)
+        assert rendered.shape == (100, 100, 3)
+
+        # With a solid-color background — should render a blank frame.
+        rendered_bg = render_image(lf, background="black")
+        assert isinstance(rendered_bg, np.ndarray)
+        assert rendered_bg.ndim == 3 and rendered_bg.shape[-1] == 3
 
     def test_render_image_video_unavailable_with_background(self, labels_predictions):
         """Test frame size estimation from keypoints when video unavailable."""
@@ -2704,6 +2718,99 @@ def test_render_image_overlay_with_scale():
 
     result = render_image(image=img, overlay=labels, overlay_alpha=0.4, scale=0.5)
     assert result.shape == (50, 50, 3)
+
+
+def test_render_image_labeled_frame_source_with_label_image_overlay():
+    """``source=lf`` + LabelImage overlay works when lf has no instances.
+
+    Regression: previously raised ``ValueError("LabeledFrame has no instances
+    with skeleton")``, forcing callers to pass ``source=None, image=lf.image``
+    for segmentation-only frames.
+    """
+    from sleap_io.model.label_image import LabelImage, UserLabelImage
+    from sleap_io.model.labeled_frame import LabeledFrame
+    from sleap_io.model.video import Video
+
+    data = np.zeros((60, 60), dtype=np.int32)
+    data[10:25, 10:25] = 1
+    data[35:50, 35:50] = 2
+    li = UserLabelImage(
+        data=data,
+        objects={1: LabelImage.Info(category="a"), 2: LabelImage.Info(category="b")},
+    )
+    lf = LabeledFrame(video=Video(filename="dummy.mp4"), frame_idx=0)
+    lf.label_images.append(li)
+
+    # Pass an explicit image so we control the canvas size.
+    base = np.zeros((60, 60, 3), dtype=np.uint8)
+    result = render_image(source=lf, image=base, overlay=li, overlay_alpha=0.45)
+    assert result.shape == (60, 60, 3)
+    # Labeled regions are visible on the black background.
+    assert result[15, 15].any()
+    assert result[40, 40].any()
+    # The two labels take different colors.
+    assert not np.array_equal(result[15, 15], result[40, 40])
+
+
+def test_render_image_labeled_frame_source_with_mask_overlay():
+    """``source=lf`` + SegmentationMask overlay works with no instances."""
+    from sleap_io.model.labeled_frame import LabeledFrame
+    from sleap_io.model.video import Video
+
+    binary = np.zeros((50, 50), dtype=bool)
+    binary[10:30, 10:30] = True
+    mask = UserSegmentationMask.from_numpy(binary)
+    lf = LabeledFrame(video=Video(filename="dummy.mp4"), frame_idx=0)
+    lf.masks.append(mask)
+
+    base = np.zeros((50, 50, 3), dtype=np.uint8)
+    result = render_image(source=lf, image=base, overlay=[mask], overlay_alpha=0.5)
+    assert result.shape == (50, 50, 3)
+    assert result[20, 20].any()
+
+
+def test_render_image_labeled_frame_source_with_roi_overlay():
+    """``source=lf`` + ROI overlay works with no instances."""
+    from sleap_io.model.labeled_frame import LabeledFrame
+    from sleap_io.model.video import Video
+
+    roi = UserROI(geometry=box(20, 20, 60, 60))
+    lf = LabeledFrame(video=Video(filename="dummy.mp4"), frame_idx=0)
+    lf.rois.append(roi)
+
+    result = render_image(
+        source=lf, overlay=[roi], overlay_alpha=0.3, background="black"
+    )
+    # Rendered at the default size (64x64) since no video and no instances.
+    assert result.ndim == 3 and result.shape[-1] == 3
+
+
+def test_render_image_labeled_frame_source_with_bbox_overlay():
+    """``source=lf`` + BoundingBox overlay works with no instances."""
+    from sleap_io.model.labeled_frame import LabeledFrame
+    from sleap_io.model.video import Video
+
+    bbox = UserBoundingBox(x1=30, y1=30, x2=70, y2=70)
+    lf = LabeledFrame(video=Video(filename="dummy.mp4"), frame_idx=0)
+    lf.bboxes.append(bbox)
+
+    result = render_image(
+        source=lf, overlay=[bbox], overlay_alpha=0.3, background="black"
+    )
+    assert result.ndim == 3 and result.shape[-1] == 3
+
+
+def test_render_image_labeled_frame_with_instances_still_uses_skeleton(
+    labels_predictions,
+):
+    """LabeledFrame with instances still goes through the skeleton-aware path.
+
+    Verifies the fix did not break the classic pose-rendering code path.
+    """
+    lf = labels_predictions.labeled_frames[0]
+    assert len(lf.instances) > 0  # sanity
+    result = render_image(source=lf, background="black")
+    assert result.ndim == 3 and result.shape[-1] == 3
 
 
 def test_render_image_source_none_requires_image():


### PR DESCRIPTION
## Summary
- `render_image(source=lf)` raised `ValueError("LabeledFrame has no instances with skeleton")` whenever a `LabeledFrame` had only segmentation annotations (masks, ROIs, label images, bounding boxes) and no `Instance` objects.
- This forced every segmentation-only workflow to fall back to the `source=None, image=lf.image` pattern — which required the caller to manually fetch `lf.image`, broadcast grayscale → RGB, and reimplement what the function already does for the pose case.
- Fix: when `lf.instances` is empty, fall through with empty pose-rendering state (mirrors the centroid-only path already used in the `source=Labels` branch). The video frame + overlay still render normally.

## The bug

```python
video = sio.Video.from_filename([...])
lf = sio.LabeledFrame(video=video, frame_idx=0)
lf.label_images.append(li)

sio.render_image(source=lf, overlay=li)
# ValueError: LabeledFrame has no instances with skeleton
```

Encountered in every script of the segmentation round-trip investigation (`scratch/2026-04-14-segmentation-data-models/roundtrip/*/run.py`). The workaround required in all of them:

```python
frame = lf.image
if frame.ndim == 2:
    frame = np.repeat(frame[..., None], 3, axis=-1)
elif frame.shape[-1] == 1:
    frame = np.repeat(frame, 3, axis=-1)
sio.render_image(source=None, image=frame, overlay=li)
```

## Fix

`sleap_io/rendering/core.py` — when `source` is a `LabeledFrame`:

```python
instances = list(lf.instances)
if instances:
    skeleton = instances[0].skeleton
    edge_inds = skeleton.edge_inds
    node_names = [n.name for n in skeleton.nodes]
else:
    # No instances — segmentation/overlay-only mode.
    edge_inds = []
    node_names = []
```

The rest of `render_image` already handles empty pose data (`render_frame` at `core.py:482-486` defensively sets `n_nodes = 0` when `node_names` is empty). The image-fetching logic below continues to pull from `lf.image` or `lf.video`, so overlays composite against the real video frame.

## API after the fix

The natural, symmetric API now works for every overlay type:

```python
img = sio.render_image(source=lf, overlay=li, overlay_alpha=0.45,
                       overlay_outline=True)              # LabelImage
img = sio.render_image(source=lf, overlay=list(lf.masks)) # SegmentationMask
img = sio.render_image(source=lf, overlay=list(lf.rois))  # ROI
img = sio.render_image(source=lf, overlay=list(lf.bboxes))# BoundingBox
```

## Test plan

- [x] Updated `test_render_image_labeled_frame_no_skeleton_error` → `test_render_image_labeled_frame_without_instances`. Now asserts render succeeds (both with explicit `image=` and with `background="black"`).
- [x] Added 5 regression tests in `tests/rendering/test_rendering.py`:
  - `test_render_image_labeled_frame_source_with_label_image_overlay`
  - `test_render_image_labeled_frame_source_with_mask_overlay`
  - `test_render_image_labeled_frame_source_with_roi_overlay`
  - `test_render_image_labeled_frame_source_with_bbox_overlay`
  - `test_render_image_labeled_frame_with_instances_still_uses_skeleton` — guards the classic pose-rendering path.
- [x] **Visual verification on four real .slp fixtures** (StarDist nuclei, DynamicNuclearNet microscopy, COCO128-seg polygons, Penn-Fudan pedestrians). All four overlay types render correctly via the new `source=lf` path.
- [x] Full rendering suite: 186/186 pass.
- [x] Full test suite: 2827 pass, 16 skipped (1 pre-existing CLI failure unrelated to this change, fails on main too).
- [x] `ruff check` + `ruff format --check` clean.

## Design decisions

- **Mirror existing centroid-only handling.** The `source=Labels` branch already gracefully handles a resolved `LabeledFrame` with no instances (line 807 in `core.py`: `skeleton = instances[0].skeleton if instances else source.skeletons[0]`), and the no-labeled-frame-but-centroids path sets `edge_inds=[], node_names=[]`. This PR applies the same pattern to the bare `LabeledFrame` branch.
- **Don't require a skeleton.** For segmentation-only data, requiring users to attach a dummy skeleton just to satisfy the renderer is bad UX. No existing rendering code needs a skeleton when pose data is empty.
- **No changes to `render_video`.** It was already handling this correctly (`test_render_video_no_skeleton_error` at line 1583 documents: *"Frames with only annotations (no instances) should not require a skeleton and should not raise"*). This PR brings `render_image` into alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)