### PR TITLE
fix: Preserve is_negative when merging colliding and new frames

### DIFF
--- a/docs/merging.md
+++ b/docs/merging.md
@@ -469,6 +469,18 @@ base.merge(other, frame="keep_both")
 base.merge(other, frame="update_tracks")
 ```
 
+### Negative (background) frames {#negative-frames}
+
+The `is_negative` marker (a frame explicitly labeled as a background/negative training
+example) is preserved across all frame strategies. If either the base or the incoming
+frame is marked negative, the merged frame stays negative — the marker is never silently
+dropped.
+
+The one exception: if the merge produces a real **user pose**, the negative marker is
+cleared (a frame with a labeled animal is not a background frame) and the merge records
+a `negative_flag_conflict` in `MergeResult.conflicts`. Predicted instances do not clear
+the marker, so the predict → merge-back workflow keeps negative frames negative.
+
 ---
 
 ## Step 5: Instance matching {#instance-matching}

--- a/sleap_io/model/labeled_frame.py
+++ b/sleap_io/model/labeled_frame.py
@@ -201,6 +201,31 @@ def _resolve_annotation_update_tracks(
         self_list[self_idx].tracking_score = other_list[other_idx].tracking_score
 
 
+def _resolve_merged_is_negative(
+    self_negative: bool, other_negative: bool, merged: list
+) -> tuple[bool, bool]:
+    """Resolve the ``is_negative`` flag for a merged frame.
+
+    A frame asserted as negative (background) by either side of a merge stays
+    negative, unless the merge produced a real user pose -- a frame with a
+    labeled animal is not a background frame. Predicted instances do not cancel
+    the flag, keeping the predict -> merge-back workflow correct.
+
+    Args:
+        self_negative: The ``is_negative`` flag of the base frame.
+        other_negative: The ``is_negative`` flag of the incoming frame.
+        merged: The merged instance list.
+
+    Returns:
+        A tuple ``(resolved, conflict)`` where ``resolved`` is the merged
+        ``is_negative`` value and ``conflict`` is ``True`` if a negative flag
+        was dropped because the merge produced a user pose.
+    """
+    either_negative = self_negative or other_negative
+    has_user_pose = any(type(inst) is Instance for inst in merged)
+    return either_negative and not has_user_pose, either_negative and has_user_pose
+
+
 @define(eq=False)
 class LabeledFrame:
     """Labeled data for a single frame of a video.
@@ -531,8 +556,10 @@ class LabeledFrame:
             - conflicts: List of (original, new, resolution) tuples for conflicts
 
         Notes:
-            This method doesn't modify the frame in place. It returns the merged
-            instance list which can be assigned back if desired.
+            The merged instance list is returned (not assigned back) so the
+            caller can decide what to do with it. Frame-level annotations
+            (centroids, bboxes, masks, label images, rois) and the
+            ``is_negative`` flag are updated on this frame in place.
         """
         from sleap_io.model.matching import InstanceMatcher, InstanceMatchMethod
 
@@ -547,12 +574,21 @@ class LabeledFrame:
 
         if frame == "keep_original":
             self._merge_annotations(other, strategy="keep_original")
+            self.is_negative, _ = _resolve_merged_is_negative(
+                self.is_negative, other.is_negative, self.instances
+            )
             return self.instances.copy(), conflicts
         elif frame == "keep_new":
             self._merge_annotations(other, strategy="keep_new")
+            self.is_negative, _ = _resolve_merged_is_negative(
+                self.is_negative, other.is_negative, other.instances
+            )
             return other.instances.copy(), conflicts
         elif frame == "keep_both":
             self._merge_annotations(other, strategy="keep_both")
+            self.is_negative, _ = _resolve_merged_is_negative(
+                self.is_negative, other.is_negative, self.instances + other.instances
+            )
             return self.instances + other.instances, conflicts
         elif frame == "update_tracks":
             # match instances and update .track and tracking score of the old instances
@@ -567,6 +603,9 @@ class LabeledFrame:
                 strategy="update_tracks",
                 threshold=instance_matcher.threshold,
             )
+            self.is_negative, _ = _resolve_merged_is_negative(
+                self.is_negative, other.is_negative, self.instances
+            )
             return self.instances, conflicts
         elif frame == "replace_predictions":
             # Keep all user instances from original frame
@@ -576,7 +615,10 @@ class LabeledFrame:
                 inst for inst in other.instances if type(inst) is PredictedInstance
             )
             self._merge_annotations(other, strategy="replace_predictions")
-            # No conflicts to report - this is a clean replacement
+            self.is_negative, _ = _resolve_merged_is_negative(
+                self.is_negative, other.is_negative, merged
+            )
+            # No instance conflicts to report - this is a clean replacement
             return merged, []
 
         # Auto merging strategy
@@ -651,6 +693,10 @@ class LabeledFrame:
         # Merge annotations from the other frame (spatial matching + resolution)
         self._merge_annotations(
             other, strategy="auto", threshold=instance_matcher.threshold
+        )
+
+        self.is_negative, _ = _resolve_merged_is_negative(
+            self.is_negative, other.is_negative, merged_instances
         )
 
         return merged_instances, conflicts

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -24,7 +24,7 @@ from sleap_io.io.utils import sanitize_filename
 from sleap_io.model.camera import RecordingSession
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, PredictedInstance, Track
-from sleap_io.model.labeled_frame import LabeledFrame
+from sleap_io.model.labeled_frame import LabeledFrame, _resolve_merged_is_negative
 from sleap_io.model.skeleton import NodeOrIndex, Skeleton
 from sleap_io.model.suggestions import SuggestionFrame
 from sleap_io.model.video import Video
@@ -3295,11 +3295,13 @@ class Labels:
                 matching_frames = self.find(mapped_video, mapped_frame_idx)
 
                 if len(matching_frames) == 0:
-                    # No matching frame, create new one
+                    # No matching frame, create new one. Preserve the negative
+                    # (background) marker from the incoming frame verbatim.
                     new_frame = LabeledFrame(
                         video=mapped_video,
                         frame_idx=mapped_frame_idx,
                         instances=[],
+                        is_negative=other_frame.is_negative,
                     )
 
                     # Map instances to new skeleton/track
@@ -3318,6 +3320,9 @@ class Labels:
                 else:
                     # Merge into existing frame
                     self_frame = matching_frames[0]
+
+                    # Capture is_negative before merge() resolves it in place.
+                    self_was_negative = self_frame.is_negative
 
                     # Merge instances using frame-level merge
                     merged_instances, conflicts = self_frame.merge(
@@ -3355,6 +3360,22 @@ class Labels:
                                 original_data=orig,
                                 new_data=new,
                                 resolution=resolution,
+                            )
+                        )
+
+                    # Record a conflict if a negative (background) marker was
+                    # dropped because the merge produced a user pose.
+                    _, negative_conflict = _resolve_merged_is_negative(
+                        self_was_negative, other_frame.is_negative, merged_instances
+                    )
+                    if negative_conflict:
+                        result.conflicts.append(
+                            ConflictResolution(
+                                frame=self_frame,
+                                conflict_type="negative_flag_conflict",
+                                original_data=self_was_negative,
+                                new_data=other_frame.is_negative,
+                                resolution="dropped_for_user_pose",
                             )
                         )
 

--- a/tests/model/test_labeled_frame.py
+++ b/tests/model/test_labeled_frame.py
@@ -1645,3 +1645,112 @@ def test_merge_annotations_auto_many_to_one():
     xs = {c.x for c in lf1.centroids}
     assert xs == {11.0, 10.0}
     assert all(not c.is_predicted for c in lf1.centroids)
+
+
+def test_merge_is_negative_incoming_negative():
+    """Auto merge carries the incoming negative flag onto an empty base frame."""
+    video = Video(filename="test.mp4", open_backend=False)
+    base = LabeledFrame(video=video, frame_idx=0)
+    incoming = LabeledFrame(video=video, frame_idx=0, is_negative=True)
+
+    base.merge(incoming, frame="auto")
+
+    assert base.is_negative is True
+
+
+def test_merge_is_negative_both_negative():
+    """Auto merge keeps the negative flag when both frames are negative."""
+    video = Video(filename="test.mp4", open_backend=False)
+    base = LabeledFrame(video=video, frame_idx=0, is_negative=True)
+    incoming = LabeledFrame(video=video, frame_idx=0, is_negative=True)
+
+    base.merge(incoming, frame="auto")
+
+    assert base.is_negative is True
+
+
+def test_merge_is_negative_user_pose_cancels():
+    """A merged-in user pose cancels the negative flag."""
+    skel = Skeleton(["A"])
+    video = Video(filename="test.mp4", open_backend=False)
+    base = LabeledFrame(video=video, frame_idx=0, is_negative=True)
+    incoming = LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[Instance([[10, 10]], skeleton=skel)],
+    )
+
+    base.merge(incoming, frame="auto")
+
+    assert base.is_negative is False
+
+
+def test_merge_is_negative_predicted_does_not_cancel():
+    """Predicted-only instances do not cancel the negative flag."""
+    skel = Skeleton(["A"])
+    video = Video(filename="test.mp4", open_backend=False)
+    base = LabeledFrame(video=video, frame_idx=0, is_negative=True)
+    incoming = LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[PredictedInstance([[10, 10]], skeleton=skel)],
+    )
+
+    base.merge(incoming, frame="auto")
+
+    assert base.is_negative is True
+
+
+def test_merge_is_negative_keep_original():
+    """keep_original still carries the incoming negative flag."""
+    video = Video(filename="test.mp4", open_backend=False)
+    base = LabeledFrame(video=video, frame_idx=0)
+    incoming = LabeledFrame(video=video, frame_idx=0, is_negative=True)
+
+    base.merge(incoming, frame="keep_original")
+
+    assert base.is_negative is True
+
+
+def test_merge_is_negative_keep_new():
+    """keep_new keeps the base negative flag (sticky OR across strategies)."""
+    video = Video(filename="test.mp4", open_backend=False)
+    base = LabeledFrame(video=video, frame_idx=0, is_negative=True)
+    incoming = LabeledFrame(video=video, frame_idx=0)
+
+    base.merge(incoming, frame="keep_new")
+
+    assert base.is_negative is True
+
+
+def test_merge_is_negative_keep_both():
+    """keep_both carries the incoming negative flag."""
+    video = Video(filename="test.mp4", open_backend=False)
+    base = LabeledFrame(video=video, frame_idx=0)
+    incoming = LabeledFrame(video=video, frame_idx=0, is_negative=True)
+
+    base.merge(incoming, frame="keep_both")
+
+    assert base.is_negative is True
+
+
+def test_merge_is_negative_update_tracks():
+    """update_tracks carries the incoming negative flag."""
+    video = Video(filename="test.mp4", open_backend=False)
+    base = LabeledFrame(video=video, frame_idx=0)
+    incoming = LabeledFrame(video=video, frame_idx=0, is_negative=True)
+
+    base.merge(incoming, frame="update_tracks")
+
+    assert base.is_negative is True
+
+
+def test_merge_is_negative_replace_predictions():
+    """replace_predictions carries the base negative flag for predicted merges."""
+    video = Video(filename="test.mp4", open_backend=False)
+    base = LabeledFrame(video=video, frame_idx=0, is_negative=True)
+    incoming = LabeledFrame(video=video, frame_idx=0)
+
+    base.merge(incoming, frame="replace_predictions")
+
+    assert base.is_negative is True

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -3315,6 +3315,109 @@ def test_labels_merge_frame_strategies():
     )  # Should keep original
 
 
+def test_labels_merge_preserves_is_negative_colliding():
+    """Merging a negative frame onto a colliding empty frame keeps the flag."""
+    skel = Skeleton(["A"])
+    video = Video(filename="test.mp4")
+
+    base = Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0)],
+    )
+    incoming = Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0, is_negative=True)],
+    )
+
+    base.merge(incoming)
+
+    assert base.labeled_frames[0].is_negative is True
+
+
+def test_labels_merge_preserves_is_negative_noncolliding():
+    """Merging a negative frame with no collision keeps the flag on the new frame."""
+    skel = Skeleton(["A"])
+    video = Video(filename="test.mp4")
+
+    base = Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=5)],
+    )
+    incoming = Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0, is_negative=True)],
+    )
+
+    base.merge(incoming)
+
+    new_frame = [lf for lf in base.labeled_frames if lf.frame_idx == 0][0]
+    assert new_frame.is_negative is True
+
+
+def test_labels_merge_is_negative_user_pose_conflict():
+    """A user pose cancels the negative flag and records a merge conflict."""
+    skel = Skeleton(["A"])
+    video = Video(filename="test.mp4")
+
+    base = Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0, is_negative=True)],
+    )
+    incoming = Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[Instance([[10, 10]], skeleton=skel)],
+            )
+        ],
+    )
+
+    result = base.merge(incoming)
+
+    assert base.labeled_frames[0].is_negative is False
+    negative_conflicts = [
+        c for c in result.conflicts if c.conflict_type == "negative_flag_conflict"
+    ]
+    assert len(negative_conflicts) == 1
+    assert negative_conflicts[0].resolution == "dropped_for_user_pose"
+
+
+def test_labels_merge_is_negative_roundtrip(tmp_path):
+    """Negative flag survives a save_slp -> load_slp -> merge round-trip."""
+    skel = Skeleton(["A"])
+    video = Video(filename="test.mp4")
+
+    base = Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0)],
+    )
+    incoming = Labels(
+        videos=[video],
+        skeletons=[skel],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0, is_negative=True)],
+    )
+
+    base_path = tmp_path / "base.slp"
+    incoming_path = tmp_path / "incoming.slp"
+    save_slp(base, base_path)
+    save_slp(incoming, incoming_path)
+
+    base_loaded = load_slp(base_path)
+    incoming_loaded = load_slp(incoming_path)
+    base_loaded.merge(incoming_loaded)
+
+    assert base_loaded.labeled_frames[0].is_negative is True
+
+
 def test_labels_merge_suggestions():
     """Test merging of suggestions."""
     video = Video(filename="test.mp4")


### PR DESCRIPTION
## Summary

Fixes #431. `LabeledFrame.merge()` and `Labels.merge()` never read or wrote the `is_negative` (background/negative training frame) marker, so merging a project that contains negative frames silently dropped those markers.

Investigation against `main` found **two** bugs (the issue described one and assumed the other path was safe — it was not):

1. **Colliding frames** — `LabeledFrame.merge()` kept `self.is_negative` and discarded `other.is_negative` for *every* `frame=` strategy.
2. **Non-colliding frames** — `Labels.merge()` builds a fresh `LabeledFrame(...)` for incoming frames with no collision and never copied `is_negative`, so even a non-colliding negative frame lost its flag.

## Key Changes

- **`sleap_io/model/labeled_frame.py`**
  - New pure helper `_resolve_merged_is_negative(self_negative, other_negative, merged) -> (resolved, conflict)` — single source of truth for the resolution rule.
  - `LabeledFrame.merge()` resolves `is_negative` in place at every strategy return point (`auto`, `keep_original`, `keep_new`, `keep_both`, `update_tracks`, `replace_predictions`).
  - Corrected the stale `merge()` docstring note about in-place modification.
- **`sleap_io/model/labels.py`**
  - Non-colliding path now copies `is_negative` from the incoming frame.
  - Colliding path records a `negative_flag_conflict` in `MergeResult.conflicts` when a user pose cancels the flag.
- **`docs/merging.md`** — new "Negative (background) frames" subsection under Frame strategies.

## Resolution rule

`is_negative = (self.is_negative or other.is_negative) and not has_user_pose`, applied uniformly across all strategies:

- A negative assertion from **either** side is sticky.
- A real **user** pose in the merged result cancels the flag (a labeled frame is not a background frame) and records a `negative_flag_conflict`.
- **Predicted** instances do not cancel the flag, keeping the predict → merge-back workflow correct.

## Example

```python
import sleap_io as sio

