### PR TITLE
fix(io): preserve edge-less nodes in SkeletonEncoder JSON output

### DIFF
--- a/sleap_io/io/skeleton.py
+++ b/sleap_io/io/skeleton.py
@@ -438,10 +438,30 @@ class SkeletonEncoder:
             if node not in node_to_py_id:
                 node_to_py_id[node] = self._get_or_create_py_id(node)
 
-        # Create nodes section with py/id references
+        # Determine which nodes were serialized with full object state inside
+        # `links`. Nodes that appear in no edge or symmetry (e.g. the lone node
+        # of a single-node skeleton, or any isolated node) are never emitted in
+        # `links`, so referencing them here by py/id alone would dangle and the
+        # decoder would silently drop them. Emit their full object state in the
+        # nodes section instead.
+        nodes_in_links = set()
+        for edge in skeleton.edges:
+            nodes_in_links.add(edge.source)
+            nodes_in_links.add(edge.destination)
+        for symmetry in skeleton.symmetries:
+            for node in symmetry.nodes:
+                nodes_in_links.add(node)
+
+        # Create nodes section: py/id references for nodes already serialized in
+        # `links`, full object state for isolated nodes. Fully-connected
+        # skeletons are unaffected (every node is in a link), so existing output
+        # is unchanged.
         nodes = []
         for node in skeleton.nodes:
-            nodes.append({"id": {"py/id": node_to_py_id[node]}})
+            if node in nodes_in_links:
+                nodes.append({"id": {"py/id": node_to_py_id[node]}})
+            else:
+                nodes.append({"id": self._encode_node(node)})
 
         # Build final skeleton dict
         return {

--- a/tests/io/test_skeleton_io.py
+++ b/tests/io/test_skeleton_io.py
@@ -301,6 +301,35 @@ def test_complex_round_trip():
     assert sym_nodes1 == sym_nodes2
 
 
+def test_round_trip_single_node_skeleton():
+    """Single-node (edge-less) skeletons must round-trip without dropping nodes.
+
+    Regression test: the encoder previously emitted isolated nodes as a bare
+    ``py/id`` back-reference to an object that was never serialized (full node
+    state is only written inside ``links``), so a skeleton with no edges decoded
+    to an empty skeleton.
+    """
+    skeleton1 = sio.Skeleton(nodes=[sio.Node("centroid")], name="centroid")
+
+    skeleton2 = decode_skeleton(encode_skeleton(skeleton1))
+
+    assert skeleton2.name == "centroid"
+    assert [n.name for n in skeleton2.nodes] == ["centroid"]
+    assert len(skeleton2.edges) == 0
+
+
+def test_round_trip_isolated_node():
+    """Skeletons with an isolated (unconnected) node retain all nodes."""
+    nodes = [sio.Node("a"), sio.Node("b"), sio.Node("c")]
+    edges = [sio.Edge(nodes[0], nodes[1])]  # "c" is isolated
+    skeleton1 = sio.Skeleton(nodes=nodes, edges=edges, name="mixed")
+
+    skeleton2 = decode_skeleton(encode_skeleton(skeleton1))
+
+    assert {n.name for n in skeleton2.nodes} == {"a", "b", "c"}
+    assert len(skeleton2.edges) == 1
+
+
 # File I/O tests using fixtures
 def test_load_minimal_skeleton_fixture(skeleton_json_minimal):
     """Test loading the minimal skeleton fixture."""


### PR DESCRIPTION
## Problem

The jsonpickle `SkeletonEncoder` drops **edge-less / isolated nodes** when encoding to JSON. A node's full `py/object`/`py/state` is only written when the node first appears inside an edge or symmetry (a `link`). Any node that appears in **no** link — the lone node of a single-node skeleton, or an isolated node in a larger skeleton — was written in the `nodes` section as a bare `py/id` back-reference to an object that was never serialized. The decoder cannot resolve the dangling reference, so the node is silently dropped and the skeleton round-trips to **empty**.

Reproduce on `main` (v0.7.1):

```python
import sleap_io as sio
from sleap_io.io.skeleton import SkeletonEncoder, SkeletonDecoder
import json
s = sio.Skeleton(["centroid"], name="centroid")
d = SkeletonDecoder().decode(data=json.loads(SkeletonEncoder().encode(s)))
print(d.node_names)   # []  <-- node lost!
```

This also surfaces via `save_skeleton(skel, "x.json")` / `load_skeleton`, and in the downstream SLEAP GUI **"Save Skeleton"** command (which defaults to `.json`) — saving a single-node skeleton silently produces an empty skeleton file (data loss). The `.slp` HDF5 path and the YAML path are unaffected.

## Fix

In `SkeletonEncoder._encode_skeleton`, emit full node object state in the `nodes` section for nodes that appear in no link, instead of a bare `py/id` reference. Fully-connected skeletons are **unaffected** (every node appears in a link), so their encoded output is byte-identical — no regression.

## Tests

- `test_round_trip_single_node_skeleton` — single-node skeleton round-trips with the node preserved.
- `test_round_trip_isolated_node` — a skeleton with an isolated node retains all nodes.
- Full `tests/io/test_skeleton_io.py` passes (58 tests), confirming no regression.

## Context

Found while adding centroid-only model support to the SLEAP frontend (single-node "centroid" skeletons). Companion frontend PRs are stacked separately in `talmolab/sleap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
