### PR TITLE
Resolve foreign Video by path/content matching in Labels lookups

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -329,6 +329,31 @@ labels.reindex()
 !!! tip "When to call `reindex()`"
     The indices rebuild automatically when you use the public `Labels` APIs. You only need `reindex()` after mutating `labels.labeled_frames` or the annotation lists in place (which bypasses the invalidation hooks).
 
+### Resolving a video by path or foreign instance
+
+`Video` objects compare by identity, so a `Video` you create yourself (e.g. with `sio.load_video`) is *not* recognized by `Labels` lookups even if it points at the same file as one already in the project. [`Labels.match_video`][sleap_io.Labels.match_video] resolves a foreign `Video` — or a plain filename — to the canonical instance, and `find`, `extract`, `__getitem__`, `numpy`, and the `get_*` family all canonicalize their `video` argument through it automatically.
+
+```python title="resolve_video.py" linenums="1"
+import sleap_io as sio
+
+labels = sio.load_slp("predictions.slp")
+
+# A freshly loaded Video is a different object than the one in the project.
+foreign = sio.load_video("predictions_video.mp4")
+
+# These all work now (previously returned [] / raised IndexError):
+labels.find(foreign)                      # by foreign Video instance
+labels.find("predictions_video.mp4")      # by filename
+labels["predictions_video.mp4"]           # __getitem__ by filename
+labels.extract([("predictions_video.mp4", 0)])
+
+# Resolve explicitly to the canonical Video stored on the project:
+canonical = labels.match_video(foreign)   # -> Video, or None if no match
+```
+
+!!! note "Matching strategy"
+    `match_video` uses a tiered cascade by default: a definitive match (same underlying file, or identical path) wins, and only if none is found does it fall back to basename matching. Ambiguous matches raise `ValueError`. Pass `method=` (`"path"`, `"basename"`, `"content"`, ...) for explicit control.
+
 ## Format conversion
 
 ### Load and save in different formats

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -654,10 +654,17 @@ class Labels:
         | slice
         | list[int]
         | np.ndarray
-        | tuple[Video, int]
-        | list[tuple[Video, int]],
+        | Video
+        | str
+        | Path
+        | tuple[Video | str | Path, int]
+        | list[tuple[Video | str | Path, int]],
     ) -> list[LabeledFrame] | LabeledFrame:
-        """Return one or more labeled frames based on indexing criteria."""
+        """Return one or more labeled frames based on indexing criteria.
+
+        A `Video`, filename (`str`/`Path`), or `(video_or_path, frame_idx)` tuple is
+        resolved to the matching `Video` in `self.videos` via `match_video`.
+        """
         if type(key) is int:
             return self.labeled_frames[key]
         elif type(key) is slice:
@@ -681,7 +688,7 @@ class Labels:
                     f"No labeled frames found for video {video} and "
                     f"frame index {frame_idx}."
                 )
-        elif type(key) is Video:
+        elif type(key) is Video or isinstance(key, (str, Path)):
             res = self.find(key)
             if len(res) == 0:
                 raise IndexError(f"No labeled frames found for video {key}.")