base = sio.Labels(
    videos=[video], skeletons=[skeleton],
    labeled_frames=[sio.LabeledFrame(video=video, frame_idx=0)],
)
incoming = sio.Labels(
    videos=[video], skeletons=[skeleton],
    labeled_frames=[sio.LabeledFrame(video=video, frame_idx=0, is_negative=True)],
)
base.merge(incoming)
print(base.labeled_frames[0].is_negative)  # now True (was False)
```

## Testing

- 9 frame-level tests in `tests/model/test_labeled_frame.py` (each strategy + user/predicted cancellation rules).
- 4 Labels-level tests in `tests/model/test_labels.py`: colliding repro, non-colliding regression lock, conflict record, and a `save_slp` → `load_slp` → `merge` round-trip.
- Full suite passes (2880 passed; two pre-existing Windows-only failures unrelated to this change — a symlink-privilege test and a Rich-panel terminal-width test, both confirmed failing on `main`).

## Design Decisions

- **Uniform OR across all strategies** (including `keep_original`/`keep_new`): `is_negative` is treated as a sticky assertion about the frame's training role rather than instance data, so it is never silently dropped regardless of strategy.
- **Conflict surfaced in `MergeResult`, not in `LabeledFrame.merge()`'s return tuple**: keeps the frame-level return signature unchanged; the negative-flag conflict is a `MergeResult`-level audit concern. A pure shared helper avoids duplicating the resolution logic across the two call sites.

Part of shipping negative frames end-to-end (talmolab/sleap#640; data-model feature PR #341).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
