### PR TITLE
fix(io/tiff): suppress ambiguous-pages warning when pages are multi-valued

### DIFF
--- a/sleap_io/io/tiff.py
+++ b/sleap_io/io/tiff.py
@@ -247,6 +247,25 @@ def _infer_tiff_axes(path: Path) -> tuple[str, int, bool]:
         return "unknown", n_pages, False
 
 
+def _pages_could_be_class_stack(frames: list[np.ndarray]) -> bool:
+    """Check whether pages plausibly form a class stack (one class per page).
+
+    A class-stack interpretation requires each page to be either a binary
+    mask (values in {0, v} for some non-negative v) or the all-zeros
+    background. If any page contains two or more distinct positive
+    integer labels, it cannot be a single class's mask — so the
+    class-stack interpretation is ruled out and the pages-as-time
+    fallback is the only sensible reading.
+    """
+    for frame in frames:
+        positive = frame[frame > 0]
+        if positive.size == 0:
+            continue
+        if np.unique(positive).size > 1:
+            return False
+    return True
+
+
 def _warn_ambiguous_pages(path: Path, n_pages: int, dtype_name: str) -> None:
     """Emit a warning when falling back to pages-as-time with no metadata.
 
@@ -575,18 +594,23 @@ def read_label_images(
 
     # --- Dispatch on layout ---------------------------------------------
     if layout in ("YX", "TYX"):
-        # Warn when we're falling back on an ambiguous plain multi-page.
+        frames_data = _iter_pages()
+
+        # Warn when we're falling back on an ambiguous plain multi-page,
+        # but only if the pages could plausibly be a binary class stack.
+        # Multi-valued integer pages rule out the class-stack reading, so
+        # the fallback is the only sensible interpretation and suggesting
+        # pages_as='classes' would be misleading.
         used_fallback = (
             pages_as == "auto" and sidecar_axes is None and tiff_axes == "unknown"
         )
-        if used_fallback:
+        if used_fallback and _pages_could_be_class_stack(frames_data):
             dtype_name = "unknown"
             with tifffile.TiffFile(str(path)) as tif:
                 if tif.pages:
                     dtype_name = str(tif.pages[0].dtype)
             _warn_ambiguous_pages(path, n_pages, dtype_name)
 
-        frames_data = _iter_pages()
         return _read_pages_as_time(
             frames_data,
             tracks,

--- a/tests/io/test_tiff.py
+++ b/tests/io/test_tiff.py
@@ -12,6 +12,7 @@ from sleap_io.io.tiff import (
     _categories_list_from_sidecar,
     _infer_label_ids_from_pages,
     _normalize_axes,
+    _pages_could_be_class_stack,
     _warn_ambiguous_pages,
     read_label_images,
     write_label_images,
@@ -445,6 +446,45 @@ def test_ambiguous_singlepage_no_warning(tmp_path):
 
     with warnings_as_errors():
         read_label_images(tiff_path)
+
+
+def test_ambiguous_multipage_multivalued_no_warning(tmp_path):
+    """Multi-page TIFF with multi-valued pages rules out class-stack reading."""
+    frames = [_make_label_array(8, 8, n_objects=3) for _ in range(4)]
+    tiff_path = tmp_path / "multivalued.tif"
+    _write_plain_multipage(tiff_path, frames)
+
+    with warnings_as_errors():
+        result = read_label_images(tiff_path)
+    assert len(result) == 4
+
+
+def test_pages_could_be_class_stack_all_binary():
+    """All-binary pages (disjoint single-class masks) could be a class stack."""
+    assert _pages_could_be_class_stack(_make_class_pages()) is True
+
+
+def test_pages_could_be_class_stack_all_zero():
+    """All-zero pages are trivially class-stack-compatible."""
+    assert _pages_could_be_class_stack([np.zeros((4, 4), dtype=np.int32)] * 3) is True
+
+
+def test_pages_could_be_class_stack_stamped_ids():
+    """Each page binary but stamped with its own ID is still class-stack-compatible."""
+    pages = [
+        np.where(np.arange(16).reshape(4, 4) < 8, i + 1, 0).astype(np.int32)
+        for i in range(3)
+    ]
+    assert _pages_could_be_class_stack(pages) is True
+
+
+def test_pages_could_be_class_stack_multivalued_ruled_out():
+    """Any page with two distinct positive labels rules out class-stack."""
+    pages = [
+        np.zeros((4, 4), dtype=np.int32),
+        np.array([[0, 1, 0, 0], [0, 1, 0, 2], [0, 0, 2, 0], [0, 0, 0, 0]]),
+    ]
+    assert _pages_could_be_class_stack(pages) is False
 
 
 def test_pages_as_invalid_raises(tmp_path):


### PR DESCRIPTION
## Summary

Follow-up to #421. The TIFF reader emits a warning on plain multi-page
files with no axis metadata:

> Loaded N frames from multi-page TIFF ... with no axis metadata. Assuming pages are time. If pages represent classes for a single frame, pass pages_as='classes' (or add a sidecar {path}.meta.json with 'axes': 'CYX') to route through from_binary_masks with categories.

This warning used to fire whenever `_infer_tiff_axes()` returned
`"unknown"`, regardless of what the pages actually contain. That made it
misleading for a common case: a time-series of integer label images,
where each page stamps multiple instance IDs as pixel values. Such
pages cannot be a stack of binary class masks — `from_binary_masks`
takes `(N, H, W)` bool arrays, so the suggested alternative would cast
each page to bool and collapse all the instance IDs into a single
"present" class.

## Key Changes

- `sleap_io/io/tiff.py`: new helper `_pages_could_be_class_stack()`
  inspects each loaded page. Returns `True` only if every page has at
  most one unique positive value (i.e., each page could plausibly be
  one class's binary mask). The warning is now gated on this helper —
  if any page has ≥2 distinct positive labels, the class-stack reading
  is ruled out and we stay silent.
- The pixel scan runs on data we were already loading for
  `_read_pages_as_time`, so there is no extra I/O.

## Behavior Matrix

| Input | Before | After |
|---|---|---|
| Multi-page, binary disjoint pages, no metadata | ⚠️ warns | ⚠️ warns (still genuinely ambiguous) |
| Multi-page, multi-valued integer labels per page, no metadata | ⚠️ warns (misleading) | ✅ silent |
| Single-page, no metadata | ✅ silent | ✅ silent |
| Any layout with OME/ImageJ/sidecar metadata | ✅ silent | ✅ silent |

## Testing

New tests in `tests/io/test_tiff.py`:

- `test_ambiguous_multipage_multivalued_no_warning` — multi-valued pages silent via `warnings_as_errors`
- `test_pages_could_be_class_stack_all_binary` — disjoint binary pages → True
- `test_pages_could_be_class_stack_all_zero` — empty pages → True
- `test_pages_could_be_class_stack_stamped_ids` — single positive value per page (≠1) → True (preserves #421 stamped-ID support)
- `test_pages_could_be_class_stack_multivalued_ruled_out` — page with ≥2 distinct positives → False

All 46 `test_tiff.py` tests pass; `sleap_io.io.tiff` coverage at 97.4%.

Verified against the segmentation round-trip script: DREEM-style
microscopy `masks.tif` (int32 integer labels with IDs 1..9) now loads
silently, while a synthetic all-binary stack still warns.

## Design Decisions

- **Check loaded arrays, not pixel samples.** The pages are already in
  memory from `_iter_pages()` for the read path; reusing that data is
  free. Sampling would be fragile for sparse masks.
- **Rule `False` only on certainty.** If we cannot *rule out* the
  class-stack reading, the warning remains — we are conservative about
  silencing.
- **Keep the warning text.** The text still accurately describes the
  only ambiguous case it now fires on (all-binary pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)