### PR TITLE
Add motion trail overlay to video rendering

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -364,6 +364,8 @@ sio.render_video(
     trail_node="centroid",   # node name, list of node names, or "centroid"
     trail_width=2.0,         # trail line width in pixels
     trail_alpha_fade=True,   # fade from faint (oldest) to opaque (newest)
+    trail_alpha=1.0,         # global trail opacity
+    trail_color=None,        # uniform color, or None to match pose colors
 )
 ```
 
@@ -372,6 +374,24 @@ sio.render_video(
 - `"centroid"` (default): trail the mean of each instance's visible nodes.
 - A node name (e.g. `"head"`): trail that single node.
 - A list of node names (e.g. `["head", "thorax"]`): draw one trail per node.
+
+By default trails are colored to match the poses (by track when tracks are
+present, otherwise by instance). Pass `trail_color` to override this with a
+single uniform color for all trails — it accepts any color spec (RGB tuple,
+named color, hex, or palette index). `trail_alpha` scales the overall opacity
+and combines with `trail_alpha_fade`.
+
+```python
+# Faint white trails, uniform color, no fade.
+sio.render_video(
+    labels,
+    save_path="output.mp4",
+    show_trails=True,
+    trail_color="white",
+    trail_alpha=0.5,
+    trail_alpha_fade=False,
+)
+```
 
 Trails need temporal context, so they are only drawn for videos or for
 `render_image` when the source is a `Labels` object (so past frames are
@@ -827,6 +847,13 @@ sio render -i predictions.slp -o output.mp4 --trails --trail-length 10
 
 # Trails for specific nodes
 sio render -i predictions.slp -o output.mp4 --trails --trail-node head,thorax
+
+# Styled trails (uniform color, faint, no fade)
+sio render -i predictions.slp -o output.mp4 --trails \
+    --trail-color white --trail-alpha 0.5 --no-trail-fade
+
+# Disable the progress bar
+sio render -i predictions.slp -o output.mp4 --no-progress
 
 # Segmentation overlay from TIFF stack
 sio render -i predictions.slp --overlay masks.tif --overlay-alpha 0.4

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -348,6 +348,46 @@ img = sio.render_image(lf, show_nodes=True, show_edges=False)
 
 ![toggle nodes only](assets/rendering/toggle_nodes_only.png)
 
+### Motion trails
+
+Motion trails draw the trajectory of a node or centroid over the last
+`trail_length` frames, so you can see how each animal moved through the
+rendered output. Trails are drawn behind the poses and colored to match them
+(by track when tracks are present, otherwise by instance).
+
+```python
+sio.render_video(
+    labels,
+    save_path="output.mp4",
+    show_trails=True,        # enable trail drawing
+    trail_length=10,         # number of past frames to trace
+    trail_node="centroid",   # node name, list of node names, or "centroid"
+    trail_width=2.0,         # trail line width in pixels
+    trail_alpha_fade=True,   # fade from faint (oldest) to opaque (newest)
+)
+```
+
+`trail_node` accepts:
+
+- `"centroid"` (default): trail the mean of each instance's visible nodes.
+- A node name (e.g. `"head"`): trail that single node.
+- A list of node names (e.g. `["head", "thorax"]`): draw one trail per node.
+
+Trails need temporal context, so they are only drawn for videos or for
+`render_image` when the source is a `Labels` object (so past frames are
+available). They are silently skipped for a single `LabeledFrame` or a list of
+instances.
+
+```python
+# Trails also work on a single rendered frame from a Labels object.
+img = sio.render_image(labels, lf_ind=100, show_trails=True, trail_length=20)
+```
+
+!!! note
+    For untracked data, trails are matched by instance index across frames,
+    which can jump between animals if the per-frame ordering changes. Trails
+    are most reliable on tracked data.
+
 ---
 
 ## Scaling and Cropping
@@ -782,6 +822,12 @@ sio render -i predictions.slp --lf 0 -o frame.png
 sio render -i predictions.slp -o styled.mp4 \
     --color-by track --palette tableau10 --marker-shape diamond
 
+# Motion trails
+sio render -i predictions.slp -o output.mp4 --trails --trail-length 10
+
+# Trails for specific nodes
+sio render -i predictions.slp -o output.mp4 --trails --trail-node head,thorax
+
 # Segmentation overlay from TIFF stack
 sio render -i predictions.slp --overlay masks.tif --overlay-alpha 0.4
 
@@ -856,6 +902,11 @@ sio render --list-colors
       heading_level: 3
 
 ::: sleap_io.draw_rois
+    options:
+      show_root_heading: true
+      heading_level: 3
+
+::: sleap_io.draw_trails
     options:
       show_root_heading: true
       heading_level: 3

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -73,6 +73,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             "draw_masks",
             "draw_bboxes",
             "draw_label_image",
+            "draw_trails",
         ],
         # Model classes from sleap_io.model.*
         "model.camera": [

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -236,6 +236,42 @@ def _get_package_version(package: str) -> str:
         return "not installed"
 
 
+def _parse_trail_color(
+    color_str: str | None,
+) -> tuple[int, int, int] | str | None:
+    """Parse a trail color string from the CLI.
+
+    Args:
+        color_str: Color string. Can be a comma-separated RGB triple
+            (``"255,128,0"``), a named color, a hex string, or None.
+
+    Returns:
+        An RGB tuple for comma-separated input, the stripped string for a name
+        or hex spec, or None if ``color_str`` is None.
+
+    Raises:
+        click.ClickException: If a comma-separated value is not a valid RGB
+            triple.
+    """
+    if color_str is None:
+        return None
+
+    if "," in color_str:
+        try:
+            parts = [int(p.strip()) for p in color_str.split(",")]
+        except ValueError:
+            raise click.ClickException(
+                f"Invalid --trail-color: '{color_str}'. Use a name, hex, or 'r,g,b'."
+            )
+        if len(parts) != 3:
+            raise click.ClickException(
+                f"Invalid --trail-color: '{color_str}'. RGB needs 3 values."
+            )
+        return (parts[0], parts[1], parts[2])
+
+    return color_str.strip()
+
+
 def _parse_crop_string(
     crop_str: str | None,
 ) -> tuple | None:
@@ -3716,18 +3752,7 @@ def render(
 
     # Parse trail color: comma-separated RGB -> tuple, else pass through as a
     # color spec (named color, hex, etc.) resolved by the renderer.
-    trail_color: tuple[int, int, int] | str | None = None
-    if trail_color_str is not None:
-        if "," in trail_color_str:
-            try:
-                trail_color = tuple(int(p.strip()) for p in trail_color_str.split(","))
-            except ValueError:
-                raise click.ClickException(
-                    f"Invalid --trail-color: '{trail_color_str}'. "
-                    "Use a name, hex, or 'r,g,b'."
-                )
-        else:
-            trail_color = trail_color_str.strip()
+    trail_color = _parse_trail_color(trail_color_str)
 
     trail_kwargs = dict(
         show_trails=show_trails,

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -3225,6 +3225,13 @@ def filenames(
     show_default=True,
     help="H.264 encoding speed/compression trade-off.",
 )
+@click.option(
+    "--progress/--no-progress",
+    "show_progress",
+    default=True,
+    show_default=True,
+    help="Show a progress bar during video rendering.",
+)
 # Appearance options
 @click.option(
     "--color-by",
@@ -3324,6 +3331,22 @@ def filenames(
     default=True,
     show_default=True,
     help="Fade trails from faint (oldest) to opaque (newest).",
+)
+@click.option(
+    "--trail-alpha",
+    "trail_alpha",
+    type=float,
+    default=1.0,
+    show_default=True,
+    help="Global trail opacity (0.0-1.0).",
+)
+@click.option(
+    "--trail-color",
+    "trail_color_str",
+    type=str,
+    default=None,
+    help="Uniform trail color (e.g., 'white', '#ff0000', '255,0,0'). "
+    "Default: match pose colors.",
 )
 # Crop options
 @click.option(
@@ -3434,6 +3457,7 @@ def render(
     fps: float | None,
     crf: int,
     x264_preset: str,
+    show_progress: bool,
     color_by: str,
     palette: str,
     marker_shape: str,
@@ -3448,6 +3472,8 @@ def render(
     trail_node_str: str,
     trail_width: float,
     trail_alpha_fade: bool,
+    trail_alpha: float,
+    trail_color_str: str | None,
     crop_str: str | None,
     background: str,
     images_path: Path | None,
@@ -3688,12 +3714,29 @@ def render(
     else:
         trail_node = trail_node_str.strip()
 
+    # Parse trail color: comma-separated RGB -> tuple, else pass through as a
+    # color spec (named color, hex, etc.) resolved by the renderer.
+    trail_color: tuple[int, int, int] | str | None = None
+    if trail_color_str is not None:
+        if "," in trail_color_str:
+            try:
+                trail_color = tuple(int(p.strip()) for p in trail_color_str.split(","))
+            except ValueError:
+                raise click.ClickException(
+                    f"Invalid --trail-color: '{trail_color_str}'. "
+                    "Use a name, hex, or 'r,g,b'."
+                )
+        else:
+            trail_color = trail_color_str.strip()
+
     trail_kwargs = dict(
         show_trails=show_trails,
         trail_length=trail_length,
         trail_node=trail_node,
         trail_width=trail_width,
         trail_alpha_fade=trail_alpha_fade,
+        trail_alpha=trail_alpha,
+        trail_color=trail_color,
     )
 
     try:
@@ -3782,7 +3825,7 @@ def render(
                 start=start_frame_idx,
                 end=end_frame_idx,
                 include_unlabeled=effective_all_frames,
-                show_progress=True,
+                show_progress=show_progress,
                 background=background,
                 **overlay_kwargs,
                 **trail_kwargs,

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -3286,6 +3286,45 @@ def filenames(
     default=False,
     help="Hide centroid markers. Default: show centroids.",
 )
+# Trail options
+@click.option(
+    "--trails",
+    "show_trails",
+    is_flag=True,
+    default=False,
+    help="Draw motion trails of node/centroid trajectories over past frames.",
+)
+@click.option(
+    "--trail-length",
+    "trail_length",
+    type=int,
+    default=10,
+    show_default=True,
+    help="Number of past frames included in each trail.",
+)
+@click.option(
+    "--trail-node",
+    "trail_node_str",
+    type=str,
+    default="centroid",
+    show_default=True,
+    help="Trail target: 'centroid', a node name, or comma-separated node names.",
+)
+@click.option(
+    "--trail-width",
+    "trail_width",
+    type=float,
+    default=2.0,
+    show_default=True,
+    help="Trail line width in pixels.",
+)
+@click.option(
+    "--trail-fade/--no-trail-fade",
+    "trail_alpha_fade",
+    default=True,
+    show_default=True,
+    help="Fade trails from faint (oldest) to opaque (newest).",
+)
 # Crop options
 @click.option(
     "--crop",
@@ -3404,6 +3443,11 @@ def render(
     no_nodes: bool,
     no_edges: bool,
     no_centroids: bool,
+    show_trails: bool,
+    trail_length: int,
+    trail_node_str: str,
+    trail_width: float,
+    trail_alpha_fade: bool,
     crop_str: str | None,
     background: str,
     images_path: Path | None,
@@ -3454,6 +3498,12 @@ def render(
         $ sio render predictions.slp --lf 0 --crop 0.25,0.25,0.75,0.75  # Normalized
 
         $ sio render predictions.slp -o cropped.mp4 --crop 100,100,300,300
+
+        [bold]Motion trails:[/]
+
+        $ sio render predictions.slp -o output.mp4 --trails --trail-length 10
+
+        $ sio render predictions.slp --trails --trail-node head,thorax
 
         [bold]Background (when video unavailable):[/]
 
@@ -3630,6 +3680,22 @@ def render(
         overlay_outline_color=overlay_outline_color,
     )
 
+    # Parse trail node specification (comma-separated names -> list).
+    if "," in trail_node_str:
+        trail_node: str | list[str] = [
+            s.strip() for s in trail_node_str.split(",") if s.strip()
+        ]
+    else:
+        trail_node = trail_node_str.strip()
+
+    trail_kwargs = dict(
+        show_trails=show_trails,
+        trail_length=trail_length,
+        trail_node=trail_node,
+        trail_width=trail_width,
+        trail_alpha_fade=trail_alpha_fade,
+    )
+
     try:
         if single_image_mode:
             # Single image rendering
@@ -3660,6 +3726,7 @@ def render(
                     show_centroids=not no_centroids,
                     background=background,
                     **overlay_kwargs,
+                    **trail_kwargs,
                 )
             else:
                 # Render by video + frame_idx
@@ -3688,6 +3755,7 @@ def render(
                     show_centroids=not no_centroids,
                     background=background,
                     **overlay_kwargs,
+                    **trail_kwargs,
                 )
         else:
             # Video rendering
@@ -3717,6 +3785,7 @@ def render(
                 show_progress=True,
                 background=background,
                 **overlay_kwargs,
+                **trail_kwargs,
             )
     except Exception as e:
         raise click.ClickException(f"Failed to render: {e}")

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -272,6 +272,39 @@ def _parse_trail_color(
     return color_str.strip()
 
 
+def _parse_trail_node(node_str: str) -> str | list[str]:
+    """Parse the ``--trail-node`` value from the CLI.
+
+    Args:
+        node_str: Trail node specification. Either a single target
+            (``"centroid"`` or a node name) or a comma-separated list of node
+            names.
+
+    Returns:
+        A single string for one target, or a list of strings for a
+        comma-separated list of node names.
+
+    Raises:
+        click.ClickException: If the value is empty or contains no names.
+    """
+    if "," in node_str:
+        names = [s.strip() for s in node_str.split(",") if s.strip()]
+        if not names:
+            raise click.ClickException(
+                f"Invalid --trail-node: '{node_str}'. Provide a node name, "
+                "'centroid', or a comma-separated list of node names."
+            )
+        return names[0] if len(names) == 1 else names
+
+    name = node_str.strip()
+    if not name:
+        raise click.ClickException(
+            "Invalid --trail-node: value is empty. Provide a node name, "
+            "'centroid', or a comma-separated list of node names."
+        )
+    return name
+
+
 def _parse_crop_string(
     crop_str: str | None,
 ) -> tuple | None:
@@ -3340,7 +3373,7 @@ def filenames(
 @click.option(
     "--trail-length",
     "trail_length",
-    type=int,
+    type=click.IntRange(min=1),
     default=10,
     show_default=True,
     help="Number of past frames included in each trail.",
@@ -3371,7 +3404,7 @@ def filenames(
 @click.option(
     "--trail-alpha",
     "trail_alpha",
-    type=float,
+    type=click.FloatRange(0.0, 1.0),
     default=1.0,
     show_default=True,
     help="Global trail opacity (0.0-1.0).",
@@ -3743,12 +3776,7 @@ def render(
     )
 
     # Parse trail node specification (comma-separated names -> list).
-    if "," in trail_node_str:
-        trail_node: str | list[str] = [
-            s.strip() for s in trail_node_str.split(",") if s.strip()
-        ]
-    else:
-        trail_node = trail_node_str.strip()
+    trail_node = _parse_trail_node(trail_node_str)
 
     # Parse trail color: comma-separated RGB -> tuple, else pass through as a
     # color spec (named color, hex, etc.) resolved by the renderer.

--- a/sleap_io/rendering/__init__.py
+++ b/sleap_io/rendering/__init__.py
@@ -27,6 +27,7 @@ from sleap_io.rendering.overlays import (
     draw_label_image,
     draw_masks,
     draw_rois,
+    draw_trails,
 )
 
 __all__ = [
@@ -42,4 +43,5 @@ __all__ = [
     "draw_masks",
     "draw_bboxes",
     "draw_label_image",
+    "draw_trails",
 ]

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -789,6 +789,8 @@ def render_image(
     trail_node: str | list[str] = "centroid",
     trail_width: float = 2.0,
     trail_alpha_fade: bool = True,
+    trail_alpha: float = 1.0,
+    trail_color: ColorSpec | None = None,
     # Background control
     background: Literal["video"] | ColorSpec = "video",
     # Callbacks
@@ -854,6 +856,11 @@ def render_image(
         trail_width: Trail line width in pixels.
         trail_alpha_fade: If ``True``, fade trails from faint (oldest) to opaque
             (newest).
+        trail_alpha: Global opacity multiplier for trails (0.0 to 1.0). Combines
+            with ``trail_alpha_fade``.
+        trail_color: Uniform color for all trails. If ``None`` (default), trails
+            are colored to match the poses (by track or instance). Accepts any
+            color spec (RGB tuple, named color, hex, or palette index).
         background: Background control. Can be:
             - ``"video"``: Load video frame (default). Raises error if unavailable.
             - Any color spec: Use solid color background, skip video loading entirely.
@@ -1152,16 +1159,23 @@ def render_image(
         if trails:
             if render_image_data.ndim == 2:
                 render_image_data = np.stack([render_image_data] * 3, axis=-1)
+            # A uniform trail_color overrides the per-track palette colors.
+            trail_draw_kwargs: dict = {}
+            if trail_color is not None:
+                trail_draw_kwargs["color"] = resolve_color(trail_color)
+            else:
+                trail_draw_kwargs["colors"] = trail_colors
             # trail_width is NOT pre-scaled: the trail is drawn here, then the
             # whole image is upscaled once by `scale` inside render_frame, so
             # the final width matches pose edges (line_width * scale).
             render_image_data = _draw_trails(
                 render_image_data,
                 trails,
-                colors=trail_colors,
                 line_width=trail_width,
                 alpha_fade=trail_alpha_fade,
+                alpha=trail_alpha,
                 offset=crop_offset,
+                **trail_draw_kwargs,
             )
 
     # Draw centroids on the image.
@@ -1295,6 +1309,8 @@ def render_video(
     trail_node: str | list[str] = "centroid",
     trail_width: float = 2.0,
     trail_alpha_fade: bool = True,
+    trail_alpha: float = 1.0,
+    trail_color: ColorSpec | None = None,
     # Video encoding
     fps: float | None = None,
     codec: str = "libx264",
@@ -1367,6 +1383,11 @@ def render_video(
         trail_width: Trail line width in pixels.
         trail_alpha_fade: If ``True``, fade trails from faint (oldest) to opaque
             (newest).
+        trail_alpha: Global opacity multiplier for trails (0.0 to 1.0). Combines
+            with ``trail_alpha_fade``.
+        trail_color: Uniform color for all trails. If ``None`` (default), trails
+            are colored to match the poses (by track or instance). Accepts any
+            color spec (RGB tuple, named color, hex, or palette index).
         fps: Output frame rate (default: source video fps).
         codec: Video codec for encoding.
         crf: Constant rate factor for quality (2-32, lower=better). Default 25.
@@ -1655,6 +1676,10 @@ def render_video(
                     (len(lf.instances) for lf in labeled_frames), default=1
                 )
             _trail_palette = get_palette(palette, max(n_trail_colors, 1))
+    # A uniform trail_color overrides the per-track palette colors.
+    _trail_color_resolved = (
+        resolve_color(trail_color) if trail_color is not None else None
+    )
 
     # Pre-process overlay: determine type for per-frame dispatch
     _overlay_is_3d = (
@@ -1809,16 +1834,23 @@ def render_video(
         if image.ndim == 2:
             image = np.stack([image] * 3, axis=-1)
 
+        # A uniform trail_color overrides the per-track palette colors.
+        if _trail_color_resolved is not None:
+            color_kwargs: dict = {"color": _trail_color_resolved}
+        else:
+            color_kwargs = {"colors": trail_colors}
+
         # trail_width is NOT pre-scaled: the trail is drawn here, then the whole
         # image is upscaled once by `scale` inside render_frame, so the final
         # width matches pose edges (line_width * scale).
         return draw_trails(
             image,
             trails,
-            colors=trail_colors,
             line_width=trail_width,
             alpha_fade=trail_alpha_fade,
+            alpha=trail_alpha,
             offset=crop_off,
+            **color_kwargs,
         )
 
     # Only accumulate frames if returning as list (no save_path)

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -6,7 +6,7 @@ This module provides the main API for rendering pose data with skia-python.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Literal
+from typing import TYPE_CHECKING, Callable, Iterable, Literal
 
 import numpy as np
 
@@ -209,6 +209,7 @@ def _compute_trails(
     track_idx_map: dict[int, int],
     palette_colors: list[tuple[int, int, int]],
     has_tracks: bool,
+    pts_cache: dict[int, np.ndarray] | None = None,
 ) -> tuple[list[np.ndarray], list[tuple[int, int, int]]]:
     """Compute motion-trail polylines ending at a given frame.
 
@@ -225,6 +226,10 @@ def _compute_trails(
             instance index (untracked data).
         has_tracks: Whether the data has track assignments. When ``False``,
             trails are keyed by instance position index instead of track.
+        pts_cache: Optional cache mapping ``id(instance)`` to its extracted
+            ``(n_nodes, 2)`` point array. When rendering a video, consecutive
+            frames share overlapping trail windows, so passing a persistent
+            cache avoids re-extracting the same instance points repeatedly.
 
     Returns:
         Tuple of ``(trails, colors)`` where ``trails`` is a list of ``(M, 2)``
@@ -252,22 +257,32 @@ def _compute_trails(
             else:
                 key_idx = inst_idx
 
-            pts = None  # Lazily computed instance.numpy() when a node is needed.
+            # Extract instance points once, reusing the cache across the
+            # overlapping trail windows of consecutive frames when provided.
+            if pts_cache is not None:
+                pts = pts_cache.get(id(inst))
+                if pts is None:
+                    pts = inst.numpy()
+                    pts_cache[id(inst)] = pts
+            else:
+                pts = inst.numpy()
+
             for t_idx, target in enumerate(trail_targets):
                 if target is None:
-                    xy = inst.centroid_xy
-                    coord = (
-                        (float(xy[0]), float(xy[1]))
-                        if xy is not None
-                        else (np.nan, np.nan)
-                    )
-                else:
-                    if pts is None:
-                        pts = inst.numpy()
-                    if target < len(pts):
-                        coord = (float(pts[target][0]), float(pts[target][1]))
+                    # Centroid: mean of visible points, matching
+                    # `Instance.centroid_xy` (visibility keyed off column 0).
+                    visible = ~np.isnan(pts[:, 0])
+                    if visible.any():
+                        coord = (
+                            float(pts[visible, 0].mean()),
+                            float(pts[visible, 1].mean()),
+                        )
                     else:
                         coord = (np.nan, np.nan)
+                elif target < len(pts):
+                    coord = (float(pts[target][0]), float(pts[target][1]))
+                else:
+                    coord = (np.nan, np.nan)
 
                 dkey = (key_idx, t_idx)
                 arr = trail_data.get(dkey)
@@ -285,6 +300,32 @@ def _compute_trails(
         colors.append(palette_colors[key_idx % len(palette_colors)])
 
     return trails, colors
+
+
+def _n_trail_palette_colors(
+    has_tracks: bool,
+    n_tracks: int,
+    labeled_frames: Iterable["LabeledFrame"],
+) -> int:
+    """Return the number of palette colors needed for motion trails.
+
+    Trails are colored by track when tracks are present, otherwise by instance
+    position index. To keep untracked colors stable across a render, the palette
+    is sized to the largest instance count over the provided frames.
+
+    Args:
+        has_tracks: Whether the data has track assignments.
+        n_tracks: Total number of tracks (used when ``has_tracks`` is ``True``).
+        labeled_frames: Frames to scan for the peak instance count (used when
+            ``has_tracks`` is ``False``).
+
+    Returns:
+        The palette size, always at least 1.
+    """
+    if has_tracks:
+        return max(n_tracks, 1)
+    peak = max((len(lf.instances) for lf in labeled_frames), default=1)
+    return max(peak, 1)
 
 
 def _prepare_frame_rgba(frame: np.ndarray) -> np.ndarray:
@@ -1139,13 +1180,17 @@ def render_image(
         )
 
     # Draw motion trails behind the poses and centroids. Trails need temporal
-    # context, so they are only drawn when the source is a Labels object.
-    if show_trails and isinstance(source, Labels) and trail_length > 0 and instances:
+    # context, so they are only drawn when the source is a Labels object. They
+    # are drawn even when the current frame has no instances, since past frames
+    # may still contribute (matching render_video).
+    if show_trails and isinstance(source, Labels) and trail_length > 0:
         from sleap_io.rendering.overlays import draw_trails as _draw_trails
 
         trail_targets = _resolve_trail_node(trail_node, skeleton)
         frame_idx_to_lf = {lframe.frame_idx: lframe for lframe in source.find(lf.video)}
-        n_trail_colors = max(n_tracks if has_tracks else len(instances), 1)
+        n_trail_colors = _n_trail_palette_colors(
+            has_tracks, n_tracks, frame_idx_to_lf.values()
+        )
         trail_palette = get_palette(palette, n_trail_colors)
         trails, trail_colors = _compute_trails(
             fidx=fidx_for_callback,
@@ -1157,8 +1202,6 @@ def render_image(
             has_tracks=has_tracks,
         )
         if trails:
-            if render_image_data.ndim == 2:
-                render_image_data = np.stack([render_image_data] * 3, axis=-1)
             # A uniform trail_color overrides the per-track palette colors.
             trail_draw_kwargs: dict = {}
             if trail_color is not None:
@@ -1656,26 +1699,18 @@ def render_video(
     if _has_video_centroids and labels is not None:
         _centroid_palette = get_palette(palette, max(len(labels.tracks), 1))
 
-    # Set up motion trails (drawn behind poses).
-    _do_trails = show_trails and trail_length > 0
+    # Set up motion trails (drawn behind poses). Trails trace instances, and
+    # every instance carries a skeleton, so a missing skeleton means there are
+    # no instances to trail.
+    _do_trails = show_trails and trail_length > 0 and skeleton is not None
     _trail_targets: list[int | None] = []
     _trail_palette: list[tuple[int, int, int]] = []
+    _trail_pts_cache: dict[int, np.ndarray] = {}
     if _do_trails:
-        if skeleton is not None:
-            _trail_targets = _resolve_trail_node(trail_node, skeleton)
-        elif isinstance(trail_node, str) and trail_node.lower() == "centroid":
-            _trail_targets = [None]
-        else:
-            # Node-name trails need a skeleton; skip trails without one.
-            _do_trails = False
-        if _do_trails:
-            if has_tracks:
-                n_trail_colors = max(n_tracks, 1)
-            else:
-                n_trail_colors = max(
-                    (len(lf.instances) for lf in labeled_frames), default=1
-                )
-            _trail_palette = get_palette(palette, max(n_trail_colors, 1))
+        _trail_targets = _resolve_trail_node(trail_node, skeleton)
+        _trail_palette = get_palette(
+            palette, _n_trail_palette_colors(has_tracks, n_tracks, labeled_frames)
+        )
     # A uniform trail_color overrides the per-track palette colors.
     _trail_color_resolved = (
         resolve_color(trail_color) if trail_color is not None else None
@@ -1824,15 +1859,12 @@ def render_video(
             track_idx_map=_track_idx_map,
             palette_colors=_trail_palette,
             has_tracks=has_tracks,
+            pts_cache=_trail_pts_cache,
         )
         if not trails:
             return image
 
         from sleap_io.rendering.overlays import draw_trails
-
-        # Ensure RGB.
-        if image.ndim == 2:
-            image = np.stack([image] * 3, axis=-1)
 
         # A uniform trail_color overrides the per-track palette colors.
         if _trail_color_resolved is not None:

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from sleap_io.model.labels import Labels
     from sleap_io.model.mask import SegmentationMask
     from sleap_io.model.roi import ROI
+    from sleap_io.model.skeleton import Skeleton
     from sleap_io.model.video import Video
 
 # Preset configurations
@@ -161,6 +162,129 @@ def _apply_crop(
         shifted_points.append(shifted)
 
     return cropped, shifted_points, scale
+
+
+def _resolve_trail_node(
+    trail_node: str | list[str],
+    skeleton: "Skeleton",
+) -> list[int | None]:
+    """Resolve a ``trail_node`` specification to a list of trail targets.
+
+    Args:
+        trail_node: Trail target specification. One of:
+
+            - ``"centroid"``: trail the instance centroid.
+            - A node name string: trail that node.
+            - A list of node name strings: trail each node separately.
+        skeleton: Skeleton used to resolve node names to indices.
+
+    Returns:
+        List of targets, one per requested node. Each target is ``None``
+        (centroid) or an integer node index.
+
+    Raises:
+        ValueError: If a node name is not present in the skeleton.
+    """
+    names = [trail_node] if isinstance(trail_node, str) else list(trail_node)
+
+    targets: list[int | None] = []
+    for name in names:
+        if isinstance(name, str) and name.lower() == "centroid":
+            targets.append(None)
+            continue
+        try:
+            targets.append(skeleton.index(name))
+        except (KeyError, IndexError):
+            raise ValueError(
+                f"Unknown trail_node {name!r}; skeleton nodes: {skeleton.node_names}"
+            )
+    return targets
+
+
+def _compute_trails(
+    fidx: int,
+    frame_idx_to_lf: dict[int, "LabeledFrame"],
+    trail_length: int,
+    trail_targets: list[int | None],
+    track_idx_map: dict[int, int],
+    palette_colors: list[tuple[int, int, int]],
+    has_tracks: bool,
+) -> tuple[list[np.ndarray], list[tuple[int, int, int]]]:
+    """Compute motion-trail polylines ending at a given frame.
+
+    Args:
+        fidx: Current frame index (the trail ends here).
+        frame_idx_to_lf: Mapping from frame index to LabeledFrame.
+        trail_length: Number of past frames behind the current frame. The trail
+            spans frames ``[fidx - trail_length, fidx]`` inclusive.
+        trail_targets: List of targets from `_resolve_trail_node`. Each is
+            ``None`` (centroid) or an integer node index.
+        track_idx_map: Mapping from ``id(track)`` to track index, used to key
+            trails by track and to assign colors.
+        palette_colors: Color palette indexed by track index (tracked data) or
+            instance index (untracked data).
+        has_tracks: Whether the data has track assignments. When ``False``,
+            trails are keyed by instance position index instead of track.
+
+    Returns:
+        Tuple of ``(trails, colors)`` where ``trails`` is a list of ``(M, 2)``
+        float arrays (``M = trail_length + 1``, oldest to newest, NaN for
+        missing positions) and ``colors`` is the parallel list of RGB tuples.
+    """
+    frame_range = range(fidx - trail_length, fidx + 1)
+    n_points = trail_length + 1
+
+    # Map from (key index, target index) -> (M, 2) array of positions, where
+    # key index is the track index (tracked) or instance index (untracked).
+    trail_data: dict[tuple[int, int], np.ndarray] = {}
+
+    for j, f in enumerate(frame_range):
+        lf = frame_idx_to_lf.get(f)
+        if lf is None:
+            continue
+        for inst_idx, inst in enumerate(lf.instances):
+            if has_tracks:
+                if inst.track is None:
+                    continue
+                key_idx = track_idx_map.get(id(inst.track))
+                if key_idx is None:
+                    continue
+            else:
+                key_idx = inst_idx
+
+            pts = None  # Lazily computed instance.numpy() when a node is needed.
+            for t_idx, target in enumerate(trail_targets):
+                if target is None:
+                    xy = inst.centroid_xy
+                    coord = (
+                        (float(xy[0]), float(xy[1]))
+                        if xy is not None
+                        else (np.nan, np.nan)
+                    )
+                else:
+                    if pts is None:
+                        pts = inst.numpy()
+                    if target < len(pts):
+                        coord = (float(pts[target][0]), float(pts[target][1]))
+                    else:
+                        coord = (np.nan, np.nan)
+
+                dkey = (key_idx, t_idx)
+                arr = trail_data.get(dkey)
+                if arr is None:
+                    arr = np.full((n_points, 2), np.nan, dtype=np.float64)
+                    trail_data[dkey] = arr
+                arr[j] = coord
+
+    trails: list[np.ndarray] = []
+    colors: list[tuple[int, int, int]] = []
+    for (key_idx, _), arr in trail_data.items():
+        if not np.isfinite(arr).any():
+            continue
+        trails.append(arr)
+        colors.append(palette_colors[key_idx % len(palette_colors)])
+
+    return trails, colors
 
 
 def _prepare_frame_rgba(frame: np.ndarray) -> np.ndarray:
@@ -659,6 +783,12 @@ def render_image(
     show_centroids: bool = True,
     centroid_marker_size: float = 5.0,
     scale: float = 1.0,
+    # Motion trails
+    show_trails: bool = False,
+    trail_length: int = 10,
+    trail_node: str | list[str] = "centroid",
+    trail_width: float = 2.0,
+    trail_alpha_fade: bool = True,
     # Background control
     background: Literal["video"] | ColorSpec = "video",
     # Callbacks
@@ -714,6 +844,16 @@ def render_image(
             ``Labels.centroids``. Centroids are colored by track.
         centroid_marker_size: Radius of centroid markers in pixels.
         scale: Output scale factor. Applied after cropping.
+        show_trails: Whether to draw motion trails tracing node or centroid
+            positions over past frames. Only takes effect when ``source`` is a
+            ``Labels`` object (trails need temporal context); ignored otherwise.
+        trail_length: Number of past frames behind the current frame to include
+            in each trail.
+        trail_node: Which point to trail. One of ``"centroid"`` (default), a
+            node name, or a list of node names (one trail per node).
+        trail_width: Trail line width in pixels.
+        trail_alpha_fade: If ``True``, fade trails from faint (oldest) to opaque
+            (newest).
         background: Background control. Can be:
             - ``"video"``: Load video frame (default). Raises error if unavailable.
             - Any color spec: Use solid color background, skip video loading entirely.
@@ -991,6 +1131,39 @@ def render_image(
             outline_color=overlay_outline_color,
         )
 
+    # Draw motion trails behind the poses and centroids. Trails need temporal
+    # context, so they are only drawn when the source is a Labels object.
+    if show_trails and isinstance(source, Labels) and trail_length > 0 and instances:
+        from sleap_io.rendering.overlays import draw_trails as _draw_trails
+
+        trail_targets = _resolve_trail_node(trail_node, skeleton)
+        frame_idx_to_lf = {lframe.frame_idx: lframe for lframe in source.find(lf.video)}
+        n_trail_colors = max(n_tracks if has_tracks else len(instances), 1)
+        trail_palette = get_palette(palette, n_trail_colors)
+        trails, trail_colors = _compute_trails(
+            fidx=fidx_for_callback,
+            frame_idx_to_lf=frame_idx_to_lf,
+            trail_length=trail_length,
+            trail_targets=trail_targets,
+            track_idx_map=img_track_idx_map,
+            palette_colors=trail_palette,
+            has_tracks=has_tracks,
+        )
+        if trails:
+            if render_image_data.ndim == 2:
+                render_image_data = np.stack([render_image_data] * 3, axis=-1)
+            # trail_width is NOT pre-scaled: the trail is drawn here, then the
+            # whole image is upscaled once by `scale` inside render_frame, so
+            # the final width matches pose edges (line_width * scale).
+            render_image_data = _draw_trails(
+                render_image_data,
+                trails,
+                colors=trail_colors,
+                line_width=trail_width,
+                alpha_fade=trail_alpha_fade,
+                offset=crop_offset,
+            )
+
     # Draw centroids on the image.
     if show_centroids and isinstance(source, Labels) and source.centroids:
         from sleap_io.rendering.overlays import draw_centroids as _draw_centroids
@@ -1116,6 +1289,12 @@ def render_video(
     show_edges: bool = True,
     show_centroids: bool = True,
     centroid_marker_size: float = 5.0,
+    # Motion trails
+    show_trails: bool = False,
+    trail_length: int = 10,
+    trail_node: str | list[str] = "centroid",
+    trail_width: float = 2.0,
+    trail_alpha_fade: bool = True,
     # Video encoding
     fps: float | None = None,
     codec: str = "libx264",
@@ -1179,6 +1358,15 @@ def render_video(
         show_centroids: Whether to draw centroid markers from
             ``Labels.centroids``. Centroids are colored by track.
         centroid_marker_size: Radius of centroid markers in pixels.
+        show_trails: Whether to draw motion trails tracing node or centroid
+            positions over past frames.
+        trail_length: Number of past frames behind each frame to include in the
+            trail.
+        trail_node: Which point to trail. One of ``"centroid"`` (default), a
+            node name, or a list of node names (one trail per node).
+        trail_width: Trail line width in pixels.
+        trail_alpha_fade: If ``True``, fade trails from faint (oldest) to opaque
+            (newest).
         fps: Output frame rate (default: source video fps).
         codec: Video codec for encoding.
         crf: Constant rate factor for quality (2-32, lower=better). Default 25.
@@ -1447,6 +1635,27 @@ def render_video(
     if _has_video_centroids and labels is not None:
         _centroid_palette = get_palette(palette, max(len(labels.tracks), 1))
 
+    # Set up motion trails (drawn behind poses).
+    _do_trails = show_trails and trail_length > 0
+    _trail_targets: list[int | None] = []
+    _trail_palette: list[tuple[int, int, int]] = []
+    if _do_trails:
+        if skeleton is not None:
+            _trail_targets = _resolve_trail_node(trail_node, skeleton)
+        elif isinstance(trail_node, str) and trail_node.lower() == "centroid":
+            _trail_targets = [None]
+        else:
+            # Node-name trails need a skeleton; skip trails without one.
+            _do_trails = False
+        if _do_trails:
+            if has_tracks:
+                n_trail_colors = max(n_tracks, 1)
+            else:
+                n_trail_colors = max(
+                    (len(lf.instances) for lf in labeled_frames), default=1
+                )
+            _trail_palette = get_palette(palette, max(n_trail_colors, 1))
+
     # Pre-process overlay: determine type for per-frame dispatch
     _overlay_is_3d = (
         overlay is not None and isinstance(overlay, np.ndarray) and overlay.ndim == 3
@@ -1575,6 +1784,43 @@ def render_video(
         )
         return image
 
+    def _draw_frame_trails(
+        image: np.ndarray, fidx: int, crop_off: tuple[float, float] = (0.0, 0.0)
+    ) -> np.ndarray:
+        """Draw motion trails for a single frame onto the image."""
+        if not _do_trails:
+            return image
+
+        trails, trail_colors = _compute_trails(
+            fidx=fidx,
+            frame_idx_to_lf=frame_idx_to_lf,
+            trail_length=trail_length,
+            trail_targets=_trail_targets,
+            track_idx_map=_track_idx_map,
+            palette_colors=_trail_palette,
+            has_tracks=has_tracks,
+        )
+        if not trails:
+            return image
+
+        from sleap_io.rendering.overlays import draw_trails
+
+        # Ensure RGB.
+        if image.ndim == 2:
+            image = np.stack([image] * 3, axis=-1)
+
+        # trail_width is NOT pre-scaled: the trail is drawn here, then the whole
+        # image is upscaled once by `scale` inside render_frame, so the final
+        # width matches pose edges (line_width * scale).
+        return draw_trails(
+            image,
+            trails,
+            colors=trail_colors,
+            line_width=trail_width,
+            alpha_fade=trail_alpha_fade,
+            offset=crop_off,
+        )
+
     # Only accumulate frames if returning as list (no save_path)
     rendered_frames: list[np.ndarray] = []
     total_frames = len(render_indices)
@@ -1636,6 +1882,11 @@ def render_video(
                     else (0.0, 0.0)
                 )
                 render_image_data = _draw_frame_centroids(
+                    render_image_data, fidx, crop_off
+                )
+
+                # Draw motion trails
+                render_image_data = _draw_frame_trails(
                     render_image_data, fidx, crop_off
                 )
 
@@ -1730,6 +1981,9 @@ def render_video(
                 else (0.0, 0.0)
             )
             render_image_data = _draw_frame_centroids(render_image_data, fidx, crop_off)
+
+            # Draw motion trails
+            render_image_data = _draw_frame_trails(render_image_data, fidx, crop_off)
 
             # Render frame
             rendered = render_frame(

--- a/sleap_io/rendering/overlays.py
+++ b/sleap_io/rendering/overlays.py
@@ -704,3 +704,109 @@ def draw_centroids(
         image[:] = result
         return image
     return result.copy()
+
+
+def draw_trails(
+    image: np.ndarray,
+    trails: list[np.ndarray],
+    color: tuple[int, int, int] = (0, 255, 0),
+    colors: list[tuple[int, int, int]] | None = None,
+    line_width: float = 2.0,
+    alpha_fade: bool = True,
+    alpha: float = 1.0,
+    offset: tuple[float, float] = (0.0, 0.0),
+) -> np.ndarray:
+    """Draw motion trails as fading polylines on an image.
+
+    Each trail is a polyline tracing a node or centroid position across past
+    frames. Segments are drawn individually so opacity can fade from faint
+    (oldest) to opaque (newest).
+
+    Args:
+        image: Image array of shape ``(H, W, 3)`` uint8. Modified in-place when
+            possible and returned.
+        trails: List of trails, where each trail is an ``(N, 2)`` float array of
+            ``(x, y)`` coordinates ordered oldest to newest. Non-finite rows
+            (NaN) break the polyline so missing detections leave gaps.
+        color: RGB color tuple used when ``colors`` is ``None``.
+        colors: Per-trail RGB color tuples. If provided, must have the same
+            length as ``trails``. Overrides ``color``.
+        line_width: Width of the trail line in pixels.
+        alpha_fade: If ``True``, fade opacity from faint at the oldest segment to
+            fully opaque at the newest. If ``False``, all segments use ``alpha``.
+        alpha: Global opacity multiplier (0.0 to 1.0).
+        offset: ``(ox, oy)`` offset subtracted from coordinates (used for
+            cropped images).
+
+    Returns:
+        The image array with trails drawn.
+    """
+    if not trails:
+        return image
+
+    import skia
+
+    ox, oy = offset
+
+    # Ensure RGB before padding to RGBA.
+    if image.ndim == 2:
+        image = np.stack([image] * 3, axis=-1)
+    elif image.ndim == 3 and image.shape[2] == 1:
+        image = np.concatenate([image] * 3, axis=-1)
+
+    # Pad to RGBA for skia surface.
+    frame_rgba = np.dstack([image, np.full(image.shape[:2], 255, dtype=np.uint8)])
+    surface = skia.Surface(frame_rgba, colorType=skia.kRGBA_8888_ColorType)
+    canvas = surface.getCanvas()
+
+    for i, trail in enumerate(trails):
+        c = colors[i] if colors is not None else color
+        n_points = len(trail)
+        if n_points < 2:
+            # A single point has no segment to draw.
+            continue
+
+        # Each segment gets its own paint so opacity can fade per segment
+        # (a single skia.Path supports only one Paint).
+        n_segments = n_points - 1
+        for k in range(n_segments):
+            x0, y0 = trail[k]
+            x1, y1 = trail[k + 1]
+            if not (
+                np.isfinite(x0)
+                and np.isfinite(y0)
+                and np.isfinite(x1)
+                and np.isfinite(y1)
+            ):
+                # Skip segments touching a missing (NaN) position.
+                continue
+
+            if alpha_fade:
+                # Newest segment (k = n_segments - 1) is fully opaque; oldest
+                # stays faintly visible rather than fully transparent.
+                seg_frac = max((k + 1) / n_segments, 0.05)
+            else:
+                seg_frac = 1.0
+            seg_alpha = max(0, min(255, int(seg_frac * alpha * 255)))
+
+            paint = skia.Paint(
+                Color=skia.Color(c[0], c[1], c[2], seg_alpha),
+                AntiAlias=True,
+                Style=skia.Paint.kStroke_Style,
+                StrokeWidth=float(line_width),
+                StrokeCap=skia.Paint.kRound_Cap,
+            )
+            canvas.drawLine(
+                float(x0) - ox,
+                float(y0) - oy,
+                float(x1) - ox,
+                float(y1) - oy,
+                paint,
+            )
+
+    surface.flushAndSubmit()
+    result = frame_rgba[:, :, :3]
+    if image.shape == result.shape:
+        image[:] = result
+        return image
+    return result.copy()

--- a/sleap_io/rendering/overlays.py
+++ b/sleap_io/rendering/overlays.py
@@ -722,6 +722,12 @@ def draw_trails(
     frames. Segments are drawn individually so opacity can fade from faint
     (oldest) to opaque (newest).
 
+    All segments are rasterized into a separate transparent buffer with the
+    ``kSrc`` blend mode, so overlapping joints (and crossing trails) take the
+    newest segment's alpha instead of accumulating it. That buffer is then
+    composited onto the image in a single pass, touching only the pixels the
+    trails actually cover.
+
     Args:
         image: Image array of shape ``(H, W, 3)`` uint8. Modified in-place when
             possible and returned.
@@ -740,23 +746,36 @@ def draw_trails(
 
     Returns:
         The image array with trails drawn.
+
+    Raises:
+        ValueError: If ``colors`` is provided and its length does not match
+            ``trails``.
     """
     if not trails:
         return image
+
+    if colors is not None and len(colors) != len(trails):
+        raise ValueError(
+            f"colors has length {len(colors)} but there are {len(trails)} "
+            "trails; they must be the same length."
+        )
 
     import skia
 
     ox, oy = offset
 
-    # Ensure RGB before padding to RGBA.
+    # Ensure RGB so trail pixels can be composited back.
     if image.ndim == 2:
         image = np.stack([image] * 3, axis=-1)
     elif image.ndim == 3 and image.shape[2] == 1:
         image = np.concatenate([image] * 3, axis=-1)
 
-    # Pad to RGBA for skia surface.
-    frame_rgba = np.dstack([image, np.full(image.shape[:2], 255, dtype=np.uint8)])
-    surface = skia.Surface(frame_rgba, colorType=skia.kRGBA_8888_ColorType)
+    # Rasterize the trails into a separate transparent RGBA buffer. Drawing into
+    # a dedicated buffer (rather than the frame) lets the kSrc blend mode below
+    # replace overlapping joints instead of accumulating their alpha.
+    h, w = image.shape[:2]
+    trail_rgba = np.zeros((h, w, 4), dtype=np.uint8)
+    surface = skia.Surface(trail_rgba, colorType=skia.kRGBA_8888_ColorType)
     canvas = surface.getCanvas()
 
     for i, trail in enumerate(trails):
@@ -795,6 +814,7 @@ def draw_trails(
                 Style=skia.Paint.kStroke_Style,
                 StrokeWidth=float(line_width),
                 StrokeCap=skia.Paint.kRound_Cap,
+                BlendMode=skia.BlendMode.kSrc,
             )
             canvas.drawLine(
                 float(x0) - ox,
@@ -805,8 +825,14 @@ def draw_trails(
             )
 
     surface.flushAndSubmit()
-    result = frame_rgba[:, :, :3]
-    if image.shape == result.shape:
-        image[:] = result
-        return image
-    return result.copy()
+
+    # Composite only the pixels the trails actually covered (typically a small
+    # fraction of the frame). The buffer is unpremultiplied, so each covered
+    # pixel blends once as ``out = dst * (1 - a) + src * a``.
+    ys, xs = np.nonzero(trail_rgba[:, :, 3])
+    if len(ys):
+        a = trail_rgba[ys, xs, 3, None].astype(np.float32) / 255.0
+        src = trail_rgba[ys, xs, :3].astype(np.float32)
+        dst = image[ys, xs].astype(np.float32)
+        image[ys, xs] = (dst * (1.0 - a) + src * a).astype(np.uint8)
+    return image

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -4650,6 +4650,72 @@ def test_render_no_progress(centered_pair, tmp_path):
     assert output_path.exists()
 
 
+def test_parse_trail_node():
+    """_parse_trail_node handles single names, lists, and empty input."""
+    from sleap_io.io.cli import _parse_trail_node
+
+    # Single targets pass through as strings.
+    assert _parse_trail_node("centroid") == "centroid"
+    assert _parse_trail_node("head") == "head"
+    # Comma-separated names become a list; whitespace and blanks are dropped.
+    assert _parse_trail_node("head,thorax") == ["head", "thorax"]
+    assert _parse_trail_node("head, ,thorax") == ["head", "thorax"]
+    # A single name with a trailing comma collapses back to a string.
+    assert _parse_trail_node("head,") == "head"
+
+    # Empty or all-blank input is rejected.
+    with pytest.raises(Exception) as exc_info:
+        _parse_trail_node(" , ")
+    assert "Invalid --trail-node" in str(exc_info.value)
+    with pytest.raises(Exception) as exc_info:
+        _parse_trail_node("")
+    assert "Invalid --trail-node" in str(exc_info.value)
+
+
+def test_render_trail_length_invalid(centered_pair, tmp_path):
+    """--trail-length below 1 is rejected by the CLI."""
+    runner = CliRunner()
+    output_path = tmp_path / "bad_length.mp4"
+
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            centered_pair,
+            "--trails",
+            "--trail-length",
+            "0",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert not output_path.exists()
+
+
+def test_render_trail_alpha_invalid(centered_pair, tmp_path):
+    """--trail-alpha outside [0, 1] is rejected by the CLI."""
+    runner = CliRunner()
+    output_path = tmp_path / "bad_alpha.mp4"
+
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            centered_pair,
+            "--trails",
+            "--trail-alpha",
+            "1.5",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert not output_path.exists()
+
+
 def test_render_crop_invalid_format():
     """Test error with invalid crop format."""
     from sleap_io.io.cli import _parse_crop_string

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -4455,6 +4455,106 @@ def test_render_crop_video(centered_pair, tmp_path):
     assert output_path.exists()
 
 
+def test_render_trails_video(centered_pair, tmp_path):
+    """Test render video with motion trails."""
+    runner = CliRunner()
+    output_path = tmp_path / "trails.mp4"
+
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            centered_pair,
+            "--trails",
+            "--trail-length",
+            "5",
+            "--start",
+            "0",
+            "--end",
+            "5",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Rendered:" in result.output
+    assert output_path.exists()
+
+
+def test_render_trails_image(centered_pair, tmp_path):
+    """Test render single image with motion trails."""
+    runner = CliRunner()
+    output_path = tmp_path / "trail.png"
+
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            centered_pair,
+            "--lf",
+            "50",
+            "--trails",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
+
+
+def test_render_trails_node_list(centered_pair, tmp_path):
+    """Test render with comma-separated trail nodes."""
+    runner = CliRunner()
+    output_path = tmp_path / "trail_nodes.mp4"
+
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            centered_pair,
+            "--trails",
+            "--trail-node",
+            "head,thorax",
+            "--start",
+            "0",
+            "--end",
+            "4",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
+
+
+def test_render_trails_no_fade(centered_pair, tmp_path):
+    """Test render with motion trails and fading disabled."""
+    runner = CliRunner()
+    output_path = tmp_path / "trail_nofade.png"
+
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            centered_pair,
+            "--lf",
+            "50",
+            "--trails",
+            "--no-trail-fade",
+            "--trail-width",
+            "3.0",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
+
+
 def test_render_crop_invalid_format():
     """Test error with invalid crop format."""
     from sleap_io.io.cli import _parse_crop_string

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -4605,28 +4605,25 @@ def test_render_trails_color_named(centered_pair, tmp_path):
     assert output_path.exists()
 
 
-def test_render_trails_color_invalid(centered_pair, tmp_path):
-    """An invalid --trail-color RGB string is reported clearly."""
-    runner = CliRunner()
-    output_path = tmp_path / "trail_bad.png"
+def test_parse_trail_color():
+    """_parse_trail_color handles RGB, named colors, and invalid input."""
+    from sleap_io.io.cli import _parse_trail_color
 
-    result = runner.invoke(
-        cli,
-        [
-            "render",
-            "-i",
-            centered_pair,
-            "--lf",
-            "50",
-            "--trails",
-            "--trail-color",
-            "1,2,bad",
-            "-o",
-            str(output_path),
-        ],
-    )
-    assert result.exit_code != 0
-    assert "Invalid --trail-color" in result.output
+    # Valid forms.
+    assert _parse_trail_color(None) is None
+    assert _parse_trail_color("255,128,0") == (255, 128, 0)
+    assert _parse_trail_color("white") == "white"
+    assert _parse_trail_color("#ff0000") == "#ff0000"
+
+    # Non-integer RGB component.
+    with pytest.raises(Exception) as exc_info:
+        _parse_trail_color("1,2,bad")
+    assert "Invalid --trail-color" in str(exc_info.value)
+
+    # Wrong number of RGB values.
+    with pytest.raises(Exception) as exc_info:
+        _parse_trail_color("255,0")
+    assert "RGB needs 3 values" in str(exc_info.value)
 
 
 def test_render_no_progress(centered_pair, tmp_path):

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -4555,6 +4555,104 @@ def test_render_trails_no_fade(centered_pair, tmp_path):
     assert output_path.exists()
 
 
+def test_render_trails_color_and_alpha(centered_pair, tmp_path):
+    """Test render with a uniform trail color and global trail alpha."""
+    runner = CliRunner()
+    output_path = tmp_path / "trail_styled.png"
+
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            centered_pair,
+            "--lf",
+            "50",
+            "--trails",
+            "--trail-color",
+            "255,128,0",
+            "--trail-alpha",
+            "0.6",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
+
+
+def test_render_trails_color_named(centered_pair, tmp_path):
+    """Test render with a named trail color."""
+    runner = CliRunner()
+    output_path = tmp_path / "trail_named.png"
+
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            centered_pair,
+            "--lf",
+            "50",
+            "--trails",
+            "--trail-color",
+            "white",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
+
+
+def test_render_trails_color_invalid(centered_pair, tmp_path):
+    """An invalid --trail-color RGB string is reported clearly."""
+    runner = CliRunner()
+    output_path = tmp_path / "trail_bad.png"
+
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            centered_pair,
+            "--lf",
+            "50",
+            "--trails",
+            "--trail-color",
+            "1,2,bad",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Invalid --trail-color" in result.output
+
+
+def test_render_no_progress(centered_pair, tmp_path):
+    """Test render video with the progress bar disabled."""
+    runner = CliRunner()
+    output_path = tmp_path / "no_progress.mp4"
+
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            centered_pair,
+            "--no-progress",
+            "--start",
+            "0",
+            "--end",
+            "5",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
+
+
 def test_render_crop_invalid_format():
     """Test error with invalid crop format."""
     from sleap_io.io.cli import _parse_crop_string

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -3643,6 +3643,32 @@ class TestDrawTrails:
         # Second trail is blue.
         assert result[60, 50, 2] > 100 and result[60, 50, 0] < 50
 
+    def test_draw_trails_global_alpha(self):
+        """A lower global alpha blends the trail more faintly into the image."""
+        trail = np.array([[10.0, 25.0], [90.0, 25.0]])
+
+        img_opaque = np.zeros((50, 100, 3), dtype=np.uint8)
+        draw_trails(
+            img_opaque,
+            [trail],
+            color=(255, 255, 255),
+            line_width=3.0,
+            alpha_fade=False,
+            alpha=1.0,
+        )
+        img_faint = np.zeros((50, 100, 3), dtype=np.uint8)
+        draw_trails(
+            img_faint,
+            [trail],
+            color=(255, 255, 255),
+            line_width=3.0,
+            alpha_fade=False,
+            alpha=0.3,
+        )
+        # The faint trail is dimmer than the opaque one.
+        assert img_faint[25, 50].mean() < img_opaque[25, 50].mean()
+        assert img_faint[25, 50].sum() > 0
+
     def test_draw_trails_offset(self):
         """The offset argument shifts trail coordinates (for cropped images)."""
         trail = np.array([[50.0, 25.0], [70.0, 25.0]])
@@ -3867,6 +3893,34 @@ class TestRenderImageTrails:
         assert with_trails.shape == without.shape
         assert not np.array_equal(with_trails, without)
 
+    def test_render_image_show_trails_color(self, labels_predictions):
+        """A uniform trail_color produces a different render than palette colors."""
+        palette_colored = render_image(
+            labels_predictions, lf_ind=50, show_trails=True, trail_length=20
+        )
+        uniform = render_image(
+            labels_predictions,
+            lf_ind=50,
+            show_trails=True,
+            trail_length=20,
+            trail_color="white",
+        )
+        assert not np.array_equal(palette_colored, uniform)
+
+    def test_render_image_show_trails_alpha(self, labels_predictions):
+        """trail_alpha changes the rendered output."""
+        opaque = render_image(
+            labels_predictions, lf_ind=50, show_trails=True, trail_length=20
+        )
+        faint = render_image(
+            labels_predictions,
+            lf_ind=50,
+            show_trails=True,
+            trail_length=20,
+            trail_alpha=0.25,
+        )
+        assert not np.array_equal(opaque, faint)
+
     def test_render_image_show_trails_node(self, labels_predictions):
         """show_trails accepts a node name as the trail target."""
         node_name = labels_predictions.skeletons[0].node_names[0]
@@ -3982,6 +4036,28 @@ class TestRenderVideoTrails:
             show_progress=False,
         )
         assert len(frames) == len(lfs)
+
+    def test_render_video_show_trails_color_and_alpha(self, labels_predictions):
+        """render_video accepts a uniform trail_color and trail_alpha."""
+        frame_inds = [lf.frame_idx for lf in labels_predictions.labeled_frames[:5]]
+        default = render_video(
+            labels_predictions,
+            frame_inds=frame_inds,
+            show_trails=True,
+            trail_length=10,
+            show_progress=False,
+        )
+        styled = render_video(
+            labels_predictions,
+            frame_inds=frame_inds,
+            show_trails=True,
+            trail_length=10,
+            trail_color=(255, 255, 255),
+            trail_alpha=0.4,
+            show_progress=False,
+        )
+        assert len(styled) == 5
+        assert not np.array_equal(default[-1], styled[-1])
 
     def test_render_video_show_trails_include_unlabeled(self):
         """render_video draws trails on unlabeled frames without error.

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -20,6 +20,7 @@ from sleap_io.rendering.overlays import (
     draw_label_image,
     draw_masks,
     draw_rois,
+    draw_trails,
 )
 
 # Skip all tests if skia-python is not installed
@@ -3520,3 +3521,483 @@ def test_render_video_centroids_no_track():
         labels, background="black", show_progress=False, frame_inds=[0]
     )
     assert len(frames) == 1
+
+
+# ============================================================================
+# Motion trail tests
+# ============================================================================
+
+
+def _make_trail_labels(n_frames=12, n_video_frames=None):
+    """Build synthetic tracked Labels with two tracks moving on straight lines.
+
+    Args:
+        n_frames: Number of labeled frames to create (frame indices 0..n-1).
+        n_video_frames: If set, attaches video shape metadata with this many
+            frames (enables ``include_unlabeled`` rendering).
+
+    Returns:
+        A `Labels` object with two single-edge tracks moving rightward.
+    """
+    skel = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    video = sio.Video(filename="trail_test.mp4", open_backend=False)
+    if n_video_frames is not None:
+        video.backend_metadata["shape"] = (n_video_frames, 200, 200, 3)
+    tracks = [sio.Track("t0"), sio.Track("t1")]
+    lfs = []
+    for fi in range(n_frames):
+        insts = []
+        for ti, tr in enumerate(tracks):
+            x = 20.0 + fi * 10.0 + ti * 5.0
+            y = 50.0 + ti * 60.0
+            insts.append(
+                sio.Instance(
+                    points={"a": [x, y], "b": [x + 8, y + 8]},
+                    skeleton=skel,
+                    track=tr,
+                )
+            )
+        lfs.append(sio.LabeledFrame(video=video, frame_idx=fi, instances=insts))
+    return sio.Labels(
+        labeled_frames=lfs, videos=[video], skeletons=[skel], tracks=tracks
+    )
+
+
+class TestDrawTrails:
+    """Tests for the draw_trails overlay function."""
+
+    def test_draw_trails_basic(self):
+        """draw_trails draws a polyline and returns the modified image."""
+        image = np.zeros((50, 100, 3), dtype=np.uint8)
+        trail = np.array([[float(x), 25.0] for x in range(10, 91, 10)])
+        result = draw_trails(image, [trail], color=(255, 0, 0), line_width=3.0)
+        assert result.shape == (50, 100, 3)
+        assert result.dtype == np.uint8
+        assert result.sum() > 0
+
+    def test_draw_trails_empty(self):
+        """draw_trails with no trails returns the image unchanged."""
+        image = np.full((20, 20, 3), 7, dtype=np.uint8)
+        result = draw_trails(image, [])
+        assert np.array_equal(result, np.full((20, 20, 3), 7, dtype=np.uint8))
+
+    def test_draw_trails_nan_gap(self):
+        """A NaN point breaks the polyline, leaving a gap."""
+        image = np.zeros((50, 100, 3), dtype=np.uint8)
+        trail = np.array(
+            [
+                [10.0, 25.0],
+                [30.0, 25.0],
+                [np.nan, np.nan],
+                [70.0, 25.0],
+                [90.0, 25.0],
+            ]
+        )
+        result = draw_trails(image, [trail], color=(255, 255, 255), line_width=3.0)
+        # Segment within [10, 30] is drawn.
+        assert result[25, 20].sum() > 0
+        # Segment spanning the NaN gap [30, 70] is not drawn.
+        assert result[25, 50].sum() == 0
+        # Segment within [70, 90] is drawn.
+        assert result[25, 80].sum() > 0
+
+    def test_draw_trails_alpha_fade(self):
+        """alpha_fade makes the oldest segment fainter than the newest."""
+        trail = np.array([[float(x), 25.0] for x in range(10, 91, 10)])
+
+        img_fade = np.zeros((50, 100, 3), dtype=np.uint8)
+        draw_trails(
+            img_fade, [trail], color=(255, 255, 255), line_width=3.0, alpha_fade=True
+        )
+        img_solid = np.zeros((50, 100, 3), dtype=np.uint8)
+        draw_trails(
+            img_solid,
+            [trail],
+            color=(255, 255, 255),
+            line_width=3.0,
+            alpha_fade=False,
+        )
+
+        left_fade = img_fade[22:28, 12:20].mean()
+        right_fade = img_fade[22:28, 80:88].mean()
+        # Oldest (left) segment is fainter than newest (right) under fade.
+        assert left_fade < right_fade
+        # Without fade, the oldest segment is brighter than the faded one.
+        left_solid = img_solid[22:28, 12:20].mean()
+        assert left_solid > left_fade
+
+    def test_draw_trails_per_trail_colors(self):
+        """Per-trail colors are applied independently."""
+        image = np.zeros((80, 100, 3), dtype=np.uint8)
+        trail0 = np.array([[10.0, 20.0], [90.0, 20.0]])
+        trail1 = np.array([[10.0, 60.0], [90.0, 60.0]])
+        result = draw_trails(
+            image,
+            [trail0, trail1],
+            colors=[(255, 0, 0), (0, 0, 255)],
+            line_width=3.0,
+            alpha_fade=False,
+        )
+        # First trail is red.
+        assert result[20, 50, 0] > 100 and result[20, 50, 2] < 50
+        # Second trail is blue.
+        assert result[60, 50, 2] > 100 and result[60, 50, 0] < 50
+
+    def test_draw_trails_offset(self):
+        """The offset argument shifts trail coordinates (for cropped images)."""
+        trail = np.array([[50.0, 25.0], [70.0, 25.0]])
+
+        img_no_offset = np.zeros((50, 100, 3), dtype=np.uint8)
+        draw_trails(img_no_offset, [trail], color=(255, 255, 255), line_width=3.0)
+        img_offset = np.zeros((50, 100, 3), dtype=np.uint8)
+        draw_trails(
+            img_offset,
+            [trail],
+            color=(255, 255, 255),
+            line_width=3.0,
+            offset=(50.0, 0.0),
+        )
+        # Without offset the trail is around x=60.
+        assert img_no_offset[25, 60].sum() > 0
+        # With offset=(50, 0) it shifts to around x=10.
+        assert img_offset[25, 10].sum() > 0
+        assert img_offset[25, 60].sum() == 0
+
+    def test_draw_trails_grayscale_input(self):
+        """A grayscale image is promoted to RGB."""
+        image = np.zeros((40, 60), dtype=np.uint8)
+        trail = np.array([[10.0, 20.0], [50.0, 20.0]])
+        result = draw_trails(image, [trail], color=(255, 0, 0), line_width=3.0)
+        assert result.ndim == 3
+        assert result.shape == (40, 60, 3)
+        assert result.sum() > 0
+
+    def test_draw_trails_single_point(self):
+        """A single-point trail has no segment and draws nothing."""
+        image = np.zeros((40, 60, 3), dtype=np.uint8)
+        trail = np.array([[30.0, 20.0]])
+        result = draw_trails(image, [trail], color=(255, 255, 255))
+        assert result.sum() == 0
+
+
+class TestTrailHelpers:
+    """Tests for _resolve_trail_node and _compute_trails."""
+
+    def test_resolve_trail_node_centroid(self):
+        """The string 'centroid' resolves to a single centroid target."""
+        from sleap_io.rendering.core import _resolve_trail_node
+
+        skel = _make_trail_labels(n_frames=1).skeletons[0]
+        assert _resolve_trail_node("centroid", skel) == [None]
+        # Case-insensitive.
+        assert _resolve_trail_node("Centroid", skel) == [None]
+
+    def test_resolve_trail_node_name(self):
+        """A node name resolves to that node's index."""
+        from sleap_io.rendering.core import _resolve_trail_node
+
+        skel = _make_trail_labels(n_frames=1).skeletons[0]
+        assert _resolve_trail_node("a", skel) == [0]
+        assert _resolve_trail_node("b", skel) == [1]
+
+    def test_resolve_trail_node_list(self):
+        """A list of node names resolves to one target per node."""
+        from sleap_io.rendering.core import _resolve_trail_node
+
+        skel = _make_trail_labels(n_frames=1).skeletons[0]
+        assert _resolve_trail_node(["a", "b"], skel) == [0, 1]
+
+    def test_resolve_trail_node_unknown(self):
+        """An unknown node name raises ValueError."""
+        from sleap_io.rendering.core import _resolve_trail_node
+
+        skel = _make_trail_labels(n_frames=1).skeletons[0]
+        with pytest.raises(ValueError, match="Unknown trail_node"):
+            _resolve_trail_node("nonexistent", skel)
+
+    def test_compute_trails_basic(self):
+        """_compute_trails produces one polyline per track."""
+        from sleap_io.rendering.core import _compute_trails
+
+        labels = _make_trail_labels(n_frames=8)
+        frame_idx_to_lf = {lf.frame_idx: lf for lf in labels.labeled_frames}
+        track_idx_map = {id(t): i for i, t in enumerate(labels.tracks)}
+        palette = [(255, 0, 0), (0, 255, 0)]
+        trails, colors = _compute_trails(
+            fidx=7,
+            frame_idx_to_lf=frame_idx_to_lf,
+            trail_length=4,
+            trail_targets=[None],
+            track_idx_map=track_idx_map,
+            palette_colors=palette,
+            has_tracks=True,
+        )
+        assert len(trails) == 2  # One per track.
+        assert all(t.shape == (5, 2) for t in trails)  # trail_length + 1.
+        assert len(colors) == 2
+        assert set(colors) == {(255, 0, 0), (0, 255, 0)}
+
+    def test_compute_trails_node_list(self):
+        """_compute_trails produces one polyline per (track, node) pair."""
+        from sleap_io.rendering.core import _compute_trails
+
+        labels = _make_trail_labels(n_frames=8)
+        frame_idx_to_lf = {lf.frame_idx: lf for lf in labels.labeled_frames}
+        track_idx_map = {id(t): i for i, t in enumerate(labels.tracks)}
+        trails, _ = _compute_trails(
+            fidx=7,
+            frame_idx_to_lf=frame_idx_to_lf,
+            trail_length=4,
+            trail_targets=[0, 1],
+            track_idx_map=track_idx_map,
+            palette_colors=[(255, 0, 0), (0, 255, 0)],
+            has_tracks=True,
+        )
+        # 2 tracks x 2 nodes.
+        assert len(trails) == 4
+
+    def test_compute_trails_missing_frame_nan(self):
+        """Missing frames leave NaN rows in the trail."""
+        from sleap_io.rendering.core import _compute_trails
+
+        labels = _make_trail_labels(n_frames=8)
+        frame_idx_to_lf = {lf.frame_idx: lf for lf in labels.labeled_frames}
+        del frame_idx_to_lf[3]
+        track_idx_map = {id(t): i for i, t in enumerate(labels.tracks)}
+        trails, _ = _compute_trails(
+            fidx=5,
+            frame_idx_to_lf=frame_idx_to_lf,
+            trail_length=5,
+            trail_targets=[None],
+            track_idx_map=track_idx_map,
+            palette_colors=[(255, 0, 0), (0, 255, 0)],
+            has_tracks=True,
+        )
+        # Frame range is [0, 5]; frame 3 is at row index 3.
+        assert all(np.isnan(t[3]).all() for t in trails)
+        assert all(np.isfinite(t[5]).all() for t in trails)
+
+    def test_compute_trails_untracked(self):
+        """Untracked data keys trails by instance index."""
+        from sleap_io.rendering.core import _compute_trails
+
+        labels = _make_trail_labels(n_frames=6)
+        frame_idx_to_lf = {lf.frame_idx: lf for lf in labels.labeled_frames}
+        trails, colors = _compute_trails(
+            fidx=5,
+            frame_idx_to_lf=frame_idx_to_lf,
+            trail_length=4,
+            trail_targets=[None],
+            track_idx_map={},
+            palette_colors=[(10, 10, 10), (20, 20, 20)],
+            has_tracks=False,
+        )
+        # One trail per instance position index.
+        assert len(trails) == 2
+
+    def test_compute_trails_skips_untracked_instance(self):
+        """In tracked data, an instance with no track is skipped."""
+        from sleap_io.rendering.core import _compute_trails
+
+        labels = _make_trail_labels(n_frames=5)
+        skel = labels.skeletons[0]
+        # Add an instance with no track assignment.
+        labels.labeled_frames[2].instances.append(
+            sio.Instance(
+                points={"a": [5.0, 5.0], "b": [9.0, 9.0]},
+                skeleton=skel,
+                track=None,
+            )
+        )
+        frame_idx_to_lf = {lf.frame_idx: lf for lf in labels.labeled_frames}
+        track_idx_map = {id(t): i for i, t in enumerate(labels.tracks)}
+        trails, _ = _compute_trails(
+            fidx=4,
+            frame_idx_to_lf=frame_idx_to_lf,
+            trail_length=4,
+            trail_targets=[None],
+            track_idx_map=track_idx_map,
+            palette_colors=[(1, 1, 1), (2, 2, 2)],
+            has_tracks=True,
+        )
+        # Only the two tracked instances yield trails.
+        assert len(trails) == 2
+
+    def test_compute_trails_drops_all_nan_trail(self):
+        """A trail that is entirely NaN (never-visible node) is dropped."""
+        from sleap_io.rendering.core import _compute_trails
+
+        skel = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+        video = sio.Video(filename="x.mp4", open_backend=False)
+        track = sio.Track("t0")
+        lfs = []
+        for fi in range(5):
+            inst = sio.Instance(
+                points={"a": [10.0 + fi, 20.0], "b": [np.nan, np.nan]},
+                skeleton=skel,
+                track=track,
+            )
+            lfs.append(sio.LabeledFrame(video=video, frame_idx=fi, instances=[inst]))
+        labels = sio.Labels(
+            labeled_frames=lfs, videos=[video], skeletons=[skel], tracks=[track]
+        )
+        frame_idx_to_lf = {lf.frame_idx: lf for lf in labels.labeled_frames}
+        trails, _ = _compute_trails(
+            fidx=4,
+            frame_idx_to_lf=frame_idx_to_lf,
+            trail_length=4,
+            trail_targets=[0, 1],
+            track_idx_map={id(track): 0},
+            palette_colors=[(1, 1, 1)],
+            has_tracks=True,
+        )
+        # Node "a" yields a trail; node "b" is all-NaN and dropped.
+        assert len(trails) == 1
+
+
+class TestRenderImageTrails:
+    """Tests for show_trails in render_image."""
+
+    def test_render_image_show_trails_centroid(self, labels_predictions):
+        """show_trails with centroid target changes the rendered output."""
+        without = render_image(labels_predictions, lf_ind=50, show_trails=False)
+        with_trails = render_image(
+            labels_predictions, lf_ind=50, show_trails=True, trail_length=20
+        )
+        assert with_trails.shape == without.shape
+        assert not np.array_equal(with_trails, without)
+
+    def test_render_image_show_trails_node(self, labels_predictions):
+        """show_trails accepts a node name as the trail target."""
+        node_name = labels_predictions.skeletons[0].node_names[0]
+        rendered = render_image(
+            labels_predictions,
+            lf_ind=50,
+            show_trails=True,
+            trail_node=node_name,
+            trail_length=15,
+        )
+        assert rendered.ndim == 3
+
+    def test_render_image_show_trails_node_list(self, labels_predictions):
+        """show_trails accepts a list of node names."""
+        node_names = labels_predictions.skeletons[0].node_names[:2]
+        rendered = render_image(
+            labels_predictions,
+            lf_ind=50,
+            show_trails=True,
+            trail_node=node_names,
+            trail_length=15,
+        )
+        assert rendered.ndim == 3
+
+    def test_render_image_show_trails_unknown_node(self, labels_predictions):
+        """An unknown trail_node raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown trail_node"):
+            render_image(
+                labels_predictions,
+                lf_ind=50,
+                show_trails=True,
+                trail_node="not_a_real_node",
+            )
+
+    def test_render_image_show_trails_labeled_frame_source_noop(
+        self, labels_predictions
+    ):
+        """show_trails on a LabeledFrame source is skipped without error."""
+        lf = labels_predictions.labeled_frames[50]
+        rendered = render_image(lf, show_trails=True, trail_length=10)
+        assert rendered.ndim == 3
+
+    def test_render_image_show_trails_with_crop(self, labels_predictions):
+        """show_trails works together with cropping."""
+        rendered = render_image(
+            labels_predictions,
+            lf_ind=50,
+            show_trails=True,
+            trail_length=15,
+            crop=(50, 50, 250, 250),
+        )
+        assert rendered.shape == (200, 200, 3)
+
+    def test_render_image_show_trails_first_frame(self, labels_predictions):
+        """show_trails on the first frame (no history) does not error."""
+        rendered = render_image(
+            labels_predictions, lf_ind=0, show_trails=True, trail_length=20
+        )
+        assert rendered.ndim == 3
+
+
+class TestRenderVideoTrails:
+    """Tests for show_trails in render_video."""
+
+    def test_render_video_show_trails(self, labels_predictions):
+        """render_video with show_trails returns rendered frames."""
+        frame_inds = [lf.frame_idx for lf in labels_predictions.labeled_frames[:5]]
+        frames = render_video(
+            labels_predictions,
+            frame_inds=frame_inds,
+            show_trails=True,
+            trail_length=10,
+            show_progress=False,
+        )
+        assert len(frames) == 5
+        assert all(f.ndim == 3 for f in frames)
+
+    def test_render_video_show_trails_save(self, labels_predictions, tmp_path):
+        """render_video with show_trails writes a video file."""
+        output_path = tmp_path / "trails.mp4"
+        frame_inds = [lf.frame_idx for lf in labels_predictions.labeled_frames[:5]]
+        render_video(
+            labels_predictions,
+            output_path,
+            frame_inds=frame_inds,
+            show_trails=True,
+            trail_length=10,
+            show_progress=False,
+        )
+        assert output_path.exists()
+
+    def test_render_video_show_trails_node(self, labels_predictions):
+        """render_video trails accept a node name."""
+        node_name = labels_predictions.skeletons[0].node_names[0]
+        frame_inds = [lf.frame_idx for lf in labels_predictions.labeled_frames[:4]]
+        frames = render_video(
+            labels_predictions,
+            frame_inds=frame_inds,
+            show_trails=True,
+            trail_node=node_name,
+            trail_length=8,
+            show_progress=False,
+        )
+        assert len(frames) == 4
+
+    def test_render_video_show_trails_list_source(self, labels_predictions):
+        """render_video trails work for a list[LabeledFrame] source."""
+        lfs = labels_predictions.labeled_frames[40:55]
+        frames = render_video(
+            lfs,
+            show_trails=True,
+            trail_length=8,
+            show_progress=False,
+        )
+        assert len(frames) == len(lfs)
+
+    def test_render_video_show_trails_include_unlabeled(self):
+        """render_video draws trails on unlabeled frames without error.
+
+        With a short trail and labeled frames only at 0-7, later frames have an
+        empty trail window, exercising the no-trails fast path too.
+        """
+        labels = _make_trail_labels(n_frames=8, n_video_frames=16)
+        frames = render_video(
+            labels,
+            background="black",
+            show_trails=True,
+            trail_length=3,
+            include_unlabeled=True,
+            start=0,
+            end=16,
+            show_progress=False,
+        )
+        assert len(frames) == 16

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -4,6 +4,8 @@ These tests validate the rendering functionality including colors, shapes,
 callbacks, and the core rendering functions.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 from shapely.geometry import box
@@ -3705,6 +3707,65 @@ class TestDrawTrails:
         result = draw_trails(image, [trail], color=(255, 255, 255))
         assert result.sum() == 0
 
+    def test_draw_trails_joint_no_double_blend(self):
+        """Overlapping segment joints take a single blend, not a doubled one."""
+        image = np.zeros((50, 120, 3), dtype=np.uint8)
+        # Three collinear points -> two segments sharing the joint at x=60.
+        trail = np.array([[20.0, 25.0], [60.0, 25.0], [100.0, 25.0]])
+        result = draw_trails(
+            image,
+            [trail],
+            color=(255, 255, 255),
+            line_width=6.0,
+            alpha_fade=False,
+            alpha=0.5,
+        )
+        mid_segment = int(result[25, 35, 0])
+        joint = int(result[25, 60, 0])
+        # A doubled blend would make the joint markedly brighter than the body.
+        assert abs(joint - mid_segment) <= 2
+
+    def test_draw_trails_uniform_alpha_flat_body(self):
+        """A uniform-alpha trail has a flat body with no joint seams."""
+        image = np.zeros((50, 200, 3), dtype=np.uint8)
+        trail = np.array([[float(x), 25.0] for x in range(20, 181, 20)])
+        result = draw_trails(
+            image,
+            [trail],
+            color=(255, 255, 255),
+            line_width=6.0,
+            alpha_fade=False,
+            alpha=0.4,
+        )
+        body = [int(result[25, x, 0]) for x in range(25, 176, 5)]
+        assert max(body) - min(body) <= 2
+
+    def test_draw_trails_colors_length_mismatch(self):
+        """A colors list whose length differs from trails raises ValueError."""
+        image = np.zeros((40, 60, 3), dtype=np.uint8)
+        trail0 = np.array([[10.0, 20.0], [50.0, 20.0]])
+        trail1 = np.array([[10.0, 30.0], [50.0, 30.0]])
+        with pytest.raises(ValueError, match="colors has length"):
+            draw_trails(image, [trail0, trail1], colors=[(255, 0, 0)])
+
+    def test_draw_trails_crossing_no_double_blend(self):
+        """Two crossing trails do not accumulate alpha where they overlap."""
+        image = np.zeros((120, 120, 3), dtype=np.uint8)
+        horizontal = np.array([[10.0, 60.0], [110.0, 60.0]])
+        vertical = np.array([[60.0, 10.0], [60.0, 110.0]])
+        result = draw_trails(
+            image,
+            [horizontal, vertical],
+            colors=[(255, 255, 255), (255, 255, 255)],
+            line_width=6.0,
+            alpha_fade=False,
+            alpha=0.5,
+        )
+        arm = int(result[60, 30, 0])
+        crossing = int(result[60, 60, 0])
+        # The crossing pixel must match a single arm, not a doubled blend.
+        assert abs(crossing - arm) <= 2
+
 
 class TestTrailHelpers:
     """Tests for _resolve_trail_node and _compute_trails."""
@@ -3880,6 +3941,115 @@ class TestTrailHelpers:
         # Node "a" yields a trail; node "b" is all-NaN and dropped.
         assert len(trails) == 1
 
+    def test_n_trail_palette_colors(self):
+        """_n_trail_palette_colors sizes by tracks or peak instance count."""
+        from sleap_io.rendering.core import _n_trail_palette_colors
+
+        lfs = _make_trail_labels(n_frames=4).labeled_frames
+        # Tracked: sized by track count, at least 1.
+        assert _n_trail_palette_colors(True, 3, lfs) == 3
+        assert _n_trail_palette_colors(True, 0, lfs) == 1
+        # Untracked: sized by the peak instance count across frames.
+        assert _n_trail_palette_colors(False, 0, lfs) == 2
+        # No frames: still at least 1.
+        assert _n_trail_palette_colors(False, 0, []) == 1
+
+    def test_compute_trails_pts_cache(self):
+        """Passing a pts_cache populates it and yields identical trails."""
+        from sleap_io.rendering.core import _compute_trails
+
+        labels = _make_trail_labels(n_frames=8)
+        frame_idx_to_lf = {lf.frame_idx: lf for lf in labels.labeled_frames}
+        track_idx_map = {id(t): i for i, t in enumerate(labels.tracks)}
+        kwargs = dict(
+            fidx=7,
+            frame_idx_to_lf=frame_idx_to_lf,
+            trail_length=4,
+            trail_targets=[None],
+            track_idx_map=track_idx_map,
+            palette_colors=[(255, 0, 0), (0, 255, 0)],
+            has_tracks=True,
+        )
+        no_cache, _ = _compute_trails(**kwargs)
+        cache: dict = {}
+        cached, _ = _compute_trails(**kwargs, pts_cache=cache)
+        assert cache  # The cache was populated.
+        assert len(cached) == len(no_cache)
+        assert all(
+            np.array_equal(a, b, equal_nan=True) for a, b in zip(cached, no_cache)
+        )
+
+    def test_compute_trails_centroid_matches_centroid_xy(self):
+        """Centroid trail coordinates match Instance.centroid_xy exactly."""
+        from sleap_io.rendering.core import _compute_trails
+
+        skel = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+        video = sio.Video(filename="c.mp4", open_backend=False)
+        track = sio.Track("t0")
+        lfs = []
+        for fi in range(4):
+            # Node "b" invisible on one frame to exercise partial visibility.
+            b = [np.nan, np.nan] if fi == 2 else [30.0 + fi, 40.0 + fi]
+            inst = sio.Instance(
+                points={"a": [10.0 + fi, 20.0 + fi], "b": b},
+                skeleton=skel,
+                track=track,
+            )
+            lfs.append(sio.LabeledFrame(video=video, frame_idx=fi, instances=[inst]))
+        labels = sio.Labels(
+            labeled_frames=lfs, videos=[video], skeletons=[skel], tracks=[track]
+        )
+        frame_idx_to_lf = {lf.frame_idx: lf for lf in labels.labeled_frames}
+        trails, _ = _compute_trails(
+            fidx=3,
+            frame_idx_to_lf=frame_idx_to_lf,
+            trail_length=3,
+            trail_targets=[None],
+            track_idx_map={id(track): 0},
+            palette_colors=[(1, 1, 1)],
+            has_tracks=True,
+        )
+        assert len(trails) == 1
+        for j, lf in enumerate(lfs):
+            np.testing.assert_allclose(trails[0][j], lf.instances[0].centroid_xy)
+
+    def test_compute_trails_centroid_all_nan_instance(self):
+        """An all-invisible instance yields a NaN centroid without warnings."""
+        from sleap_io.rendering.core import _compute_trails
+
+        skel = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+        video = sio.Video(filename="n.mp4", open_backend=False)
+        track = sio.Track("t0")
+        lfs = []
+        for fi in range(3):
+            pts = (
+                {"a": [np.nan, np.nan], "b": [np.nan, np.nan]}
+                if fi == 1
+                else {"a": [10.0 + fi, 20.0], "b": [18.0 + fi, 28.0]}
+            )
+            inst = sio.Instance(points=pts, skeleton=skel, track=track)
+            lfs.append(sio.LabeledFrame(video=video, frame_idx=fi, instances=[inst]))
+        labels = sio.Labels(
+            labeled_frames=lfs, videos=[video], skeletons=[skel], tracks=[track]
+        )
+        frame_idx_to_lf = {lf.frame_idx: lf for lf in labels.labeled_frames}
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            trails, _ = _compute_trails(
+                fidx=2,
+                frame_idx_to_lf=frame_idx_to_lf,
+                trail_length=2,
+                trail_targets=[None],
+                track_idx_map={id(track): 0},
+                palette_colors=[(1, 1, 1)],
+                has_tracks=True,
+            )
+        assert len(trails) == 1
+        # The all-invisible frame (row 1) is NaN; the visible frames are finite.
+        assert np.isnan(trails[0][1]).all()
+        assert np.isfinite(trails[0][0]).all()
+        assert np.isfinite(trails[0][2]).all()
+
 
 class TestRenderImageTrails:
     """Tests for show_trails in render_image."""
@@ -3981,6 +4151,42 @@ class TestRenderImageTrails:
         )
         assert rendered.ndim == 3
 
+    def test_render_image_show_trails_empty_current_frame(self):
+        """Trails are drawn even when the current frame has no instances."""
+        labels = _make_trail_labels(n_frames=10, n_video_frames=10)
+        labels.labeled_frames[8].instances = []
+        without = render_image(labels, lf_ind=8, background="black", show_trails=False)
+        with_trails = render_image(
+            labels, lf_ind=8, background="black", show_trails=True, trail_length=8
+        )
+        # Past frames still contribute trails despite the empty current frame.
+        assert not np.array_equal(without, with_trails)
+
+    def test_render_image_show_trails_untracked_varied_counts(self):
+        """Untracked trails render when past frames have more instances."""
+        skel = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+        video = sio.Video(filename="uv.mp4", open_backend=False)
+        video.backend_metadata["shape"] = (6, 200, 200, 3)
+        lfs = []
+        for fi in range(6):
+            n = 3 if fi < 3 else 1  # Past frames have more instances than current.
+            insts = [
+                sio.Instance(
+                    points={
+                        "a": [20.0 + fi * 8 + k * 5, 40.0 + k * 30],
+                        "b": [28.0 + fi * 8 + k * 5, 48.0 + k * 30],
+                    },
+                    skeleton=skel,
+                )
+                for k in range(n)
+            ]
+            lfs.append(sio.LabeledFrame(video=video, frame_idx=fi, instances=insts))
+        labels = sio.Labels(labeled_frames=lfs, videos=[video], skeletons=[skel])
+        rendered = render_image(
+            labels, lf_ind=5, background="black", show_trails=True, trail_length=5
+        )
+        assert rendered.shape == (200, 200, 3)
+
 
 class TestRenderVideoTrails:
     """Tests for show_trails in render_video."""
@@ -4077,3 +4283,21 @@ class TestRenderVideoTrails:
             show_progress=False,
         )
         assert len(frames) == 16
+
+    def test_render_video_show_trails_no_skeleton(self):
+        """show_trails on data with no skeleton renders without error."""
+        video = sio.Video(filename="ns.mp4", open_backend=False)
+        video.backend_metadata["shape"] = (4, 120, 120, 3)
+        lfs = [
+            sio.LabeledFrame(video=video, frame_idx=fi, instances=[]) for fi in range(4)
+        ]
+        labels = sio.Labels(labeled_frames=lfs, videos=[video], skeletons=[])
+        frames = render_video(
+            labels,
+            background="black",
+            show_trails=True,
+            trail_length=5,
+            show_progress=False,
+        )
+        assert len(frames) == 4
+        assert all(f.ndim == 3 for f in frames)


### PR DESCRIPTION
## Summary

Implements [#428](https://github.com/talmolab/sleap-io/issues/428): a motion **trail overlay** that traces a node or centroid trajectory over the last N frames, so users can see how animals moved through rendered output.

Adds a `draw_trails` overlay function and `show_trails` / `trail_*` parameters wired into `render_image`, `render_video`, and the `sio render` CLI.

## Key Changes

- **`draw_trails`** (`rendering/overlays.py`): pure skia-based polyline drawing, consistent with the existing `draw_centroids` / `draw_masks` overlays. Draws each trail segment-by-segment so opacity can fade from faint (oldest) to opaque (newest); non-finite points break the line into gaps.
- **`_resolve_trail_node` / `_compute_trails`** (`rendering/core.py`): resolve the `trail_node` argument and build per-frame trail polylines. Trails are keyed by track (tracked data) or instance index (untracked), and colored to match the poses by default.
- **`render_image` / `render_video`**: new `show_trails`, `trail_length`, `trail_node`, `trail_width`, `trail_alpha_fade`, `trail_alpha`, and `trail_color` parameters. Trails are drawn behind poses, just before pose rendering.
- **CLI**: `--trails`, `--trail-length`, `--trail-node` (comma-separated → list), `--trail-width`, `--trail-fade/--no-trail-fade`, `--trail-alpha`, and `--trail-color` on `sio render`. Also adds `--progress/--no-progress` to toggle the video render progress bar.
- **Public API**: `sio.draw_trails` exported.
- **Docs**: new "Motion trails" section, CLI examples, and API reference entry in `docs/rendering.md`.

## Example Usage

```python
import sleap_io as sio

