### PR TITLE
chore(release): Bump version to 0.7.1

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -141,6 +141,7 @@ sio render predictions.slp --start 100 --end 200
 sio render predictions.slp --lf 0                          # Single frame -> PNG
 sio render predictions.slp --lf 0 --crop auto              # Auto-fit to instances
 sio render predictions.slp --color-by track --marker-shape diamond
+sio render predictions.slp --trails --trail-length 10           # Motion trails
 
 # Trim video and labels to a frame range
 sio trim labels.slp --start 100 --end 1000                 # -> labels.trim.slp
@@ -1836,6 +1837,22 @@ See [Segmentation Overlays](#segmentation-overlays) for end-to-end examples.
 | `--overlay-outline` / `--no-overlay-outline` | off | Draw outlines around segmented regions |
 | `--overlay-outline-width` | 1 | Outline width in pixels |
 | `--overlay-outline-color` | (darkened fill) | Outline color (e.g., `white`, `#ff0000`, `255,0,0`) |
+
+#### Motion Trail Options
+
+Trace each animal's path over the last `N` frames behind the current frame.
+Only takes effect when rendering a video (a single labeled frame has no
+temporal context).
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--trails` | off | Enable motion-trail overlay drawn beneath poses and centroids. |
+| `--trail-length` | 10 | Number of past frames to include in each trail. |
+| `--trail-node` | `centroid` | Point to trail. Either `centroid`, a single node name, or a comma-separated list of node names (one trail per node). |
+| `--trail-width` | 2.0 | Trail line width in pixels. |
+| `--trail-fade` / `--no-trail-fade` | `--trail-fade` | Fade trails from faint (oldest) to opaque (newest). |
+| `--trail-alpha` | 1.0 | Global opacity multiplier for trails (0.0–1.0). Combines with fade. |
+| `--trail-color` | (match poses) | Uniform color for all trails (e.g., `white`, `#ff0000`, `255,0,0`). Default matches the pose color (by track or instance). |
 
 #### Discovery Options
 

--- a/docs/model/labels.md
+++ b/docs/model/labels.md
@@ -114,6 +114,13 @@ You can also index with a `(video, frame_idx)` tuple:
 lf = labels[video, 0]  # same as labels.find(video, 0)[0]
 ```
 
+`find`, `__getitem__`, `extract`, `numpy`, and the `get_*` family also accept a
+filename (`str` / `Path`) or a foreign `Video` (one constructed outside the
+project) and resolve it to the canonical `Video` already on the labels via
+[`Labels.match_video`][sleap_io.Labels.match_video]. See
+[Resolving a video by path or foreign instance](../examples.md#resolving-a-video-by-path-or-foreign-instance)
+for the full pattern.
+
 ### Fast lookups
 
 `Labels` maintains lazy indices for O(1) frame and track lookups. Use

--- a/sleap_io/codecs/numpy.py
+++ b/sleap_io/codecs/numpy.py
@@ -346,6 +346,10 @@ def to_analysis_arrays(
     instance-slotting logic as `to_numpy` so that projects without track
     assignments keep every instance instead of collapsing to one per frame.
 
+    This is an internal building block — most users should call
+    `sleap_io.save_analysis_h5` instead, which writes these arrays to disk in
+    the SLEAP analysis HDF5 layout.
+
     Args:
         labels: The `Labels` from which to get data.
         video: Video (or video index) to export. If None, uses the first video.

--- a/sleap_io/model/matching.py
+++ b/sleap_io/model/matching.py
@@ -1153,8 +1153,11 @@ class ConflictResolution:
 
     Attributes:
         frame: The labeled frame where the conflict occurred.
-        conflict_type: Type of conflict (e.g., "duplicate_instance",
-            "skeleton_mismatch").
+        conflict_type: Type of conflict. Emitted values are
+            ``"instance_conflict"`` (an instance pair conflicted under the
+            chosen frame strategy) and ``"negative_flag_conflict"`` (the
+            ``is_negative`` background marker was cleared because the merged
+            frame now contains a user pose).
         original_data: The original data before resolution.
         new_data: The new/incoming data that caused the conflict.
         resolution: Description of how the conflict was resolved.

--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -3,4 +3,4 @@
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release
 # version.
-__version__ = "0.7.0"
+__version__ = "0.7.1"


### PR DESCRIPTION
## Summary

Bumps `sleap_io.__version__` to `0.7.1` and rolls in the small follow-ups surfaced by the v0.7.0→v0.7.1 release review.

## Release scope

v0.7.1 = v0.7.0 + 6 merged PRs:

| PR  | Title |
|-----|-------|
| #418 | Preserve images with 0 instances as empty labeled frames in DLC and COCO readers |
| #432 | fix: Preserve `is_negative` when merging colliding and new frames (#431) |
| #433 | fix: Preserve all instances in analysis HDF5 export for untracked multi-animal projects |
| #434 | Add motion trail overlay to video rendering |
| #435 | ci: Bump GitHub Actions off deprecated Node.js 20 |
| #436 | Resolve foreign `Video` by path/content matching in `Labels` lookups |

The headline data-loss fix is **#433** (untracked multi-animal analysis HDF5 export silently kept only one instance per frame on v0.7.0); release notes recommend re-export. The only net-new feature is **#434** (motion trail overlays in `sio.render_video` / `sio render`). Draft release notes for v0.7.1 are in `scratch/2026-05-26-release-v0.7.1/RELEASE_NOTES.md` (not checked in).

## Follow-ups included in this PR

Small, scoped fixes from the review — not new behavior:

- **`docs/cli.md`** — added Motion Trail Options subtable under `sio render` (closes the only CLI doc gap from #434) + a one-liner trail example in the Quick Reference.
- **`docs/model/labels.md`** — Querying section now cross-references `Labels.match_video` and the widened lookup signatures from #436 (previously only documented under `docs/examples.md`).
- **`sleap_io/model/matching.py`** — `ConflictResolution.conflict_type` docstring cited stale example values (`"duplicate_instance"`, `"skeleton_mismatch"`); refreshed to cite the actually-emitted `"instance_conflict"` and (new in #432) `"negative_flag_conflict"`.
- **`sleap_io/codecs/numpy.py`** — `to_analysis_arrays` is intentionally omitted from `sleap_io.codecs.__all__` but module-level discoverable; added a one-line docstring note that it's the internal building block behind `save_analysis_h5`.

## Testing

No behavior changes — version bump + docstring / docs edits only. `ruff check` and `ruff format --check` pass on the edited Python files.

## Design Decisions

- Pre-existing doc drift (`docs/install.md` and `docs/cli.md` examples still mentioning `0.6.0`, `docs/examples.md` "TiffVideo" cross-ref) deliberately deferred to a docs-only sweep — not blocking the patch release.
- All edits scoped narrowly to items where the v0.7.1 PRs left something stale or under-documented; no new features added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)