@@ -883,7 +890,7 @@ class Labels:
 
     def numpy(
         self,
-        video: Video | int | None = None,
+        video: Video | str | Path | int | None = None,
         untracked: bool = False,
         return_confidence: bool = False,
         user_instances: bool = True,
@@ -891,8 +898,10 @@ class Labels:
         """Construct a numpy array from instance points.
 
         Args:
-            video: Video or video index to convert to numpy arrays. If `None` (the
-                default), uses the first video.
+            video: Video, filename, or video index to convert to numpy arrays. If
+                `None` (the default), uses the first video. A foreign `Video`
+                instance or filename is resolved to the matching `Video` in
+                `self.videos` via `match_video`.
             untracked: If `False` (the default), include only instances that have a
                 track assignment. If `True`, includes all instances in each frame in
                 arbitrary order.
@@ -924,18 +933,13 @@ class Labels:
             objects. This method now delegates to `sleap_io.codecs.numpy.to_numpy()`.
             See that function for implementation details.
         """
+        # Canonicalize a foreign Video / filename / index to the matching Video.
+        video = self._resolve_video(video)
+
         # Fast path for lazy-loaded Labels
         if self.is_lazy:
-            # Resolve video argument
-            if video is None:
-                resolved_video = None  # Will default to first video
-            elif isinstance(video, int):
-                resolved_video = self.videos[video]
-            else:
-                resolved_video = video
-
             return self._lazy_store.to_numpy(
-                video=resolved_video,
+                video=video,
                 untracked=untracked,
                 return_confidence=return_confidence,
                 user_instances=user_instances,
@@ -1209,16 +1213,155 @@ class Labels:
                 "saved in the labels. Use Labels.skeletons instead."
             )
 
+    def match_video(
+        self,
+        video_or_path: Video | str | Path,
+        method: "str | VideoMatcher" = "auto",
+    ) -> Video | None:
+        """Resolve a foreign `Video` or path to the canonical `Video` in this `Labels`.
+
+        `Video` objects compare by identity (`eq=False`), so a freshly created
+        `Video` pointing at the same file as one already in `self.videos` will not
+        be recognized by `find`, `extract`, or `__getitem__`. This method maps such
+        a foreign `Video` (or a plain filename) to the matching `Video` instance
+        already stored on this `Labels`.
+
+        Args:
+            video_or_path: A `Video` instance or a filename (`str` or `Path`) to
+                resolve against `self.videos`.
+            method: Matching strategy. Either a string (`"auto"`, `"path"`,
+                `"basename"`, `"content"`, `"shape"`, `"image_dedup"`) or a
+                `VideoMatcher` instance. The default `"auto"` uses a tiered cascade:
+                it first looks for a definitive match (same underlying file, or an
+                identical path), and only if none is found falls back to basename
+                matching.
+
+        Returns:
+            The canonical `Video` from `self.videos` that matches, or `None` if no
+            video matches.
+
+        Raises:
+            ValueError: If more than one video matches ambiguously.
+            TypeError: If `video_or_path` is not a `Video`, `str`, or `Path`.
+
+        Notes:
+            For HDF5-backed videos (e.g. embedded videos in `.pkg.slp` files),
+            matching disambiguates on both `dataset` and `source_filename`, so
+            multiple videos sharing the same `.pkg.slp` path resolve correctly. A
+            bare path string cannot carry a `dataset`, so resolving a multi-dataset
+            `.pkg.slp` by path alone may raise the ambiguity error -- pass a `Video`
+            instance in that case.
+
+            For image-sequence (`ImageVideo`) backends, `"auto"` matching requires
+            the full set of image filenames to match. Pass `method="image_dedup"`
+            to resolve sequences that only partially overlap.
+
+        Example:
+            >>> video = sio.load_video("path/to/video.mp4")  # doctest: +SKIP
+            >>> canonical = labels.match_video(video)  # doctest: +SKIP
+            >>> labels.find(canonical)  # equivalently: labels.find(video)
+        """
+        from sleap_io.model.matching import (
+            VideoMatcher,
+            VideoMatchMethod,
+            is_same_file,
+        )
+
+        # Coerce a path argument into a Video for comparison purposes. The backend
+        # is left unopened so dead/network paths never trigger I/O here.
+        if isinstance(video_or_path, Video):
+            query = video_or_path
+        elif isinstance(video_or_path, (str, Path)):
+            query = Video(filename=str(video_or_path), open_backend=False)
+        else:
+            raise TypeError(
+                "match_video() expects a Video, str, or Path, got "
+                f"{type(video_or_path).__name__}."
+            )
+
+        # Identity short-circuit: already a canonical video in this Labels.
+        for video in self.videos:
+            if video is query:
+                return video
+
+        def _ambiguous(candidates: list[Video], by: str) -> ValueError:
+            names = ", ".join(repr(v.filename) for v in candidates)
+            return ValueError(
+                f"Ambiguous video match for {query.filename!r}: matched "
+                f"{len(candidates)} videos {by}: {names}."
+            )
+
+        if isinstance(method, str) and method == "auto":
+            # Tiered cascade: prefer a definitive (file identity / exact path)
+            # match so a shared basename never shadows a true match.
+            definitive = [
+                v
+                for v in self.videos
+                if is_same_file(v, query) or v.matches_path(query, strict=True)
+            ]
+            if len(definitive) > 1:
+                raise _ambiguous(definitive, "by file identity")
+            if definitive:
+                return definitive[0]
+
+            basename = [v for v in self.videos if v.matches_path(query, strict=False)]
+            if len(basename) > 1:
+                raise _ambiguous(basename, "by basename")
+            return basename[0] if basename else None
+
+        # Explicit matching strategy.
+        if isinstance(method, str):
+            matcher = VideoMatcher(method=VideoMatchMethod(method))
+        else:
+            matcher = method
+        matches = [v for v in self.videos if matcher.match(v, query)]
+        if len(matches) > 1:
+            raise _ambiguous(matches, f"with method {matcher.method.value!r}")
+        return matches[0] if matches else None
+
+    def _resolve_video(self, video: Video | str | Path | int | None) -> Video | None:
+        """Resolve a video argument to the canonical `Video` in this `Labels`.
+
+        Used internally by video-accepting query methods (`find`, `numpy`, and the
+        `get_*` family) to canonicalize a foreign `Video` or filename so that
+        identity-based lookups succeed. See `match_video` for the matching rules.
+
+        Args:
+            video: A `Video`, filename (`str`/`Path`), integer index into
+                `self.videos`, or `None`.
+
+        Returns:
+            The canonical `Video`, or `None` if `video` is `None`. If no video
+            matches, a foreign `Video` is returned unchanged and a path is coerced
+            into a new (unopened) `Video`, so identity-based lookups simply yield
+            empty results (preserving the "no match" behavior).
+        """
+        if video is None:
+            return None
+        if isinstance(video, int):
+            return self.videos[video]
+        matched = self.match_video(video)
+        if matched is not None:
+            return matched
+        # No match: return a usable Video so callers (e.g. find(..., return_new))
+        # can still attach it to new frames.
+        if isinstance(video, Video):
+            return video
+        return Video(filename=str(video), open_backend=False)
+
     def find(
         self,
-        video: Video,
+        video: Video | str | Path,
         frame_idx: int | list[int] | None = None,
         return_new: bool = False,
     ) -> list[LabeledFrame]:
         """Search for labeled frames given video and/or frame index.
 
         Args:
-            video: A `Video` that is associated with the project.
+            video: A `Video` associated with the project, or a filename (`str` or
+                `Path`). A foreign `Video` instance or filename is resolved to the
+                matching `Video` in `self.videos` via `match_video`, so an object
+                created independently (e.g. with `sio.load_video`) still works.
             frame_idx: The frame index (or indices) which we want to find in the video.
                 If a range is specified, we'll return all frames with indices in that
                 range. If not specific, then we'll return all labeled frames for video.
@@ -1232,6 +1375,7 @@ class Labels:
             which case it contains new (empty) `LabeledFrame` objects with `video` and
             `frame_index` set.
         """
+        video = self._resolve_video(video)
         results = []
 
         # Lazy fast path: scan raw arrays directly
@@ -1603,8 +1747,8 @@ class Labels:
         frames, use ``Labels.temporal_rois``.
 
         Args:
-            video: If specified, only return ROIs for this video (identity
-                comparison).
+            video: If specified, only return ROIs for this video. A foreign
+                `Video` instance or filename is resolved via `match_video`.
             frame_idx: If specified, only return ROIs for this frame index.
             category: If specified, only return ROIs with this category.
             track: If specified, only return ROIs for this track (identity
@@ -1617,6 +1761,7 @@ class Labels:
         Returns:
             A list of matching ROIs.
         """
+        video = self._resolve_video(video)
         # Fast path: O(1) frame lookup when both video and frame_idx given
         if video is not None and frame_idx is not None:
             lf = self.get_frame(video, frame_idx)
@@ -1663,8 +1808,8 @@ class Labels:
               ``self.masks``.
 
         Args:
-            video: If specified, only return masks for this video (identity
-                comparison).
+            video: If specified, only return masks for this video. A foreign
+                `Video` instance or filename is resolved via `match_video`.
             frame_idx: If specified, only return masks for this frame index.
             category: If specified, only return masks with this category.
             track: If specified, only return masks for this track (identity
@@ -1677,6 +1822,7 @@ class Labels:
         Returns:
             A list of matching segmentation masks.
         """
+        video = self._resolve_video(video)
         # Fast path: O(1) frame lookup when both video and frame_idx given
         if video is not None and frame_idx is not None:
             lf = self.get_frame(video, frame_idx)
@@ -1723,8 +1869,8 @@ class Labels:
               ``self.bboxes``.
 
         Args:
-            video: If specified, only return bboxes for this video (identity
-                comparison).
+            video: If specified, only return bboxes for this video. A foreign
+                `Video` instance or filename is resolved via `match_video`.
             frame_idx: If specified, only return bboxes for this frame index.
             category: If specified, only return bboxes with this category.
             track: If specified, only return bboxes for this track (identity
@@ -1742,6 +1888,7 @@ class Labels:
             hierarchy (``UserBoundingBox`` vs ``PredictedBoundingBox``) for
             user/predicted distinction.
         """
+        video = self._resolve_video(video)
         # Fast path: O(1) frame lookup when both video and frame_idx given
         if video is not None and frame_idx is not None:
             lf = self.get_frame(video, frame_idx)
@@ -1788,8 +1935,8 @@ class Labels:
               ``self.centroids``.
 
         Args:
-            video: If specified, only return centroids for this video (identity
-                comparison).
+            video: If specified, only return centroids for this video. A foreign
+                `Video` instance or filename is resolved via `match_video`.
             frame_idx: If specified, only return centroids for this frame index.
             category: If specified, only return centroids with this category.
             track: If specified, only return centroids for this track (identity
@@ -1803,6 +1950,7 @@ class Labels:
         Returns:
             A list of matching centroids.
         """
+        video = self._resolve_video(video)
         # Fast path: O(1) frame lookup when both video and frame_idx given
         if video is not None and frame_idx is not None:
             lf = self.get_frame(video, frame_idx)
@@ -1856,8 +2004,8 @@ class Labels:
               ``predicted``), the search runs over ``self.label_images``.
 
         Args:
-            video: If specified, only return label images for this video
-                (identity comparison).
+            video: If specified, only return label images for this video. A
+                foreign `Video` instance or filename is resolved via `match_video`.
             frame_idx: If specified, only return label images for this frame
                 index.
             track: If specified, only return label images containing this track
@@ -1871,6 +2019,7 @@ class Labels:
         Returns:
             A list of matching label images.
         """
+        video = self._resolve_video(video)
         # Fast path: O(1) frame lookup when both video and frame_idx given
         if video is not None and frame_idx is not None:
             lf = self.get_frame(video, frame_idx)
@@ -2307,13 +2456,23 @@ class Labels:
                             video.replace_filename(new_fn, open=open_videos)
 
     def extract(
-        self, inds: list[int] | list[tuple[Video, int]] | np.ndarray, copy: bool = True
+        self,
+        inds: list[int]
+        | list[tuple[Video | str | Path, int]]
+        | np.ndarray
+        | Video
+        | str
+        | Path,
+        copy: bool = True,
     ) -> "Labels":
         """Extract a set of frames into a new Labels object.
 
         Args:
-            inds: Indices of labeled frames. Can be specified as a list of array of
-                integer indices of labeled frames or tuples of Video and frame indices.
+            inds: Indices of labeled frames. Can be specified as a list or array of
+                integer indices of labeled frames, tuples of `(video, frame_idx)`,
+                or a single `Video`/filename to extract all of its frames. A
+                foreign `Video` instance or filename is resolved to the matching
+                `Video` in `self.videos` via `match_video`.
             copy: If `True` (the default), return a copy of the frames and containing
                 objects. Otherwise, return a reference to the data.
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1234,15 +1234,18 @@ class Labels:
                 `VideoMatcher` instance. The default `"auto"` uses a tiered cascade:
                 it first looks for a definitive match (same underlying file, or an
                 identical path), and only if none is found falls back to basename
-                matching.
+                matching. A `VideoMatcher` whose method is `AUTO` (equivalently, the
+                string `"auto"`) uses this same tiered cascade.
 
         Returns:
             The canonical `Video` from `self.videos` that matches, or `None` if no
             video matches.
 
         Raises:
-            ValueError: If more than one video matches ambiguously.
-            TypeError: If `video_or_path` is not a `Video`, `str`, or `Path`.
+            ValueError: If more than one video matches ambiguously, or if `method`
+                is a string that is not a recognized matching strategy.
+            TypeError: If `video_or_path` is not a `Video`, `str`, or `Path`, or if
+                `method` is not a string or `VideoMatcher`.
 
         Notes:
             For HDF5-backed videos (e.g. embedded videos in `.pkg.slp` files),
@@ -1256,6 +1259,11 @@ class Labels:
             the full set of image filenames to match. Pass `method="image_dedup"`
             to resolve sequences that only partially overlap.
 
+            The `"content"` and `"shape"` methods compare shape metadata, which a
+            bare path argument cannot provide (its backend is left unopened). Pass
+            a `Video` instance to resolve by content/shape, or use
+            `"auto"`/`"path"`/`"basename"` to resolve a path by filename.
+
         Example:
             >>> video = sio.load_video("path/to/video.mp4")  # doctest: +SKIP
             >>> canonical = labels.match_video(video)  # doctest: +SKIP
@@ -1268,7 +1276,8 @@ class Labels:
         )
 
         # Coerce a path argument into a Video for comparison purposes. The backend
-        # is left unopened so dead/network paths never trigger I/O here.
+        # is left unopened, so resolution never opens (or hangs on decoding) a video
+        # file -- though path-based checks may still stat the filesystem.
         if isinstance(video_or_path, Video):
             query = video_or_path
         elif isinstance(video_or_path, (str, Path)):
@@ -1277,6 +1286,25 @@ class Labels:
             raise TypeError(
                 "match_video() expects a Video, str, or Path, got "
                 f"{type(video_or_path).__name__}."
+            )
+
+        # Normalize the matching strategy. A string is validated eagerly (raising
+        # ValueError for an unrecognized strategy). The AUTO method -- whether given
+        # as the "auto" string or an AUTO `VideoMatcher` -- uses the tiered cascade,
+        # signaled by leaving `matcher` as None.
+        if isinstance(method, str):
+            method_enum = VideoMatchMethod(method)
+            matcher = (
+                None
+                if method_enum == VideoMatchMethod.AUTO
+                else VideoMatcher(method=method_enum)
+            )
+        elif isinstance(method, VideoMatcher):
+            matcher = None if method.method == VideoMatchMethod.AUTO else method
+        else:
+            raise TypeError(
+                "match_video() expects method to be a str or VideoMatcher, got "
+                f"{type(method).__name__}."
             )
 
         # Identity short-circuit: already a canonical video in this Labels.
@@ -1291,7 +1319,7 @@ class Labels:
                 f"{len(candidates)} videos {by}: {names}."
             )
 