labels = sio.load_slp("predictions.slp")

# Video with centroid trails fading over the last 10 frames
sio.render_video(
    labels,
    save_path="output.mp4",
    show_trails=True,
    trail_length=10,
    trail_node="centroid",
    trail_width=2.0,
    trail_alpha_fade=True,
)

# Single frame, trailing specific nodes (one trail per node)
img = sio.render_image(labels, lf_ind=100, show_trails=True, trail_node=["head", "thorax"])

# Faint, uniform-colored trails
sio.render_video(
    labels, save_path="output.mp4", show_trails=True,
    trail_color="white", trail_alpha=0.5, trail_alpha_fade=False,
)
```

```bash
sio render predictions.slp -o output.mp4 --trails --trail-length 10
sio render predictions.slp -o output.mp4 --trails --trail-node head,thorax
sio render predictions.slp -o output.mp4 --trails --trail-color white --trail-alpha 0.5
sio render predictions.slp -o output.mp4 --no-progress
```

`trail_node` accepts `"centroid"`, a node name, or a list of node names.

## API Changes

New keyword-only parameters on `render_image` and `render_video` (all optional, default off / appearance-neutral):

- `show_trails: bool = False` — enable trail drawing.
- `trail_length: int = 10` — number of past frames behind the current frame.
- `trail_node: str | list[str] = "centroid"` — `"centroid"`, a node name, or a list of node names.
- `trail_width: float = 2.0` — trail line width in pixels.
- `trail_alpha_fade: bool = True` — fade from faint (oldest) to opaque (newest).
- `trail_alpha: float = 1.0` — global trail opacity multiplier.
- `trail_color: ColorSpec | None = None` — uniform trail color; `None` matches pose colors.

New public function `sio.draw_trails`. New `sio render` CLI flags: `--trails`, `--trail-length`, `--trail-node`, `--trail-width`, `--trail-fade/--no-trail-fade`, `--trail-alpha`, `--trail-color`, `--progress/--no-progress`. No breaking changes.

## Progress monitoring

`render_video` already exposes a `progress_callback: Callable[[int, int], bool]` hook (for GUI progress bars; return `False` to cancel) and a `show_progress` toggle for the built-in tqdm bar. This PR adds the matching `--progress/--no-progress` CLI flag so the bar can be disabled from the command line.

## Testing

- `TestDrawTrails`: basic draw, empty input, NaN gaps, alpha fade, global alpha, per-trail colors, offset, grayscale input, single-point trail.
- `TestTrailHelpers`: `_resolve_trail_node` (centroid / name / list / unknown), `_compute_trails` (per-track polylines, node lists, missing-frame NaN rows, untracked keying, untracked-instance skipping, all-NaN drop).
- `TestRenderImageTrails` / `TestRenderVideoTrails`: integration with `render_image` / `render_video`, including `trail_color` / `trail_alpha`, crop, first frame, node lists, `LabeledFrame` source no-op, `list[LabeledFrame]` source, save-to-file, and unlabeled frames.
- CLI tests for `--trails` on video and image, `--trail-node` list parsing, `--no-trail-fade`, `--trail-color` (RGB / named / invalid), `--trail-alpha`, and `--no-progress`.

Full `tests/rendering/test_rendering.py` (220) and `sio render` CLI tests pass; `ruff check`/`format` clean.

## Design Decisions

- **`trail_node` list → one trail per node**, each sharing the instance/track color — the natural reading of "which node(s) to trail".
- **`trail_color` overrides the palette**: when set, all trails use one uniform color; otherwise trails match pose colors (by track, or by instance when untracked).
- **Trails are skipped, not errored**, when there is no temporal context (a single `LabeledFrame`, instance list, or image-only source) — they need sibling frames.
- **Missing `LabeledFrame`s / detections produce gaps**, not false connections: a missing frame, missing track, or invisible node leaves a NaN gap in the trail. In `render_video`, frames with no `LabeledFrame` still get trails drawn when `include_unlabeled=True`.
- **Line width is not pre-scaled**: the trail is rasterized onto the frame, which `render_frame` then upscales once by `scale`, so the final width matches pose edges.
- **Untracked data** keys trails by instance index (documented caveat: identity can jump), consistent with how `render_frame` colors untracked instances.

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)