### PR TITLE
fix: Preserve all instances in analysis HDF5 export for untracked multi-animal projects

### DIFF
--- a/docs/formats/analysis_h5.md
+++ b/docs/formats/analysis_h5.md
@@ -167,6 +167,14 @@ Array of track name strings.
 | Dtype | Variable-length string |
 | Length | `n_tracks` |
 
+!!! note "Projects without track assignments"
+    When the source project has no `Track` assignments, `n_tracks` is sized to
+    the largest number of instances found in any single frame, so every
+    instance is exported (a multi-animal project is no longer collapsed to one
+    instance per frame). Synthetic names `track_0 ... track_{n-1}` are used. The
+    per-slot assignment is arbitrary across frames since no track identity
+    exists — consistent with `to_numpy(untracked=True)`.
+
 ### `node_names`
 
 Array of skeleton node/keypoint names.

--- a/sleap_io/codecs/numpy.py
+++ b/sleap_io/codecs/numpy.py
@@ -21,6 +21,147 @@ if TYPE_CHECKING:
     pass
 
 
+def _max_instances_per_frame(
+    lfs: list[LabeledFrame],
+    *,
+    user_instances: bool,
+    predicted_instances: bool,
+) -> int:
+    """Return the maximum number of instances to export from any single frame.
+
+    Args:
+        lfs: Labeled frames to scan.
+        user_instances: If True, count user instances.
+        predicted_instances: If True, count predicted instances.
+
+    Returns:
+        The largest per-frame instance count. When both instance types are
+        included, user and predicted instances are assumed to overlap, so the
+        per-frame count is `max(n_user, n_predicted)` rather than their sum.
+    """
+    n_instances = 0
+    for lf in lfs:
+        n_user = len(lf.user_instances) if user_instances else 0
+        n_predicted = len(lf.predicted_instances) if predicted_instances else 0
+
+        if user_instances and predicted_instances:
+            # Count max of either user or predicted instances per frame (not sum).
+            n_frame_instances = max(n_user, n_predicted)
+        else:
+            n_frame_instances = n_user + n_predicted
+
+        n_instances = max(n_instances, n_frame_instances)
+    return n_instances
+
+
+def _untracked_frame_instances(
+    lf: LabeledFrame,
+    *,
+    is_single_instance: bool,
+    user_instances: bool,
+    predicted_instances: bool,
+) -> list[Instance]:
+    """Select instances to export from a frame without using track identity.
+
+    User instances are preferred. Predicted instances that duplicate a user
+    instance (linked via `from_predicted` or sharing the same track) are
+    dropped. For single-instance projects, any user instance fully suppresses
+    predicted instances in the same frame.
+
+    Args:
+        lf: The labeled frame to select instances from.
+        is_single_instance: True if the project has at most one instance per
+            frame.
+        user_instances: If True, include user instances, preferring them over
+            predicted instances.
+        predicted_instances: If True, include predicted instances.
+
+    Returns:
+        A new list of instances to export, in frame order.
+    """
+    instances_to_include: list[Instance] = []
+
+    if user_instances and lf.has_user_instances:
+        # Collect all user instances first.
+        for inst in lf.user_instances:
+            instances_to_include.append(inst)
+
+        # For the trivial case (single instance per frame), if we found user
+        # instances, we shouldn't include any predicted instances.
+        if is_single_instance and len(instances_to_include) > 0:
+            return instances_to_include
+
+        # Add predicted instances that don't have a corresponding user instance.
+        if predicted_instances:
+            for inst in lf.predicted_instances:
+                skip = False
+                for user_inst in lf.user_instances:
+                    # Skip if this predicted instance is linked to a user
+                    # instance via from_predicted.
+                    if (
+                        hasattr(user_inst, "from_predicted")
+                        and user_inst.from_predicted == inst
+                    ):
+                        skip = True
+                        break
+                    # Skip if user and predicted instances share same track.
+                    if (
+                        user_inst.track is not None
+                        and inst.track is not None
+                        and user_inst.track == inst.track
+                    ):
+                        skip = True
+                        break
+                if not skip:
+                    instances_to_include.append(inst)
+    else:
+        # If user_instances=False or there are no user instances, only include
+        # predicted instances (or fall back to user instances).
+        if predicted_instances:
+            instances_to_include = list(lf.predicted_instances)
+        elif user_instances:
+            instances_to_include = list(lf.user_instances)
+
+    return instances_to_include
+
+
+def _tracked_frame_instances(
+    lf: LabeledFrame,
+    *,
+    user_instances: bool,
+    predicted_instances: bool,
+) -> dict[Track, Instance]:
+    """Select one instance per track from a frame.
+
+    Predicted instances are added first, then user instances override them for
+    the same track. Instances without a track assignment are ignored.
+
+    Args:
+        lf: The labeled frame to select instances from.
+        user_instances: If True, include user instances, preferring them over
+            predicted instances with the same track.
+        predicted_instances: If True, include predicted instances.
+
+    Returns:
+        A mapping from `Track` to the instance to export for that track.
+    """
+    track_to_instance: dict[Track, Instance] = {}
+
+    # First, add predicted instances to the mapping.
+    if predicted_instances:
+        for inst in lf.predicted_instances:
+            if inst.track is not None:
+                track_to_instance[inst.track] = inst
+
+    # Then, add user instances to the mapping (they override predicted).
+    if user_instances:
+        for inst in lf.user_instances:
+            if inst.track is not None:
+                track_to_instance[inst.track] = inst
+
+    return track_to_instance
+
+
 def to_numpy(
     labels: Labels,
     *,
@@ -111,19 +252,9 @@ def to_numpy(
         last_frame = max(last_frame, video_length - 1)
 
     # Figure out the number of tracks based on number of instances in each frame.
-    n_instances = 0
-    for lf in lfs:
-        # Count instances based on what we're including
-        n_user = len(lf.user_instances) if user_instances else 0
-        n_predicted = len(lf.predicted_instances) if predicted_instances else 0
-
-        if user_instances and predicted_instances:
-            # Count max of either user or predicted instances per frame (not sum)
-            n_frame_instances = max(n_user, n_predicted)
-        else:
-            n_frame_instances = n_user + n_predicted
-
-        n_instances = max(n_instances, n_frame_instances)
+    n_instances = _max_instances_per_frame(
+        lfs, user_instances=user_instances, predicted_instances=predicted_instances
+    )
 
     # Case 1: We don't care about order because there's only 1 instance per frame,
     # or we're considering untracked instances.
@@ -148,54 +279,14 @@ def to_numpy(
         i = int(lf.frame_idx - first_frame)
 
         if untracked:
-            # For untracked instances, fill them in arbitrary order
-            j = 0
-            instances_to_include = []
-
-            # If user instances are preferred, add them first
-            if user_instances and lf.has_user_instances:
-                # First collect all user instances
-                for inst in lf.user_instances:
-                    instances_to_include.append(inst)
-
-                # For the trivial case (single instance per frame), if we found
-                # user instances, we shouldn't include any predicted instances
-                if is_single_instance and len(instances_to_include) > 0:
-                    pass  # Skip adding predicted instances
-                else:
-                    # Add predicted instances that don't have a corresponding
-                    # user instance
-                    if predicted_instances:
-                        for inst in lf.predicted_instances:
-                            skip = False
-                            for user_inst in lf.user_instances:
-                                # Skip if this predicted instance is linked to a user
-                                # instance via from_predicted
-                                if (
-                                    hasattr(user_inst, "from_predicted")
-                                    and user_inst.from_predicted == inst
-                                ):
-                                    skip = True
-                                    break
-                                # Skip if user and predicted instances share same track
-                                if (
-                                    user_inst.track is not None
-                                    and inst.track is not None
-                                    and user_inst.track == inst.track
-                                ):
-                                    skip = True
-                                    break
-                            if not skip:
-                                instances_to_include.append(inst)
-            else:
-                # If user_instances=False, only include predicted instances
-                if predicted_instances:
-                    instances_to_include = lf.predicted_instances
-                elif user_instances:
-                    instances_to_include = lf.user_instances
-
-            # Now process all the instances we want to include
-            for inst in instances_to_include:
+            # For untracked instances, fill them in arbitrary order.
+            frame_instances = _untracked_frame_instances(
+                lf,
+                is_single_instance=is_single_instance,
+                user_instances=user_instances,
+                predicted_instances=predicted_instances,
+            )
+            for j, inst in enumerate(frame_instances):
                 if j < n_tracks:
                     if return_confidence:
                         if isinstance(inst, PredictedInstance):
@@ -209,28 +300,14 @@ def to_numpy(
                             tracks[i, j] = np.hstack((points_data, confidence))
                     else:
                         tracks[i, j] = inst.numpy()
-                    j += 1
         else:  # untracked is False
-            # For tracked instances, organize by track ID
-
-            # Create mapping from track to best instance for this frame
-            track_to_instance = {}
-
-            # First, add predicted instances to the mapping
-            if predicted_instances:
-                for inst in lf.predicted_instances:
-                    if inst.track is not None:
-                        track_to_instance[inst.track] = inst
-
-            # Then, add user instances to the mapping (if user_instances=True)
-            if user_instances:
-                for inst in lf.user_instances:
-                    if inst.track is not None:
-                        track_to_instance[inst.track] = inst
-
-            # Process the preferred instances for each track
-            for track in track_to_instance:
-                inst = track_to_instance[track]
+            # For tracked instances, organize by track ID.
+            track_to_instance = _tracked_frame_instances(
+                lf,
+                user_instances=user_instances,
+                predicted_instances=predicted_instances,
+            )
+            for track, inst in track_to_instance.items():
                 j = labels.tracks.index(track)
 
                 if type(inst) is PredictedInstance:
@@ -243,6 +320,195 @@ def to_numpy(
                         tracks[i, j, :, 2] = 1.0
 
     return tracks
+
+
+def to_analysis_arrays(
+    labels: Labels,
+    *,
+    video: Video | int | None = None,
+    all_frames: bool = True,
+    min_occupancy: float = 0.0,
+    user_instances: bool = True,
+    predicted_instances: bool = True,
+) -> tuple[
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    np.ndarray,
+    list[str],
+    int,
+]:
+    """Build occupancy and point-data matrices for an analysis HDF5 export.
+
+    All returned arrays are in canonical shape (frame-first ordering). This is
+    the shared builder behind `save_analysis_h5`; it reuses the same
+    instance-slotting logic as `to_numpy` so that projects without track
+    assignments keep every instance instead of collapsing to one per frame.
+
+    Args:
+        labels: The `Labels` from which to get data.
+        video: Video (or video index) to export. If None, uses the first video.
+        all_frames: If True, include all frames from 0 to the end of the video.
+            If False, only include frames from the first labeled frame onward.
+        min_occupancy: Minimum occupancy ratio (0-1) for a track to be kept.
+            0 keeps all non-empty tracks (default SLEAP behavior).
+        user_instances: If True, include user instances, preferring them over
+            predicted instances.
+        predicted_instances: If True, include predicted instances.
+
+    Returns:
+        A tuple of (all arrays in canonical shape):
+
+        - occupancy: shape `(n_frames, n_tracks)`, binary `uint8` matrix
+          indicating track presence per frame.
+        - locations: shape `(n_frames, n_tracks, n_nodes, 2)`, point
+          coordinates `(x, y)`.
+        - point_scores: shape `(n_frames, n_tracks, n_nodes)`, per-point
+          confidence.
+        - instance_scores: shape `(n_frames, n_tracks)`, instance confidence.
+        - tracking_scores: shape `(n_frames, n_tracks)`, tracking confidence.
+        - track_names: list of track name strings, length `n_tracks`.
+        - first_frame: first frame index (int).
+
+    Raises:
+        ValueError: If there are no labeled frames for the selected video.
+
+    Notes:
+        When the project has no `Track` assignments, instances are slotted in
+        arbitrary per-frame order and `n_tracks` is sized to the largest number
+        of instances in any frame (matching `to_numpy(untracked=True)`).
+        Synthetic track names `track_0 ... track_{n-1}` are generated in that
+        case. Per-slot animal identity is arbitrary across frames without real
+        track information, but no data is dropped.
+    """
+    # Resolve video.
+    if video is None:
+        video = labels.videos[0]
+    elif type(video) is int:
+        video = labels.videos[video]
+
+    # Get labeled frames for this video.
+    lfs = labels.find(video)
+    if not lfs:
+        raise ValueError(f"No labeled frames in video: {video.filename}")
+
+    frame_idxs = sorted(lf.frame_idx for lf in lfs)
+    first_frame = 0 if all_frames else frame_idxs[0]
+
+    # Use video length when available so output spans the full video duration.
+    last_frame = frame_idxs[-1]
+    video_length = len(video)
+    if video_length > 0:
+        last_frame = max(last_frame, video_length - 1)
+
+    n_frames = last_frame - first_frame + 1
+
+    skeleton = labels.skeletons[0]
+    node_count = len(skeleton.nodes)
+
+    # Size the track axis. With no track assignments, fall back to untracked
+    # slotting so multi-animal projects keep every instance.
+    untracked = len(labels.tracks) == 0
+    if untracked:
+        n_instances = _max_instances_per_frame(
+            lfs,
+            user_instances=user_instances,
+            predicted_instances=predicted_instances,
+        )
+        is_single_instance = n_instances == 1
+        n_tracks = n_instances
+    else:
+        n_tracks = len(labels.tracks)
+        track_to_slot = {track: i for i, track in enumerate(labels.tracks)}
+
+    # Initialize matrices in canonical shape: (frame, track, ...).
+    occupancy = np.zeros((n_frames, n_tracks), dtype=np.uint8)
+    locations = np.full((n_frames, n_tracks, node_count, 2), np.nan, dtype=np.float64)
+    point_scores = np.full((n_frames, n_tracks, node_count), np.nan, dtype=np.float64)
+    instance_scores = np.full((n_frames, n_tracks), np.nan, dtype=np.float64)
+    tracking_scores = np.full((n_frames, n_tracks), np.nan, dtype=np.float64)
+
+    # Build lookup for frame index -> LabeledFrame.
+    lf_map = {lf.frame_idx: lf for lf in lfs}
+
+    # Fill matrices.
+    for frame_idx in range(first_frame, last_frame + 1):
+        frame_i = frame_idx - first_frame
+        lf = lf_map.get(frame_idx)
+        if lf is None:
+            continue
+
+        # Determine which instances go into which track slot.
+        if untracked:
+            slotted = enumerate(
+                _untracked_frame_instances(
+                    lf,
+                    is_single_instance=is_single_instance,
+                    user_instances=user_instances,
+                    predicted_instances=predicted_instances,
+                )
+            )
+        else:
+            slotted = (
+                (track_to_slot[track], inst)
+                for track, inst in _tracked_frame_instances(
+                    lf,
+                    user_instances=user_instances,
+                    predicted_instances=predicted_instances,
+                ).items()
+                if track in track_to_slot
+            )
+
+        for track_i, inst in slotted:
+            # Defensive: per-frame dedup can occasionally leave more instances
+            # than the global maximum; extra instances are dropped to stay
+            # consistent with to_numpy's `j < n_tracks` guard.
+            if track_i >= n_tracks:
+                continue
+
+            occupancy[frame_i, track_i] = 1
+            locations[frame_i, track_i, :, :] = inst.numpy()
+
+            if hasattr(inst, "tracking_score") and inst.tracking_score is not None:
+                tracking_scores[frame_i, track_i] = inst.tracking_score
+
+            if isinstance(inst, PredictedInstance):
+                if "score" in inst.points.dtype.names:
+                    point_scores[frame_i, track_i, :] = inst.points["score"]
+                if inst.score is not None:
+                    instance_scores[frame_i, track_i] = inst.score
+
+    # Filter empty/low-occupancy tracks.
+    occupied_frames = np.sum(occupancy, axis=0)
+    occupancy_ratio = occupied_frames / n_frames
+    keep_mask = (occupied_frames > 0) & (occupancy_ratio >= min_occupancy)
+
+    if not np.all(keep_mask):
+        occupancy = occupancy[:, keep_mask]
+        locations = locations[:, keep_mask, :, :]
+        point_scores = point_scores[:, keep_mask, :]
+        instance_scores = instance_scores[:, keep_mask]
+        tracking_scores = tracking_scores[:, keep_mask]
+
+    # Build track names sized to the surviving tracks.
+    if untracked:
+        # Synthesize positional names, renumbered after filtering (no gaps).
+        track_names = [f"track_{i}" for i in range(occupancy.shape[1])]
+    else:
+        track_names = [
+            track.name for i, track in enumerate(labels.tracks) if keep_mask[i]
+        ]
+
+    return (
+        occupancy,
+        locations,
+        point_scores,
+        instance_scores,
+        tracking_scores,
+        track_names,
+        first_frame,
+    )
 
 
 def from_numpy(

--- a/sleap_io/io/analysis_h5.py
+++ b/sleap_io/io/analysis_h5.py
@@ -99,6 +99,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 
+from sleap_io.codecs.numpy import to_analysis_arrays
 from sleap_io.model.instance import PredictedInstance, Track
 from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
@@ -474,157 +475,6 @@ def read_labels(
 # =============================================================================
 
 
-def _get_occupancy_and_points(
-    labels: Labels,
-    video: Video | None = None,
-    all_frames: bool = True,
-    min_occupancy: float = 0.0,
-) -> tuple[
-    np.ndarray,
-    np.ndarray,
-    np.ndarray,
-    np.ndarray,
-    np.ndarray,
-    list[str],
-    int,
-]:
-    """Build numpy matrices with track occupancy and point location data.
-
-    All returned arrays are in canonical shape (frame-first ordering).
-
-    Args:
-        labels: The Labels from which to get data.
-        video: Video to export. If None, uses first video.
-        all_frames: If True, include all frames from 0 to end of video.
-            If False, only include frames from first labeled frame to end of
-            video.
-        min_occupancy: Minimum occupancy ratio (0-1) to keep a track.
-            0 = keep all non-empty tracks (default SLEAP behavior).
-
-    Returns:
-        Tuple of (all in canonical shape):
-
-        - occupancy_matrix: shape (n_frames, n_tracks)
-            Binary matrix indicating track presence per frame.
-
-        - locations_matrix: shape (n_frames, n_tracks, n_nodes, 2)
-            Point coordinates (x, y) for each frame, track, and node.
-
-        - point_scores: shape (n_frames, n_tracks, n_nodes)
-            Confidence score for each point.
-
-        - instance_scores: shape (n_frames, n_tracks)
-            Overall instance confidence score.
-
-        - tracking_scores: shape (n_frames, n_tracks)
-            Tracking confidence score.
-
-        - track_names: list of track name strings, length n_tracks
-
-        - first_frame: first frame index (int)
-    """
-    if video is None:
-        video = labels.videos[0]
-
-    # Get labeled frames for this video
-    lfs = labels.find(video)
-    if not lfs:
-        raise ValueError(f"No labeled frames in video: {video.filename}")
-
-    frame_idxs = sorted(lf.frame_idx for lf in lfs)
-    first_frame = 0 if all_frames else frame_idxs[0]
-
-    # Use video length when available so output spans the full video duration.
-    last_frame = frame_idxs[-1]
-    video_length = len(video)
-    if video_length > 0:
-        last_frame = max(last_frame, video_length - 1)
-
-    n_frames = last_frame - first_frame + 1
-
-    # Get track and node info
-    tracks = labels.tracks or [None]  # Handle untracked case
-    track_count = len(tracks)
-    skeleton = labels.skeletons[0]
-    node_count = len(skeleton.nodes)
-
-    # Initialize matrices in canonical shape: (frame, track, ...)
-    occupancy = np.zeros((n_frames, track_count), dtype=np.uint8)
-    locations = np.full(
-        (n_frames, track_count, node_count, 2), np.nan, dtype=np.float64
-    )
-    point_scores = np.full(
-        (n_frames, track_count, node_count), np.nan, dtype=np.float64
-    )
-    instance_scores = np.full((n_frames, track_count), np.nan, dtype=np.float64)
-    tracking_scores = np.full((n_frames, track_count), np.nan, dtype=np.float64)
-
-    # Build lookup for frame index -> LabeledFrame
-    lf_map = {lf.frame_idx: lf for lf in lfs}
-
-    # Fill matrices
-    for frame_idx in range(first_frame, last_frame + 1):
-        frame_i = frame_idx - first_frame
-        lf = lf_map.get(frame_idx)
-        if lf is None:
-            continue
-
-        # Prefer user instances over predicted for same track
-        track_instances = {}
-
-        # Add predicted first (will be overwritten by user if exists)
-        for inst in lf.predicted_instances:
-            track = inst.track
-            track_i = tracks.index(track) if track in tracks else 0
-            track_instances[track_i] = inst
-
-        # Add user instances (override predicted)
-        for inst in lf.user_instances:
-            track = inst.track
-            track_i = tracks.index(track) if track in tracks else 0
-            track_instances[track_i] = inst
-
-        # Fill matrices
-        for track_i, inst in track_instances.items():
-            occupancy[frame_i, track_i] = 1
-            locations[frame_i, track_i, :, :] = inst.numpy()
-
-            if hasattr(inst, "tracking_score") and inst.tracking_score is not None:
-                tracking_scores[frame_i, track_i] = inst.tracking_score
-
-            if isinstance(inst, PredictedInstance):
-                if "score" in inst.points.dtype.names:
-                    point_scores[frame_i, track_i, :] = inst.points["score"]
-                if inst.score is not None:
-                    instance_scores[frame_i, track_i] = inst.score
-
-    # Filter empty/low-occupancy tracks
-    occupied_frames = np.sum(occupancy, axis=0)
-    occupancy_ratio = occupied_frames / n_frames
-    keep_mask = (occupied_frames > 0) & (occupancy_ratio >= min_occupancy)
-
-    if not np.all(keep_mask):
-        occupancy = occupancy[:, keep_mask]
-        locations = locations[:, keep_mask, :, :]
-        point_scores = point_scores[:, keep_mask, :]
-        instance_scores = instance_scores[:, keep_mask]
-        tracking_scores = tracking_scores[:, keep_mask]
-        tracks = [t for i, t in enumerate(tracks) if keep_mask[i]]
-
-    # Get track names
-    track_names = [t.name if t else "" for t in tracks]
-
-    return (
-        occupancy,
-        locations,
-        point_scores,
-        instance_scores,
-        tracking_scores,
-        track_names,
-        first_frame,
-    )
-
-
 def write_labels(
     labels: Labels,
     filename: str | Path,
@@ -721,7 +571,9 @@ def write_labels(
         tracking_scores,
         track_names,
         first_frame,
-    ) = _get_occupancy_and_points(labels, video, all_frames, min_occupancy)
+    ) = to_analysis_arrays(
+        labels, video=video, all_frames=all_frames, min_occupancy=min_occupancy
+    )
 
     # Define canonical order
     canonical_order_4d = {"frame": 0, "track": 1, "node": 2, "xy": 3}

--- a/tests/codecs/test_numpy.py
+++ b/tests/codecs/test_numpy.py
@@ -13,7 +13,7 @@ from sleap_io import (
     Video,
     load_slp,
 )
-from sleap_io.codecs.numpy import from_numpy, to_numpy
+from sleap_io.codecs.numpy import from_numpy, to_analysis_arrays, to_numpy
 
 
 def test_to_numpy_basic(slp_typical):
@@ -890,3 +890,285 @@ def test_to_numpy_lazy_spans_full_video(slp_real_data):
 
     arr = to_numpy(labels)
     assert arr.shape[0] == video_length
+
+
+# =============================================================================
+# to_analysis_arrays
+# =============================================================================
+
+
+def test_to_analysis_arrays_untracked_multi():
+    """Untracked multi-animal project keeps every instance (issue #430)."""
+    skeleton = Skeleton(["a", "b"])
+    video = Video(filename="test.mp4")
+
+    lfs = []
+    for f in range(3):
+        i1 = Instance.from_numpy(
+            np.array([[10.0 + f, 20.0 + f], [30.0 + f, 40.0 + f]]), skeleton=skeleton
+        )
+        i2 = Instance.from_numpy(
+            np.array([[100.0 + f, 200.0 + f], [300.0 + f, 400.0 + f]]),
+            skeleton=skeleton,
+        )
+        lfs.append(LabeledFrame(video=video, frame_idx=f, instances=[i1, i2]))
+    labels = Labels(labeled_frames=lfs)
+
+    occupancy, locations, point_scores, instance_scores, tracking_scores, names, ff = (
+        to_analysis_arrays(labels)
+    )
+
+    # Both instances survive in distinct slots (was 1 slot before the fix).
+    assert occupancy.shape == (3, 2)
+    assert locations.shape == (3, 2, 2, 2)
+    assert names == ["track_0", "track_1"]
+    assert ff == 0
+    assert np.all(occupancy == 1)
+    np.testing.assert_array_equal(locations[0, 0], [[10.0, 20.0], [30.0, 40.0]])
+    np.testing.assert_array_equal(locations[0, 1], [[100.0, 200.0], [300.0, 400.0]])
+    # User instances carry no scores.
+    assert np.all(np.isnan(point_scores))
+    assert np.all(np.isnan(instance_scores))
+    assert np.all(np.isnan(tracking_scores))
+
+
+def test_to_analysis_arrays_untracked_single():
+    """Single-instance untracked project still exports one track slot."""
+    skeleton = Skeleton(["a", "b"])
+    video = Video(filename="test.mp4")
+
+    lfs = [
+        LabeledFrame(
+            video=video,
+            frame_idx=f,
+            instances=[
+                Instance.from_numpy(
+                    np.array([[float(f), float(f)], [float(f), float(f)]]),
+                    skeleton=skeleton,
+                )
+            ],
+        )
+        for f in range(3)
+    ]
+    labels = Labels(labeled_frames=lfs)
+
+    occupancy, locations, _, _, _, names, _ = to_analysis_arrays(labels)
+
+    assert occupancy.shape == (3, 1)
+    assert locations.shape == (3, 1, 2, 2)
+    assert names == ["track_0"]
+
+
+def test_to_analysis_arrays_tracked():
+    """Tracked project slots instances by track and keeps real names/scores."""
+    skeleton = Skeleton(["a", "b"])
+    video = Video(filename="test.mp4")
+    track1 = Track("animal1")
+    track2 = Track("animal2")
+
+    lfs = []
+    for f in range(3):
+        i1 = PredictedInstance.from_numpy(
+            points_data=np.array([[1.0 + f, 1.0 + f], [2.0 + f, 2.0 + f]]),
+            skeleton=skeleton,
+            point_scores=np.array([0.9, 0.8]),
+            score=0.95,
+            track=track1,
+            tracking_score=0.7,
+        )
+        i2 = PredictedInstance.from_numpy(
+            points_data=np.array([[5.0 + f, 5.0 + f], [6.0 + f, 6.0 + f]]),
+            skeleton=skeleton,
+            point_scores=np.array([0.6, 0.5]),
+            score=0.85,
+            track=track2,
+            tracking_score=0.4,
+        )
+        lfs.append(LabeledFrame(video=video, frame_idx=f, instances=[i1, i2]))
+    labels = Labels(labeled_frames=lfs, tracks=[track1, track2])
+
+    occupancy, locations, point_scores, instance_scores, tracking_scores, names, _ = (
+        to_analysis_arrays(labels)
+    )
+
+    assert names == ["animal1", "animal2"]
+    assert occupancy.shape == (3, 2)
+    np.testing.assert_array_equal(locations[0, 0], [[1.0, 1.0], [2.0, 2.0]])
+    np.testing.assert_array_equal(locations[0, 1], [[5.0, 5.0], [6.0, 6.0]])
+    np.testing.assert_array_equal(point_scores[0, 0], [0.9, 0.8])
+    assert instance_scores[0, 0] == pytest.approx(0.95)
+    assert instance_scores[0, 1] == pytest.approx(0.85)
+    assert tracking_scores[0, 0] == pytest.approx(0.7)
+
+
+def test_to_analysis_arrays_tracked_drops_untracked_instance():
+    """An untracked instance in a tracked project is dropped, not slot-0'd."""
+    skeleton = Skeleton(["pt"])
+    video = Video(filename="test.mp4")
+    track1 = Track("animal1")
+    track2 = Track("animal2")
+
+    tracked1 = PredictedInstance.from_numpy(
+        points_data=np.array([[1.0, 1.0]]), skeleton=skeleton, score=0.9, track=track1
+    )
+    tracked2 = PredictedInstance.from_numpy(
+        points_data=np.array([[2.0, 2.0]]), skeleton=skeleton, score=0.9, track=track2
+    )
+    stray = PredictedInstance.from_numpy(
+        points_data=np.array([[9.0, 9.0]]), skeleton=skeleton, score=0.9, track=None
+    )
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[tracked1, tracked2, stray])
+    labels = Labels(labeled_frames=[lf], tracks=[track1, track2])
+
+    occupancy, locations, _, _, _, names, _ = to_analysis_arrays(labels)
+
+    assert names == ["animal1", "animal2"]
+    assert occupancy.shape == (1, 2)
+    # Track 0 keeps its own instance; the stray instance is not slotted here.
+    np.testing.assert_array_equal(locations[0, 0], [[1.0, 1.0]])
+    np.testing.assert_array_equal(locations[0, 1], [[2.0, 2.0]])
+    assert not np.any(locations == 9.0)
+
+
+def test_to_analysis_arrays_min_occupancy_untracked():
+    """min_occupancy filtering renumbers synthesized track names without gaps."""
+    skeleton = Skeleton(["pt"])
+    video = Video(filename="test.mp4")
+
+    lfs = []
+    for f in range(10):
+        # Frame 0 has 3 instances; all others have 1 -> slots 1 and 2 are sparse.
+        n = 3 if f == 0 else 1
+        instances = [
+            Instance.from_numpy(np.array([[float(k), float(f)]]), skeleton=skeleton)
+            for k in range(n)
+        ]
+        lfs.append(LabeledFrame(video=video, frame_idx=f, instances=instances))
+    labels = Labels(labeled_frames=lfs)
+
+    # Without filtering: 3 slots.
+    occ_all, _, _, _, _, names_all, _ = to_analysis_arrays(labels)
+    assert occ_all.shape[1] == 3
+    assert names_all == ["track_0", "track_1", "track_2"]
+
+    # With filtering: only the dense slot 0 survives, renumbered with no gaps.
+    occ, _, _, _, _, names, _ = to_analysis_arrays(labels, min_occupancy=0.5)
+    assert occ.shape[1] == 1
+    assert names == ["track_0"]
+
+
+def test_to_analysis_arrays_variable_instance_count():
+    """n_tracks is sized to the largest per-frame instance count."""
+    skeleton = Skeleton(["pt"])
+    video = Video(filename="test.mp4")
+
+    lf0 = LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[Instance.from_numpy(np.array([[1.0, 1.0]]), skeleton=skeleton)],
+    )
+    lf1 = LabeledFrame(
+        video=video,
+        frame_idx=1,
+        instances=[
+            Instance.from_numpy(np.array([[float(k), 2.0]]), skeleton=skeleton)
+            for k in range(3)
+        ],
+    )
+    labels = Labels(labeled_frames=[lf0, lf1])
+
+    occupancy, _, _, _, _, names, _ = to_analysis_arrays(labels)
+
+    assert occupancy.shape[1] == 3
+    assert names == ["track_0", "track_1", "track_2"]
+    # Frame 0 occupies only the first slot.
+    np.testing.assert_array_equal(occupancy[0], [1, 0, 0])
+    np.testing.assert_array_equal(occupancy[1], [1, 1, 1])
+
+
+def test_to_analysis_arrays_all_frames_toggle():
+    """all_frames controls whether output starts at frame 0 or first label."""
+    skeleton = Skeleton(["pt"])
+    video = Video(filename="test.mp4")
+
+    lfs = [
+        LabeledFrame(
+            video=video,
+            frame_idx=f,
+            instances=[Instance.from_numpy(np.array([[1.0, 1.0]]), skeleton=skeleton)],
+        )
+        for f in (5, 6, 7)
+    ]
+    labels = Labels(labeled_frames=lfs)
+
+    occ_all, _, _, _, _, _, ff_all = to_analysis_arrays(labels, all_frames=True)
+    assert ff_all == 0
+    assert occ_all.shape[0] == 8
+
+    occ_some, _, _, _, _, _, ff_some = to_analysis_arrays(labels, all_frames=False)
+    assert ff_some == 5
+    assert occ_some.shape[0] == 3
+
+
+def test_to_analysis_arrays_no_labeled_frames():
+    """A video with no labeled frames raises ValueError."""
+    video = Video(filename="test.mp4")
+    labels = Labels(videos=[video], skeletons=[Skeleton(["pt"])])
+
+    with pytest.raises(ValueError, match="No labeled frames"):
+        to_analysis_arrays(labels)
+
+
+def test_to_analysis_arrays_video_index():
+    """A video may be selected by integer index."""
+    skeleton = Skeleton(["pt"])
+    video0 = Video(filename="v0.mp4")
+    video1 = Video(filename="v1.mp4")
+
+    lf0 = LabeledFrame(
+        video=video0,
+        frame_idx=0,
+        instances=[Instance.from_numpy(np.array([[1.0, 1.0]]), skeleton=skeleton)],
+    )
+    lf1 = LabeledFrame(
+        video=video1,
+        frame_idx=0,
+        instances=[Instance.from_numpy(np.array([[2.0, 2.0]]), skeleton=skeleton)],
+    )
+    labels = Labels(labeled_frames=[lf0, lf1])
+
+    _, locations, _, _, _, _, _ = to_analysis_arrays(labels, video=1)
+    np.testing.assert_array_equal(locations[0, 0], [[2.0, 2.0]])
+
+
+def test_to_analysis_arrays_extra_instances_dropped():
+    """Instances beyond the global per-frame max are dropped, not crashed on.
+
+    Per-frame dedup can leave more instances than `max(n_user, n_predicted)`
+    when user and predicted instances are unrelated, so the track-slot guard
+    must drop the overflow instead of writing out of bounds.
+    """
+    skeleton = Skeleton(["pt"])
+    video = Video(filename="test.mp4")
+
+    user1 = Instance.from_numpy(np.array([[1.0, 1.0]]), skeleton=skeleton)
+    user2 = Instance.from_numpy(np.array([[2.0, 2.0]]), skeleton=skeleton)
+    # Predicted instances unrelated to the user instances (no from_predicted
+    # link, no shared track) so dedup keeps them all.
+    pred1 = PredictedInstance.from_numpy(
+        points_data=np.array([[3.0, 3.0]]), skeleton=skeleton, score=0.9
+    )
+    pred2 = PredictedInstance.from_numpy(
+        points_data=np.array([[4.0, 4.0]]), skeleton=skeleton, score=0.9
+    )
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[user1, user2, pred1, pred2])
+    labels = Labels(labeled_frames=[lf])
+
+    # n_instances = max(2 user, 2 predicted) = 2, so only 2 slots exist.
+    occupancy, locations, _, _, _, names, _ = to_analysis_arrays(labels)
+
+    assert occupancy.shape[1] == 2
+    assert names == ["track_0", "track_1"]
+    # User instances are slotted first; the extra predicted ones are dropped.
+    np.testing.assert_array_equal(locations[0, 0], [[1.0, 1.0]])
+    np.testing.assert_array_equal(locations[0, 1], [[2.0, 2.0]])

--- a/tests/io/test_analysis_h5.py
+++ b/tests/io/test_analysis_h5.py
@@ -974,6 +974,85 @@ class TestEdgeCases:
             inst.numpy(),
         )
 
+    def test_untracked_single_instance_track_count(self, simple_skeleton, tmp_path):
+        """A single-instance untracked project exports exactly one track."""
+        video = Video(str(tmp_path / "video.mp4"))
+
+        lfs = []
+        for i in range(3):
+            inst = PredictedInstance.from_numpy(
+                np.array([[100.0 + i, 200.0 + i], [150.0 + i, 250.0 + i]]),
+                simple_skeleton,
+                np.array([0.9, 0.85]),
+                0.95,
+                track=None,
+            )
+            lfs.append(LabeledFrame(video=video, frame_idx=i, instances=[inst]))
+        labels = Labels(labeled_frames=lfs, tracks=[])
+
+        h5_path = tmp_path / "untracked_single.analysis.h5"
+        analysis_h5.write_labels(labels, h5_path, preset="standard")
+
+        with h5py.File(h5_path, "r") as f:
+            # Standard preset: (frame, track, node, xy).
+            assert f["tracks"].shape == (3, 1, 2, 2)
+            assert [n.decode() for n in f["track_names"][:]] == ["track_0"]
+
+    def test_untracked_multi_animal_keeps_all_instances(
+        self, simple_skeleton, tmp_path
+    ):
+        """Untracked multi-animal export keeps every instance (issue #430).
+
+        Before the fix, an untracked 2-animal project collapsed to a single
+        track slot, silently dropping the second instance of every frame.
+        """
+        video = Video(str(tmp_path / "video.mp4"))
+
+        lfs = []
+        for i in range(5):
+            inst1 = PredictedInstance.from_numpy(
+                np.array([[10.0 + i, 20.0 + i], [30.0 + i, 40.0 + i]]),
+                simple_skeleton,
+                np.array([0.9, 0.85]),
+                0.95,
+                track=None,
+            )
+            inst2 = PredictedInstance.from_numpy(
+                np.array([[100.0 + i, 200.0 + i], [300.0 + i, 400.0 + i]]),
+                simple_skeleton,
+                np.array([0.8, 0.75]),
+                0.9,
+                track=None,
+            )
+            lfs.append(LabeledFrame(video=video, frame_idx=i, instances=[inst1, inst2]))
+        labels = Labels(labeled_frames=lfs, tracks=[])
+
+        for preset, expected_shape in [
+            ("matlab", (2, 2, 2, 5)),  # (track, xy, node, frame)
+            ("standard", (5, 2, 2, 2)),  # (frame, track, node, xy)
+        ]:
+            h5_path = tmp_path / f"untracked_multi_{preset}.analysis.h5"
+            analysis_h5.write_labels(labels, h5_path, preset=preset)
+
+            with h5py.File(h5_path, "r") as f:
+                assert f["tracks"].shape == expected_shape
+                assert [n.decode() for n in f["track_names"][:]] == [
+                    "track_0",
+                    "track_1",
+                ]
+
+            # Round-trip: both instances of every frame survive.
+            loaded = analysis_h5.read_labels(h5_path)
+            assert len(loaded) == 5
+            for i in range(5):
+                assert len(loaded[i].instances) == 2
+                np.testing.assert_allclose(
+                    loaded[i].instances[0].numpy(), lfs[i].instances[0].numpy()
+                )
+                np.testing.assert_allclose(
+                    loaded[i].instances[1].numpy(), lfs[i].instances[1].numpy()
+                )
+
 
 # =============================================================================
 # Integration with Real Data


### PR DESCRIPTION
## Summary

Fixes #430. `save_analysis_h5` silently collapsed every frame to a **single
instance** when a project had multiple instances per frame but **no `Track`
assignments** — a 2-animal untracked project exported as 1-animal, with the
second (and any further) instance of every frame overwritten and lost.
Reported downstream in talmolab/sleap#2190 (3 affected users).

## Root cause

`_get_occupancy_and_points` (`analysis_h5.py`) sized its output by track count
only — `tracks = labels.tracks or [None]` yields one slot when there are no
tracks — and routed every untracked instance to slot `0`, where each instance
overwrote the last.

The numpy codec `to_numpy` already handled this correctly via its `untracked`
path (sizing by max instances per frame). Both were introduced in the same
commit (`3c3da70`, PR #337); the analysis builder ported legacy SLEAP matrix
logic that assumed "no tracks ⇒ single instance", while the codec was written
fresh.

## Key changes

- **`sleap_io/codecs/numpy.py`**
  - Extracted three pure, behavior-preserving helpers from `to_numpy`:
    `_max_instances_per_frame`, `_untracked_frame_instances`,
    `_tracked_frame_instances`. `to_numpy`'s eager path now calls them; its
    public behavior is unchanged.
  - Added `to_analysis_arrays`, which builds the full analysis bundle
    (`occupancy`, `locations`, `point_scores`, `instance_scores`,
    `tracking_scores`, `track_names`, `first_frame`) using the same correct
    instance-slotting. When `len(labels.tracks) == 0` it falls back to
    untracked slotting (`n_tracks = max instances per frame`) and synthesizes
    names `track_0 … track_{n-1}`.
- **`sleap_io/io/analysis_h5.py`**
  - Removed the bespoke (buggy) `_get_occupancy_and_points`; `write_labels`
    now delegates to `to_analysis_arrays`. Preset/axis-transposition logic is
    unchanged.
- **`docs/formats/analysis_h5.md`** — documented the untracked-project
  behavior under `track_names`.

## Example

```python
import numpy as np, sleap_io as sio, h5py
from sleap_io import Skeleton, Instance, LabeledFrame, Labels, Video

skel = Skeleton(["a", "b"])
vid = Video.from_filename("fake.mp4")
vid.backend_metadata = {"shape": (5, 480, 640, 3)}

# 5 frames, 2 instances each, NO track assignments
lfs = []
for f in range(5):
    i1 = Instance.from_numpy(np.array([[10 + f, 20 + f], [30 + f, 40 + f]], float), skeleton=skel)
    i2 = Instance.from_numpy(np.array([[100 + f, 200 + f], [300 + f, 400 + f]], float), skeleton=skel)
    lfs.append(LabeledFrame(video=vid, frame_idx=f, instances=[i1, i2]))
labels = Labels(labeled_frames=lfs)

sio.save_analysis_h5(labels, "out.h5", all_frames=True, preset="matlab")
with h5py.File("out.h5") as f:
    print("tracks shape:", f["tracks"].shape)
# Before: (1, 2, 2, 5)  -> second instance of every frame dropped
# After:  (2, 2, 2, 5)  -> both instances preserved
```

## API changes

- New: `sleap_io.codecs.numpy.to_analysis_arrays` — the shared analysis-array
  builder behind `save_analysis_h5`. Importable but intentionally not added to
  `sleap_io.codecs.__all__` (it returns a 7-tuple and is an internal building
  block rather than a polished public codec).
- No change to the `save_analysis_h5` / `write_labels` signature.

## Behavior changes (intentional)

- **Untracked multi-animal:** exports `n_tracks == max instances/frame` (was
  always 1) — the fix.
- **Single-instance untracked:** `track_names` becomes `["track_0"]` (was
  `[""]`). Round-trips only points; harmless, strictly better.
- **Tracked project with a stray `track=None` instance:** such instances are
  now dropped (matching `to_numpy`) instead of overwriting track slot 0. The
  old slot-0 routing was itself a data-corrupting bug; fully-tracked projects
  are unaffected.

## Testing

- `tests/codecs/test_numpy.py`: 10 new `to_analysis_arrays` tests — untracked
  multi/single, tracked, dropped stray-`None` instance, `min_occupancy`
  filtering with renumbered names, variable per-frame counts, video-by-index,
  the defensive overflow guard, and the no-frames `ValueError`.
- `tests/io/test_analysis_h5.py`: end-to-end regression test
  (`test_untracked_multi_animal_keeps_all_instances`, matlab + standard
  presets, with round-trip) plus a single-instance track-count assertion.
- Full `tests/` suite passes (2890 passed); the 2 unrelated failures
  (`test_samefile_with_symlink`, `test_export_csv_dlc_chunked_error`) are
  pre-existing Windows-environment failures confirmed on a clean tree.

## Design decisions

- **Shared helpers instead of a parallel reimplementation.** The untracked
  dedup logic (user-preferred, `from_predicted` / shared-track suppression)
  previously lived only in `to_numpy`. Extracting it means the analysis export
  and `to_numpy` share one source of truth for instance slotting.
- **`untracked` is purely `len(labels.tracks) == 0`** for the analysis export
  — it is *not* also forced on for single-instance projects (as `to_numpy`
  does), because a single-animal *tracked* project must keep its real track
  name rather than being renamed `track_0`.
- **No warning emitted** on the untracked fallback (per maintainer
  preference) — silent fix, consistent with `to_numpy(untracked=True)`.
- **Defensive slot guard kept.** Per-frame dedup can occasionally yield more
  instances than the global maximum; the `track_i >= n_tracks` guard drops
  the overflow rather than writing out of bounds (mirrors `to_numpy`'s
  `j < n_tracks` guard). Covered by a dedicated test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
