### PR TITLE
ci: Bump GitHub Actions off deprecated Node.js 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Setup UV
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.13"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup UV
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8
       with:
         python-version: "3.13"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -43,10 +43,10 @@ jobs:
     steps:
 
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup UV
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8
       with:
         python-version: "3.13"
 
@@ -77,10 +77,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup UV
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: ${{ matrix.python }}
 
@@ -105,7 +105,7 @@ jobs:
           uv run pytest --cov=sleap_io --cov-report=xml --durations=-1 tests/
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: true
           verbose: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v6
 
     - name: Setup UV
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v7
       with:
         python-version: "3.13"
 
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup UV
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Annotate locations with typos
         uses: codespell-project/codespell-problem-matcher@v1
       - name: Codespell

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for all branches
 
       - name: Setup UV
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,12 +32,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for all branches
 
       - name: Setup UV
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.13"
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0  # Fetch all history for diff computation
 
       - name: Setup UV
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.13"
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Fetch all history for diff computation
 
       - name: Setup UV
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: "3.13"
 
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
 


### PR DESCRIPTION
## Summary

GitHub flagged several actions in our workflows for running on the **deprecated Node.js 20** runtime (forced to Node 24 in June 2026, removed from runners September 2026). This bumps them to current major versions.

## Changes

| Action | Before | After | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | v6 | Node 24 |
| `astral-sh/setup-uv` | v6 | v7 | Node 24 (no `v8` major tag is published) |
| `codecov/codecov-action` | v4 | v6 | composite action |

Applied across all 7 workflow files (`build`, `ci`, `docs`, `pr-preview`, `claude`, `claude-code-review`, `codespell`).

## Compatibility

All workflow `with:` inputs currently in use are unchanged across these version bumps:

- **checkout** — `fetch-depth`, `ref`
- **setup-uv** — `python-version`
- **codecov-action** — `fail_ci_if_error`, `verbose`, `token`

No behavioral change expected; this is purely a runtime/version refresh to clear the deprecation warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)