-        if isinstance(method, str) and method == "auto":
+        if matcher is None:
             # Tiered cascade: prefer a definitive (file identity / exact path)
             # match so a shared basename never shadows a true match.
             definitive = [
@@ -1309,11 +1337,7 @@ class Labels:
                 raise _ambiguous(basename, "by basename")
             return basename[0] if basename else None
 
-        # Explicit matching strategy.
-        if isinstance(method, str):
-            matcher = VideoMatcher(method=VideoMatchMethod(method))
-        else:
-            matcher = method
+        # Explicit (non-AUTO) matching strategy.
         matches = [v for v in self.videos if matcher.match(v, query)]
         if len(matches) > 1:
             raise _ambiguous(matches, f"with method {matcher.method.value!r}")

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -340,6 +340,207 @@ def test_labels_getitem_list_of_tuples(slp_typical):
     assert len(lfs) == 0
 
 
+def test_match_video_foreign_instance(slp_typical):
+    """match_video resolves a foreign Video with the same path to the canonical."""
+    labels = load_slp(slp_typical)
+    canonical = labels.video
+
+    # A freshly created Video is not identity-equal (Video is eq=False).
+    foreign = Video(filename=canonical.filename, open_backend=False)
+    assert foreign is not canonical
+    assert labels.match_video(foreign) is canonical
+
+    # An identity argument is returned unchanged.
+    assert labels.match_video(canonical) is canonical
+
+
+def test_match_video_by_path(slp_typical):
+    """match_video resolves str and Path filenames to the canonical Video."""
+    labels = load_slp(slp_typical)
+    canonical = labels.video
+
+    assert labels.match_video(str(canonical.filename)) is canonical
+    assert labels.match_video(Path(canonical.filename)) is canonical
+
+
+def test_match_video_no_match(slp_typical):
+    """match_video returns None when no video matches."""
+    labels = load_slp(slp_typical)
+    assert labels.match_video("not_in_project.mp4") is None
+    assert labels.match_video(Video(filename="not_in_project.mp4")) is None
+
+
+def test_match_video_basename_fallback():
+    """match_video falls back to basename matching for relocated files."""
+    video = Video(filename="/original/dir/video.mp4", open_backend=False)
+    labels = Labels(videos=[video])
+
+    # Same basename in a different directory still resolves.
+    assert labels.match_video("/new/location/video.mp4") is video
+
+
+def test_match_video_definitive_over_basename():
+    """An exact path match wins over a shared basename (no false ambiguity)."""
+    v1 = Video(filename="/dir1/vid.mp4", open_backend=False)
+    v2 = Video(filename="/dir2/vid.mp4", open_backend=False)
+    labels = Labels(videos=[v1, v2])
+
+    # Exact path -> definitive tier resolves to v1 despite the shared basename.
+    assert labels.match_video("/dir1/vid.mp4") is v1
+    assert labels.match_video("/dir2/vid.mp4") is v2
+
+
+def test_match_video_ambiguous_raises():
+    """match_video raises when multiple videos match by basename."""
+    v1 = Video(filename="/dir1/vid.mp4", open_backend=False)
+    v2 = Video(filename="/dir2/vid.mp4", open_backend=False)
+    labels = Labels(videos=[v1, v2])
+
+    with pytest.raises(ValueError, match="Ambiguous video match"):
+        labels.match_video("/elsewhere/vid.mp4")
+
+
+def test_match_video_ambiguous_definitive_raises():
+    """match_video raises when multiple videos share the exact same path."""
+    v1 = Video(filename="/dir/vid.mp4", open_backend=False)
+    v2 = Video(filename="/dir/vid.mp4", open_backend=False)
+    labels = Labels(videos=[v1, v2])
+
+    with pytest.raises(ValueError, match="by file identity"):
+        labels.match_video("/dir/vid.mp4")
+
+
+def test_match_video_explicit_method():
+    """match_video accepts an explicit method string or VideoMatcher."""
+    v1 = Video(filename="/dir1/vid.mp4", open_backend=False)
+    v2 = Video(filename="/dir2/other.mp4", open_backend=False)
+    labels = Labels(videos=[v1, v2])
+
+    # Basename method resolves a relocated file.
+    assert labels.match_video("/x/vid.mp4", method="basename") is v1
+    # Path method (lenient by default) also matches by basename.
+    assert labels.match_video("/x/other.mp4", method="path") is v2
+    # A VideoMatcher instance works too.
+    matcher = VideoMatcher(method=VideoMatchMethod.BASENAME)
+    assert labels.match_video("/x/vid.mp4", method=matcher) is v1
+
+
+def test_match_video_explicit_method_ambiguous():
+    """Explicit-method matching raises on ambiguous matches."""
+    v1 = Video(filename="/dir1/vid.mp4", open_backend=False)
+    v2 = Video(filename="/dir2/vid.mp4", open_backend=False)
+    labels = Labels(videos=[v1, v2])
+
+    with pytest.raises(ValueError, match="Ambiguous video match"):
+        labels.match_video("/x/vid.mp4", method="basename")
+
+
+def test_match_video_bad_type():
+    """match_video raises TypeError for unsupported argument types."""
+    labels = Labels(videos=[Video(filename="vid.mp4", open_backend=False)])
+    with pytest.raises(TypeError):
+        labels.match_video(42)
+
+
+def test_match_video_hdf5_pkg(slp_minimal_pkg):
+    """match_video resolves embedded HDF5 videos in a .pkg.slp file."""
+    labels = load_slp(slp_minimal_pkg)
+    canonical = labels.video
+
+    # Foreign Video carrying the HDF5 backend resolves on dataset identity.
+    foreign = Video(filename=canonical.filename, open_backend=False)
+    foreign.backend = canonical.backend
+    assert labels.match_video(foreign) is canonical
+
+    # Resolving by the .pkg.slp path alone also works (single embedded video).
+    assert labels.match_video(canonical.filename) is canonical
+
+
+def test_find_foreign_video(slp_typical):
+    """Find accepts a foreign Video, str, or Path argument."""
+    labels = load_slp(slp_typical)
+    canonical = labels.video
+    labels.labeled_frames.append(LabeledFrame(video=canonical, frame_idx=1))
+
+    foreign = Video(filename=canonical.filename, open_backend=False)
+    assert len(labels.find(foreign)) == 2
+    assert len(labels.find(str(canonical.filename))) == 2
+    assert len(labels.find(Path(canonical.filename))) == 2
+    assert len(labels.find(foreign, frame_idx=0)) == 1
+
+
+def test_find_returns_new_for_unmatched_path(slp_typical):
+    """find(..., return_new=True) attaches a usable Video for an unmatched path."""
+    labels = load_slp(slp_typical)
+    results = labels.find("unmatched.mp4", frame_idx=0, return_new=True)
+    assert len(results) == 1
+    assert results[0].frame_idx == 0
+    assert isinstance(results[0].video, Video)
+    assert Path(results[0].video.filename).name == "unmatched.mp4"
+
+
+def test_getitem_by_path(slp_typical):
+    """__getitem__ accepts str/Path videos and (path, frame_idx) tuples."""
+    labels = load_slp(slp_typical)
+    canonical = labels.video
+    labels.labeled_frames.append(LabeledFrame(video=canonical, frame_idx=1))
+
+    assert len(labels[str(canonical.filename)]) == 2
+    assert len(labels[Path(canonical.filename)]) == 2
+    assert labels[(str(canonical.filename), 0)].frame_idx == 0
+
+    foreign = Video(filename=canonical.filename, open_backend=False)
+    assert len(labels[foreign]) == 2
+
+    # List of (path, frame_idx) tuples.
+    keys = [(str(canonical.filename), 0), (str(canonical.filename), 1)]
+    lfs = labels[keys]
+    assert [lf.frame_idx for lf in lfs] == [0, 1]
+
+    with pytest.raises(IndexError):
+        labels["not_in_project.mp4"]
+
+
+def test_extract_foreign_video(slp_typical):
+    """Extract resolves foreign Video / path arguments via __getitem__."""
+    labels = load_slp(slp_typical)
+    canonical = labels.video
+    foreign = Video(filename=canonical.filename, open_backend=False)
+
+    assert len(labels.extract([(foreign, 0)])) == 1
+    assert len(labels.extract(str(canonical.filename))) == 1
+
+
+def test_get_queries_foreign_video():
+    """get_* and numpy resolve a foreign Video argument."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="/data/vid.mp4", open_backend=False)
+    inst = Instance.from_numpy(np.array([[1.0, 2.0], [3.0, 4.0]]), skeleton=skel)
+    centroid = UserCentroid(x=5.0, y=10.0)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst], centroids=[centroid])
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skel])
+
+    foreign = Video(filename="/data/vid.mp4", open_backend=False)
+    assert len(labels.get_centroids(video=foreign)) == 1
+    assert len(labels.get_centroids(video="/data/vid.mp4")) == 1
+    assert labels.numpy(video=foreign, untracked=True).shape[0] == 1
+    # Integer index still selects the video.
+    assert labels.numpy(video=0, untracked=True).shape[0] == 1
+
+
+def test_match_video_image_sequence(centered_pair_frame_paths):
+    """match_video resolves image-sequence videos by their full filename list."""
+    video = Video(filename=list(centered_pair_frame_paths), open_backend=False)
+    labels = Labels(videos=[video])
+
+    foreign = Video(filename=list(centered_pair_frame_paths), open_backend=False)
+    assert labels.match_video(foreign) is video
+
+    # A partially overlapping sequence is not an "auto" match.
+    partial = Video(filename=list(centered_pair_frame_paths[:1]), open_backend=False)
+    assert labels.match_video(partial) is None
+
+
 def test_labels_save(tmp_path, slp_typical):
     labels = load_slp(slp_typical)
     labels.save(tmp_path / "test.slp")

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -435,11 +435,39 @@ def test_match_video_explicit_method_ambiguous():
         labels.match_video("/x/vid.mp4", method="basename")
 
 
+def test_match_video_auto_matcher_instance():
+    """An AUTO VideoMatcher instance uses the same tiered cascade as method='auto'."""
+    v1 = Video(filename="/dir1/vid.mp4", open_backend=False)
+    v2 = Video(filename="/dir2/vid.mp4", open_backend=False)
+    labels = Labels(videos=[v1, v2])
+
+    # An exact path resolves via the definitive tier despite the shared basename,
+    # exactly as method="auto" does (not the simplified pairwise AUTO check, which
+    # would treat the basename match as a second, ambiguous candidate).
+    matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+    assert labels.match_video("/dir1/vid.mp4", method=matcher) is v1
+    assert labels.match_video("/dir1/vid.mp4", method="auto") is v1
+
+
 def test_match_video_bad_type():
     """match_video raises TypeError for unsupported argument types."""
     labels = Labels(videos=[Video(filename="vid.mp4", open_backend=False)])
     with pytest.raises(TypeError):
         labels.match_video(42)
+
+
+def test_match_video_bad_method_type():
+    """match_video raises TypeError for an unsupported method argument."""
+    labels = Labels(videos=[Video(filename="vid.mp4", open_backend=False)])
+    with pytest.raises(TypeError, match="method"):
+        labels.match_video("vid.mp4", method=42)
+
+
+def test_match_video_bad_method_string():
+    """match_video raises ValueError for an unrecognized method string."""
+    labels = Labels(videos=[Video(filename="vid.mp4", open_backend=False)])
+    with pytest.raises(ValueError):
+        labels.match_video("vid.mp4", method="not_a_method")
 
 
 def test_match_video_hdf5_pkg(slp_minimal_pkg):


### PR DESCRIPTION
## Summary

Closes #426.

`Video` is `@attrs.define(eq=False)`, so two `Video` instances pointing at the same file are **not** equal — they compare only by object identity. As a result, `Labels.find`, `Labels.extract`, `Labels.__getitem__`, `Labels.numpy`, and the `get_*` family all silently failed when handed a `Video` created independently of the project:

```python
video = sio.load_video(file)
labels.find(video)   # -> []  (even though labels.videos has that file!)
labels[video]        # -> IndexError
```

The only workaround was to manually walk `labels.videos` and match by filename (see talmolab/sleap#2137).

This PR adds a resolver so a foreign `Video` — or a plain filename — transparently resolves to the canonical `Video` already stored on the `Labels`.

## Key Changes

- **New `Labels.match_video(video_or_path, method="auto")`** — public resolver mapping a foreign `Video` / `str` / `Path` to the canonical `Video` in `labels.videos`. Returns `None` when there is no match; raises `ValueError` on an ambiguous match.
- **New private `Labels._resolve_video()`** — canonicalizes the `video` argument used internally by the query methods.
- **Canonicalization wired into** `find`, `__getitem__` (now accepts `str`/`Path` and `(path, frame_idx)` tuples), `numpy`, `get_rois`, `get_masks`, `get_bboxes`, `get_centroids`, and `get_label_images`. `extract` inherits this for free via `__getitem__`.
- Reuses the existing matching system (`sleap_io.model.matching.is_same_file`, `VideoMatcher`, `Video.matches_path`) — no matching rules were reinvented.

## Example Usage

```python
labels = sio.load_slp("predictions.slp")
foreign = sio.load_video("predictions_video.mp4")  # a different object

labels.find(foreign)                   # ✓ resolves to the project video
labels.find("predictions_video.mp4")   # ✓ by filename
labels["predictions_video.mp4"]        # ✓ __getitem__ by filename
labels.extract([("predictions_video.mp4", 0)])

canonical = labels.match_video(foreign)  # -> Video, or None
```

## API Changes

- **Added**: `Labels.match_video()` (public).
- **Widened** (backwards compatible): `find`, `__getitem__`, `numpy`, and `extract` now also accept a `str`/`Path` filename or a foreign `Video` wherever they accepted a project `Video`.
- No removals or behavior changes for existing callers passing canonical `Video` objects.

## Design Decisions

- **`method` argument over boolean flags.** The issue sketched `strict_path` / `by_content` booleans, but the codebase already exposes `Labels.match(other, video: str | VideoMatcher | None)`. `match_video` mirrors that API (`method` accepts a strategy string or a `VideoMatcher`) for consistency.
- **Tiered `"auto"` cascade.** A *definitive* match (same underlying file via `is_same_file`, or an identical path) is preferred so a shared basename never shadows a true match; basename matching is only a fallback. This means an exact path resolves cleanly even when the project has two videos with the same filename in different directories. The `AUTO` method takes this cascade whether passed as the `"auto"` string or as a `VideoMatcher(method=AUTO)` instance — the two are normalized to behave identically (rather than the instance falling through to `VideoMatcher`'s simplified pairwise `AUTO` check).
- **Ambiguity raises.** When more than one video matches within the winning tier, `match_video` raises `ValueError` listing the candidates, rather than guessing.
- **No backend I/O on resolution.** Path arguments are coerced to `Video(..., open_backend=False)`, so resolution never opens (or hangs on decoding) a video file. Path-based matching may still `stat` the filesystem via the reused helpers (`is_same_file`, `matches_path`), which themselves already avoid `resolve()` on paths that don't exist locally.
- **HDF5 / `.pkg.slp`** multi-dataset disambiguation (on `dataset` + `source_filename`) comes for free from the reused helpers.

## Testing

- 20 new focused tests in `tests/model/test_labels.py` covering: foreign-`Video`/`str`/`Path` resolution, identity short-circuit, no-match → `None`, basename fallback, definitive-over-basename precedence, ambiguity (`ValueError`) for both the basename and definitive tiers, explicit `method` (string and `VideoMatcher` instance, including an `AUTO` `VideoMatcher` taking the tiered cascade), `TypeError` on a bad `video_or_path` or `method` argument, `ValueError` on an unrecognized `method` string, HDF5 `.pkg.slp` resolution, image-sequence full vs. partial overlap, and canonicalization through `find` / `__getitem__` / `extract` / `numpy` / `get_*`.
- Full `tests/model/test_labels.py` (267 tests) and the `numpy` / `lazy` / `matching` / `video` suites pass. The one unrelated failure (`test_samefile_with_symlink`) is a pre-existing Windows symlink-privilege `OSError` — confirmed failing on `main`.
- `docs/examples.md` gains a "Resolving a video by path or foreign instance" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
