### PR TITLE
feat(io): Load .slp from URLs and cloud buckets via fsspec (PR 1/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Complements the core [SLEAP](https://github.com/talmolab/sleap) package but does
 - **Codecs** -- Convert to/from NumPy arrays, DataFrames (pandas/polars), and dictionaries
 - **Video I/O** -- Read any video format via pluggable backends (FFMPEG, OpenCV, PyAV) with a NumPy-like interface
 - **Lazy loading** -- Load large SLP files up to 90x faster by deferring object creation
+- **Remote URLs** -- Load `.slp` files directly from `https://`, `s3://`, `gs://`, and `az://` URLs with lazy range-based reads and optional persistent caching
 - **Dataset splits** -- Create train/val/test splits and export to formats like Ultralytics YOLO
 
 ## Installation

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -626,6 +626,183 @@ sio.save_coco(
     - [`load_coco`](formats/#sleap_io.load_coco): COCO import documentation
     - [COCO Format](formats/#coco-format-json): COCO format details
 
+## Loading from URLs
+
+Load `.slp` files directly from HTTP/HTTPS and cloud-storage URLs. Reads are
+lazy and range-based: for the default streaming mode only the bytes actually
+needed (typically a small fraction of the file) are pulled over the network.
+
+### Quickstart
+
+[`load_slp`][sleap_io.load_slp] (and the universal
+[`load_file`][sleap_io.load_file]) accept a URL anywhere a local path is
+accepted:
+
+```python
+import sleap_io as sio
+
+# Just works for http/https out of the box
+labels = sio.load_slp("https://example.com/path/labels.slp")
+
+# load_file also accepts URLs (dispatches by extension)
+labels = sio.load_file("https://example.com/path/labels.slp")
+```
+
+`pkg.slp` files with embedded frames work too — the embedded `HDF5Video`
+backends reopen the remote file lazily when you read frames, reusing the same
+streaming configuration.
+
+!!! info "What is and isn't supported"
+    URL loading covers `.slp`/`.pkg.slp` and the other labels formats through
+    [`load_file`][sleap_io.load_file]. Remote *video* loading
+    (`sio.load_video("https://.../movie.mp4")`) is not yet implemented and
+    raises `NotImplementedError`; download the video locally first.
+
+### Supported schemes and install matrix
+
+| Scheme | Requires | Notes |
+|--------|----------|-------|
+| `http`, `https` | nothing extra | Works with a plain `pip install sleap-io` |
+| `s3` | `sleap-io[cloud]` | Amazon S3 (via `s3fs`) |
+| `gs`, `gcs` | `sleap-io[cloud]` | Google Cloud Storage (via `gcsfs`) |
+| `az`, `abfs` | `sleap-io[cloud]` | Azure Blob / ADLS (via `adlfs`) |
+
+```bash
+pip install sleap-io               # http/https only
+pip install "sleap-io[cloud]"      # + s3, gs/gcs, az/abfs
+pip install "sleap-io[all]"        # everything (cloud schemes included)
+```
+
+```python
+# Cloud scheme (requires sleap-io[cloud])
+labels = sio.load_slp("s3://my-bucket/path/labels.slp")
+```
+
+!!! warning "Missing cloud extra"
+    Using a cloud scheme without the `[cloud]` extra raises an `ImportError`
+    whose message names the missing package and the
+    `pip install 'sleap-io[cloud]'` install hint.
+
+### Streaming modes
+
+Control how bytes are fetched with the `stream_mode` keyword argument:
+
+| `stream_mode` | Backing strategy | Memory | Disk cache | Revalidation | Best for |
+|---------------|------------------|--------|------------|--------------|----------|
+| `"auto"` (default) | fsspec `blockcache` | Low (LRU of `max_blocks`) | None | n/a | One-off lazy reads, low memory |
+| `"blockcache"` | fsspec `blockcache` | Low | None | n/a | Same as `auto` (explicit) |
+| `"cache"` | fsspec `simplecache` | Whole file on disk | Persistent | None | Repeated opens of an immutable file |
+| `"filecache"` | fsspec `filecache` | Whole file on disk | Persistent | ETag / `Last-Modified` after `cache_expiry` | Repeated opens of a file that may change |
+| `"download"` | Full read into memory | Whole file in RAM | None | n/a | Small files, ephemeral environments |
+
+```python
+# Default: lazy range reads, low memory
+labels = sio.load_slp("https://example.com/labels.slp")
+
+# Persistent on-disk cache with daily ETag revalidation
+labels = sio.load_slp(
+    "https://example.com/labels.slp",
+    stream_mode="filecache",
+    cache_storage="~/.cache/sleap-io",
+    cache_expiry=86400,  # revalidate after a day
+)
+
+# Ephemeral full download into memory (no disk cache)
+labels = sio.load_slp("https://example.com/labels.slp", stream_mode="download")
+```
+
+The `"auto"`/`"blockcache"` reads can be tuned with `block_size` (range block
+size, default 1 MiB) and `max_blocks` (in-memory LRU cap per open file,
+default 32 → ~32 MiB per file).
+
+### Authentication
+
+Pass HTTP headers (such as a bearer token) with `headers=`:
+
+```python
+labels = sio.load_slp(
+    "https://my-org.example/private/labels.slp",
+    headers={"Authorization": "Bearer <token>"},
+)
+```
+
+!!! warning "Headers are stripped on cross-origin redirect"
+    For security, sensitive headers (`Authorization`, `Cookie`,
+    `Proxy-Authorization`) are **dropped automatically** if the request is
+    redirected to a different origin (scheme/host/port). This prevents leaking
+    credentials to a third-party host and is intentional — if a download
+    redirects cross-origin (e.g. to a pre-signed CDN URL), put the credentials
+    in the redirect target's query string rather than in `headers`.
+
+    Cloud schemes (`s3://`, `gs://`, …) use their own per-provider credential
+    chains (environment variables, credential files, instance metadata) rather
+    than `headers=`.
+
+### Caching: location, override, and clearing
+
+For `"cache"` and `"filecache"` modes, downloaded files live in the directory
+you pass as `cache_storage=`. sleap-io writes a small marker file there so it
+can later identify and clean up only its own cache files.
+
+To clear the cache, call [`clear_remote_cache`][sleap_io.clear_remote_cache]
+with the **same** `cache_storage` you loaded with:
+
+```python
+import sleap_io as sio
+
+# Delete every sleap-io cache file in the directory
+sio.clear_remote_cache(cache_storage="~/.cache/sleap-io")
+
+# Or only files older than an hour (3600 seconds)
+sio.clear_remote_cache(cache_storage="~/.cache/sleap-io", older_than=3600)
+```
+
+!!! note "An explicit `cache_storage` is required to clear the cache"
+    `clear_remote_cache` only operates on a directory that contains the
+    sleap-io marker file, and it only deletes files matching fsspec's
+    cache-key naming pattern — so it will never touch unrelated files even if
+    you point it at a shared directory. It refuses to run on a directory with
+    no marker, or on forbidden paths like `/` or `$HOME`. Because fsspec's
+    *default* cache directory is a per-process temporary location that cannot
+    be cleared reliably, you must pass the explicit `cache_storage` you used
+    when loading.
+
+### CI and ephemeral environments
+
+In CI or other short-lived environments, prefer the default `stream_mode="auto"`
+(no persistent cache to manage), or scope a per-run cache to a temporary
+directory you control:
+
+```python
+import os
+import sleap_io as sio
+
+cache_dir = os.path.join(os.environ.get("RUNNER_TEMP", "/tmp"), "sleap-io-cache")
+labels = sio.load_slp(url, stream_mode="filecache", cache_storage=cache_dir)
+```
+
+### Troubleshooting
+
+- **`RemoteIOError`** — raised for HTTP-level failures (404 not found, 416 range
+  past end of file, 5xx after retries, connection errors, timeouts). The
+  exception carries a `status` (HTTP code or `None`) and a credential-redacted
+  `url` so tokens never leak into logs or tracebacks. See
+  [`RemoteIOError`][sleap_io.RemoteIOError].
+- **`ImportError` for cloud schemes** — install the cloud adapters with
+  `pip install 'sleap-io[cloud]'` (covers `s3`, `gs`/`gcs`, `az`/`abfs`).
+- **`RuntimeWarning` about `aiohttp`** — remote loading needs
+  `aiohttp >= 3.13.5` for safe cross-origin header stripping. If you see this
+  warning, upgrade with `pip install --upgrade 'aiohttp>=3.13.5'`.
+- **`NotImplementedError` from `load_video(url)`** — remote video loading is not
+  supported yet; download the file locally first.
+
+!!! note "See also"
+    - [`load_slp`][sleap_io.load_slp]: Full URL keyword-argument reference
+    - [`load_file`][sleap_io.load_file]: Universal loader with URL sniffing
+    - [`clear_remote_cache`][sleap_io.clear_remote_cache]: Cache cleanup helper
+    - [`RemoteIOError`][sleap_io.RemoteIOError]: Remote I/O error surface
+    - [SLP Format](formats/slp.md): The on-disk `.slp` layout that URL loading streams
+
 ## Editing labels data
 
 ### Fix video paths

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -653,10 +653,12 @@ backends reopen the remote file lazily when you read frames, reusing the same
 streaming configuration.
 
 !!! info "What is and isn't supported"
-    URL loading covers `.slp`/`.pkg.slp` and the other labels formats through
-    [`load_file`][sleap_io.load_file]. Remote *video* loading
-    (`sio.load_video("https://.../movie.mp4")`) is not yet implemented and
-    raises `NotImplementedError`; download the video locally first.
+    URL loading currently covers `.slp`/`.pkg.slp` only (including through the
+    universal [`load_file`][sleap_io.load_file]). Other labels formats (NWB,
+    COCO, Label Studio, JABS, DLC, TrackMate, LEAP, GeoJSON, Ultralytics) and
+    remote *video* loading (`sio.load_video("https://.../movie.mp4")`) are not
+    yet implemented over URLs and raise `NotImplementedError`; download the file
+    locally first. These are tracked as follow-ups.
 
 ### Supported schemes and install matrix
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,7 @@ does *not* include labeling, training, or inference.
 - **Codecs** -- Convert to/from NumPy arrays, DataFrames (pandas/polars), and dictionaries ([guide](codecs.md))
 - **Video I/O** -- Read any video format via pluggable backends (FFMPEG, OpenCV, PyAV) with a NumPy-like interface ([model](model/video.md))
 - **Lazy loading** -- Load large SLP files up to 90x faster by deferring object creation ([details](formats/slp.md#lazy-loading))
+- **Remote URLs** -- Load `.slp` files directly from `https://`, `s3://`, `gs://`, and `az://` URLs with lazy range-based reads and optional persistent caching ([guide](examples.md#loading-from-urls))
 - **Dataset splits** -- Create train/val/test splits and export to formats like Ultralytics YOLO ([example](examples.md#make-trainingvalidationtest-splits))
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,9 @@ filterwarnings = [
     "ignore:ROI\\.from_bbox\\(\\) is deprecated:DeprecationWarning",
     "ignore:ROI\\.from_xyxy\\(\\) is deprecated:DeprecationWarning",
 ]
+markers = [
+    "live: tests that require live internet access (deselect with '-m \"not live\"').",
+]
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ dependencies = [
     "shapely>=2.0",
     "lazy-loader>=0.4",
     "skia-python>=87.0",
-    "colorcet>=3.0"]
+    "colorcet>=3.0",
+    "fsspec>=2024.10.0",
+    "aiohttp>=3.13.5"]
 dynamic = ["version", "readme"]
 
 [tool.setuptools.dynamic]
@@ -49,7 +51,16 @@ opencv = ["opencv-python"]
 pyav = ["av<16.0.0"]
 mat = ["pymatreader"]
 polars = ["polars", "pyarrow"]
-all = ["opencv-python", "av<16.0.0", "pymatreader", "polars", "pyarrow"]
+cloud = ["s3fs>=2024.10.0", "gcsfs>=2024.10.0", "adlfs>=2024.10.0"]
+all = [
+    "opencv-python",
+    "av<16.0.0",
+    "pymatreader",
+    "polars",
+    "pyarrow",
+    "s3fs>=2024.10.0",
+    "gcsfs>=2024.10.0",
+    "adlfs>=2024.10.0"]
 
 [dependency-groups]
 # PEP 735: Dev-only dependencies (`dev` is installed automatically by `uv`)
@@ -57,6 +68,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "pytest-watch",
+    "pytest-httpserver>=1.0",
     "ruff",
     "toml",
     "twine",

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -64,6 +64,8 @@ __getattr__, __dir__, __all__ = lazy.attach(
         "io.video_writing": ["VideoWriter"],
         # Streaming label image writer from sleap_io.io.slp
         "io.slp": ["LabelImageWriter"],
+        # Remote URL loading helpers from sleap_io.io._remote
+        "io._remote": ["clear_remote_cache", "RemoteIOError"],
         # Rendering from sleap_io.rendering
         "rendering.core": ["render_video", "render_image"],
         "rendering.colors": ["get_palette"],

--- a/sleap_io/io/_remote.py
+++ b/sleap_io/io/_remote.py
@@ -88,6 +88,15 @@ _RETRY_BACKOFF_MAX = 30.0
 #: Pattern matching fsspec cache filenames (sha hex hashes, optional ``.tags``).
 _CACHE_KEY_PATTERN = re.compile(r"^[0-9a-f]{32,64}(\.tags)?$")
 
+#: Pattern matching any remote URL embedded in free text (e.g. an exception
+#: message). Used to redact credential-bearing URLs out of a cause summary. The
+#: scheme alternation mirrors :data:`_URL_SCHEMES`; the body stops at the first
+#: whitespace or quote so a single URL token is captured.
+_URL_IN_TEXT_PATTERN = re.compile(
+    r"(?:" + "|".join(sorted(_URL_SCHEMES)) + r")://[^\s\"'<>]+",
+    re.IGNORECASE,
+)
+
 
 # ---------------------------------------------------------------------------
 # Errors
@@ -100,9 +109,18 @@ class RemoteIOError(OSError):
     Subclasses :class:`OSError` so that callers which already handle
     ``OSError`` (e.g. ``HDF5Video.__attrs_post_init__``) degrade gracefully.
 
+    The original aiohttp/fsspec exception is intentionally *not* chained as
+    ``__cause__`` / ``__context__`` because its string form embeds the raw URL
+    (userinfo password, ``?token=`` query parameter, etc.), which
+    :func:`traceback.format_exception` would otherwise leak. A redacted summary
+    of the cause (type name + redacted message) is preserved instead via
+    :attr:`cause_summary`.
+
     Attributes:
         url: Redacted URL (credentials stripped if present), or None.
         status: HTTP status code, or None for connection-level errors.
+        cause_summary: Redacted, one-line summary of the underlying exception
+            (type name plus redacted message), or None.
     """
 
     def __init__(
@@ -111,7 +129,7 @@ class RemoteIOError(OSError):
         *,
         url: str | None = None,
         status: int | None = None,
-        cause: BaseException | None = None,
+        cause_summary: str | None = None,
     ) -> None:
         """Build a RemoteIOError with a redacted, composed message.
 
@@ -120,17 +138,22 @@ class RemoteIOError(OSError):
             url: Raw URL associated with the failure. It is redacted before
                 being stored or surfaced in the message.
             status: HTTP status code, if known.
-            cause: The underlying exception, preserved as ``__cause__``.
+            cause_summary: A pre-redacted summary of the underlying exception
+                (see :func:`_redacted_cause_summary`). It is stored on the
+                instance and appended to the message. The raw exception is
+                never chained, so no credential-bearing string can leak through
+                ``__cause__`` / ``__context__``.
         """
         self.url = _redact_url(url) if url else None
         self.status = status
-        if cause is not None:
-            self.__cause__ = cause
+        self.cause_summary = cause_summary
         parts = [message]
         if self.status is not None:
             parts.append(f"status={self.status}")
         if self.url:
             parts.append(f"url={self.url}")
+        if self.cause_summary:
+            parts.append(f"cause={self.cause_summary}")
         super().__init__("; ".join(parts))
 
 
@@ -298,15 +321,46 @@ def _strip_cross_origin_headers(prev_url, new_url, headers) -> None:
     Args:
         prev_url: The URL the request was redirected from (an ``aiohttp.URL``),
             or None if there is no prior URL (in which case nothing is done).
-        new_url: The redirect target URL (an ``aiohttp.URL``).
+        new_url: The redirect target URL (an ``aiohttp.URL``), or None if it
+            could not be determined (in which case nothing is done).
         headers: A mutable, case-insensitive header mapping to scrub in place.
     """
-    if prev_url is None:
+    if prev_url is None or new_url is None:
         return
     if prev_url.origin() != new_url.origin():
         for header in list(headers):
             if header.lower() in _SENSITIVE_HEADERS:
                 headers.pop(header, None)
+
+
+def _redirect_target(prev_url, response):
+    """Resolve a redirect's target URL from its ``Location`` header.
+
+    aiohttp's ``on_request_redirect`` trace hook fires when a redirect response
+    is received but before the redirected request is built, so the target is
+    not yet on ``params.url`` (which is still the *source* URL). The actual
+    target is the ``Location`` header resolved against the source URL (handling
+    relative redirects).
+
+    Args:
+        prev_url: The source request URL (an ``aiohttp.URL``).
+        response: The redirect response (must expose ``.headers``), or None.
+
+    Returns:
+        The resolved target ``aiohttp.URL``, or None if there is no usable
+        ``Location`` header (in which case the caller leaves headers untouched).
+    """
+    import yarl
+
+    if response is None:
+        return None
+    location = response.headers.get("Location")
+    if not location:
+        return None
+    try:
+        return prev_url.join(yarl.URL(location))
+    except (ValueError, TypeError):  # pragma: no cover - defensive: malformed URL
+        return None
 
 
 async def _safe_get_client(**client_kwargs: Any):
@@ -328,9 +382,12 @@ async def _safe_get_client(**client_kwargs: Any):
     trace_config = aiohttp.TraceConfig()
 
     async def on_redirect(session, ctx, params):
-        history = params.response.history if params.response else []
-        prev_url = history[-1].url if history else None
-        _strip_cross_origin_headers(prev_url, params.url, params.headers)
+        # In aiohttp 3.13.x the redirect hook fires with ``params.url`` still
+        # pointing at the *source* request and an empty ``response.history``;
+        # the target is the redirect ``Location`` resolved against the source.
+        prev_url = params.url
+        target = _redirect_target(prev_url, params.response)
+        _strip_cross_origin_headers(prev_url, target, params.headers)
 
     trace_config.on_request_redirect.append(on_redirect)
     return aiohttp.ClientSession(trace_configs=[trace_config], **client_kwargs)
@@ -666,8 +723,42 @@ def _status_from_exception(e: BaseException) -> int | None:
     return resp.status if resp is not None else None
 
 
+def _redacted_cause_summary(e: BaseException) -> str:
+    """Build a credential-safe one-line summary of an exception.
+
+    aiohttp / fsspec exceptions embed the raw request URL (which may include a
+    userinfo password or a ``?token=`` query parameter) in their string form.
+    This returns ``"<TypeName>: <redacted message>"`` so the summary can be
+    surfaced to users for debugging without leaking credentials. Every
+    URL-looking substring in the message is run through :func:`_redact_url`.
+
+    Args:
+        e: The underlying exception.
+
+    Returns:
+        A redacted, single-line summary (type name plus redacted message).
+    """
+    try:
+        raw = str(e)
+    except Exception:
+        # Some exceptions (e.g. an aiohttp.ClientResponseError without a
+        # request_info) raise from their own __str__; fall back to the type name.
+        return type(e).__name__
+    redacted = _URL_IN_TEXT_PATTERN.sub(lambda m: _redact_url(m.group(0)), raw)
+    redacted = redacted.replace("\n", " ").replace("\r", " ").strip()
+    if redacted:
+        return f"{type(e).__name__}: {redacted}"
+    return type(e).__name__
+
+
 def _raise_remote(e: BaseException, *, url: str) -> None:
     """Convert an aiohttp/fsspec exception into a :class:`RemoteIOError`.
+
+    The original exception is deliberately *not* chained (``from None``): its
+    string form embeds the raw URL (credentials, ``?token=``), which
+    :func:`traceback.format_exception` would otherwise leak via ``__cause__`` /
+    ``__context__``. A redacted summary is preserved on the raised error
+    instead (see :func:`_redacted_cause_summary`).
 
     Args:
         e: The caught exception.
@@ -681,6 +772,8 @@ def _raise_remote(e: BaseException, *, url: str) -> None:
     if isinstance(e, RemoteIOError):
         raise e
 
+    summary = _redacted_cause_summary(e)
+
     # fsspec wraps HTTP error responses (e.g. as FileNotFoundError); recover the
     # underlying ClientResponseError from the chain so the status is preserved.
     resp = _find_response_error(e)
@@ -690,16 +783,23 @@ def _raise_remote(e: BaseException, *, url: str) -> None:
             416: "range past end of file",
             412: "file changed since cached (ETag mismatch)",
         }.get(resp.status, f"HTTP {resp.status}")
-        raise RemoteIOError(msg, url=url, status=resp.status, cause=e) from e
-    if isinstance(e, aiohttp.ClientConnectorError):
-        raise RemoteIOError("connection error", url=url, cause=e) from e
-    if isinstance(e, aiohttp.ClientPayloadError):
-        raise RemoteIOError("truncated body", url=url, cause=e) from e
-    if isinstance(e, asyncio.TimeoutError):
-        raise RemoteIOError("timeout", url=url, cause=e) from e
-    raise RemoteIOError(
-        f"unexpected error: {type(e).__name__}", url=url, cause=e
-    ) from e
+        err = RemoteIOError(msg, url=url, status=resp.status, cause_summary=summary)
+    elif isinstance(e, aiohttp.ClientConnectorError):
+        err = RemoteIOError("connection error", url=url, cause_summary=summary)
+    elif isinstance(e, aiohttp.ClientPayloadError):
+        err = RemoteIOError("truncated body", url=url, cause_summary=summary)
+    elif isinstance(e, asyncio.TimeoutError):
+        err = RemoteIOError("timeout", url=url, cause_summary=summary)
+    else:
+        err = RemoteIOError(
+            f"unexpected error: {type(e).__name__}", url=url, cause_summary=summary
+        )
+
+    # Break the credential-bearing chain: `raise ... from None` clears
+    # `__cause__` and sets `__suppress_context__`, so `traceback.format_exception`
+    # never prints the raw aiohttp/fsspec exception (whose string embeds the raw
+    # URL). The redacted `cause_summary` carries the useful debugging info.
+    raise err from None
 
 
 # ---------------------------------------------------------------------------

--- a/sleap_io/io/_remote.py
+++ b/sleap_io/io/_remote.py
@@ -1,0 +1,684 @@
+"""Internals for remote URL loading via fsspec.
+
+This module contains all URL-handling primitives used by the high-level loaders
+in :mod:`sleap_io.io.main` (and the helper refactors in
+:mod:`sleap_io.io.slp` / :mod:`sleap_io.io.utils`). The public surface exposed
+to users is :func:`clear_remote_cache` and :class:`RemoteIOError` (re-exported
+at the package top level); everything else is private (underscore-prefixed).
+
+Heavy third-party dependencies (``fsspec``, ``aiohttp``) are imported lazily
+inside the functions that need them so that ``import sleap_io`` stays fast and
+the cheap, pure-stdlib helpers (:func:`_is_url`, :func:`_redact_url`,
+:func:`_identify_magic`) remain usable with zero heavy imports on the local
+hot path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import io
+import os
+import pathlib
+import re
+import time
+import urllib.parse
+import warnings
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: URL schemes recognized as remote (vs. local filesystem paths). Single-letter
+#: schemes (e.g. Windows drive letters like ``c``) are intentionally excluded.
+_URL_SCHEMES = frozenset({"http", "https", "s3", "gs", "gcs", "az", "abfs"})
+
+#: Alias for clarity at call sites.
+_REMOTE_SCHEMES = _URL_SCHEMES
+
+#: Cloud schemes that require an fsspec adapter package from the ``[cloud]``
+#: extra.
+_CLOUD_SCHEMES = frozenset({"s3", "gs", "gcs", "az", "abfs"})
+
+#: Maps each cloud scheme to the fsspec adapter package that provides it.
+_CLOUD_PROTOCOL_TO_PACKAGE = {
+    "s3": "s3fs",
+    "gs": "gcsfs",
+    "gcs": "gcsfs",
+    "az": "adlfs",
+    "abfs": "adlfs",
+}
+
+#: HTTP headers stripped on cross-origin redirect (case-insensitive).
+_SENSITIVE_HEADERS = frozenset({"authorization", "cookie", "proxy-authorization"})
+
+#: Query-string parameter names whose values are redacted by :func:`_redact_url`.
+_SENSITIVE_QUERY_PARAMS = frozenset(
+    {"token", "access_token", "x-amz-security-token", "sas", "sig"}
+)
+
+#: Magic-byte prefixes mapped to a format family (checked in order).
+_FORMAT_MAGIC: tuple[tuple[bytes, str], ...] = (
+    (b"\x89HDF\r\n\x1a\n", "hdf5"),
+    (b"{", "json"),
+    (b"[", "json"),
+    (b"PK\x03\x04", "zip"),
+)
+
+#: Minimum ``aiohttp`` version for safe cross-origin redirect header stripping.
+_MIN_AIOHTTP = "3.13.5"
+
+#: Filename written into a cache directory to mark it as managed by sleap-io.
+_CACHE_MARKER_NAME = ".sleap-io-cache-marker"
+
+#: Pattern matching fsspec cache filenames (sha hex hashes, optional ``.tags``).
+_CACHE_KEY_PATTERN = re.compile(r"^[0-9a-f]{32,64}(\.tags)?$")
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class RemoteIOError(OSError):
+    """Raised for HTTP-level failures during remote loading.
+
+    Subclasses :class:`OSError` so that callers which already handle
+    ``OSError`` (e.g. ``HDF5Video.__attrs_post_init__``) degrade gracefully.
+
+    Attributes:
+        url: Redacted URL (credentials stripped if present), or None.
+        status: HTTP status code, or None for connection-level errors.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        url: str | None = None,
+        status: int | None = None,
+        cause: BaseException | None = None,
+    ) -> None:
+        """Build a RemoteIOError with a redacted, composed message.
+
+        Args:
+            message: Human-readable description of the failure.
+            url: Raw URL associated with the failure. It is redacted before
+                being stored or surfaced in the message.
+            status: HTTP status code, if known.
+            cause: The underlying exception, preserved as ``__cause__``.
+        """
+        self.url = _redact_url(url) if url else None
+        self.status = status
+        if cause is not None:
+            self.__cause__ = cause
+        parts = [message]
+        if self.status is not None:
+            parts.append(f"status={self.status}")
+        if self.url:
+            parts.append(f"url={self.url}")
+        super().__init__("; ".join(parts))
+
+
+# ---------------------------------------------------------------------------
+# URL detection + redaction (pure stdlib)
+# ---------------------------------------------------------------------------
+
+
+def _is_url(filename: str | os.PathLike) -> bool:
+    r"""Return True if ``filename`` is a remote URL (vs. a local path).
+
+    Robust against Windows-style absolute paths (e.g. ``C:\foo``): urlparse
+    reports ``scheme='c'`` for those, but single-letter schemes are not in
+    :data:`_URL_SCHEMES`.
+
+    Args:
+        filename: Candidate path or URL.
+
+    Returns:
+        True if the scheme is a recognized remote scheme, else False.
+    """
+    if not isinstance(filename, (str, os.PathLike)):
+        return False
+    s = os.fspath(filename) if isinstance(filename, os.PathLike) else filename
+    if not s:
+        return False
+    scheme = urllib.parse.urlparse(s).scheme.lower()
+    return scheme in _URL_SCHEMES
+
+
+def _redact_url(url: str) -> str:
+    """Strip credentials from a URL for safe logging/error display.
+
+    ``https://user:pass@host/path?token=xyz`` becomes
+    ``https://***:***@host/path?token=%2A%2A%2A``. Userinfo is replaced and
+    token-like query parameters have their values redacted.
+
+    Args:
+        url: The URL to redact.
+
+    Returns:
+        The redacted URL. If parsing fails, returns the input unchanged.
+    """
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except (ValueError, TypeError):  # pragma: no cover - urlparse is permissive
+        return url
+    netloc = parsed.netloc
+    if "@" in netloc:
+        netloc = "***:***@" + netloc.split("@", 1)[1]
+    if parsed.query:
+        params = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+        redacted_params = []
+        for k, v in params:
+            if k.lower() in _SENSITIVE_QUERY_PARAMS:
+                redacted_params.append((k, "***"))
+            else:
+                redacted_params.append((k, v))
+        new_query = urllib.parse.urlencode(redacted_params)
+    else:
+        new_query = ""
+    return urllib.parse.urlunparse(parsed._replace(netloc=netloc, query=new_query))
+
+
+# ---------------------------------------------------------------------------
+# Cloud scheme gating
+# ---------------------------------------------------------------------------
+
+
+def _require_package(package_name: str, *, scheme: str, extra: str = "cloud") -> None:
+    """Import ``package_name``, raising a user-friendly ImportError if absent.
+
+    Factored out of :func:`_ensure_cloud_extra` so the missing-package branch
+    can be exercised with a genuinely-absent package name (no mocking).
+
+    Args:
+        package_name: The importable module name to require.
+        scheme: The URL scheme that triggered the requirement (for messaging).
+        extra: The sleap-io extra that provides the package.
+
+    Raises:
+        ImportError: If ``package_name`` cannot be imported. The message
+            includes the ``pip install 'sleap-io[<extra>]'`` hint.
+    """
+    try:
+        importlib.import_module(package_name)
+    except ImportError as e:
+        raise ImportError(
+            f"Loading {scheme}:// URLs requires the {package_name!r} package. "
+            f"Install with: pip install 'sleap-io[{extra}]' "
+            "(covers s3, gs/gcs, az/abfs)."
+        ) from e
+
+
+def _ensure_cloud_extra(scheme: str) -> None:
+    """Raise a user-friendly ImportError for a cloud scheme missing its adapter.
+
+    Args:
+        scheme: The URL scheme being opened.
+
+    Raises:
+        ImportError: If ``scheme`` is a cloud scheme whose fsspec adapter
+            package is not installed.
+    """
+    if scheme not in _CLOUD_SCHEMES:
+        return
+    _require_package(_CLOUD_PROTOCOL_TO_PACKAGE[scheme], scheme=scheme)
+
+
+# ---------------------------------------------------------------------------
+# aiohttp version check
+# ---------------------------------------------------------------------------
+
+
+def _warn_if_old_aiohttp(version_str: str) -> None:
+    """Warn if ``version_str`` is below the safe minimum aiohttp version.
+
+    Factored from :func:`_check_aiohttp_version` so the warning branch is
+    testable by passing an old version string directly (no monkeypatch).
+
+    Args:
+        version_str: The installed aiohttp version (e.g. ``"3.13.0"``).
+    """
+    from packaging.version import Version
+
+    if Version(version_str) < Version(_MIN_AIOHTTP):
+        warnings.warn(
+            f"aiohttp {version_str} is below sleap-io's minimum {_MIN_AIOHTTP} "
+            "for safe cross-origin redirect header stripping. Upgrade with: "
+            "pip install --upgrade 'aiohttp>=3.13.5'. The belt-and-suspenders "
+            "redirect hook will still apply, but the built-in aiohttp safety "
+            "is not guaranteed on this version.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+def _check_aiohttp_version() -> None:
+    """Check the installed aiohttp version and warn if it is too old.
+
+    Called at module import time. If aiohttp is not importable (it is a base
+    dependency, so this should not happen in practice), the check is skipped.
+    """
+    try:
+        import aiohttp
+    except ImportError:  # pragma: no cover - aiohttp is a base dependency
+        return
+    _warn_if_old_aiohttp(aiohttp.__version__)
+
+
+# ---------------------------------------------------------------------------
+# fsspec filesystem builder
+# ---------------------------------------------------------------------------
+
+
+async def _safe_get_client(**client_kwargs: Any):
+    """Build an aiohttp.ClientSession that strips sensitive headers on redirect.
+
+    Installs an ``on_request_redirect`` trace hook that drops
+    ``Authorization`` / ``Cookie`` / ``Proxy-Authorization`` headers when a
+    redirect crosses origins. aiohttp >= 3.13.5 already does this; the hook is
+    belt-and-suspenders.
+
+    Args:
+        **client_kwargs: Forwarded to ``aiohttp.ClientSession``.
+
+    Returns:
+        A configured ``aiohttp.ClientSession``.
+    """
+    import aiohttp
+
+    trace_config = aiohttp.TraceConfig()
+
+    async def on_redirect(session, ctx, params):
+        history = params.response.history if params.response else []
+        prev_url = history[-1].url if history else None
+        new_url = params.url
+        if prev_url is None:
+            return
+        if prev_url.origin() != new_url.origin():
+            for header in list(params.headers):
+                if header.lower() in _SENSITIVE_HEADERS:
+                    params.headers.pop(header, None)
+
+    trace_config.on_request_redirect.append(on_redirect)
+    return aiohttp.ClientSession(trace_configs=[trace_config], **client_kwargs)
+
+
+def _build_fsspec_filesystem(
+    scheme: str,
+    *,
+    headers: dict[str, str] | None = None,
+    block_size: int = 1 << 20,
+    max_blocks: int = 32,
+):
+    """Build an fsspec ``AbstractFileSystem`` for ``scheme`` with our defaults.
+
+    ``block_size`` / ``max_blocks`` are accepted for signature symmetry but are
+    applied at ``fs.open(...)`` time (see :func:`open_url`), not on the
+    filesystem constructor.
+
+    Args:
+        scheme: The URL scheme (``http``, ``https``, or a cloud scheme).
+        headers: HTTP headers to send (HTTP/HTTPS only).
+        block_size: Range block size in bytes (used by the caller).
+        max_blocks: Max in-memory blocks per file (used by the caller).
+
+    Returns:
+        The configured fsspec filesystem.
+
+    Raises:
+        ImportError: If a cloud scheme's adapter package is missing.
+    """
+    import fsspec
+
+    _ensure_cloud_extra(scheme)
+
+    if scheme in ("http", "https"):
+        from fsspec.implementations.http import HTTPFileSystem
+
+        # Always set identity encoding to avoid the gzip/content-length
+        # ambiguity for ranged reads.
+        merged = {"Accept-Encoding": "identity", **(headers or {})}
+        return HTTPFileSystem(
+            client_kwargs={"headers": merged},
+            get_client=_safe_get_client,
+        )
+
+    # s3 / gs / gcs / az / abfs: fsspec's per-scheme registry handles auth via
+    # per-scheme kwargs. PR 1 does not forward HTTP headers here.
+    return fsspec.filesystem(scheme)
+
+
+def _http_inner_options(headers: dict[str, str] | None) -> dict[str, Any]:
+    """Build the inner-http options for chained ``simplecache::``/``filecache::``.
+
+    Args:
+        headers: Optional HTTP headers to forward.
+
+    Returns:
+        A mapping suitable for the ``http=`` kwarg of ``fsspec.open``.
+    """
+    merged = {"Accept-Encoding": "identity", **(headers or {})}
+    return {"client_kwargs": {"headers": merged}, "get_client": _safe_get_client}
+
+
+# ---------------------------------------------------------------------------
+# Open a URL
+# ---------------------------------------------------------------------------
+
+
+def open_url(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    stream_mode: str = "auto",
+    cache_storage: str | os.PathLike | None = None,
+    cache_expiry: float | None = None,
+    block_size: int = 1 << 20,
+    max_blocks: int = 32,
+):
+    """Open ``url`` as a file-like object using the configured strategy.
+
+    Args:
+        url: The remote URL to open.
+        headers: HTTP headers (HTTP/HTTPS only).
+        stream_mode: One of ``"auto"`` (alias for ``"blockcache"``),
+            ``"blockcache"``, ``"cache"`` (simplecache), ``"filecache"``, or
+            ``"download"`` (ephemeral full read into BytesIO).
+        cache_storage: Override the cache directory for cache/filecache modes.
+        cache_expiry: TTL (seconds) for ``filecache`` revalidation. Defaults to
+            3600 when not given.
+        block_size: Range block size in bytes for ``blockcache``.
+        max_blocks: Max in-memory LRU blocks per open file for ``blockcache``.
+
+    Returns:
+        A file-like object (fsspec buffered file or ``io.BytesIO``) ready to be
+        passed to ``h5py.File(...)`` or a reader.
+
+    Raises:
+        RemoteIOError: For HTTP / connection failures.
+        ImportError: For cloud schemes when the extra is not installed.
+        ValueError: For an unrecognized ``stream_mode``.
+    """
+    parsed = urllib.parse.urlparse(url)
+    scheme = parsed.scheme.lower()
+    fs = _build_fsspec_filesystem(
+        scheme, headers=headers, block_size=block_size, max_blocks=max_blocks
+    )
+
+    if stream_mode == "auto":
+        stream_mode = "blockcache"
+
+    if stream_mode not in ("blockcache", "cache", "filecache", "download"):
+        raise ValueError(
+            f"Invalid stream_mode={stream_mode!r}; expected one of "
+            "{'auto', 'blockcache', 'cache', 'filecache', 'download'}."
+        )
+
+    try:
+        if stream_mode == "blockcache":
+            return fs.open(
+                url,
+                mode="rb",
+                cache_type="blockcache",
+                block_size=block_size,
+                cache_options={"max_blocks": max_blocks},
+            )
+
+        if stream_mode == "cache":
+            import fsspec
+
+            simplecache_opts: dict[str, Any] = {}
+            if cache_storage is not None:
+                _mark_cache_dir(cache_storage)
+                simplecache_opts["cache_storage"] = str(cache_storage)
+            return fsspec.open(
+                f"simplecache::{url}",
+                mode="rb",
+                simplecache=simplecache_opts,
+                http=_http_inner_options(headers),
+            ).open()
+
+        if stream_mode == "filecache":
+            import fsspec
+
+            options: dict[str, Any] = {
+                "expiry_time": cache_expiry if cache_expiry is not None else 3600
+            }
+            if cache_storage is not None:
+                _mark_cache_dir(cache_storage)
+                options["cache_storage"] = str(cache_storage)
+            return fsspec.open(
+                f"filecache::{url}",
+                mode="rb",
+                filecache=options,
+                http=_http_inner_options(headers),
+            ).open()
+
+        # stream_mode == "download"
+        with fs.open(url, mode="rb") as src:
+            return io.BytesIO(src.read())
+    except Exception as e:
+        _raise_remote(e, url=url)
+
+
+def open_remote_h5(url: str, *, headers: dict[str, str] | None = None):
+    """Open a remote HDF5 file for membership/existence probing.
+
+    Thin convenience wrapper around :func:`open_url` using ``blockcache`` mode,
+    used by ``Video.exists`` to probe a remote ``.slp``/``pkg.slp`` URL.
+
+    Args:
+        url: The remote HDF5 URL.
+        headers: Optional HTTP headers.
+
+    Returns:
+        A file-like object suitable for ``h5py.File(...)``.
+    """
+    return open_url(url, headers=headers, stream_mode="blockcache")
+
+
+# ---------------------------------------------------------------------------
+# Error mapping
+# ---------------------------------------------------------------------------
+
+
+def _raise_remote(e: BaseException, *, url: str) -> None:
+    """Convert an aiohttp/fsspec exception into a :class:`RemoteIOError`.
+
+    Args:
+        e: The caught exception.
+        url: The URL involved (redacted before display).
+
+    Raises:
+        RemoteIOError: Always (this function never returns normally).
+    """
+    import aiohttp
+
+    if isinstance(e, RemoteIOError):
+        raise e
+    if isinstance(e, aiohttp.ClientResponseError):
+        msg = {
+            404: "file not found",
+            416: "range past end of file",
+            412: "file changed since cached (ETag mismatch)",
+        }.get(e.status, f"HTTP {e.status}")
+        raise RemoteIOError(msg, url=url, status=e.status, cause=e) from e
+    if isinstance(e, aiohttp.ClientConnectorError):
+        raise RemoteIOError("connection error", url=url, cause=e) from e
+    if isinstance(e, aiohttp.ClientPayloadError):
+        raise RemoteIOError("truncated body", url=url, cause=e) from e
+    if isinstance(e, asyncio.TimeoutError):
+        raise RemoteIOError("timeout", url=url, cause=e) from e
+    raise RemoteIOError(
+        f"unexpected error: {type(e).__name__}", url=url, cause=e
+    ) from e
+
+
+# ---------------------------------------------------------------------------
+# Magic-byte sniffing
+# ---------------------------------------------------------------------------
+
+
+def _identify_magic(head: bytes) -> str:
+    """Classify a byte prefix into a format family.
+
+    Args:
+        head: The first bytes of a file (typically 16).
+
+    Returns:
+        One of ``"hdf5"``, ``"json"``, ``"csv"``, ``"zip"``, or ``"unknown"``.
+    """
+    for prefix, fmt in _FORMAT_MAGIC:
+        if head.startswith(prefix):
+            return fmt
+    # CSV: non-empty, ASCII-printable (plus tab/CR/LF), contains a comma.
+    if head and all(32 <= b < 127 or b in (9, 10, 13) for b in head) and b"," in head:
+        return "csv"
+    return "unknown"
+
+
+def _sniff_format(url: str, *, headers: dict | None = None) -> str:
+    """Fetch the first 16 bytes of ``url`` and identify the format family.
+
+    Args:
+        url: The remote URL to sniff.
+        headers: Optional HTTP headers.
+
+    Returns:
+        One of ``"hdf5"``, ``"json"``, ``"csv"``, ``"zip"``, ``"unknown"``.
+
+    Raises:
+        RemoteIOError: For HTTP / connection failures.
+    """
+    parsed = urllib.parse.urlparse(url)
+    scheme = parsed.scheme.lower()
+    fs = _build_fsspec_filesystem(scheme, headers=headers)
+    try:
+        with fs.open(url, mode="rb") as f:
+            head = f.read(16)
+    except Exception as e:
+        _raise_remote(e, url=url)
+    return _identify_magic(head)
+
+
+def _head_or_range_probe(url: str, *, headers: dict[str, str] | None = None) -> bool:
+    """Check whether ``url`` exists via a HEAD request, falling back to a Range.
+
+    Some servers reject HEAD (405); in that case a single-byte
+    ``Range: bytes=0-0`` GET is used.
+
+    Args:
+        url: The remote URL to probe.
+        headers: Optional HTTP headers.
+
+    Returns:
+        True if the resource appears to exist and is reachable, else False.
+    """
+    parsed = urllib.parse.urlparse(url)
+    scheme = parsed.scheme.lower()
+    try:
+        fs = _build_fsspec_filesystem(scheme, headers=headers)
+        try:
+            return bool(fs.exists(url))
+        except Exception:
+            # HEAD may be unsupported; fall back to a tiny ranged read.
+            with fs.open(url, mode="rb") as f:
+                f.read(1)
+            return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Cache management
+# ---------------------------------------------------------------------------
+
+
+def _mark_cache_dir(cache_storage: str | os.PathLike) -> None:
+    """Write the sleap-io marker file into ``cache_storage`` (idempotent).
+
+    The marker opts a directory into :func:`clear_remote_cache`, preventing
+    accidental deletion of files in unrelated directories.
+
+    Args:
+        cache_storage: The cache directory to mark.
+    """
+    cache_dir = pathlib.Path(cache_storage).expanduser()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    marker = cache_dir / _CACHE_MARKER_NAME
+    if not marker.exists():
+        marker.touch()
+
+
+def clear_remote_cache(
+    *,
+    older_than: float | None = None,
+    cache_storage: str | os.PathLike | None = None,
+) -> int:
+    """Clear sleap-io's fsspec remote cache.
+
+    Only deletes files whose names match fsspec's cache-key pattern (sha-style
+    hex hashes, optionally with a ``.tags`` sidecar), preventing accidental
+    deletion of unrelated files if ``cache_storage`` points at a shared dir.
+
+    Args:
+        older_than: If set, only delete files whose modification time is older
+            than this many seconds.
+        cache_storage: The cache directory to clear. Required to contain the
+            sleap-io marker file. fsspec's built-in default cache directory is a
+            per-process temporary directory (the ``"TMP"`` sentinel), which is
+            not a stable, clearable location, so an explicit path is required
+            here.
+
+    Returns:
+        The number of files deleted.
+
+    Raises:
+        RuntimeError: If ``cache_storage`` is None, a forbidden path (root,
+            ``$HOME``), or does not contain the sleap-io cache marker file.
+    """
+    if cache_storage is None:
+        raise RuntimeError(
+            "clear_remote_cache requires an explicit cache_storage path: "
+            "the same path passed to load_slp(..., cache_storage=...). fsspec's "
+            "default cache directory is a per-process temporary directory and "
+            "cannot be cleared reliably."
+        )
+    cache_dir = pathlib.Path(cache_storage).expanduser().resolve()
+
+    forbidden = {pathlib.Path("/").resolve(), pathlib.Path.home().resolve()}
+    if cache_dir in forbidden:
+        raise RuntimeError(
+            f"Refusing to clear cache: cache_storage={str(cache_dir)!r} is a "
+            "forbidden path (root, $HOME, etc.)."
+        )
+
+    marker = cache_dir / _CACHE_MARKER_NAME
+    if not marker.exists():
+        raise RuntimeError(
+            f"Refusing to clear cache: {str(cache_dir)!r} does not contain a "
+            f"sleap-io cache marker file ({_CACHE_MARKER_NAME!r}). It was not "
+            "written by sleap-io."
+        )
+
+    deleted = 0
+    now = time.time()
+    for p in cache_dir.iterdir():
+        if not p.is_file():
+            continue
+        if not _CACHE_KEY_PATTERN.match(p.name):
+            continue
+        if older_than is not None:
+            if (now - p.stat().st_mtime) < older_than:
+                continue
+        p.unlink()
+        deleted += 1
+
+    return deleted
+
+
+# Run the aiohttp version check at import time (cheap; warns on downgrade).
+_check_aiohttp_version()

--- a/sleap_io/io/_remote.py
+++ b/sleap_io/io/_remote.py
@@ -72,6 +72,19 @@ _MIN_AIOHTTP = "3.13.5"
 #: Filename written into a cache directory to mark it as managed by sleap-io.
 _CACHE_MARKER_NAME = ".sleap-io-cache-marker"
 
+#: HTTP status codes that are retried (transient server / rate-limit errors).
+_RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+
+#: Base backoff (seconds) for exponential retry: attempt N waits
+#: ``_RETRY_BACKOFF_BASE * 2**N`` (200/400/800 ms for the default 3 retries),
+#: unless the server sends a ``Retry-After`` header which takes precedence.
+_RETRY_BACKOFF_BASE = 0.2
+
+#: Upper bound (seconds) on any single retry sleep, including a server-provided
+#: ``Retry-After`` value. Caps pathological ``Retry-After`` values from blocking
+#: a load indefinitely.
+_RETRY_BACKOFF_MAX = 30.0
+
 #: Pattern matching fsspec cache filenames (sha hex hashes, optional ``.tags``).
 _CACHE_KEY_PATTERN = re.compile(r"^[0-9a-f]{32,64}(\.tags)?$")
 
@@ -273,6 +286,29 @@ def _check_aiohttp_version() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _strip_cross_origin_headers(prev_url, new_url, headers) -> None:
+    """Drop sensitive headers in-place when a redirect crosses origins.
+
+    Factored out of the :func:`_safe_get_client` trace hook so the
+    credential-stripping decision is directly unit-testable (the hook itself
+    runs inside aiohttp's event-loop thread). Mutates ``headers`` in place,
+    removing :data:`_SENSITIVE_HEADERS` (case-insensitive) only when the origin
+    of ``new_url`` differs from ``prev_url``.
+
+    Args:
+        prev_url: The URL the request was redirected from (an ``aiohttp.URL``),
+            or None if there is no prior URL (in which case nothing is done).
+        new_url: The redirect target URL (an ``aiohttp.URL``).
+        headers: A mutable, case-insensitive header mapping to scrub in place.
+    """
+    if prev_url is None:
+        return
+    if prev_url.origin() != new_url.origin():
+        for header in list(headers):
+            if header.lower() in _SENSITIVE_HEADERS:
+                headers.pop(header, None)
+
+
 async def _safe_get_client(**client_kwargs: Any):
     """Build an aiohttp.ClientSession that strips sensitive headers on redirect.
 
@@ -294,13 +330,7 @@ async def _safe_get_client(**client_kwargs: Any):
     async def on_redirect(session, ctx, params):
         history = params.response.history if params.response else []
         prev_url = history[-1].url if history else None
-        new_url = params.url
-        if prev_url is None:
-            return
-        if prev_url.origin() != new_url.origin():
-            for header in list(params.headers):
-                if header.lower() in _SENSITIVE_HEADERS:
-                    params.headers.pop(header, None)
+        _strip_cross_origin_headers(prev_url, params.url, params.headers)
 
     trace_config.on_request_redirect.append(on_redirect)
     return aiohttp.ClientSession(trace_configs=[trace_config], **client_kwargs)
@@ -369,6 +399,84 @@ def _http_inner_options(headers: dict[str, str] | None) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _retry_after_seconds(e: BaseException) -> float | None:
+    """Extract a ``Retry-After`` delay (seconds) from an HTTP error, if present.
+
+    Only the integer-seconds form of ``Retry-After`` is honored (the
+    HTTP-date form is ignored and falls back to exponential backoff).
+
+    Args:
+        e: The caught exception (its chain is searched for a response error).
+
+    Returns:
+        The non-negative ``Retry-After`` value in seconds, or None if the
+        header is absent or not an integer.
+    """
+    resp = _find_response_error(e)
+    if resp is None or resp.headers is None:
+        return None
+    raw = resp.headers.get("Retry-After")
+    if raw is None:
+        return None
+    try:
+        value = float(int(str(raw).strip()))
+    except (TypeError, ValueError):
+        return None
+    return max(0.0, value)
+
+
+def _retry_sleep_seconds(attempt: int, exc: BaseException) -> float:
+    """Compute the sleep before the next attempt.
+
+    Honors a server ``Retry-After`` header if present, else uses exponential
+    backoff (``_RETRY_BACKOFF_BASE * 2**attempt``). The result is clamped to
+    ``_RETRY_BACKOFF_MAX``.
+
+    Args:
+        attempt: Zero-based index of the attempt that just failed.
+        exc: The exception from the failed attempt.
+
+    Returns:
+        Seconds to sleep before retrying.
+    """
+    retry_after = _retry_after_seconds(exc)
+    if retry_after is not None:
+        return min(retry_after, _RETRY_BACKOFF_MAX)
+    return min(_RETRY_BACKOFF_BASE * (2**attempt), _RETRY_BACKOFF_MAX)
+
+
+def _open_with_retries(open_fn, *, url: str, retries: int):
+    """Call ``open_fn()`` with retries on transient HTTP errors.
+
+    Retries are attempted only for the statuses in :data:`_RETRYABLE_STATUSES`
+    (429/500/502/503/504). All other errors (and a final retryable error after
+    the budget is exhausted) are converted via :func:`_raise_remote`.
+
+    Args:
+        open_fn: A zero-argument callable that performs the open and returns a
+            file-like object.
+        url: The URL involved (for error redaction).
+        retries: Maximum number of retries (so up to ``retries + 1`` attempts).
+
+    Returns:
+        Whatever ``open_fn()`` returns on success.
+
+    Raises:
+        RemoteIOError: If all attempts fail.
+    """
+    attempt = 0
+    while True:
+        try:
+            return open_fn()
+        except Exception as e:  # noqa: BLE001 - mapped via _raise_remote below
+            status = _status_from_exception(e)
+            if status in _RETRYABLE_STATUSES and attempt < retries:
+                time.sleep(_retry_sleep_seconds(attempt, e))
+                attempt += 1
+                continue
+            _raise_remote(e, url=url)
+
+
 def open_url(
     url: str,
     *,
@@ -378,6 +486,7 @@ def open_url(
     cache_expiry: float | None = None,
     block_size: int = 1 << 20,
     max_blocks: int = 32,
+    retries: int = 3,
 ):
     """Open ``url`` as a file-like object using the configured strategy.
 
@@ -392,6 +501,8 @@ def open_url(
             3600 when not given.
         block_size: Range block size in bytes for ``blockcache``.
         max_blocks: Max in-memory LRU blocks per open file for ``blockcache``.
+        retries: Maximum retries for transient HTTP errors (429/500/502/503/504),
+            with exponential backoff honoring ``Retry-After``. Default: 3.
 
     Returns:
         A file-like object (fsspec buffered file or ``io.BytesIO``) ready to be
@@ -417,17 +528,21 @@ def open_url(
             "{'auto', 'blockcache', 'cache', 'filecache', 'download'}."
         )
 
-    try:
-        if stream_mode == "blockcache":
+    if stream_mode == "blockcache":
+
+        def _open():
             return fs.open(
                 url,
                 mode="rb",
                 cache_type="blockcache",
                 block_size=block_size,
-                cache_options={"max_blocks": max_blocks},
+                # fsspec's BlockCache uses ``maxblocks`` (no underscore).
+                cache_options={"maxblocks": max_blocks},
             )
 
-        if stream_mode == "cache":
+    elif stream_mode == "cache":
+
+        def _open():
             import fsspec
 
             simplecache_opts: dict[str, Any] = {}
@@ -441,7 +556,9 @@ def open_url(
                 http=_http_inner_options(headers),
             ).open()
 
-        if stream_mode == "filecache":
+    elif stream_mode == "filecache":
+
+        def _open():
             import fsspec
 
             options: dict[str, Any] = {
@@ -457,11 +574,13 @@ def open_url(
                 http=_http_inner_options(headers),
             ).open()
 
-        # stream_mode == "download"
-        with fs.open(url, mode="rb") as src:
-            return io.BytesIO(src.read())
-    except Exception as e:
-        _raise_remote(e, url=url)
+    else:  # stream_mode == "download"
+
+        def _open():
+            with fs.open(url, mode="rb") as src:
+                return io.BytesIO(src.read())
+
+    return _open_with_retries(_open, url=url, retries=retries)
 
 
 def open_remote_h5(url: str, *, headers: dict[str, str] | None = None):
@@ -485,6 +604,47 @@ def open_remote_h5(url: str, *, headers: dict[str, str] | None = None):
 # ---------------------------------------------------------------------------
 
 
+def _find_response_error(e: BaseException):
+    """Find a wrapped ``aiohttp.ClientResponseError`` in an exception chain.
+
+    fsspec wraps the underlying ``aiohttp.ClientResponseError`` as the
+    ``__cause__`` (or ``__context__``) of a ``FileNotFoundError`` for HTTP error
+    responses, so the HTTP status is not visible on the top-level exception.
+    This walks the chain (bounded) to recover it.
+
+    Args:
+        e: The caught exception.
+
+    Returns:
+        The first ``aiohttp.ClientResponseError`` found in ``e``'s cause/context
+        chain (including ``e`` itself), or None if there is none.
+    """
+    import aiohttp
+
+    seen: set[int] = set()
+    cur: BaseException | None = e
+    while cur is not None and id(cur) not in seen:
+        if isinstance(cur, aiohttp.ClientResponseError):
+            return cur
+        seen.add(id(cur))
+        cur = cur.__cause__ or cur.__context__
+    return None
+
+
+def _status_from_exception(e: BaseException) -> int | None:
+    """Return the HTTP status of an exception (unwrapping fsspec's wrapper).
+
+    Args:
+        e: The caught exception.
+
+    Returns:
+        The HTTP status code if an ``aiohttp.ClientResponseError`` is found in
+        the chain, else None.
+    """
+    resp = _find_response_error(e)
+    return resp.status if resp is not None else None
+
+
 def _raise_remote(e: BaseException, *, url: str) -> None:
     """Convert an aiohttp/fsspec exception into a :class:`RemoteIOError`.
 
@@ -499,13 +659,17 @@ def _raise_remote(e: BaseException, *, url: str) -> None:
 
     if isinstance(e, RemoteIOError):
         raise e
-    if isinstance(e, aiohttp.ClientResponseError):
+
+    # fsspec wraps HTTP error responses (e.g. as FileNotFoundError); recover the
+    # underlying ClientResponseError from the chain so the status is preserved.
+    resp = _find_response_error(e)
+    if resp is not None:
         msg = {
             404: "file not found",
             416: "range past end of file",
             412: "file changed since cached (ETag mismatch)",
-        }.get(e.status, f"HTTP {e.status}")
-        raise RemoteIOError(msg, url=url, status=e.status, cause=e) from e
+        }.get(resp.status, f"HTTP {resp.status}")
+        raise RemoteIOError(msg, url=url, status=resp.status, cause=e) from e
     if isinstance(e, aiohttp.ClientConnectorError):
         raise RemoteIOError("connection error", url=url, cause=e) from e
     if isinstance(e, aiohttp.ClientPayloadError):
@@ -583,12 +747,15 @@ def _head_or_range_probe(url: str, *, headers: dict[str, str] | None = None) -> 
         fs = _build_fsspec_filesystem(scheme, headers=headers)
         try:
             return bool(fs.exists(url))
-        except Exception:
-            # HEAD may be unsupported; fall back to a tiny ranged read.
+        except Exception:  # pragma: no cover - defensive: fsspec's _exists
+            # swallows HTTP/ClientError internally and returns a bool, so this
+            # only fires for unusual non-HTTP failures. Fall back to a tiny
+            # ranged read in case HEAD is unsupported.
             with fs.open(url, mode="rb") as f:
                 f.read(1)
             return True
-    except Exception:
+    except Exception:  # pragma: no cover - defensive: filesystem construction
+        # or the ranged-read fallback failing is not reachable via real servers.
         return False
 
 

--- a/sleap_io/io/_remote.py
+++ b/sleap_io/io/_remote.py
@@ -336,6 +336,27 @@ async def _safe_get_client(**client_kwargs: Any):
     return aiohttp.ClientSession(trace_configs=[trace_config], **client_kwargs)
 
 
+def _identity_headers(headers: dict[str, str] | None) -> dict[str, str]:
+    """Merge user headers but force ``Accept-Encoding: identity`` to win.
+
+    Identity encoding is required on every ranged HTTP request to avoid the
+    gzip/content-length ambiguity. Any user-supplied ``Accept-Encoding`` (in any
+    casing, since aiohttp coalesces header keys case-insensitively) is dropped so
+    the identity guarantee cannot be silently weakened.
+
+    Args:
+        headers: Optional user-supplied HTTP headers.
+
+    Returns:
+        A new header mapping with ``Accept-Encoding`` forced to ``identity``.
+    """
+    merged = {
+        k: v for k, v in (headers or {}).items() if k.lower() != "accept-encoding"
+    }
+    merged["Accept-Encoding"] = "identity"
+    return merged
+
+
 def _build_fsspec_filesystem(
     scheme: str,
     *,
@@ -369,8 +390,8 @@ def _build_fsspec_filesystem(
         from fsspec.implementations.http import HTTPFileSystem
 
         # Always set identity encoding to avoid the gzip/content-length
-        # ambiguity for ranged reads.
-        merged = {"Accept-Encoding": "identity", **(headers or {})}
+        # ambiguity for ranged reads (user headers cannot override it).
+        merged = _identity_headers(headers)
         return HTTPFileSystem(
             client_kwargs={"headers": merged},
             get_client=_safe_get_client,
@@ -390,7 +411,7 @@ def _http_inner_options(headers: dict[str, str] | None) -> dict[str, Any]:
     Returns:
         A mapping suitable for the ``http=`` kwarg of ``fsspec.open``.
     """
-    merged = {"Accept-Encoding": "identity", **(headers or {})}
+    merged = _identity_headers(headers)
     return {"client_kwargs": {"headers": merged}, "get_client": _safe_get_client}
 
 

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -1115,6 +1115,8 @@ def _dispatch_url_format(filename: str, format: str, **kwargs) -> Labels | Video
     Raises:
         ValueError: If `format` is not a recognized format.
     """
+    from sleap_io.io import _remote
+
     if format != "slp":
         kwargs = {k: v for k, v in kwargs.items() if k not in _URL_STREAM_KWARGS}
     dispatch: dict[str, Callable[..., Labels | Video]] = {
@@ -1136,7 +1138,9 @@ def _dispatch_url_format(filename: str, format: str, **kwargs) -> Labels | Video
         return Labels(rois=load_geojson(filename, **kwargs))
     loader = dispatch.get(format)
     if loader is None:
-        raise ValueError(f"Unsupported format '{format}' for URL: '{filename}'.")
+        raise ValueError(
+            f"Unsupported format '{format}' for URL: '{_remote._redact_url(filename)}'."
+        )
     return loader(filename, **kwargs)
 
 
@@ -1227,9 +1231,9 @@ def _load_file_url(
         if sniff is False:
             raise ValueError(
                 f"Cannot infer format for URL with ambiguous extension "
-                f"'{ext}' when sniff=False: '{filename}'. Pass an explicit "
-                "format= (e.g. 'analysis_h5', 'jabs', 'coco', 'labelstudio', "
-                "'alphatracker', 'dlc', 'trackmate', 'csv')."
+                f"'{ext}' when sniff=False: '{_remote._redact_url(filename)}'. "
+                "Pass an explicit format= (e.g. 'analysis_h5', 'jabs', 'coco', "
+                "'labelstudio', 'alphatracker', 'dlc', 'trackmate', 'csv')."
             )
         headers = kwargs.get("headers")
         stream_mode = kwargs.get("stream_mode", "auto")
@@ -1252,7 +1256,7 @@ def _load_file_url(
             return _dispatch_url_format(filename, "csv", **kwargs)
         raise ValueError(
             f"Unsupported or unrecognized content (sniffed '{family}') for "
-            f"URL: '{filename}'. Pass an explicit format=."
+            f"URL: '{_remote._redact_url(filename)}'. Pass an explicit format=."
         )
 
     # Video extension fallback (the genuine video extensions).
@@ -1260,7 +1264,9 @@ def _load_file_url(
         if filename.lower().endswith(vid_ext.lower()):
             return _dispatch_url_format(filename, "video", **kwargs)
 
-    raise ValueError(f"Could not infer format from URL: '{filename}'.")
+    raise ValueError(
+        f"Could not infer format from URL: '{_remote._redact_url(filename)}'."
+    )
 
 
 def _detect_alphatracker_url(url: str, headers: dict[str, str] | None) -> bool:

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
@@ -23,27 +24,106 @@ if TYPE_CHECKING:
     from sleap_io.model.labels_set import LabelsSet
 
 
-def load_slp(filename: str, open_videos: bool = True, lazy: bool = False) -> Labels:
-    """Load a SLEAP dataset.
+def load_slp(
+    filename: str | os.PathLike,
+    open_videos: bool = True,
+    lazy: bool = False,
+    *,
+    headers: dict[str, str] | None = None,
+    stream_mode: str = "auto",
+    cache_storage: str | os.PathLike | None = None,
+    cache_expiry: float | None = None,
+    block_size: int = 1 << 20,
+    max_blocks: int = 32,
+    retries: int = 3,
+) -> Labels:
+    """Load a SLEAP dataset from a local path or HTTP/cloud URL.
+
+    For local paths, all URL-specific keyword arguments are ignored.
 
     Args:
-        filename: Path to a SLEAP labels file (`.slp`).
+        filename: Path to a SLEAP labels file (`.slp`), or a URL. Supported URL
+            schemes: `http`, `https`, `s3`, `gs`, `gcs`, `az`, `abfs`. Cloud
+            schemes require `pip install 'sleap-io[cloud]'`.
         open_videos: If `True` (the default), attempt to open the video backend for
             I/O. If `False`, the backend will not be opened (useful for reading metadata
             when the video files are not available).
         lazy: If `True`, defer instance materialization for faster loading.
             Lazy-loaded Labels support read operations and fast numpy/save.
             To modify, call `labels.materialize()` first. Default is `False`.
+        headers: HTTP headers (e.g. `{"Authorization": "Bearer ..."}`) forwarded
+            to fsspec for URL loads. Stripped on cross-origin redirect. Ignored
+            for local paths.
+        stream_mode: Remote streaming strategy (ignored for local paths). One of:
+            `"auto"` (default; uses fsspec `blockcache` for lazy range reads),
+            `"blockcache"`, `"cache"` (full download via `simplecache`),
+            `"filecache"` (download with ETag revalidation), or `"download"`
+            (ephemeral full download into memory).
+        cache_storage: Override fsspec's cache directory for `cache`/`filecache`
+            modes. Ignored for local paths.
+        cache_expiry: TTL (seconds) for `filecache` revalidation. Defaults to
+            3600 (1h) when not given. Ignored for other modes and local paths.
+        block_size: Range block size in bytes for `blockcache` mode. Default:
+            1 MiB. Ignored for local paths.
+        max_blocks: Max blocks kept in the in-memory LRU per open file. Default:
+            32 (32 MiB cap per open file). Ignored for local paths.
+        retries: Retry count for transient HTTP errors. Default: 3. Ignored for
+            local paths.
 
     Returns:
         The dataset as a `Labels` object.
+
+    Raises:
+        RemoteIOError: For HTTP errors against URLs (404, 416, 5xx after
+            retries, connection failures).
+        ImportError: For cloud schemes when the corresponding extra is not
+            installed.
+        ValueError: For an unrecognized `stream_mode`.
 
     See Also:
         Labels.is_lazy: Check if Labels is lazy-loaded.
         Labels.materialize: Convert lazy Labels to eager.
     """
-    from sleap_io.io import slp
+    import h5py
 
+    from sleap_io.io import _remote, slp
+
+    if _remote._is_url(filename):
+        url = os.fspath(filename) if isinstance(filename, os.PathLike) else filename
+        file_like = _remote.open_url(
+            url,
+            headers=headers,
+            stream_mode=stream_mode,
+            cache_storage=cache_storage,
+            cache_expiry=cache_expiry,
+            block_size=block_size,
+            max_blocks=max_blocks,
+        )
+        try:
+            with h5py.File(file_like, "r") as f:
+                if lazy:
+                    labels = slp._read_labels_lazy_from_open_file(
+                        url, f, open_videos=open_videos
+                    )
+                else:
+                    labels = slp._read_labels_from_open_file(
+                        url, f, open_videos=open_videos
+                    )
+        finally:
+            file_like.close()
+
+        # Propagate URL config to embedded HDF5Video backends so they can reopen
+        # the remote file lazily on frame reads.
+        from sleap_io.io.video_reading import HDF5Video
+
+        resolved_mode = "blockcache" if stream_mode == "auto" else stream_mode
+        for video in labels.videos:
+            if isinstance(video.backend, HDF5Video):
+                object.__setattr__(video.backend, "_url_headers", headers)
+                object.__setattr__(video.backend, "_url_stream_mode", resolved_mode)
+        return labels
+
+    # Local path - UNCHANGED behaviour; URL-specific kwargs are no-ops.
     if lazy:
         return slp._read_labels_lazy(filename, open_videos=open_videos)
     return slp.read_labels(filename, open_videos=open_videos)
@@ -462,6 +542,73 @@ def save_geojson(rois: list, filename: str) -> None:
     geojson.write_rois(rois, filename)
 
 
+def _is_alphatracker_data(data: object) -> bool:
+    """Classify already-parsed JSON data as AlphaTracker format.
+
+    Args:
+        data: The parsed JSON object.
+
+    Returns:
+        True if the data matches the AlphaTracker schema, False otherwise.
+    """
+    # AlphaTracker format is a list of frame objects
+    if not isinstance(data, list):
+        return False
+
+    if len(data) == 0:
+        return False
+
+    # Check first frame structure
+    first_frame = data[0]
+    if not isinstance(first_frame, dict):
+        return False
+
+    # AlphaTracker frames have "filename", "class": "image", and "annotations"
+    has_required = (
+        "filename" in first_frame
+        and first_frame.get("class") == "image"
+        and "annotations" in first_frame
+    )
+
+    if not has_required:
+        return False
+
+    # Check annotations structure
+    annotations = first_frame.get("annotations", [])
+    if not isinstance(annotations, list):
+        return False
+
+    # Check for Face and point classes
+    has_face = any(a.get("class") == "Face" for a in annotations)
+    has_point = any(a.get("class") == "point" for a in annotations)
+
+    return has_face and has_point
+
+
+def _is_coco_data(data: object) -> bool:
+    """Classify already-parsed JSON data as COCO (pose) format.
+
+    Args:
+        data: The parsed JSON object.
+
+    Returns:
+        True if the data matches the COCO pose schema, False otherwise.
+    """
+    if not isinstance(data, dict):
+        return False
+
+    # COCO format has specific top-level fields
+    coco_fields = {"images", "annotations", "categories"}
+    has_coco_fields = all(field in data for field in coco_fields)
+
+    # Check if categories have keypoints (pose data)
+    has_keypoints = False
+    if "categories" in data:
+        has_keypoints = any("keypoints" in cat for cat in data["categories"])
+
+    return has_coco_fields and has_keypoints
+
+
 def _detect_alphatracker_format(json_path: str) -> bool:
     """Detect if a JSON file is in AlphaTracker format.
 
@@ -476,42 +623,9 @@ def _detect_alphatracker_format(json_path: str) -> bool:
 
         with open(json_path, "r") as f:
             data = json.load(f)
-
-        # AlphaTracker format is a list of frame objects
-        if not isinstance(data, list):
-            return False
-
-        if len(data) == 0:
-            return False
-
-        # Check first frame structure
-        first_frame = data[0]
-        if not isinstance(first_frame, dict):
-            return False
-
-        # AlphaTracker frames have "filename", "class": "image", and "annotations"
-        has_required = (
-            "filename" in first_frame
-            and first_frame.get("class") == "image"
-            and "annotations" in first_frame
-        )
-
-        if not has_required:
-            return False
-
-        # Check annotations structure
-        annotations = first_frame.get("annotations", [])
-        if not isinstance(annotations, list):
-            return False
-
-        # Check for Face and point classes
-        has_face = any(a.get("class") == "Face" for a in annotations)
-        has_point = any(a.get("class") == "point" for a in annotations)
-
-        return has_face and has_point
-
     except Exception:
         return False
+    return _is_alphatracker_data(data)
 
 
 def _detect_coco_format(json_path: str) -> bool:
@@ -528,19 +642,9 @@ def _detect_coco_format(json_path: str) -> bool:
 
         with open(json_path, "r") as f:
             data = json.load(f)
-
-        # COCO format has specific top-level fields
-        coco_fields = {"images", "annotations", "categories"}
-        has_coco_fields = all(field in data for field in coco_fields)
-
-        # Check if categories have keypoints (pose data)
-        has_keypoints = False
-        if "categories" in data:
-            has_keypoints = any("keypoints" in cat for cat in data["categories"])
-
-        return has_coco_fields and has_keypoints
     except Exception:
         return False
+    return _is_coco_data(data)
 
 
 def load_leap(
@@ -773,6 +877,15 @@ def load_video(filename: str, **kwargs) -> Video:
         set_default_video_plugin: Set the default video plugin globally.
         get_default_video_plugin: Get the current default video plugin.
     """
+    from sleap_io.io import _remote
+
+    if _remote._is_url(filename):
+        raise NotImplementedError(
+            "Remote video loading is not yet implemented "
+            f"(URL: {_remote._redact_url(str(filename))}). Tracked as a "
+            "follow-up PR in the remote loaders feature stack. For now, "
+            "download the file locally before calling load_video()."
+        )
     return Video.from_filename(filename, **kwargs)
 
 
@@ -826,16 +939,27 @@ def save_video(
 
 
 def load_file(
-    filename: str | Path, format: str | None = None, **kwargs
+    filename: str | Path,
+    format: str | None = None,
+    *,
+    sniff: bool | None = None,
+    **kwargs,
 ) -> Labels | Video:
     """Load a file and return the appropriate object.
 
     Args:
-        filename: Path to a file.
+        filename: Path to a file, or a URL (`http`, `https`, `s3`, `gs`, `gcs`,
+            `az`, `abfs`).
         format: Optional format to load as. If not provided, will be inferred from the
             file extension. Available formats are: "slp", "nwb", "geojson",
             "alphatracker", "labelstudio", "coco", "jabs", "analysis_h5", "dlc",
             "trackmate", "ultralytics", "leap", and "video".
+        sniff: Controls magic-byte sniffing for URLs with ambiguous extensions
+            (`.h5`, `.json`, `.csv`). If `True`, fetch the first bytes via a
+            Range request to disambiguate. If `None` (default), sniff only for
+            URLs with ambiguous extensions (never for local paths, where opening
+            the file is cheap). If `False`, never sniff; raise `ValueError` on an
+            ambiguous URL extension when no explicit `format` is given.
         **kwargs: Additional arguments passed to the format-specific loading function:
             - For "slp" format: No additional arguments.
             - For "nwb" format: No additional arguments.
@@ -862,6 +986,11 @@ def load_file(
     """
     if isinstance(filename, Path):
         filename = filename.as_posix()
+
+    from sleap_io.io import _remote
+
+    if _remote._is_url(filename):
+        return _load_file_url(filename, format=format, sniff=sniff, **kwargs)
 
     if format is None:
         if filename.lower().endswith(".slp"):
@@ -939,6 +1068,246 @@ def load_file(
         return Labels(rois=load_geojson(filename))
     elif format == "video":
         return load_video(filename, **kwargs)
+
+
+#: Loaders for unambiguous URL extensions that need no magic-byte sniffing.
+_URL_UNAMBIGUOUS_EXTS: dict[str, str] = {
+    ".slp": "slp",
+    ".nwb": "nwb",
+    ".mat": "leap",
+    ".geojson": "geojson",
+}
+
+#: URL extensions that map to multiple formats and require sniffing.
+_URL_AMBIGUOUS_EXTS = frozenset({".h5", ".json", ".csv"})
+
+#: Keyword args understood only by `load_slp` (the only URL-aware loader in this
+#: PR). They are stripped before dispatching to any other loader.
+_URL_STREAM_KWARGS = frozenset(
+    {
+        "headers",
+        "stream_mode",
+        "cache_storage",
+        "cache_expiry",
+        "block_size",
+        "max_blocks",
+        "retries",
+    }
+)
+
+
+def _dispatch_url_format(filename: str, format: str, **kwargs) -> Labels | Video:
+    """Dispatch a URL to a concrete loader given a resolved format string.
+
+    URL-streaming-only kwargs (see `_URL_STREAM_KWARGS`) are forwarded only to
+    `load_slp`; other loaders are not URL-aware in this PR and would reject
+    them, so they are stripped before dispatch.
+
+    Args:
+        filename: The URL to load.
+        format: The resolved format name (e.g. ``"slp"``, ``"coco"``).
+        **kwargs: Forwarded to the underlying loader.
+
+    Returns:
+        The loaded `Labels` or `Video` object.
+
+    Raises:
+        ValueError: If `format` is not a recognized format.
+    """
+    if format != "slp":
+        kwargs = {k: v for k, v in kwargs.items() if k not in _URL_STREAM_KWARGS}
+    dispatch: dict[str, Callable[..., Labels | Video]] = {
+        "slp": load_slp,
+        "nwb": load_nwb,
+        "leap": load_leap,
+        "alphatracker": load_alphatracker,
+        "coco": load_coco,
+        "labelstudio": load_labelstudio,
+        "analysis_h5": load_analysis_h5,
+        "jabs": load_jabs,
+        "dlc": load_dlc,
+        "csv": load_csv,
+        "trackmate": load_trackmate,
+        "ultralytics": load_ultralytics,
+        "video": load_video,
+    }
+    if format == "geojson":
+        return Labels(rois=load_geojson(filename, **kwargs))
+    loader = dispatch.get(format)
+    if loader is None:
+        raise ValueError(f"Unsupported format '{format}' for URL: '{filename}'.")
+    return loader(filename, **kwargs)
+
+
+def _resolve_hdf5_url_format(
+    url: str,
+    headers: dict[str, str] | None,
+    *,
+    stream_mode: str = "auto",
+) -> str:
+    """Disambiguate an HDF5 URL into ``slp``/``analysis_h5``/``jabs``.
+
+    Opens the remote file via fsspec and inspects its top-level group
+    structure: a `track_occupancy` dataset marks an Analysis HDF5 file, a
+    `metadata` group marks a `.slp` file, and anything else falls back to JABS.
+
+    Args:
+        url: The HDF5 URL to inspect.
+        headers: Optional HTTP headers for the probe.
+        stream_mode: Streaming strategy for the probe (mirrors the value that
+            will be used for the full load).
+
+    Returns:
+        One of ``"slp"``, ``"analysis_h5"``, or ``"jabs"``.
+    """
+    import h5py
+
+    from sleap_io.io import _remote
+
+    file_like = _remote.open_url(url, headers=headers, stream_mode=stream_mode)
+    try:
+        with h5py.File(file_like, "r") as f:
+            if "track_occupancy" in f:
+                return "analysis_h5"
+            if "metadata" in f:
+                return "slp"
+            return "jabs"
+    finally:
+        file_like.close()
+
+
+def _load_file_url(
+    filename: str,
+    *,
+    format: str | None = None,
+    sniff: bool | None = None,
+    **kwargs,
+) -> Labels | Video:
+    """Load a labels/video file from a URL with extension + magic-byte routing.
+
+    The local content-detectors used by `load_file` call `open()` on the path,
+    which breaks for URLs, so URL routing relies on the extension plus (for
+    ambiguous extensions) a magic-byte sniff via a ranged read.
+
+    Args:
+        filename: The URL to load.
+        format: Explicit format. If given, dispatch directly.
+        sniff: Sniff control (see `load_file`). For ambiguous extensions,
+            `True`/`None` sniff via fsspec; `False` raises without a format.
+        **kwargs: Forwarded to the underlying loader (URL streaming kwargs such
+            as `headers`/`stream_mode` flow through to `load_slp`).
+
+    Returns:
+        The loaded `Labels` or `Video` object.
+
+    Raises:
+        ValueError: If the format cannot be inferred and sniffing is disabled,
+            or the sniffed magic bytes are unsupported/unrecognized.
+    """
+    import urllib.parse
+
+    from sleap_io.io import _remote
+
+    # Explicit format always wins, bypassing detection entirely.
+    if format is not None:
+        return _dispatch_url_format(filename, format, **kwargs)
+
+    parsed = urllib.parse.urlparse(filename)
+    ext = "".join(Path(parsed.path).suffixes[-1:]).lower()
+
+    # Unambiguous labels extension: dispatch by extension exactly like local.
+    if ext in _URL_UNAMBIGUOUS_EXTS:
+        return _dispatch_url_format(filename, _URL_UNAMBIGUOUS_EXTS[ext], **kwargs)
+
+    # Ambiguous extension (.h5/.json/.csv): sniff unless explicitly disabled.
+    # Checked before the video-extension fallback because `Video.EXTS` also
+    # lists `h5`/`hdf5`, which here mean a labels file, not a video.
+    if ext in _URL_AMBIGUOUS_EXTS:
+        if sniff is False:
+            raise ValueError(
+                f"Cannot infer format for URL with ambiguous extension "
+                f"'{ext}' when sniff=False: '{filename}'. Pass an explicit "
+                "format= (e.g. 'analysis_h5', 'jabs', 'coco', 'labelstudio', "
+                "'alphatracker', 'dlc', 'trackmate', 'csv')."
+            )
+        headers = kwargs.get("headers")
+        stream_mode = kwargs.get("stream_mode", "auto")
+        family = _remote._sniff_format(filename, headers=headers)
+        if family == "hdf5":
+            resolved = _resolve_hdf5_url_format(
+                filename, headers, stream_mode=stream_mode
+            )
+            return _dispatch_url_format(filename, resolved, **kwargs)
+        if family == "json":
+            if _detect_alphatracker_url(filename, headers):
+                return _dispatch_url_format(filename, "alphatracker", **kwargs)
+            if _detect_coco_url(filename, headers):
+                return _dispatch_url_format(filename, "coco", **kwargs)
+            return _dispatch_url_format(filename, "labelstudio", **kwargs)
+        if family == "csv":
+            # Without downloading the full CSV we cannot cheaply distinguish
+            # DLC/TrackMate from a generic SLEAP CSV; default to the generic
+            # reader. Pass an explicit format= to force dlc/trackmate.
+            return _dispatch_url_format(filename, "csv", **kwargs)
+        raise ValueError(
+            f"Unsupported or unrecognized content (sniffed '{family}') for "
+            f"URL: '{filename}'. Pass an explicit format=."
+        )
+
+    # Video extension fallback (the genuine video extensions).
+    for vid_ext in Video.EXTS:
+        if filename.lower().endswith(vid_ext.lower()):
+            return _dispatch_url_format(filename, "video", **kwargs)
+
+    raise ValueError(f"Could not infer format from URL: '{filename}'.")
+
+
+def _detect_alphatracker_url(url: str, headers: dict[str, str] | None) -> bool:
+    """Return True if a JSON URL is in AlphaTracker format.
+
+    Args:
+        url: The JSON URL to inspect.
+        headers: Optional HTTP headers.
+
+    Returns:
+        True if the content matches the AlphaTracker schema, else False.
+    """
+    import json
+
+    from sleap_io.io import _remote
+
+    file_like = _remote.open_url(url, headers=headers, stream_mode="download")
+    try:
+        data = json.loads(file_like.read())
+    except Exception:
+        return False
+    finally:
+        file_like.close()
+    return _is_alphatracker_data(data)
+
+
+def _detect_coco_url(url: str, headers: dict[str, str] | None) -> bool:
+    """Return True if a JSON URL is in COCO format.
+
+    Args:
+        url: The JSON URL to inspect.
+        headers: Optional HTTP headers.
+
+    Returns:
+        True if the content matches the COCO schema, else False.
+    """
+    import json
+
+    from sleap_io.io import _remote
+
+    file_like = _remote.open_url(url, headers=headers, stream_mode="download")
+    try:
+        data = json.loads(file_like.read())
+    except Exception:
+        return False
+    finally:
+        file_like.close()
+    return _is_coco_data(data)
 
 
 def save_file(

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -100,15 +100,24 @@ def load_slp(
             max_blocks=max_blocks,
             retries=retries,
         )
+        resolved_mode = "blockcache" if stream_mode == "auto" else stream_mode
         try:
             with h5py.File(file_like, "r") as f:
                 if lazy:
                     labels = slp._read_labels_lazy_from_open_file(
-                        url, f, open_videos=open_videos
+                        url,
+                        f,
+                        open_videos=open_videos,
+                        _url_headers=headers,
+                        _url_stream_mode=resolved_mode,
                     )
                 else:
                     labels = slp._read_labels_from_open_file(
-                        url, f, open_videos=open_videos
+                        url,
+                        f,
+                        open_videos=open_videos,
+                        _url_headers=headers,
+                        _url_stream_mode=resolved_mode,
                     )
         finally:
             file_like.close()
@@ -117,7 +126,6 @@ def load_slp(
         # the remote file lazily on frame reads.
         from sleap_io.io.video_reading import HDF5Video
 
-        resolved_mode = "blockcache" if stream_mode == "auto" else stream_mode
         for video in labels.videos:
             if isinstance(video.backend, HDF5Video):
                 object.__setattr__(video.backend, "_url_headers", headers)
@@ -1082,27 +1090,21 @@ _URL_UNAMBIGUOUS_EXTS: dict[str, str] = {
 #: URL extensions that map to multiple formats and require sniffing.
 _URL_AMBIGUOUS_EXTS = frozenset({".h5", ".json", ".csv"})
 
-#: Keyword args understood only by `load_slp` (the only URL-aware loader in this
-#: PR). They are stripped before dispatching to any other loader.
-_URL_STREAM_KWARGS = frozenset(
-    {
-        "headers",
-        "stream_mode",
-        "cache_storage",
-        "cache_expiry",
-        "block_size",
-        "max_blocks",
-        "retries",
-    }
-)
+
+#: URL-loadable formats. Only `.slp` (and `.pkg.slp`) loading is implemented
+#: for remote URLs in this PR; every other format's loader opens the path
+#: locally and would fail with a cryptic `OSError` over a URL, so those are
+#: gated behind a clean `NotImplementedError` (mirroring `load_video(url)`).
+_URL_IMPLEMENTED_FORMATS = frozenset({"slp"})
 
 
 def _dispatch_url_format(filename: str, format: str, **kwargs) -> Labels | Video:
     """Dispatch a URL to a concrete loader given a resolved format string.
 
-    URL-streaming-only kwargs (see `_URL_STREAM_KWARGS`) are forwarded only to
-    `load_slp`; other loaders are not URL-aware in this PR and would reject
-    them, so they are stripped before dispatch.
+    Only the `slp` format is URL-aware in this PR; every other format's loader
+    opens the path with a local file `open()` and would fail with a cryptic
+    `OSError` over a URL, so those are gated behind a clean `NotImplementedError`
+    (mirroring `load_video(url)`).
 
     Args:
         filename: The URL to load.
@@ -1114,34 +1116,40 @@ def _dispatch_url_format(filename: str, format: str, **kwargs) -> Labels | Video
 
     Raises:
         ValueError: If `format` is not a recognized format.
+        NotImplementedError: If `format` is recognized but remote loading for it
+            is not yet implemented (every format other than `slp`).
     """
     from sleap_io.io import _remote
 
-    if format != "slp":
-        kwargs = {k: v for k, v in kwargs.items() if k not in _URL_STREAM_KWARGS}
-    dispatch: dict[str, Callable[..., Labels | Video]] = {
-        "slp": load_slp,
-        "nwb": load_nwb,
-        "leap": load_leap,
-        "alphatracker": load_alphatracker,
-        "coco": load_coco,
-        "labelstudio": load_labelstudio,
-        "analysis_h5": load_analysis_h5,
-        "jabs": load_jabs,
-        "dlc": load_dlc,
-        "csv": load_csv,
-        "trackmate": load_trackmate,
-        "ultralytics": load_ultralytics,
-        "video": load_video,
+    known_formats = {
+        "slp",
+        "nwb",
+        "leap",
+        "alphatracker",
+        "coco",
+        "labelstudio",
+        "analysis_h5",
+        "jabs",
+        "dlc",
+        "csv",
+        "trackmate",
+        "ultralytics",
+        "video",
+        "geojson",
     }
-    if format == "geojson":
-        return Labels(rois=load_geojson(filename, **kwargs))
-    loader = dispatch.get(format)
-    if loader is None:
+    if format not in known_formats:
         raise ValueError(
             f"Unsupported format '{format}' for URL: '{_remote._redact_url(filename)}'."
         )
-    return loader(filename, **kwargs)
+
+    if format not in _URL_IMPLEMENTED_FORMATS:
+        raise NotImplementedError(
+            f"Remote {format} loading is not yet implemented "
+            f"(URL: {_remote._redact_url(filename)}); tracked as a follow-up. "
+            "Download the file locally first."
+        )
+
+    return load_slp(filename, **kwargs)
 
 
 def _resolve_hdf5_url_format(

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -98,6 +98,7 @@ def load_slp(
             cache_expiry=cache_expiry,
             block_size=block_size,
             max_blocks=max_blocks,
+            retries=retries,
         )
         try:
             with h5py.File(file_like, "r") as f:

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import sys
 import warnings
 import zlib
+from contextlib import nullcontext
 from enum import Enum, IntEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
@@ -346,7 +347,12 @@ def make_video(
     )
 
 
-def read_videos(labels_path: str, open_backend: bool = True) -> list[Video]:
+def read_videos(
+    labels_path: str,
+    open_backend: bool = True,
+    *,
+    _hdf5_file: h5py.File | None = None,
+) -> list[Video]:
     """Read `Video` dataset in a SLEAP labels file.
 
     Args:
@@ -354,14 +360,18 @@ def read_videos(labels_path: str, open_backend: bool = True) -> list[Video]:
         open_backend: If `True` (the default), attempt to open the video backend for
             I/O. If `False`, the backend will not be opened (useful for reading metadata
             when the video files are not available).
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (which is left open for the caller
+            to close) and threaded into `make_video`; otherwise `labels_path` is
+            opened and closed internally. This is a private argument used to thread
+            a single open handle through multiple reads.
 
     Returns:
         A list of `Video` objects.
     """
     videos = []
-    # Open file once and pass handle to make_video to avoid repeated opens
-    # for embedded videos (which would otherwise open the file per video).
-    with h5py.File(labels_path, "r") as f:
+
+    def _read_videos(f: h5py.File) -> None:
         videos_metadata = f["videos_json"][:]
         for video_data in videos_metadata:
             video_json = json.loads(video_data)
@@ -369,6 +379,14 @@ def read_videos(labels_path: str, open_backend: bool = True) -> list[Video]:
                 labels_path, video_json, open_backend=open_backend, _hdf5_file=f
             )
             videos.append(video)
+
+    # Open file once and pass handle to make_video to avoid repeated opens
+    # for embedded videos (which would otherwise open the file per video).
+    if _hdf5_file is not None:
+        _read_videos(_hdf5_file)
+    else:
+        with h5py.File(labels_path, "r") as f:
+            _read_videos(f)
     return videos
 
 
@@ -1176,16 +1194,25 @@ def write_videos(
                     )
 
 
-def read_tracks(labels_path: str) -> list[Track]:
+def read_tracks(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> list[Track]:
     """Read `Track` dataset in a SLEAP labels file.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A list of `Track` objects.
     """
-    tracks = [json.loads(x) for x in read_hdf5_dataset(labels_path, "tracks_json")]
+    tracks = [
+        json.loads(x)
+        for x in read_hdf5_dataset(labels_path, "tracks_json", _hdf5_file=_hdf5_file)
+    ]
     track_objects = []
     for track in tracks:
         track_objects.append(Track(name=track[1]))
@@ -1209,17 +1236,25 @@ def write_tracks(labels_path: str, tracks: list[Track]):
         f.create_dataset("tracks_json", data=tracks_json, maxshape=(None,))
 
 
-def read_identities(labels_path: str) -> list[Identity]:
+def read_identities(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> list[Identity]:
     """Read Identity dataset from a SLEAP labels file.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A list of `Identity` objects.
     """
     try:
-        identities = read_hdf5_dataset(labels_path, "identities_json")
+        identities = read_hdf5_dataset(
+            labels_path, "identities_json", _hdf5_file=_hdf5_file
+        )
     except KeyError:
         return []
     identity_objects = []
@@ -1257,18 +1292,29 @@ def write_identities(labels_path: str, identities: list[Identity]):
         f.create_dataset("identities_json", data=identities_json, maxshape=(None,))
 
 
-def read_suggestions(labels_path: str, videos: list[Video]) -> list[SuggestionFrame]:
+def read_suggestions(
+    labels_path: str,
+    videos: list[Video],
+    *,
+    _hdf5_file: h5py.File | None = None,
+) -> list[SuggestionFrame]:
     """Read `SuggestionFrame` dataset in a SLEAP labels file.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
         videos: A list of `Video` objects.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A list of `SuggestionFrame` objects.
     """
     try:
-        suggestions = read_hdf5_dataset(labels_path, "suggestions_json")
+        suggestions = read_hdf5_dataset(
+            labels_path, "suggestions_json", _hdf5_file=_hdf5_file
+        )
     except KeyError:
         return []
     suggestions = [json.loads(x) for x in suggestions]
@@ -1368,33 +1414,43 @@ def write_negative_frames(labels_path: str, labels: Labels):
             f.create_dataset("negative_frames", data=data)
 
 
-def read_negative_frames(labels_path: str) -> set[tuple[int, int]]:
+def read_negative_frames(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> set[tuple[int, int]]:
     """Read negative frame markers from a SLEAP labels file.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A set of (sparse_video_id, frame_idx) tuples identifying negative frames.
         Returns empty set if no negative frames dataset exists.
     """
     try:
-        data = read_hdf5_dataset(labels_path, "negative_frames")
+        data = read_hdf5_dataset(labels_path, "negative_frames", _hdf5_file=_hdf5_file)
         return {(int(row["video_id"]), int(row["frame_idx"])) for row in data}
     except KeyError:
         return set()
 
 
-def read_metadata(labels_path: str) -> dict:
+def read_metadata(labels_path: str, *, _hdf5_file: h5py.File | None = None) -> dict:
     """Read metadata from a SLEAP labels file.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A dict containing the metadata from a SLEAP labels file.
     """
-    md = read_hdf5_attrs(labels_path, "metadata", "json")
+    md = read_hdf5_attrs(labels_path, "metadata", "json", _hdf5_file=_hdf5_file)
     if isinstance(md, bytes):
         md = md.decode()
     elif isinstance(md, np.ndarray):
@@ -1403,16 +1459,22 @@ def read_metadata(labels_path: str) -> dict:
     return json.loads(md)
 
 
-def read_skeletons(labels_path: str) -> list[Skeleton]:
+def read_skeletons(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> list[Skeleton]:
     """Read `Skeleton` dataset from a SLEAP labels file.
 
     Args:
         labels_path: A string that contains the path to the labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A list of `Skeleton` objects.
     """
-    metadata = read_metadata(labels_path)
+    metadata = read_metadata(labels_path, _hdf5_file=_hdf5_file)
 
     # Get node names. This is a superset of all nodes across all skeletons. Note that
     # node ordering is specific to each skeleton, so we'll need to fix this afterwards.
@@ -1528,29 +1590,39 @@ def write_metadata(labels_path: str, labels: Labels):
         grp.attrs["json"] = np.bytes_(json.dumps(md, separators=(",", ":")))
 
 
-def read_points(labels_path: str) -> np.ndarray:
+def read_points(labels_path: str, *, _hdf5_file: h5py.File | None = None) -> np.ndarray:
     """Read points dataset from a SLEAP labels file.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A structured array of point data.
     """
-    pts = read_hdf5_dataset(labels_path, "points")
+    pts = read_hdf5_dataset(labels_path, "points", _hdf5_file=_hdf5_file)
     return pts
 
 
-def read_pred_points(labels_path: str) -> np.ndarray:
+def read_pred_points(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> np.ndarray:
     """Read predicted points dataset from a SLEAP labels file.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A structured array of predicted point data.
     """
-    pred_pts = read_hdf5_dataset(labels_path, "pred_points")
+    pred_pts = read_hdf5_dataset(labels_path, "pred_points", _hdf5_file=_hdf5_file)
     return pred_pts
 
 
@@ -1600,6 +1672,8 @@ def read_instances(
     points: np.ndarray,
     pred_points: np.ndarray,
     format_id: float,
+    *,
+    _hdf5_file: h5py.File | None = None,
 ) -> list[Instance | PredictedInstance]:
     """Read `Instance` dataset in a SLEAP labels file.
 
@@ -1612,11 +1686,15 @@ def read_instances(
             `read_pred_points`).
         format_id: The format version identifier used to specify the format of the input
             file.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A list of `Instance` and/or `PredictedInstance` objects.
     """
-    instances_data = read_hdf5_dataset(labels_path, "instances")
+    instances_data = read_hdf5_dataset(labels_path, "instances", _hdf5_file=_hdf5_file)
 
     instances = {}
     from_predicted_pairs = []
@@ -2209,6 +2287,8 @@ def read_sessions(
     videos: list[Video],
     labeled_frames: list[LabeledFrame],
     identities: list[Identity] | None = None,
+    *,
+    _hdf5_file: h5py.File | None = None,
 ) -> list[RecordingSession]:
     """Read `RecordingSession` dataset from a SLEAP labels file.
 
@@ -2221,12 +2301,18 @@ def read_sessions(
         labeled_frames: A list of `LabeledFrame` objects.
         identities: Optional list of `Identity` objects for resolving identity
             indices.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A list of `RecordingSession` objects.
     """
     try:
-        sessions = read_hdf5_dataset(labels_path, "sessions_json")
+        sessions = read_hdf5_dataset(
+            labels_path, "sessions_json", _hdf5_file=_hdf5_file
+        )
     except KeyError:
         return []
     sessions = [json.loads(x) for x in sessions]
@@ -2550,30 +2636,53 @@ def _read_labels_lazy(labels_path: str, open_videos: bool = True) -> Labels:
     Returns:
         Labels with LazyFrameList for labeled_frames.
     """
+    with h5py.File(labels_path, "r") as f:
+        return _read_labels_lazy_from_open_file(labels_path, f, open_videos=open_videos)
+
+
+def _read_labels_lazy_from_open_file(
+    labels_path: str, f: h5py.File, *, open_videos: bool = True
+) -> Labels:
+    """Build a lazy `Labels` from an already-open `h5py.File`.
+
+    Threads `_hdf5_file=f` through every `read_*` helper so the entire metadata
+    read happens against a single open handle. Does NOT close `f` (the caller's
+    `with` block owns it). The long-lived label-image handle returned by
+    `read_label_images` (a separate, second handle) is attached to
+    `labels._label_image_file` and intentionally outlives `f`.
+
+    Args:
+        labels_path: Path to .slp file.
+        f: An already-open `h5py.File` handle to read from.
+        open_videos: Whether to open video backends.
+
+    Returns:
+        Labels with LazyFrameList for labeled_frames.
+    """
     from sleap_io.io.slp_lazy import LazyDataStore, LazyFrameList
 
     # Read raw arrays
-    frames_data = read_hdf5_dataset(labels_path, "frames")
-    instances_data = read_hdf5_dataset(labels_path, "instances")
-    points_data = read_points(labels_path)
-    pred_points_data = read_pred_points(labels_path)
+    frames_data = read_hdf5_dataset(labels_path, "frames", _hdf5_file=f)
+    instances_data = read_hdf5_dataset(labels_path, "instances", _hdf5_file=f)
+    points_data = read_points(labels_path, _hdf5_file=f)
+    pred_points_data = read_pred_points(labels_path, _hdf5_file=f)
 
     # Read format ID
-    format_id = read_hdf5_attrs(labels_path, "metadata", "format_id")
+    format_id = read_hdf5_attrs(labels_path, "metadata", "format_id", _hdf5_file=f)
 
     # Read metadata eagerly (these are small and needed for lazy access)
-    videos = read_videos(labels_path, open_backend=open_videos)
-    skeletons = read_skeletons(labels_path)
-    tracks = read_tracks(labels_path)
-    suggestions = read_suggestions(labels_path, videos)
-    metadata = read_metadata(labels_path)
+    videos = read_videos(labels_path, open_backend=open_videos, _hdf5_file=f)
+    skeletons = read_skeletons(labels_path, _hdf5_file=f)
+    tracks = read_tracks(labels_path, _hdf5_file=f)
+    suggestions = read_suggestions(labels_path, videos, _hdf5_file=f)
+    metadata = read_metadata(labels_path, _hdf5_file=f)
     provenance = metadata.get("provenance", dict())
-    negative_frames = read_negative_frames(labels_path)
+    negative_frames = read_negative_frames(labels_path, _hdf5_file=f)
 
     # Read sessions (small, no need for lazy loading)
     # Note: sessions require labeled_frames for full linking, but for lazy loading
     # we pass an empty list since we don't have materialized frames yet
-    sessions = read_sessions(labels_path, videos, [])
+    sessions = read_sessions(labels_path, videos, [], _hdf5_file=f)
 
     # Create LazyDataStore
     lazy_store = LazyDataStore(
@@ -2593,11 +2702,11 @@ def _read_labels_lazy(labels_path: str, open_videos: bool = True) -> Labels:
     lazy_frames = LazyFrameList(lazy_store)
 
     # Read ROIs, masks, bboxes, and label images eagerly (typically small count)
-    roi_tuples = read_rois(labels_path, videos, tracks)
-    mask_tuples = read_masks(labels_path, videos, tracks)
-    bbox_tuples = read_bboxes(labels_path, videos, tracks)
-    centroid_tuples = read_centroids(labels_path, videos, tracks)
-    li_tuples, li_file = read_label_images(labels_path, videos, tracks)
+    roi_tuples = read_rois(labels_path, videos, tracks, _hdf5_file=f)
+    mask_tuples = read_masks(labels_path, videos, tracks, _hdf5_file=f)
+    bbox_tuples = read_bboxes(labels_path, videos, tracks, _hdf5_file=f)
+    centroid_tuples = read_centroids(labels_path, videos, tracks, _hdf5_file=f)
+    li_tuples, li_file = read_label_images(labels_path, videos, tracks, _hdf5_file=f)
 
     # Build per-frame annotation dicts for lazy materialization
     def _build_ann_by_frame(ann_tuples):
@@ -2692,6 +2801,8 @@ def read_rois(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
+    *,
+    _hdf5_file: h5py.File | None = None,
 ) -> list[tuple[ROI, int, int]]:
     """Read ROI annotations from a SLEAP labels file.
 
@@ -2702,6 +2813,10 @@ def read_rois(
         instances: Optional list of Instance/PredictedInstance objects for
             relinking ROI instance associations. If ``None``, instance
             associations will not be restored.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A list of ``(roi, video_idx, frame_idx)`` tuples. ``video_idx`` and
@@ -2711,7 +2826,7 @@ def read_rois(
     import shapely
 
     try:
-        roi_data = read_hdf5_dataset(labels_path, "rois")
+        roi_data = read_hdf5_dataset(labels_path, "rois", _hdf5_file=_hdf5_file)
     except KeyError:
         return []
 
@@ -2720,12 +2835,17 @@ def read_rois(
 
     # Read packed WKB geometry bytes
     try:
-        roi_wkb_flat = read_hdf5_dataset(labels_path, "roi_wkb")
+        roi_wkb_flat = read_hdf5_dataset(labels_path, "roi_wkb", _hdf5_file=_hdf5_file)
     except KeyError:
         return []
 
     # Read string metadata from string datasets first, fall back to JSON attributes
-    with h5py.File(labels_path, "r") as f:
+    cm = (
+        nullcontext(_hdf5_file)
+        if _hdf5_file is not None
+        else h5py.File(labels_path, "r")
+    )
+    with cm as f:
         roi_grp = f["rois"]
         if "roi_categories" in f:
             categories = [
@@ -2922,6 +3042,8 @@ def read_bboxes(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
+    *,
+    _hdf5_file: h5py.File | None = None,
 ) -> list[tuple[BoundingBox, int, int]]:
     """Read bounding box annotations from a SLEAP labels file.
 
@@ -2932,13 +3054,22 @@ def read_bboxes(
         instances: Optional list of Instance/PredictedInstance objects for
             relinking bounding box instance associations. If ``None``, instance
             associations will not be restored.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A list of ``(bbox, video_idx, frame_idx)`` tuples. ``video_idx`` and
         ``frame_idx`` are the routing context read from the file (``-1``
         means undistributable). Returns an empty list if no bboxes are stored.
     """
-    with h5py.File(labels_path, "r") as f:
+    cm = (
+        nullcontext(_hdf5_file)
+        if _hdf5_file is not None
+        else h5py.File(labels_path, "r")
+    )
+    with cm as f:
         if "bboxes" not in f:
             return []
 
@@ -3191,6 +3322,8 @@ def read_centroids(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
+    *,
+    _hdf5_file: h5py.File | None = None,
 ) -> "list[tuple[Centroid, int, int]]":
     """Read centroid annotations from a SLEAP labels file.
 
@@ -3200,6 +3333,10 @@ def read_centroids(
         tracks: List of Track objects for relinking.
         instances: Optional list of Instance/PredictedInstance objects for
             relinking centroid instance associations.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A list of ``(centroid, video_idx, frame_idx)`` tuples. ``video_idx``
@@ -3209,7 +3346,12 @@ def read_centroids(
     """
     from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 
-    with h5py.File(labels_path, "r") as f:
+    cm = (
+        nullcontext(_hdf5_file)
+        if _hdf5_file is not None
+        else h5py.File(labels_path, "r")
+    )
+    with cm as f:
         if "centroids" not in f:
             return []
 
@@ -3383,6 +3525,8 @@ def read_masks(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
+    *,
+    _hdf5_file: h5py.File | None = None,
 ) -> list[tuple[SegmentationMask, int, int]]:
     """Read segmentation masks from a SLEAP labels file.
 
@@ -3393,6 +3537,10 @@ def read_masks(
         instances: Optional list of Instance/PredictedInstance objects for
             relinking mask instance associations. If ``None``, instance
             associations will not be restored.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally. This is a
+            private argument used to thread a single open handle through reads.
 
     Returns:
         A list of ``(mask, video_idx, frame_idx)`` tuples. ``video_idx`` and
@@ -3400,7 +3548,7 @@ def read_masks(
         means undistributable). Returns empty list if none stored.
     """
     try:
-        mask_data = read_hdf5_dataset(labels_path, "masks")
+        mask_data = read_hdf5_dataset(labels_path, "masks", _hdf5_file=_hdf5_file)
     except KeyError:
         return []
 
@@ -3409,13 +3557,20 @@ def read_masks(
 
     # Read packed RLE bytes
     try:
-        mask_rle_flat = read_hdf5_dataset(labels_path, "mask_rle")
+        mask_rle_flat = read_hdf5_dataset(
+            labels_path, "mask_rle", _hdf5_file=_hdf5_file
+        )
     except KeyError:
         return []
 
     # Read string metadata and score maps in a single file open
     score_map_by_idx: dict[int, np.ndarray] = {}
-    with h5py.File(labels_path, "r") as f:
+    cm = (
+        nullcontext(_hdf5_file)
+        if _hdf5_file is not None
+        else h5py.File(labels_path, "r")
+    )
+    with cm as f:
         mask_grp = f["masks"]
         if "mask_categories" in f:
             categories = [
@@ -3734,6 +3889,8 @@ def read_label_images(
     videos: list[Video],
     tracks: list[Track],
     instances: list[Instance | PredictedInstance] | None = None,
+    *,
+    _hdf5_file: h5py.File | None = None,
 ) -> tuple[list[tuple[LabelImage, int, int]], "h5py.File | None"]:
     """Read label image annotations from a SLEAP labels file.
 
@@ -3749,6 +3906,13 @@ def read_label_images(
         instances: Optional list of Instance/PredictedInstance objects for
             relinking label image instance associations. If ``None``, instance
             associations will not be restored.
+        _hdf5_file: An already-open `h5py.File` handle to use for the metadata
+            reads (``label_images`` and ``label_image_objects``). If provided,
+            those reads use this handle (left open for the caller to close).
+            A separate long-lived handle is always opened for lazy pixel data
+            access regardless of this argument, since that handle must outlive
+            the caller's `with` block. This is a private argument used to thread
+            a single open handle through reads.
 
     Returns:
         A tuple of ``(label_image_tuples, h5py_file)`` where
@@ -3760,14 +3924,16 @@ def read_label_images(
         file handle.
     """
     try:
-        li_data = read_hdf5_dataset(labels_path, "label_images")
+        li_data = read_hdf5_dataset(labels_path, "label_images", _hdf5_file=_hdf5_file)
     except KeyError:
         return [], None
 
     if len(li_data) == 0:
         return [], None
 
-    # Open file for lazy pixel data reading
+    # Open a SECOND, long-lived file handle for lazy pixel data reading. This
+    # handle intentionally outlives the orchestrator's `with` block (the closures
+    # below capture it), so it cannot reuse `_hdf5_file`.
     f = h5py.File(labels_path, "r")
 
     if "label_image_data" not in f:
@@ -3779,7 +3945,9 @@ def read_label_images(
 
     # Read objects table
     try:
-        obj_data = read_hdf5_dataset(labels_path, "label_image_objects")
+        obj_data = read_hdf5_dataset(
+            labels_path, "label_image_objects", _hdf5_file=_hdf5_file
+        )
     except KeyError:
         obj_dtype = [
             ("label_id", "i4"),
@@ -5086,21 +5254,45 @@ def read_labels(labels_path: str, open_videos: bool = True) -> Labels:
     Returns:
         The processed `Labels` object.
     """
-    tracks = read_tracks(labels_path)
-    videos = read_videos(labels_path, open_backend=open_videos)
-    skeletons = read_skeletons(labels_path)
-    points = read_points(labels_path)
-    pred_points = read_pred_points(labels_path)
-    format_id = read_hdf5_attrs(labels_path, "metadata", "format_id")
+    with h5py.File(labels_path, "r") as f:
+        return _read_labels_from_open_file(labels_path, f, open_videos=open_videos)
+
+
+def _read_labels_from_open_file(
+    labels_path: str, f: h5py.File, *, open_videos: bool = True
+) -> Labels:
+    """Build a `Labels` from an already-open `h5py.File`.
+
+    Threads `_hdf5_file=f` through every `read_*` helper so the entire eager
+    read happens against a single open handle. Does NOT close `f` (the caller's
+    `with` block owns it). The long-lived label-image handle returned by
+    `read_label_images` (a separate, second handle) is attached to
+    `labels._label_image_file` and intentionally outlives `f`.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        f: An already-open `h5py.File` handle to read from.
+        open_videos: If `True` (the default), attempt to open the video backend
+            for I/O.
+
+    Returns:
+        The processed `Labels` object.
+    """
+    tracks = read_tracks(labels_path, _hdf5_file=f)
+    videos = read_videos(labels_path, open_backend=open_videos, _hdf5_file=f)
+    skeletons = read_skeletons(labels_path, _hdf5_file=f)
+    points = read_points(labels_path, _hdf5_file=f)
+    pred_points = read_pred_points(labels_path, _hdf5_file=f)
+    format_id = read_hdf5_attrs(labels_path, "metadata", "format_id", _hdf5_file=f)
     instances = read_instances(
-        labels_path, skeletons, tracks, points, pred_points, format_id
+        labels_path, skeletons, tracks, points, pred_points, format_id, _hdf5_file=f
     )
-    suggestions = read_suggestions(labels_path, videos)
-    metadata = read_metadata(labels_path)
+    suggestions = read_suggestions(labels_path, videos, _hdf5_file=f)
+    metadata = read_metadata(labels_path, _hdf5_file=f)
     provenance = metadata.get("provenance", dict())
 
-    frames = read_hdf5_dataset(labels_path, "frames")
-    negative_markers = read_negative_frames(labels_path)
+    frames = read_hdf5_dataset(labels_path, "frames", _hdf5_file=f)
+    negative_markers = read_negative_frames(labels_path, _hdf5_file=f)
 
     # Check if video IDs in frames are sequential list indices (0, 1, 2, ..., n-1)
     # or sparse embedded IDs (e.g., 0, 15, 29, 47, ...) that need remapping
@@ -5161,13 +5353,19 @@ def read_labels(labels_path: str, open_videos: bool = True) -> Labels:
             )
         )
 
-    identities = read_identities(labels_path)
-    sessions = read_sessions(labels_path, videos, labeled_frames, identities=identities)
-    roi_tuples = read_rois(labels_path, videos, tracks, instances)
-    mask_tuples = read_masks(labels_path, videos, tracks, instances)
-    bbox_tuples = read_bboxes(labels_path, videos, tracks, instances)
-    centroid_tuples = read_centroids(labels_path, videos, tracks, instances)
-    li_tuples, _li_file = read_label_images(labels_path, videos, tracks, instances)
+    identities = read_identities(labels_path, _hdf5_file=f)
+    sessions = read_sessions(
+        labels_path, videos, labeled_frames, identities=identities, _hdf5_file=f
+    )
+    roi_tuples = read_rois(labels_path, videos, tracks, instances, _hdf5_file=f)
+    mask_tuples = read_masks(labels_path, videos, tracks, instances, _hdf5_file=f)
+    bbox_tuples = read_bboxes(labels_path, videos, tracks, instances, _hdf5_file=f)
+    centroid_tuples = read_centroids(
+        labels_path, videos, tracks, instances, _hdf5_file=f
+    )
+    li_tuples, _li_file = read_label_images(
+        labels_path, videos, tracks, instances, _hdf5_file=f
+    )
 
     # Attach annotations to their corresponding LabeledFrames
     frame_lookup: dict[tuple[int, int], LabeledFrame] = {}

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -216,8 +216,14 @@ def make_video(
         video_path = labels_path
         is_embedded = True
 
-    # Basic path resolution.
-    video_path = Path(sanitize_filename(video_path))
+    # Basic path resolution. Keep URLs as strings — wrapping a URL in ``Path``
+    # would collapse the ``//`` after the scheme (e.g. ``https://`` -> ``https:/``),
+    # corrupting the URL for embedded videos loaded from a remote ``.pkg.slp``.
+    from sleap_io.io._remote import _is_url
+
+    video_path = sanitize_filename(video_path)
+    if not _is_url(video_path):
+        video_path = Path(video_path)
 
     if is_embedded:
         # Try to recover the source video from HDF5 attrs.
@@ -291,7 +297,11 @@ def make_video(
     backend = None
     if open_backend:
         try:
-            if not isinstance(video_path, list) and not is_file_accessible(video_path):
+            if (
+                not isinstance(video_path, list)
+                and not _is_url(video_path)
+                and not is_file_accessible(video_path)
+            ):
                 # Check for the same filename in the same directory as the labels file.
                 candidate_video_path = Path(labels_path).parent / video_path.name
                 if is_file_accessible(candidate_video_path):

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -2651,7 +2651,12 @@ def _read_labels_lazy(labels_path: str, open_videos: bool = True) -> Labels:
 
 
 def _read_labels_lazy_from_open_file(
-    labels_path: str, f: h5py.File, *, open_videos: bool = True
+    labels_path: str,
+    f: h5py.File,
+    *,
+    open_videos: bool = True,
+    _url_headers: dict[str, str] | None = None,
+    _url_stream_mode: str = "blockcache",
 ) -> Labels:
     """Build a lazy `Labels` from an already-open `h5py.File`.
 
@@ -2662,9 +2667,13 @@ def _read_labels_lazy_from_open_file(
     `labels._label_image_file` and intentionally outlives `f`.
 
     Args:
-        labels_path: Path to .slp file.
+        labels_path: Path or URL to .slp file.
         f: An already-open `h5py.File` handle to read from.
         open_videos: Whether to open video backends.
+        _url_headers: HTTP headers forwarded to the long-lived label-image
+            handle when `labels_path` is a URL. Ignored for local paths.
+        _url_stream_mode: Streaming strategy for the long-lived label-image
+            handle when `labels_path` is a URL. Ignored for local paths.
 
     Returns:
         Labels with LazyFrameList for labeled_frames.
@@ -2716,7 +2725,14 @@ def _read_labels_lazy_from_open_file(
     mask_tuples = read_masks(labels_path, videos, tracks, _hdf5_file=f)
     bbox_tuples = read_bboxes(labels_path, videos, tracks, _hdf5_file=f)
     centroid_tuples = read_centroids(labels_path, videos, tracks, _hdf5_file=f)
-    li_tuples, li_file = read_label_images(labels_path, videos, tracks, _hdf5_file=f)
+    li_tuples, li_file = read_label_images(
+        labels_path,
+        videos,
+        tracks,
+        _hdf5_file=f,
+        _url_headers=_url_headers,
+        _url_stream_mode=_url_stream_mode,
+    )
 
     # Build per-frame annotation dicts for lazy materialization
     def _build_ann_by_frame(ann_tuples):
@@ -3901,6 +3917,8 @@ def read_label_images(
     instances: list[Instance | PredictedInstance] | None = None,
     *,
     _hdf5_file: h5py.File | None = None,
+    _url_headers: dict[str, str] | None = None,
+    _url_stream_mode: str = "blockcache",
 ) -> tuple[list[tuple[LabelImage, int, int]], "h5py.File | None"]:
     """Read label image annotations from a SLEAP labels file.
 
@@ -3910,7 +3928,7 @@ def read_label_images(
     access.
 
     Args:
-        labels_path: A string path to the SLEAP labels file.
+        labels_path: A string path or URL to the SLEAP labels file.
         videos: List of Video objects for relinking.
         tracks: List of Track objects for relinking.
         instances: Optional list of Instance/PredictedInstance objects for
@@ -3923,6 +3941,11 @@ def read_label_images(
             access regardless of this argument, since that handle must outlive
             the caller's `with` block. This is a private argument used to thread
             a single open handle through reads.
+        _url_headers: HTTP headers used when ``labels_path`` is a URL and the
+            long-lived lazy-access handle must be opened over the network.
+            Ignored for local paths.
+        _url_stream_mode: Streaming strategy for the long-lived lazy-access
+            handle when ``labels_path`` is a URL. Ignored for local paths.
 
     Returns:
         A tuple of ``(label_image_tuples, h5py_file)`` where
@@ -3943,8 +3966,22 @@ def read_label_images(
 
     # Open a SECOND, long-lived file handle for lazy pixel data reading. This
     # handle intentionally outlives the orchestrator's `with` block (the closures
-    # below capture it), so it cannot reuse `_hdf5_file`.
-    f = h5py.File(labels_path, "r")
+    # below capture it), so it cannot reuse `_hdf5_file`. For URL loads,
+    # ``labels_path`` is the raw URL string, which ``h5py.File`` cannot open
+    # directly; open a FRESH, independent fsspec file-like instead.
+    from sleap_io.io import _remote
+
+    if _remote._is_url(labels_path):
+        f = h5py.File(
+            _remote.open_url(
+                labels_path,
+                headers=_url_headers,
+                stream_mode=_url_stream_mode,
+            ),
+            "r",
+        )
+    else:
+        f = h5py.File(labels_path, "r")
 
     if "label_image_data" not in f:
         f.close()
@@ -5269,7 +5306,12 @@ def read_labels(labels_path: str, open_videos: bool = True) -> Labels:
 
 
 def _read_labels_from_open_file(
-    labels_path: str, f: h5py.File, *, open_videos: bool = True
+    labels_path: str,
+    f: h5py.File,
+    *,
+    open_videos: bool = True,
+    _url_headers: dict[str, str] | None = None,
+    _url_stream_mode: str = "blockcache",
 ) -> Labels:
     """Build a `Labels` from an already-open `h5py.File`.
 
@@ -5280,10 +5322,14 @@ def _read_labels_from_open_file(
     `labels._label_image_file` and intentionally outlives `f`.
 
     Args:
-        labels_path: A string path to the SLEAP labels file.
+        labels_path: A string path or URL to the SLEAP labels file.
         f: An already-open `h5py.File` handle to read from.
         open_videos: If `True` (the default), attempt to open the video backend
             for I/O.
+        _url_headers: HTTP headers forwarded to the long-lived label-image
+            handle when `labels_path` is a URL. Ignored for local paths.
+        _url_stream_mode: Streaming strategy for the long-lived label-image
+            handle when `labels_path` is a URL. Ignored for local paths.
 
     Returns:
         The processed `Labels` object.
@@ -5374,7 +5420,13 @@ def _read_labels_from_open_file(
         labels_path, videos, tracks, instances, _hdf5_file=f
     )
     li_tuples, _li_file = read_label_images(
-        labels_path, videos, tracks, instances, _hdf5_file=f
+        labels_path,
+        videos,
+        tracks,
+        instances,
+        _hdf5_file=f,
+        _url_headers=_url_headers,
+        _url_stream_mode=_url_stream_mode,
     )
 
     # Attach annotations to their corresponding LabeledFrames

--- a/sleap_io/io/utils.py
+++ b/sleap_io/io/utils.py
@@ -10,11 +10,40 @@ import h5py  # type: ignore[import]
 import numpy as np
 
 
-def read_hdf5_dataset(filename: str, dataset: str) -> np.ndarray:
+def read_hdf5_dataset(
+    filename: str,
+    dataset: str,
+    *,
+    _hdf5_file: h5py.File | None = None,
+) -> np.ndarray:
     """Read data from an HDF5 file.
 
     Args:
         filename: Path to an HDF5 file.
+        dataset: Path to a dataset.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (which is left open for the caller
+            to close); otherwise `filename` is opened and closed internally. This
+            is a private argument used to thread a single open handle (e.g. an
+            fsspec-backed remote file) through multiple reads.
+
+    Returns:
+        The data as an array. If the dataset is a flat 2D array with a
+        ``"field_names"`` JSON attribute (as written by h5wasm), it will be
+        converted to a structured array so that field-name access works
+        identically to compound-dtype datasets written by h5py.
+    """
+    if _hdf5_file is not None:
+        return _read_dataset_from_open_file(_hdf5_file, dataset)
+    with h5py.File(filename, "r") as f:
+        return _read_dataset_from_open_file(f, dataset)
+
+
+def _read_dataset_from_open_file(f: h5py.File, dataset: str) -> np.ndarray:
+    """Read a dataset from an already-open HDF5 file.
+
+    Args:
+        f: An open `h5py.File` handle.
         dataset: Path to a dataset.
 
     Returns:
@@ -23,23 +52,22 @@ def read_hdf5_dataset(filename: str, dataset: str) -> np.ndarray:
         converted to a structured array so that field-name access works
         identically to compound-dtype datasets written by h5py.
     """
-    with h5py.File(filename, "r") as f:
-        ds = f[dataset]
-        data = ds[()]
-        # h5wasm writes flat 2D arrays with column names in a "field_names"
-        # JSON attribute instead of compound dtypes. Convert to a structured
-        # array so downstream code can use field-name access unchanged.
-        if data.ndim == 2 and data.dtype.names is None:
-            field_names_raw = ds.attrs.get("field_names", None)
-            if field_names_raw is not None:
-                if isinstance(field_names_raw, (bytes, np.bytes_)):
-                    field_names_raw = field_names_raw.decode()
-                field_names = json.loads(field_names_raw)
-                dtype = [(name, data.dtype) for name in field_names]
-                structured = np.empty(data.shape[0], dtype=dtype)
-                for i, name in enumerate(field_names):
-                    structured[name] = data[:, i]
-                return structured
+    ds = f[dataset]
+    data = ds[()]
+    # h5wasm writes flat 2D arrays with column names in a "field_names"
+    # JSON attribute instead of compound dtypes. Convert to a structured
+    # array so downstream code can use field-name access unchanged.
+    if data.ndim == 2 and data.dtype.names is None:
+        field_names_raw = ds.attrs.get("field_names", None)
+        if field_names_raw is not None:
+            if isinstance(field_names_raw, (bytes, np.bytes_)):
+                field_names_raw = field_names_raw.decode()
+            field_names = json.loads(field_names_raw)
+            dtype = [(name, data.dtype) for name in field_names]
+            structured = np.empty(data.shape[0], dtype=dtype)
+            for i, name in enumerate(field_names):
+                structured[name] = data[:, i]
+            return structured
     return data
 
 
@@ -70,13 +98,40 @@ def write_hdf5_dataset(filename: str, dataset: str, data: np.ndarray):
         _overwrite_hdf5_dataset(f, dataset, data)
 
 
-def read_hdf5_group(filename: str, group: str = "/") -> dict[str, np.ndarray]:
+def read_hdf5_group(
+    filename: str,
+    group: str = "/",
+    *,
+    _hdf5_file: h5py.File | None = None,
+) -> dict[str, np.ndarray]:
     """Read an entire group from an HDF5 file.
 
     Args:
         filename: Path an HDF5 file.
         group: Path to a group within the HDF5 file. Defaults to "/" (read the entire
             file).
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (which is left open for the caller
+            to close); otherwise `filename` is opened and closed internally. This
+            is a private argument used to thread a single open handle (e.g. an
+            fsspec-backed remote file) through multiple reads.
+
+    Returns:
+        A flat dictionary with keys corresponding to dataset paths and values
+        corresponding to the datasets as arrays.
+    """
+    if _hdf5_file is not None:
+        return _read_group_from_open_file(_hdf5_file, group)
+    with h5py.File(filename, "r") as f:
+        return _read_group_from_open_file(f, group)
+
+
+def _read_group_from_open_file(f: h5py.File, group: str) -> dict[str, np.ndarray]:
+    """Read an entire group from an already-open HDF5 file.
+
+    Args:
+        f: An open `h5py.File` handle.
+        group: Path to a group within the HDF5 file.
 
     Returns:
         A flat dictionary with keys corresponding to dataset paths and values
@@ -88,8 +143,7 @@ def read_hdf5_group(filename: str, group: str = "/") -> dict[str, np.ndarray]:
         if type(v) is h5py.Dataset:
             data[v.name] = v[()]
 
-    with h5py.File(filename, "r") as f:
-        f[group].visititems(read_datasets)
+    f[group].visititems(read_datasets)
 
     return data
 
@@ -139,7 +193,11 @@ def write_hdf5_group(filename: str, data: dict[str, np.ndarray]):
 
 
 def read_hdf5_attrs(
-    filename: str, dataset: str = "/", attribute: str | None = None
+    filename: str,
+    dataset: str = "/",
+    attribute: str | None = None,
+    *,
+    _hdf5_file: h5py.File | None = None,
 ) -> Any | dict[str, Any]:
     """Read attributes from an HDF5 dataset.
 
@@ -148,18 +206,41 @@ def read_hdf5_attrs(
         dataset: Path to a dataset or group from which attributes will be read.
         attribute: If specified, the attribute name to read. If `None` (the default),
             all attributes for the dataset will be returned.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (which is left open for the caller
+            to close); otherwise `filename` is opened and closed internally. This
+            is a private argument used to thread a single open handle (e.g. an
+            fsspec-backed remote file) through multiple reads.
 
     Returns:
         The attributes in a dictionary, or the attribute field if `attribute` was
         provided.
     """
+    if _hdf5_file is not None:
+        return _read_attrs_from_open_file(_hdf5_file, dataset, attribute)
     with h5py.File(filename, "r") as f:
-        ds = f[dataset]
-        if attribute is None:
-            data = dict(ds.attrs)
-        else:
-            data = ds.attrs[attribute]
-    return data
+        return _read_attrs_from_open_file(f, dataset, attribute)
+
+
+def _read_attrs_from_open_file(
+    f: h5py.File, dataset: str, attribute: str | None
+) -> Any | dict[str, Any]:
+    """Read attributes from a dataset in an already-open HDF5 file.
+
+    Args:
+        f: An open `h5py.File` handle.
+        dataset: Path to a dataset or group from which attributes will be read.
+        attribute: If specified, the attribute name to read. If `None`, all
+            attributes for the dataset will be returned.
+
+    Returns:
+        The attributes in a dictionary, or the attribute field if `attribute` was
+        provided.
+    """
+    ds = f[dataset]
+    if attribute is None:
+        return dict(ds.attrs)
+    return ds.attrs[attribute]
 
 
 def write_hdf5_attrs(filename: str, dataset: str, attributes: dict[str, Any]):

--- a/sleap_io/io/utils.py
+++ b/sleap_io/io/utils.py
@@ -307,7 +307,16 @@ def sanitize_filename(
     Returns:
         A sanitized filename as a string (or list of strings if a list was provided)
         with forward slashes and posix-formatted.
+
+    Notes:
+        URLs (e.g. ``https://...``, ``s3://...``) are returned unchanged. Passing a
+        URL through ``Path`` would collapse the ``//`` after the scheme (turning
+        ``https://host/x`` into ``https:/host/x``), corrupting the URL.
     """
     if isinstance(filename, list):
         return [sanitize_filename(f) for f in filename]
+    from sleap_io.io._remote import _is_url
+
+    if isinstance(filename, str) and _is_url(filename):
+        return filename
     return Path(filename).as_posix().replace("\\", "/")

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -345,6 +345,27 @@ class VideoBackend:
             raise ValueError(f"FPS must be positive, got {value}")
         self._fps = value
 
+    def __getstate__(self) -> dict:
+        """Return state for pickling/deepcopy, dropping the open reader handle.
+
+        The cached ``_open_reader`` (e.g. an ``h5py.File`` or video container) is
+        not picklable and is reopened lazily on next access, so it is excluded.
+        """
+        import attr
+
+        state = {a.name: getattr(self, a.name) for a in attr.fields(type(self))}
+        state["_open_reader"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore state from pickling/deepcopy.
+
+        attrs slotted classes need ``object.__setattr__`` to set slots directly.
+        Validators are skipped, which is safe since state came from a valid object.
+        """
+        for key, value in state.items():
+            object.__setattr__(self, key, value)
+
     @classmethod
     def from_filename(
         cls,
@@ -955,14 +976,57 @@ class HDF5Video(VideoBackend):
     image_format: str = "hdf5"
     channel_order: str = "RGB"
     plugin: str | None = None
+    _url_file: object | None = attrs.field(
+        init=False, default=None, repr=False, eq=False
+    )
+    _url_headers: dict[str, str] | None = attrs.field(
+        init=False, default=None, repr=False, eq=False
+    )
+    _url_stream_mode: str = attrs.field(
+        init=False, default="blockcache", repr=False, eq=False
+    )
 
     EXTS = ("h5", "hdf5", "slp")
+
+    def _open_h5(self) -> h5py.File:
+        """Open the backing HDF5 file as an ``h5py.File`` in read mode.
+
+        For local paths this opens ``self.filename`` directly. For URLs it lazily
+        opens (and caches on ``self._url_file``) an fsspec-backed file-like object
+        via :func:`sleap_io.io._remote.open_url` and wraps it with ``h5py``.
+
+        Returns:
+            An open ``h5py.File`` handle. The caller owns closing the returned
+            handle; the cached ``self._url_file`` is reused across reads and
+            dropped on pickling.
+        """
+        from sleap_io.io import _remote
+
+        if _remote._is_url(self.filename):
+            if self._url_file is None:
+                self._url_file = _remote.open_url(
+                    self.filename,
+                    headers=self._url_headers,
+                    stream_mode=self._url_stream_mode,
+                )
+            return h5py.File(self._url_file, "r")
+        return h5py.File(self.filename, "r")
+
+    def __getstate__(self) -> dict:
+        """Return state for pickling/deepcopy, dropping unpicklable handles.
+
+        Extends :meth:`VideoBackend.__getstate__` to also drop the cached
+        fsspec-backed ``_url_file`` (reopened lazily by :meth:`_open_h5`).
+        """
+        state = super().__getstate__()
+        state["_url_file"] = None
+        return state
 
     def __attrs_post_init__(self):
         """Auto-detect dataset and frame map heuristically."""
         # Check if the file accessible before applying heuristics.
         try:
-            f = h5py.File(self.filename, "r")
+            f = self._open_h5()
         except OSError:
             return
 
@@ -1046,13 +1110,13 @@ class HDF5Video(VideoBackend):
     @property
     def num_frames(self) -> int:
         """Number of frames in the video."""
-        with h5py.File(self.filename, "r") as f:
+        with self._open_h5() as f:
             return f[self.dataset].shape[0]
 
     @property
     def img_shape(self) -> tuple[int, int, int]:
         """Shape of a single frame in the video as `(height, width, channels)`."""
-        with h5py.File(self.filename, "r") as f:
+        with self._open_h5() as f:
             ds = f[self.dataset]
 
             img_shape = None
@@ -1181,10 +1245,10 @@ class HDF5Video(VideoBackend):
         # Read directly from dataset
         if self.keep_open:
             if self._open_reader is None:
-                self._open_reader = h5py.File(self.filename, "r")
+                self._open_reader = self._open_h5()
             f = self._open_reader
         else:
-            f = h5py.File(self.filename, "r")
+            f = self._open_h5()
 
         ds = f[self.dataset]
         raw_bytes = ds[internal_idx]
@@ -1218,10 +1282,10 @@ class HDF5Video(VideoBackend):
         """
         if self.keep_open:
             if self._open_reader is None:
-                self._open_reader = h5py.File(self.filename, "r")
+                self._open_reader = self._open_h5()
             f = self._open_reader
         else:
-            f = h5py.File(self.filename, "r")
+            f = self._open_h5()
 
         ds = f[self.dataset]
 
@@ -1255,10 +1319,10 @@ class HDF5Video(VideoBackend):
         """
         if self.keep_open:
             if self._open_reader is None:
-                self._open_reader = h5py.File(self.filename, "r")
+                self._open_reader = self._open_h5()
             f = self._open_reader
         else:
-            f = h5py.File(self.filename, "r")
+            f = self._open_h5()
 
         if self.frame_map:
             frame_inds = [self.frame_map[idx] for idx in frame_inds]

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -1012,6 +1012,26 @@ class HDF5Video(VideoBackend):
             return h5py.File(self._url_file, "r")
         return h5py.File(self.filename, "r")
 
+    def _release_probe_url_file(self, preexisting: bool) -> None:
+        """Close and drop ``self._url_file`` if a probe opened it.
+
+        Used by :meth:`__attrs_post_init__` so that a remote handle opened just
+        to sniff the dataset/frame-map does not leak and is not reused by later
+        (possibly authenticated) reads. A no-op for local files and when the
+        cached file-like already existed before the probe.
+
+        Args:
+            preexisting: Whether ``self._url_file`` was already set before the
+                probe opened the file (in which case it is left untouched).
+        """
+        if preexisting or self._url_file is None:
+            return
+        try:
+            self._url_file.close()
+        except Exception:  # pragma: no cover - defensive: close() should not raise
+            pass
+        self._url_file = None
+
     def __getstate__(self) -> dict:
         """Return state for pickling/deepcopy, dropping unpicklable handles.
 
@@ -1025,76 +1045,87 @@ class HDF5Video(VideoBackend):
     def __attrs_post_init__(self):
         """Auto-detect dataset and frame map heuristically."""
         # Check if the file accessible before applying heuristics.
+        # For URLs, track whether this probe opened the cached fsspec file-like
+        # so it can be released afterwards (it would otherwise leak the handle on
+        # an early return / exception, and a probe-time open may predate the
+        # final auth headers being applied).
+        url_file_preexisting = self._url_file is not None
         try:
             f = self._open_h5()
         except OSError:
+            self._release_probe_url_file(url_file_preexisting)
             return
 
-        if self.dataset is None:
-            # Iterate through datasets to find a rank 4 array.
-            def find_movies(name, obj):
-                if isinstance(obj, h5py.Dataset) and obj.ndim == 4:
-                    self.dataset = name
-                    return True
+        try:
+            if self.dataset is None:
+                # Iterate through datasets to find a rank 4 array.
+                def find_movies(name, obj):
+                    if isinstance(obj, h5py.Dataset) and obj.ndim == 4:
+                        self.dataset = name
+                        return True
 
-            f.visititems(find_movies)
+                f.visititems(find_movies)
 
-        if self.dataset is None:
-            # Iterate through datasets to find an embedded video dataset.
-            def find_embedded(name, obj):
-                if isinstance(obj, h5py.Dataset) and name.endswith("/video"):
-                    self.dataset = name
-                    return True
+            if self.dataset is None:
+                # Iterate through datasets to find an embedded video dataset.
+                def find_embedded(name, obj):
+                    if isinstance(obj, h5py.Dataset) and name.endswith("/video"):
+                        self.dataset = name
+                        return True
 
-            f.visititems(find_embedded)
+                f.visititems(find_embedded)
 
-        if self.dataset is None:
-            # Couldn't find video datasets.
-            return
+            if self.dataset is None:
+                # Couldn't find video datasets.
+                return
 
-        if isinstance(f[self.dataset], h5py.Group):
-            # If this is a group, assume it's an embedded video dataset.
-            if "video" in f[self.dataset]:
-                self.dataset = f"{self.dataset}/video"
+            if isinstance(f[self.dataset], h5py.Group):
+                # If this is a group, assume it's an embedded video dataset.
+                if "video" in f[self.dataset]:
+                    self.dataset = f"{self.dataset}/video"
 
-        if self.dataset.split("/")[-1] == "video":
-            # This may be an embedded video dataset. Check for frame map.
-            ds = f[self.dataset]
+            if self.dataset.split("/")[-1] == "video":
+                # This may be an embedded video dataset. Check for frame map.
+                ds = f[self.dataset]
 
-            if "format" in ds.attrs:
-                self.image_format = ds.attrs["format"]
+                if "format" in ds.attrs:
+                    self.image_format = ds.attrs["format"]
 
-            # Read channel_order, with backwards compatibility
-            if "channel_order" in ds.attrs:
-                self.channel_order = ds.attrs["channel_order"]
-            else:
-                # Backwards compatibility: Check format_id for older files
-                # Prior to format 1.4, embedded images were primarily encoded with
-                # OpenCV which uses BGR, so default to BGR for older formats
-                if "metadata" in f and "format_id" in f["metadata"].attrs:
-                    format_id = f["metadata"].attrs["format_id"]
-                    if format_id < 1.4:
-                        self.channel_order = "BGR"  # Legacy default
-                # If no format_id found, assume BGR (safest legacy default)
-                # since most embedded images before this change used OpenCV
+                # Read channel_order, with backwards compatibility
+                if "channel_order" in ds.attrs:
+                    self.channel_order = ds.attrs["channel_order"]
+                else:
+                    # Backwards compatibility: Check format_id for older files
+                    # Prior to format 1.4, embedded images were primarily encoded
+                    # with OpenCV which uses BGR, so default to BGR for older
+                    # formats
+                    if "metadata" in f and "format_id" in f["metadata"].attrs:
+                        format_id = f["metadata"].attrs["format_id"]
+                        if format_id < 1.4:
+                            self.channel_order = "BGR"  # Legacy default
+                    # If no format_id found, assume BGR (safest legacy default)
+                    # since most embedded images before this change used OpenCV
 
-            if "frame_numbers" in ds.parent:
-                frame_numbers = ds.parent["frame_numbers"][:].astype(int)
-                self.frame_map = {frame: idx for idx, frame in enumerate(frame_numbers)}
-                self.source_inds = frame_numbers
+                if "frame_numbers" in ds.parent:
+                    frame_numbers = ds.parent["frame_numbers"][:].astype(int)
+                    self.frame_map = {
+                        frame: idx for idx, frame in enumerate(frame_numbers)
+                    }
+                    self.source_inds = frame_numbers
 
-            if "source_video" in ds.parent:
-                self.source_filename = json.loads(
-                    ds.parent["source_video"].attrs["json"]
-                )["backend"]["filename"]
+                if "source_video" in ds.parent:
+                    self.source_filename = json.loads(
+                        ds.parent["source_video"].attrs["json"]
+                    )["backend"]["filename"]
 
-            # Read FPS from attributes if present
-            if "fps" in ds.attrs:
-                self._fps = float(ds.attrs["fps"])
-            elif "fps" in ds.parent.attrs:
-                self._fps = float(ds.parent.attrs["fps"])
-
-        f.close()
+                # Read FPS from attributes if present
+                if "fps" in ds.attrs:
+                    self._fps = float(ds.attrs["fps"])
+                elif "fps" in ds.parent.attrs:
+                    self._fps = float(ds.parent.attrs["fps"])
+        finally:
+            f.close()
+            self._release_probe_url_file(url_file_preexisting)
 
         # Set default plugin if not specified (use image plugin, not video plugin)
         if self.plugin is None:

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -435,7 +435,12 @@ class Video:
         from sleap_io.io._remote import _head_or_range_probe
 
         key = (self.filename, dataset)
-        ttl = float(os.environ.get("SLEAP_IO_EXISTS_TTL", "60"))
+        try:
+            ttl = float(os.environ.get("SLEAP_IO_EXISTS_TTL", "60"))
+        except ValueError:
+            # A malformed env value must not break the never-raise bool
+            # contract of exists()/is_open; fall back to the 60s default.
+            ttl = 60.0
         cached = self._exists_cache.get(key)
         if cached is not None and (time.monotonic() - cached[1]) < ttl:
             return cached[0]

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -6,6 +6,8 @@ a video and its components used in SLEAP.
 
 from __future__ import annotations
 
+import os
+import time
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +47,13 @@ class Video:
             Set this to `False` when you want to manually open the backend, or when the
             you know the video file does not exist and you want to avoid trying to open
             the file.
+        _exists_cache: Per-instance TTL cache for the result of `exists()` when the
+            `filename` is a remote URL. Keyed by `(filename, dataset)` and storing
+            `(exists_bool, monotonic_timestamp)`. This avoids issuing a network probe
+            on every call (e.g. from the `is_open` property, which GUIs poll on each
+            render). The TTL defaults to 60 seconds and can be overridden via the
+            `SLEAP_IO_EXISTS_TTL` environment variable. The cache is cleared on
+            `replace_filename`.
 
     Notes:
         Instances of this class are hashed by identity, not by value. This means that
@@ -79,6 +88,9 @@ class Video:
     backend_metadata: dict[str, any] = attrs.field(factory=dict)
     source_video: "Video | None" = None
     open_backend: bool = True
+    _exists_cache: dict[tuple[str, str | None], tuple[bool, float]] = attrs.field(
+        init=False, factory=dict, repr=False, eq=False
+    )
 
     EXTS = MediaVideo.EXTS + HDF5Video.EXTS + ImageVideo.EXTS + ("seq",)
 
@@ -370,6 +382,13 @@ class Video:
             else:
                 return is_file_accessible(self.filename[0])
 
+        # URL fast path: must run BEFORE `is_file_accessible`, which treats the
+        # filename as a local path and would spuriously return False for a URL.
+        from sleap_io.io._remote import _is_url
+
+        if _is_url(self.filename):
+            return self._url_exists(dataset)
+
         file_is_accessible = is_file_accessible(self.filename)
         if not file_is_accessible:
             # Check if it's a directory (ImageVideo source)
@@ -394,6 +413,76 @@ class Video:
             return has_dataset
 
         return True
+
+    def _url_exists(self, dataset: str | None) -> bool:
+        """Check whether a remote URL `filename` exists, with a TTL cache.
+
+        Args:
+            dataset: Name of dataset in the (remote) HDF5 file. If specified (or
+                derivable from `backend_metadata`), existence additionally requires
+                that the dataset be present in the file.
+
+        Returns:
+            `True` if the URL is reachable (and, if a dataset was requested, the
+            dataset exists), `False` otherwise.
+
+        Notes:
+            Results are cached per instance keyed by `(filename, dataset)` for a
+            TTL (default 60s, overridable via the `SLEAP_IO_EXISTS_TTL` env var) so
+            repeated calls (e.g. from the `is_open` property in a GUI render loop)
+            do not issue a network probe each time.
+        """
+        from sleap_io.io._remote import _head_or_range_probe
+
+        key = (self.filename, dataset)
+        ttl = float(os.environ.get("SLEAP_IO_EXISTS_TTL", "60"))
+        cached = self._exists_cache.get(key)
+        if cached is not None and (time.monotonic() - cached[1]) < ttl:
+            return cached[0]
+
+        try:
+            if not _head_or_range_probe(self.filename):
+                result = False
+            else:
+                if dataset is None or dataset == "":
+                    dataset = self.backend_metadata.get("dataset", None)
+                if dataset is None or dataset == "":
+                    result = True
+                else:
+                    result = self._url_dataset_exists(dataset)
+        except Exception:
+            result = False
+
+        self._exists_cache[key] = (result, time.monotonic())
+        return result
+
+    def _url_dataset_exists(self, dataset: str) -> bool:
+        """Check whether `dataset` is present in the remote HDF5 file.
+
+        Reuses the backend's already-open HDF5 reader when available; otherwise
+        opens the remote file via fsspec for a single membership check.
+
+        Args:
+            dataset: Name of dataset in the remote HDF5 file.
+
+        Returns:
+            `True` if the dataset is present, `False` otherwise.
+        """
+        if (
+            self.backend is not None
+            and type(self.backend) is HDF5Video
+            and self.backend._open_reader is not None
+        ):
+            return dataset in self.backend._open_reader
+
+        from sleap_io.io._remote import open_remote_h5
+
+        url_file = open_remote_h5(self.filename)
+        try:
+            with h5py.File(url_file, "r") as f:
+                return dataset in f
+        finally:
+            url_file.close()
 
     @property
     def is_open(self) -> bool:
@@ -523,6 +612,8 @@ class Video:
 
         self.filename = new_filename
         self.backend_metadata["filename"] = new_filename
+        # Invalidate any cached URL existence results for the previous filename.
+        self._exists_cache.clear()
 
         if open:
             if self.exists():

--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -1,0 +1,41 @@
+"""Shared fixtures for `tests/io`.
+
+Provides the `httpserver_dual` fixture used by the remote-loading network tests
+to exercise cross-origin redirects (two distinct origins).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from pytest_httpserver import HTTPServer
+
+
+@pytest.fixture
+def httpserver_dual() -> Generator[tuple[HTTPServer, HTTPServer], None, None]:
+    """Yield two `HTTPServer` instances bound to distinct ports (two origins).
+
+    A request that 302-redirects from server ``a`` to a URL on server ``b``
+    crosses origins (different port => different origin), which is what the
+    cross-origin credential-stripping tests need. Both servers are stopped on
+    teardown.
+
+    Yields:
+        A ``(a, b)`` tuple of started `HTTPServer` instances on the loopback
+        host with OS-assigned (distinct) ports.
+    """
+    host = HTTPServer.DEFAULT_LISTEN_HOST
+    a = HTTPServer(host=host, port=0)
+    b = HTTPServer(host=host, port=0)
+    a.start()
+    b.start()
+    try:
+        yield a, b
+    finally:
+        a.clear()
+        if a.is_running():
+            a.stop()
+        b.clear()
+        if b.is_running():
+            b.stop()

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -471,6 +471,68 @@ def test_load_slp_url_embedded_pkg_keeps_clean_url_and_reads_frame(
     assert frame.dtype.name == "uint8"
 
 
+def _make_label_image_pkg(tmp_path):
+    """Build a `.pkg.slp` containing a single `UserLabelImage` and return path.
+
+    Returns the path and the raw label-image pixel data so callers can assert a
+    pixel-perfect round-trip.
+    """
+    import numpy as np
+
+    from sleap_io import LabeledFrame, Skeleton, Track, Video
+    from sleap_io.io.main import save_slp
+    from sleap_io.model.label_image import LabelImage, UserLabelImage
+
+    data = np.zeros((8, 10), dtype=np.int32)
+    data[1:3, 2:5] = 1
+    data[5:7, 6:9] = 2
+
+    video = Video(filename="remote_label_image_test.mp4")
+    track = Track(name="cell_1")
+    li = UserLabelImage(
+        data=data,
+        objects={1: LabelImage.Info(track=track, category="neuron", name="n1")},
+        source="cellpose",
+    )
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.label_images.append(li)
+    labels = Labels(
+        labeled_frames=[lf],
+        videos=[video],
+        skeletons=[Skeleton(nodes=["A"])],
+        tracks=[track],
+    )
+    path = str(tmp_path / "label_image.pkg.slp")
+    save_slp(labels, path)
+    return path, data
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_load_slp_url_label_image_roundtrip(httpserver, tmp_path, lazy):
+    """A remote `.pkg.slp` with a `LabelImage` loads and reads pixels over HTTP.
+
+    Regression test for finding 1: the long-lived lazy-access handle in
+    `read_label_images` was opened unconditionally as
+    `h5py.File(labels_path, "r")`, which raised `OSError` for URL loads (where
+    `labels_path` is the raw URL). It must now open a fresh fsspec file-like.
+    """
+    import numpy as np
+
+    path, data = _make_label_image_pkg(tmp_path)
+    file_bytes = Path(path).read_bytes()
+    _serve_with_range(httpserver, "/label_image.pkg.slp", file_bytes)
+    url = httpserver.url_for("/label_image.pkg.slp")
+
+    labels = load_slp(url, lazy=lazy, stream_mode="download")
+    assert len(labels.label_images) == 1
+
+    rli = labels.label_images[0]
+    assert rli.source == "cellpose"
+    assert rli.objects[1].category == "neuron"
+    # The pixel data must be readable over HTTP via the lazy loader.
+    np.testing.assert_array_equal(rli.data, data)
+
+
 def test_load_video_url_raises_not_implemented():
     """`load_video(url)` raises `NotImplementedError` with a redacted URL.
 
@@ -487,6 +549,36 @@ def test_load_video_url_raises_not_implemented():
     assert "secret" not in message
     assert "abc123" not in message
     assert "example.com" in message
+
+
+def test_load_file_url_nwb_raises_not_implemented():
+    """A `.nwb` URL raises a clean `NotImplementedError`, not a raw `OSError`.
+
+    No network request is issued: the extension routes directly to the
+    (unimplemented) `nwb` format before any I/O.
+    """
+    url = "https://user:s3cr3t@example.invalid/data.nwb?token=TOPSECRET"
+    with pytest.raises(NotImplementedError) as exc_info:
+        load_file(url)
+    message = str(exc_info.value)
+    assert "not yet implemented" in message
+    assert "nwb" in message
+    # Credentials are redacted out of the surfaced URL.
+    assert "s3cr3t" not in message
+    assert "TOPSECRET" not in message
+    assert "example.invalid" in message
+
+
+def test_load_file_url_slp_still_loads(httpserver, slp_minimal):
+    """A `.slp` URL still loads after the non-slp gate was added (finding 4)."""
+    file_bytes = Path(slp_minimal).read_bytes()
+    httpserver.expect_request("/labels.slp").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.slp")
+    labels = load_file(url, stream_mode="download")
+    assert type(labels) is Labels
+    assert len(labels) == 1
 
 
 def test_load_file_url_sniff_routes_slp(httpserver, slp_minimal):

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -421,6 +421,56 @@ def test_load_slp_url_invalid_stream_mode(httpserver, slp_minimal):
         load_slp(url, stream_mode="not-a-real-mode")
 
 
+def _serve_with_range(httpserver, path, data):
+    """Serve `data` at `path` honoring HTTP Range requests (206 partial content)."""
+    from werkzeug.wrappers import Response
+
+    def handler(request):
+        rng = request.headers.get("Range")
+        if rng and rng.startswith("bytes="):
+            spec = rng.split("=", 1)[1].split(",")[0]
+            start_s, _, end_s = spec.partition("-")
+            start = int(start_s) if start_s else 0
+            end = int(end_s) if end_s else len(data) - 1
+            end = min(end, len(data) - 1)
+            chunk = data[start : end + 1]
+            resp = Response(chunk, status=206)
+            resp.headers["Content-Range"] = f"bytes {start}-{end}/{len(data)}"
+        else:
+            resp = Response(data, status=200)
+        resp.headers["Accept-Ranges"] = "bytes"
+        return resp
+
+    httpserver.expect_request(path).respond_with_handler(handler)
+
+
+def test_load_slp_url_embedded_pkg_keeps_clean_url_and_reads_frame(
+    httpserver, slp_minimal_pkg
+):
+    """Embedded ``pkg.slp`` over a URL keeps a clean URL and streams frames.
+
+    Regression test: ``make_video`` previously ran the embedded video's URL
+    through ``Path``, collapsing ``https://`` to ``https:/`` so the embedded
+    ``HDF5Video`` could not be reopened over the network.
+    """
+    data = Path(slp_minimal_pkg).read_bytes()
+    _serve_with_range(httpserver, "/minimal.pkg.slp", data)
+    url = httpserver.url_for("/minimal.pkg.slp")
+
+    labels = load_slp(url)
+    video = labels.videos[0]
+
+    # The embedded video filename must be the unmangled URL (scheme "//" intact).
+    assert str(video.filename) == url
+    assert "://" in str(video.filename)
+    assert type(video.backend).__name__ == "HDF5Video"
+
+    # The embedded frame must be readable over the URL (range-streamed).
+    frame = video[0]
+    assert frame.shape == (384, 384, 1)
+    assert frame.dtype.name == "uint8"
+
+
 def test_load_video_url_raises_not_implemented():
     """`load_video(url)` raises `NotImplementedError` with a redacted URL.
 

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -1,10 +1,12 @@
 """Tests for functions in the sleap_io.io.main file."""
 
 import shutil
+from pathlib import Path
 
 import pytest
 
-from sleap_io import Labels, LabelsSet
+from sleap_io import Labels, LabelsSet, RemoteIOError, clear_remote_cache
+from sleap_io.io._remote import _require_package
 from sleap_io.io.main import (
     load_file,
     load_jabs,
@@ -368,3 +370,136 @@ def test_load_labels_set_format_detection_edge_cases(tmp_path, slp_minimal):
         load_labels_set(str(single_file), format="slp")
     except ValueError as e:
         assert "Path must be a directory" in str(e)
+
+
+# ---------------------------------------------------------------------------
+# Remote URL loading (PR 1)
+# ---------------------------------------------------------------------------
+
+
+def test_load_slp_url_via_httpserver(httpserver, slp_minimal):
+    """`load_slp` loads a `.slp` served over HTTP into a `Labels` object.
+
+    The fixture is served with a plain 200 (no Range support), so the
+    ``download`` stream mode (full read into memory) is used.
+    """
+    file_bytes = Path(slp_minimal).read_bytes()
+    httpserver.expect_request("/labels.slp").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.slp")
+
+    labels = load_slp(url, stream_mode="download")
+    assert type(labels) is Labels
+    assert len(labels) == 1
+
+
+def test_load_slp_url_preserves_lazy(httpserver, slp_minimal):
+    """`load_slp(url, lazy=True)` produces a lazy `Labels` over HTTP."""
+    file_bytes = Path(slp_minimal).read_bytes()
+    httpserver.expect_request("/labels.slp").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.slp")
+
+    lazy_labels = load_slp(url, lazy=True, stream_mode="download")
+    assert type(lazy_labels) is Labels
+    assert lazy_labels.is_lazy
+    # Lazy labels still expose frames.
+    assert len(lazy_labels) == 1
+
+
+def test_load_slp_url_invalid_stream_mode(httpserver, slp_minimal):
+    """An unrecognized `stream_mode` raises `ValueError` (not RemoteIOError)."""
+    file_bytes = Path(slp_minimal).read_bytes()
+    httpserver.expect_request("/labels.slp").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.slp")
+
+    with pytest.raises(ValueError, match="Invalid stream_mode"):
+        load_slp(url, stream_mode="not-a-real-mode")
+
+
+def test_load_video_url_raises_not_implemented():
+    """`load_video(url)` raises `NotImplementedError` with a redacted URL.
+
+    The message must mention the follow-up PR and must not leak credentials.
+    """
+    url = "https://user:secret@example.com/movie.mp4?token=abc123"
+    with pytest.raises(NotImplementedError) as exc_info:
+        load_video(url)
+
+    message = str(exc_info.value)
+    # Follow-up PR is mentioned.
+    assert "follow-up" in message.lower()
+    # Credentials are redacted out of the surfaced URL.
+    assert "secret" not in message
+    assert "abc123" not in message
+    assert "example.com" in message
+
+
+def test_load_file_url_sniff_routes_slp(httpserver, slp_minimal):
+    """`load_file` sniffs an ambiguous `.h5` URL and routes it to `load_slp`."""
+    file_bytes = Path(slp_minimal).read_bytes()
+    httpserver.expect_request("/labels.h5").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.h5")
+
+    # `.h5` is an ambiguous extension; sniffing the HDF5 magic + group
+    # structure should route to the slp loader.
+    labels = load_file(url, stream_mode="download")
+    assert type(labels) is Labels
+    assert len(labels) == 1
+
+
+def test_load_file_url_sniff_false_ambiguous_raises(httpserver, slp_minimal):
+    """`load_file(url, sniff=False)` on an ambiguous extension raises."""
+    file_bytes = Path(slp_minimal).read_bytes()
+    httpserver.expect_request("/labels.h5").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.h5")
+
+    with pytest.raises(ValueError, match="ambiguous extension"):
+        load_file(url, sniff=False)
+
+
+def test_load_file_url_explicit_format_skips_sniff(httpserver, slp_minimal):
+    """An explicit `format` dispatches a URL directly without sniffing."""
+    file_bytes = Path(slp_minimal).read_bytes()
+    httpserver.expect_request("/labels.h5").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.h5")
+
+    labels = load_file(url, format="slp", stream_mode="download")
+    assert type(labels) is Labels
+    assert len(labels) == 1
+
+
+def test_load_slp_url_cloud_missing_extra():
+    """A missing cloud adapter raises `ImportError` with the `[cloud]` hint.
+
+    Exercised via `_require_package` with a genuinely-absent package name so no
+    mocking is needed (CI installs the real cloud adapters).
+    """
+    with pytest.raises(ImportError) as exc_info:
+        _require_package("definitely_not_installed_pkg_xyz", scheme="s3")
+    message = str(exc_info.value)
+    assert "sleap-io[cloud]" in message
+    assert "definitely_not_installed_pkg_xyz" in message
+
+
+def test_imports_clear_remote_cache_at_top_level():
+    """`clear_remote_cache` and `RemoteIOError` are importable from the top.
+
+    Also verifies the lazy re-exports resolve to the underlying objects.
+    """
+    import sleap_io as sio
+
+    assert sio.clear_remote_cache is clear_remote_cache
+    assert sio.RemoteIOError is RemoteIOError
+    assert issubclass(RemoteIOError, OSError)
+    assert callable(clear_remote_cache)

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -529,6 +529,70 @@ def test_load_file_url_explicit_format_skips_sniff(httpserver, slp_minimal):
     assert len(labels) == 1
 
 
+def test_load_file_url_unsupported_format_redacts_credentials():
+    """An explicit unsupported `format` on a URL raises with a redacted URL.
+
+    The `ValueError` from the URL dispatcher must not leak userinfo or
+    token-like query parameters (S4).
+    """
+    url = "https://user:s3cr3t@example.com/data.slp?token=TOPSECRET"
+    with pytest.raises(ValueError) as exc_info:
+        load_file(url, format="not_a_real_format")
+    message = str(exc_info.value)
+    assert "s3cr3t" not in message
+    assert "TOPSECRET" not in message
+    assert "example.com" in message
+
+
+def test_load_file_url_ambiguous_sniff_false_redacts_credentials():
+    """`load_file(url, sniff=False)` on an ambiguous extension redacts the URL.
+
+    No network request is issued: the error is raised before any I/O.
+    """
+    url = "https://user:s3cr3t@example.com/data.h5?token=TOPSECRET"
+    with pytest.raises(ValueError) as exc_info:
+        load_file(url, sniff=False)
+    message = str(exc_info.value)
+    assert "s3cr3t" not in message
+    assert "TOPSECRET" not in message
+    assert "example.com" in message
+
+
+def test_load_file_url_unknown_extension_redacts_credentials():
+    """A URL with an unrecognized extension raises with a redacted URL.
+
+    No network request is issued: the error is raised before any I/O.
+    """
+    url = "https://user:s3cr3t@example.com/data.unknownext?token=TOPSECRET"
+    with pytest.raises(ValueError) as exc_info:
+        load_file(url)
+    message = str(exc_info.value)
+    assert "s3cr3t" not in message
+    assert "TOPSECRET" not in message
+    assert "example.com" in message
+
+
+def test_load_file_url_unrecognized_content_redacts_credentials(httpserver):
+    """A sniffed-but-unsupported body raises with a redacted URL (S4).
+
+    The body is binary that the magic sniffer classifies as `unknown`, so the
+    ambiguous-extension sniff path reaches the unsupported-content branch.
+    """
+    httpserver.expect_request("/data.h5").respond_with_data(
+        b"\xff\xfe\x00\x01nonsense-binary-body",
+        content_type="application/octet-stream",
+    )
+    base = httpserver.url_for("/data.h5")
+    # Inject credentials + token into the loopback URL the loader surfaces.
+    scheme, rest = base.split("://", 1)
+    url = f"{scheme}://user:s3cr3t@{rest}?token=TOPSECRET"
+    with pytest.raises(ValueError) as exc_info:
+        load_file(url)
+    message = str(exc_info.value)
+    assert "s3cr3t" not in message
+    assert "TOPSECRET" not in message
+
+
 def test_load_slp_url_cloud_missing_extra():
     """A missing cloud adapter raises `ImportError` with the `[cloud]` hint.
 

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -30,7 +30,9 @@ from sleap_io.io._remote import (
     _build_fsspec_filesystem,
     _find_response_error,
     _head_or_range_probe,
+    _http_inner_options,
     _identify_magic,
+    _identity_headers,
     _is_url,
     _mark_cache_dir,
     _raise_remote,
@@ -973,6 +975,27 @@ def test_build_fsspec_filesystem_http_sets_identity_encoding(httpserver):
 
     assert encodings_seen
     assert all(enc == "identity" for enc in encodings_seen)
+
+
+def test_identity_headers_user_cannot_override_accept_encoding():
+    """User-supplied Accept-Encoding (any casing) cannot weaken identity (S5)."""
+    # Exact-case override.
+    assert _identity_headers({"Accept-Encoding": "gzip"}) == {
+        "Accept-Encoding": "identity"
+    }
+    # Different casing (aiohttp coalesces header keys case-insensitively).
+    merged = _identity_headers({"accept-encoding": "gzip, br", "X-Custom": "1"})
+    assert merged["Accept-Encoding"] == "identity"
+    assert "accept-encoding" not in merged
+    assert merged["X-Custom"] == "1"
+    # None headers still yields the identity guarantee.
+    assert _identity_headers(None) == {"Accept-Encoding": "identity"}
+
+
+def test_http_inner_options_forces_identity_encoding():
+    """`_http_inner_options` forces identity even if the user passes gzip (S5)."""
+    opts = _http_inner_options({"Accept-Encoding": "gzip"})
+    assert opts["client_kwargs"]["headers"]["Accept-Encoding"] == "identity"
 
 
 def test_open_url_download_mode_returns_bytesio(httpserver):

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -1,7 +1,13 @@
-"""Non-network unit tests for sleap_io.io._remote.
+"""Unit and network tests for sleap_io.io._remote.
 
-Network and security (cross-origin redirect) tests live in a later step; these
-tests exercise only the pure / local-filesystem logic.
+The first half of this module exercises the pure / local-filesystem logic
+(URL detection, redaction, magic-byte sniffing, error mapping, cache helpers).
+The second half drives real HTTP requests through ``open_url`` /
+``_build_fsspec_filesystem`` / ``_sniff_format`` against a loopback
+``pytest-httpserver`` so the cross-origin credential-stripping trace hook,
+retry/backoff logic, and HTTP-status mapping are exercised end-to-end. No
+test in this module requires live internet access; the lone optional
+live-internet test is marked ``@pytest.mark.live``.
 """
 
 import asyncio
@@ -13,18 +19,80 @@ from pathlib import Path
 import aiohttp
 import pytest
 from aiohttp.client_reqrep import ConnectionKey
+from multidict import CIMultiDict
+from werkzeug.wrappers import Response
+from yarl import URL
 
 from sleap_io.io._remote import (
     _CACHE_MARKER_NAME,
+    _RETRY_BACKOFF_BASE,
     RemoteIOError,
+    _build_fsspec_filesystem,
+    _find_response_error,
+    _head_or_range_probe,
     _identify_magic,
     _is_url,
+    _mark_cache_dir,
     _raise_remote,
     _redact_url,
     _require_package,
+    _retry_after_seconds,
+    _retry_sleep_seconds,
+    _sniff_format,
+    _status_from_exception,
+    _strip_cross_origin_headers,
     _warn_if_old_aiohttp,
     clear_remote_cache,
+    open_remote_h5,
+    open_url,
 )
+
+#: HDF5 superblock signature followed by filler; serves as a sniffable body.
+_HDF5_BODY = b"\x89HDF\r\n\x1a\n" + b"\x00" * 128
+
+
+def _make_range_handler(body: bytes):
+    """Return a werkzeug handler that honors HTTP Range requests for ``body``.
+
+    fsspec's ``blockcache`` cache type issues ``Range`` requests; a plain
+    ``respond_with_data`` server (200 with no ranged support) is rejected by
+    fsspec. This handler answers ``HEAD`` (with ``Content-Length`` /
+    ``Accept-Ranges``) and ranged / full ``GET`` requests.
+
+    Args:
+        body: The full response body to serve.
+
+    Returns:
+        A callable suitable for ``HTTPServer.respond_with_handler``.
+    """
+    import re
+
+    total = len(body)
+
+    def _handler(request):
+        if request.method == "HEAD":
+            resp = Response(b"", status=200)
+            resp.headers["Content-Length"] = str(total)
+            resp.headers["Accept-Ranges"] = "bytes"
+            return resp
+        rng = request.headers.get("Range")
+        if rng:
+            match = re.match(r"bytes=(\d+)-(\d*)", rng)
+            start = int(match.group(1))
+            end = int(match.group(2)) if match.group(2) else total - 1
+            end = min(end, total - 1)
+            chunk = body[start : end + 1]
+            resp = Response(chunk, status=206)
+            resp.headers["Content-Range"] = f"bytes {start}-{end}/{total}"
+            resp.headers["Accept-Ranges"] = "bytes"
+            return resp
+        resp = Response(body, status=200)
+        resp.headers["Content-Length"] = str(total)
+        resp.headers["Accept-Ranges"] = "bytes"
+        return resp
+
+    return _handler
+
 
 # ---------------------------------------------------------------------------
 # _is_url
@@ -215,10 +283,21 @@ def test_remote_io_error_preserves_cause():
 # ---------------------------------------------------------------------------
 
 
-def _make_response_error(status: int) -> aiohttp.ClientResponseError:
-    """Construct a real aiohttp.ClientResponseError with the given status."""
+def _make_response_error(
+    status: int, *, headers: dict[str, str] | None = None
+) -> aiohttp.ClientResponseError:
+    """Construct a real aiohttp.ClientResponseError with the given status.
+
+    Args:
+        status: HTTP status code to set on the error.
+        headers: Optional response headers (e.g. ``{"Retry-After": "5"}``).
+    """
     return aiohttp.ClientResponseError(
-        request_info=None, history=(), status=status, message="err"
+        request_info=None,
+        history=(),
+        status=status,
+        message="err",
+        headers=headers,
     )
 
 
@@ -264,6 +343,14 @@ def test_raise_remote_maps_timeout():
     assert "timeout" in str(ei.value)
 
 
+def test_raise_remote_maps_payload_error():
+    """aiohttp.ClientPayloadError maps to a truncated-body RemoteIOError."""
+    with pytest.raises(RemoteIOError) as ei:
+        _raise_remote(aiohttp.ClientPayloadError("short"), url="https://host/x")
+    assert ei.value.status is None
+    assert "truncated body" in str(ei.value)
+
+
 def test_raise_remote_passthrough_remote_io_error():
     """An existing RemoteIOError is re-raised unchanged."""
     original = RemoteIOError("already wrapped", status=418)
@@ -289,6 +376,109 @@ def test_raise_remote_redacts_url_in_error():
         )
     assert "pass" not in str(ei.value)
     assert "SECRET" not in str(ei.value)
+
+
+# ---------------------------------------------------------------------------
+# _find_response_error / _status_from_exception (fsspec wrapper unwrapping)
+# ---------------------------------------------------------------------------
+
+
+def test_find_response_error_unwraps_cause_chain():
+    """A ClientResponseError wrapped as __cause__ is recovered from the chain."""
+    inner = _make_response_error(404)
+    wrapper = FileNotFoundError("url")
+    wrapper.__cause__ = inner
+    assert _find_response_error(wrapper) is inner
+
+
+def test_find_response_error_unwraps_context_chain():
+    """A ClientResponseError reachable only via __context__ is recovered."""
+    inner = _make_response_error(500)
+    wrapper = OSError("boom")
+    wrapper.__context__ = inner
+    assert _find_response_error(wrapper) is inner
+
+
+def test_find_response_error_none_when_absent():
+    """An exception chain with no ClientResponseError returns None."""
+    assert _find_response_error(ValueError("nope")) is None
+
+
+def test_find_response_error_handles_cycle():
+    """A cyclic cause/context chain does not loop forever."""
+    a = ValueError("a")
+    b = ValueError("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    assert _find_response_error(a) is None
+
+
+def test_status_from_exception_unwraps():
+    """_status_from_exception returns the wrapped status, or None."""
+    wrapper = FileNotFoundError("url")
+    wrapper.__cause__ = _make_response_error(416)
+    assert _status_from_exception(wrapper) == 416
+    assert _status_from_exception(ValueError("x")) is None
+
+
+# ---------------------------------------------------------------------------
+# Retry backoff helpers
+# ---------------------------------------------------------------------------
+
+
+def test_retry_after_seconds_integer():
+    """An integer Retry-After header is parsed to seconds."""
+    err = _make_response_error(429, headers={"Retry-After": "5"})
+    assert _retry_after_seconds(err) == 5.0
+
+
+def test_retry_after_seconds_absent_header():
+    """A response error without a Retry-After header returns None."""
+    assert _retry_after_seconds(_make_response_error(429)) is None
+
+
+def test_retry_after_seconds_non_integer_returns_none():
+    """A non-integer (HTTP-date) Retry-After value falls back to None."""
+    err = _make_response_error(429, headers={"Retry-After": "Wed, 21 Oct 2025 GMT"})
+    assert _retry_after_seconds(err) is None
+
+
+def test_retry_after_seconds_no_response_error_returns_none():
+    """A non-HTTP exception has no Retry-After."""
+    assert _retry_after_seconds(ValueError("x")) is None
+
+
+def test_retry_sleep_seconds_exponential_backoff():
+    """Without Retry-After, sleep grows exponentially from the base."""
+    exc = _make_response_error(500)
+    assert _retry_sleep_seconds(0, exc) == _RETRY_BACKOFF_BASE
+    assert _retry_sleep_seconds(1, exc) == _RETRY_BACKOFF_BASE * 2
+    assert _retry_sleep_seconds(2, exc) == _RETRY_BACKOFF_BASE * 4
+
+
+def test_retry_sleep_seconds_honors_retry_after():
+    """A Retry-After header overrides the exponential backoff."""
+    exc = _make_response_error(429, headers={"Retry-After": "2"})
+    assert _retry_sleep_seconds(5, exc) == 2.0
+
+
+# ---------------------------------------------------------------------------
+# _mark_cache_dir
+# ---------------------------------------------------------------------------
+
+
+def test_mark_cache_dir_creates_marker(tmp_path):
+    """_mark_cache_dir creates the directory and writes the marker file."""
+    target = tmp_path / "cache" / "nested"
+    _mark_cache_dir(target)
+    assert (target / _CACHE_MARKER_NAME).exists()
+
+
+def test_mark_cache_dir_idempotent(tmp_path):
+    """Calling _mark_cache_dir twice does not error and keeps one marker."""
+    _mark_cache_dir(tmp_path)
+    _mark_cache_dir(tmp_path)
+    assert (tmp_path / _CACHE_MARKER_NAME).exists()
 
 
 # ---------------------------------------------------------------------------
@@ -410,3 +600,496 @@ def test_clear_remote_cache_empty_dir_with_marker(tmp_path):
     """A marked dir with no cache files deletes nothing and returns 0."""
     (tmp_path / _CACHE_MARKER_NAME).touch()
     assert clear_remote_cache(cache_storage=tmp_path) == 0
+
+
+# ---------------------------------------------------------------------------
+# _strip_cross_origin_headers (the trace-hook decision, unit-tested directly)
+# ---------------------------------------------------------------------------
+
+
+def test_strip_cross_origin_headers_strips_on_different_origin():
+    """Sensitive headers are removed when the origin changes."""
+    headers = CIMultiDict(
+        {
+            "Authorization": "Bearer secret",
+            "Cookie": "sid=abc",
+            "Proxy-Authorization": "Basic xyz",
+            "Accept": "application/json",
+        }
+    )
+    _strip_cross_origin_headers(
+        URL("https://a.example/x"), URL("https://b.example/x"), headers
+    )
+    assert "Authorization" not in headers
+    assert "Cookie" not in headers
+    assert "Proxy-Authorization" not in headers
+    # Non-sensitive headers are preserved.
+    assert headers.get("Accept") == "application/json"
+
+
+def test_strip_cross_origin_headers_keeps_on_same_origin():
+    """Sensitive headers survive a same-origin redirect."""
+    headers = CIMultiDict({"Authorization": "Bearer secret"})
+    _strip_cross_origin_headers(
+        URL("https://a.example/start"), URL("https://a.example/final"), headers
+    )
+    assert headers.get("Authorization") == "Bearer secret"
+
+
+def test_strip_cross_origin_headers_noop_without_prev_url():
+    """With no prior URL (prev_url=None) nothing is stripped."""
+    headers = CIMultiDict({"Authorization": "Bearer secret"})
+    _strip_cross_origin_headers(None, URL("https://b.example/x"), headers)
+    assert headers.get("Authorization") == "Bearer secret"
+
+
+def test_strip_cross_origin_headers_port_change_is_cross_origin():
+    """A different port is a different origin, so headers are stripped."""
+    headers = CIMultiDict({"Authorization": "Bearer secret"})
+    _strip_cross_origin_headers(
+        URL("http://host:8001/x"), URL("http://host:8002/x"), headers
+    )
+    assert "Authorization" not in headers
+
+
+# ---------------------------------------------------------------------------
+# Network: cross-origin redirect credential stripping (S2)
+#
+# These drive real HTTP requests through open_url / _sniff_format against a
+# loopback pytest-httpserver, exercising the _safe_get_client trace hook.
+# ---------------------------------------------------------------------------
+
+
+def test_strips_auth_on_cross_origin_redirect(httpserver_dual):
+    """Authorization is dropped when a redirect crosses origins (S2).
+
+    Server A 302-redirects to server B (a different port = different origin).
+    The Authorization header must NOT reach B.
+    """
+    server_a, server_b = httpserver_dual
+    auth_seen_at_b: list[str | None] = []
+
+    def _b_handler(request):
+        auth_seen_at_b.append(request.headers.get("Authorization"))
+        return Response(_HDF5_BODY, status=200)
+
+    server_b.expect_request("/labels.slp").respond_with_handler(_b_handler)
+    b_url = server_b.url_for("/labels.slp")
+    server_a.expect_request("/labels.slp").respond_with_response(
+        Response(status=302, headers={"Location": b_url})
+    )
+    a_url = server_a.url_for("/labels.slp")
+
+    fmt = _sniff_format(a_url, headers={"Authorization": "Bearer secret"})
+
+    assert fmt == "hdf5"
+    assert auth_seen_at_b, "redirect target B was never reached"
+    assert all(a is None for a in auth_seen_at_b), (
+        "Authorization leaked to the cross-origin redirect target"
+    )
+
+
+def test_strips_cookie_on_cross_origin_redirect(httpserver_dual):
+    """Cookie is dropped when a redirect crosses origins (S2)."""
+    server_a, server_b = httpserver_dual
+    cookie_seen_at_b: list[str | None] = []
+
+    def _b_handler(request):
+        cookie_seen_at_b.append(request.headers.get("Cookie"))
+        return Response(_HDF5_BODY, status=200)
+
+    server_b.expect_request("/labels.slp").respond_with_handler(_b_handler)
+    b_url = server_b.url_for("/labels.slp")
+    server_a.expect_request("/labels.slp").respond_with_response(
+        Response(status=302, headers={"Location": b_url})
+    )
+    a_url = server_a.url_for("/labels.slp")
+
+    fmt = _sniff_format(a_url, headers={"Cookie": "session=abc123"})
+
+    assert fmt == "hdf5"
+    assert cookie_seen_at_b, "redirect target B was never reached"
+    assert all(c is None for c in cookie_seen_at_b), (
+        "Cookie leaked to the cross-origin redirect target"
+    )
+
+
+def test_same_origin_redirect_keeps_auth(httpserver):
+    """Authorization survives a same-origin redirect (we do not over-strip)."""
+    auth_seen_at_final: list[str | None] = []
+
+    def _final_handler(request):
+        auth_seen_at_final.append(request.headers.get("Authorization"))
+        return Response(_HDF5_BODY, status=200)
+
+    httpserver.expect_request("/final.slp").respond_with_handler(_final_handler)
+    httpserver.expect_request("/start.slp").respond_with_response(
+        Response(status=302, headers={"Location": httpserver.url_for("/final.slp")})
+    )
+    url = httpserver.url_for("/start.slp")
+
+    fmt = _sniff_format(url, headers={"Authorization": "Bearer secret"})
+
+    assert fmt == "hdf5"
+    assert auth_seen_at_final, "redirect target was never reached"
+    assert all(a == "Bearer secret" for a in auth_seen_at_final), (
+        "Authorization was wrongly stripped on a same-origin redirect"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Network: credential redaction in errors (S4)
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_redacted_in_errors(httpserver):
+    """A 404 against a userinfo URL surfaces no credentials in RemoteIOError (S4)."""
+    httpserver.expect_request("/missing.slp").respond_with_data("nope", status=404)
+    # Inject userinfo + a token query param into the URL host part.
+    plain = httpserver.url_for("/missing.slp")
+    scheme, rest = plain.split("://", 1)
+    creds_url = f"{scheme}://user:s3cr3t@{rest}?token=TOPSECRET"
+
+    with pytest.raises(RemoteIOError) as exc_info:
+        open_url(creds_url, retries=0)
+
+    message = str(exc_info.value)
+    assert "s3cr3t" not in message
+    assert "TOPSECRET" not in message
+    assert "user:" not in message
+    # The redacted URL attribute is also scrubbed.
+    assert exc_info.value.url is not None
+    assert "s3cr3t" not in exc_info.value.url
+    assert "TOPSECRET" not in exc_info.value.url
+
+
+# ---------------------------------------------------------------------------
+# Network: HTTP-status mapping through open_url
+# ---------------------------------------------------------------------------
+
+
+def test_remote_io_error_maps_404(httpserver):
+    """A 404 maps to RemoteIOError(status=404) through open_url."""
+    httpserver.expect_request("/missing.slp").respond_with_data("nope", status=404)
+    url = httpserver.url_for("/missing.slp")
+
+    with pytest.raises(RemoteIOError) as exc_info:
+        open_url(url, retries=0)
+
+    assert exc_info.value.status == 404
+    assert "file not found" in str(exc_info.value)
+
+
+def test_remote_io_error_maps_416(httpserver):
+    """A 416 maps to RemoteIOError(status=416) through open_url."""
+    httpserver.expect_request("/short.slp").respond_with_data("x", status=416)
+    url = httpserver.url_for("/short.slp")
+
+    with pytest.raises(RemoteIOError) as exc_info:
+        open_url(url, retries=0)
+
+    assert exc_info.value.status == 416
+    assert "range past end of file" in str(exc_info.value)
+
+
+def test_remote_io_error_maps_500_after_retries(httpserver):
+    """A persistent 500 is retried, then mapped to RemoteIOError(status=500).
+
+    With ``retries=2`` there should be exactly 3 GET attempts (one initial plus
+    two retries) before the error is surfaced.
+    """
+    get_count = {"n": 0}
+
+    def _handler(request):
+        if request.method == "GET":
+            get_count["n"] += 1
+        return Response("boom", status=500)
+
+    httpserver.expect_request("/err.slp").respond_with_handler(_handler)
+    url = httpserver.url_for("/err.slp")
+
+    with pytest.raises(RemoteIOError) as exc_info:
+        open_url(url, retries=2)
+
+    assert exc_info.value.status == 500
+    # 1 initial attempt + 2 retries = 3 GETs.
+    assert get_count["n"] == 3, f"expected 3 GET attempts, saw {get_count['n']}"
+
+
+def test_retries_honor_retry_after(httpserver):
+    """A 429 with Retry-After is retried and the next attempt succeeds.
+
+    A ``Retry-After: 0`` keeps the test sub-second while still routing through
+    the Retry-After parsing/honoring path.
+    """
+    get_count = {"n": 0}
+
+    def _handler(request):
+        if request.method != "GET":
+            return Response(status=200)
+        get_count["n"] += 1
+        if get_count["n"] == 1:
+            return Response("slow down", status=429, headers={"Retry-After": "0"})
+        return Response(_HDF5_BODY, status=200)
+
+    httpserver.expect_request("/rate.slp").respond_with_handler(_handler)
+    url = httpserver.url_for("/rate.slp")
+
+    file_like = open_url(url, retries=3)
+    try:
+        assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+    finally:
+        file_like.close()
+    # First GET 429'd, second GET succeeded.
+    assert get_count["n"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Network: HEAD 405 fallback + sniff over HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_head_405_fallback(httpserver):
+    """A server that rejects HEAD with 405 still resolves via a ranged GET.
+
+    ``_head_or_range_probe`` must return True even though HEAD is unsupported.
+    """
+    methods_seen: list[str] = []
+
+    def _handler(request):
+        methods_seen.append(request.method)
+        if request.method == "HEAD":
+            return Response(status=405)
+        return Response(_HDF5_BODY, status=200)
+
+    httpserver.expect_request("/probe.slp").respond_with_handler(_handler)
+    url = httpserver.url_for("/probe.slp")
+
+    assert _head_or_range_probe(url) is True
+    # The probe issued a GET (fsspec uses GET for existence), proving it did not
+    # give up on the HEAD 405.
+    assert "GET" in methods_seen
+
+
+def test_head_or_range_probe_false_on_404(httpserver):
+    """A 404 makes the existence probe return False (not raise)."""
+    httpserver.expect_request("/missing.slp").respond_with_data("no", status=404)
+    url = httpserver.url_for("/missing.slp")
+
+    assert _head_or_range_probe(url) is False
+
+
+@pytest.mark.parametrize(
+    "body,expected",
+    [
+        (b"\x89HDF\r\n\x1a\n" + b"\x00" * 16, "hdf5"),
+        (b'{"version": 1, "skeleton": []}', "json"),
+        (b"[1, 2, 3, 4, 5, 6, 7, 8, 9]", "json"),
+        (b"a,b,c,d\n1,2,3,4\n", "csv"),
+        (b"PK\x03\x04rest-of-zip-archive", "zip"),
+        (b"\x00\x01\x02\x03\xff\xfe\xfd\xfc", "unknown"),
+    ],
+)
+def test_sniff_over_http(httpserver, body, expected):
+    """`_sniff_format` fetches the first bytes over HTTP and classifies them."""
+    httpserver.expect_request("/data").respond_with_data(
+        body, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/data")
+
+    assert _sniff_format(url) == expected
+
+
+def test_sniff_over_http_404_raises(httpserver):
+    """`_sniff_format` maps an HTTP error to RemoteIOError with the status."""
+    httpserver.expect_request("/missing").respond_with_data("no", status=404)
+    url = httpserver.url_for("/missing")
+
+    with pytest.raises(RemoteIOError) as exc_info:
+        _sniff_format(url)
+
+    assert exc_info.value.status == 404
+
+
+def test_sniff_over_http_via_open_remote_h5(httpserver):
+    """`open_remote_h5` opens a served HDF5 body via blockcache."""
+    httpserver.expect_request("/data.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/data.slp")
+
+    file_like = open_remote_h5(url)
+    try:
+        assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+    finally:
+        file_like.close()
+
+
+# ---------------------------------------------------------------------------
+# Cloud-scheme filesystem construction + invalid stream mode
+# ---------------------------------------------------------------------------
+
+
+def test_build_fsspec_filesystem_cloud_scheme():
+    """A cloud scheme routes through `_ensure_cloud_extra` + `fsspec.filesystem`.
+
+    CI installs the cloud extras, so `s3` resolves to an `s3fs` filesystem
+    rather than raising.
+    """
+    import s3fs
+
+    fs = _build_fsspec_filesystem("s3")
+    assert isinstance(fs, s3fs.S3FileSystem)
+
+
+def test_open_url_invalid_stream_mode_raises_value_error(httpserver):
+    """`open_url` raises ValueError (not RemoteIOError) for a bad stream_mode."""
+    httpserver.expect_request("/data.slp").respond_with_data(_HDF5_BODY)
+    url = httpserver.url_for("/data.slp")
+
+    with pytest.raises(ValueError, match="Invalid stream_mode"):
+        open_url(url, stream_mode="not-a-real-mode")
+
+
+# ---------------------------------------------------------------------------
+# Network: open_url stream modes + filesystem builder over HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_build_fsspec_filesystem_http_sets_identity_encoding(httpserver):
+    """`_build_fsspec_filesystem` sets Accept-Encoding: identity on requests (S5)."""
+    encodings_seen: list[str | None] = []
+
+    def _handler(request):
+        encodings_seen.append(request.headers.get("Accept-Encoding"))
+        return Response(_HDF5_BODY, status=200)
+
+    httpserver.expect_request("/data").respond_with_handler(_handler)
+    url = httpserver.url_for("/data")
+
+    fs = _build_fsspec_filesystem("https", headers={"X-Custom": "1"})
+    with fs.open(url, mode="rb") as f:
+        assert f.read(8) == b"\x89HDF\r\n\x1a\n"
+
+    assert encodings_seen
+    assert all(enc == "identity" for enc in encodings_seen)
+
+
+def test_open_url_download_mode_returns_bytesio(httpserver):
+    """`stream_mode='download'` returns an in-memory BytesIO with the full body."""
+    httpserver.expect_request("/data.slp").respond_with_data(
+        _HDF5_BODY, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/data.slp")
+
+    file_like = open_url(url, stream_mode="download")
+    data = file_like.read()
+    assert data == _HDF5_BODY
+
+
+def test_open_url_cache_mode_writes_marker(httpserver, tmp_path):
+    """`stream_mode='cache'` (simplecache) writes the sleap-io cache marker."""
+    httpserver.expect_request("/data.slp").respond_with_data(
+        _HDF5_BODY, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/data.slp")
+
+    file_like = open_url(url, stream_mode="cache", cache_storage=tmp_path)
+    try:
+        assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+    finally:
+        file_like.close()
+    assert (tmp_path / _CACHE_MARKER_NAME).exists()
+
+
+def test_open_url_filecache_mode_writes_marker(httpserver, tmp_path):
+    """`stream_mode='filecache'` writes the marker and serves the content."""
+    httpserver.expect_request("/data.slp").respond_with_data(
+        _HDF5_BODY, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/data.slp")
+
+    file_like = open_url(
+        url, stream_mode="filecache", cache_storage=tmp_path, cache_expiry=10
+    )
+    try:
+        assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+    finally:
+        file_like.close()
+    assert (tmp_path / _CACHE_MARKER_NAME).exists()
+
+
+def test_open_url_cache_mode_default_storage(httpserver):
+    """`stream_mode='cache'` without an explicit cache_storage uses fsspec's default."""
+    httpserver.expect_request("/data.slp").respond_with_data(
+        _HDF5_BODY, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/data.slp")
+
+    file_like = open_url(url, stream_mode="cache")
+    try:
+        assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+    finally:
+        file_like.close()
+
+
+def test_open_url_filecache_mode_default_expiry(httpserver):
+    """`stream_mode='filecache'` without cache_storage/cache_expiry serves content."""
+    httpserver.expect_request("/data.slp").respond_with_data(
+        _HDF5_BODY, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/data.slp")
+
+    file_like = open_url(url, stream_mode="filecache")
+    try:
+        assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+    finally:
+        file_like.close()
+
+
+def test_open_url_blockcache_reads_body(httpserver):
+    """`stream_mode='auto'` -> blockcache reads the served body via Range GETs.
+
+    Uses a Range-capable handler because fsspec's blockcache relies on ranged
+    reads.
+    """
+    httpserver.expect_request("/data.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/data.slp")
+
+    file_like = open_url(url)  # auto -> blockcache
+    try:
+        assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+    finally:
+        file_like.close()
+
+
+def test_open_url_blockcache_explicit_max_blocks(httpserver):
+    """Explicit `block_size`/`max_blocks` are accepted by the blockcache open."""
+    httpserver.expect_request("/data.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/data.slp")
+
+    file_like = open_url(
+        url, stream_mode="blockcache", block_size=1 << 16, max_blocks=4
+    )
+    try:
+        assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+    finally:
+        file_like.close()
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not os.environ.get("SLEAP_IO_RUN_LIVE"),
+    reason="live-internet test; set SLEAP_IO_RUN_LIVE=1 to enable",
+)
+def test_sniff_over_http_live():
+    """Optional: sniff a real public `.slp` URL.
+
+    Skipped by default (CI has no guaranteed network); opt in with
+    ``SLEAP_IO_RUN_LIVE=1`` and select ``-m live``.
+    """
+    assert _sniff_format("https://slp.sh/4M16VD/labels.slp") == "hdf5"

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -13,6 +13,7 @@ live-internet test is marked ``@pytest.mark.live``.
 import asyncio
 import os
 import time
+import traceback
 import warnings
 from pathlib import Path
 
@@ -37,6 +38,8 @@ from sleap_io.io._remote import (
     _mark_cache_dir,
     _raise_remote,
     _redact_url,
+    _redacted_cause_summary,
+    _redirect_target,
     _require_package,
     _retry_after_seconds,
     _retry_sleep_seconds,
@@ -273,11 +276,29 @@ def test_remote_io_error_no_url_no_status():
     assert str(err) == "boom"
 
 
-def test_remote_io_error_preserves_cause():
-    """The underlying cause is preserved as __cause__."""
-    cause = ValueError("inner")
-    err = RemoteIOError("wrap", cause=cause)
-    assert err.__cause__ is cause
+def test_remote_io_error_stores_redacted_cause_summary():
+    """A redacted cause summary is stored and surfaced without chaining."""
+    err = RemoteIOError("wrap", cause_summary="ValueError: inner")
+    # The raw exception is never chained (no credential leak via __cause__).
+    assert err.__cause__ is None
+    assert err.cause_summary == "ValueError: inner"
+    assert "cause=ValueError: inner" in str(err)
+
+
+def test_redacted_cause_summary_redacts_embedded_url():
+    """A URL embedded in an exception message is redacted in the summary."""
+    e = FileNotFoundError(
+        "GET https://user:s3cr3t@host/missing.slp?token=TOPSECRET -> 404"
+    )
+    summary = _redacted_cause_summary(e)
+    assert "s3cr3t" not in summary
+    assert "TOPSECRET" not in summary
+    assert summary.startswith("FileNotFoundError:")
+
+
+def test_redacted_cause_summary_empty_message():
+    """An exception with no message degrades to just its type name."""
+    assert _redacted_cause_summary(ValueError()) == "ValueError"
 
 
 # ---------------------------------------------------------------------------
@@ -654,6 +675,76 @@ def test_strip_cross_origin_headers_port_change_is_cross_origin():
     assert "Authorization" not in headers
 
 
+def test_strip_cross_origin_headers_noop_without_new_url():
+    """With no resolvable target (new_url=None) nothing is stripped."""
+    headers = CIMultiDict({"Authorization": "Bearer secret"})
+    _strip_cross_origin_headers(URL("https://a.example/x"), None, headers)
+    assert headers.get("Authorization") == "Bearer secret"
+
+
+# ---------------------------------------------------------------------------
+# _redirect_target (resolve a redirect's Location header against the source)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRedirectResponse:
+    """Minimal stand-in for an aiohttp redirect response with headers."""
+
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = CIMultiDict(headers)
+
+
+def test_redirect_target_absolute_location():
+    """An absolute Location header resolves to its own origin (cross-origin)."""
+    prev = URL("https://a.example/start")
+    resp = _FakeRedirectResponse({"Location": "https://b.example/final"})
+    target = _redirect_target(prev, resp)
+    assert target == URL("https://b.example/final")
+    assert target.origin() != prev.origin()
+
+
+def test_redirect_target_relative_location_is_same_origin():
+    """A relative Location header resolves against the source (same origin)."""
+    prev = URL("https://a.example/dir/start")
+    resp = _FakeRedirectResponse({"Location": "/dir/final"})
+    target = _redirect_target(prev, resp)
+    assert target.origin() == prev.origin()
+
+
+def test_redirect_target_missing_location_returns_none():
+    """No Location header yields None (caller leaves headers untouched)."""
+    prev = URL("https://a.example/start")
+    assert _redirect_target(prev, _FakeRedirectResponse({})) is None
+
+
+def test_redirect_target_no_response_returns_none():
+    """A None response yields None."""
+    assert _redirect_target(URL("https://a.example/start"), None) is None
+
+
+def test_strip_cross_origin_via_redirect_target_strips():
+    """End-to-end of our logic: cross-origin Location strips sensitive headers.
+
+    Exercises ``_redirect_target`` + ``_strip_cross_origin_headers`` together
+    independent of aiohttp's native redirect handling.
+    """
+    prev = URL("https://a.example/start")
+    resp = _FakeRedirectResponse({"Location": "https://b.example/final"})
+    headers = CIMultiDict({"Authorization": "Bearer secret", "Accept": "*/*"})
+    _strip_cross_origin_headers(prev, _redirect_target(prev, resp), headers)
+    assert "Authorization" not in headers
+    assert headers.get("Accept") == "*/*"
+
+
+def test_strip_cross_origin_via_redirect_target_keeps_same_origin():
+    """Same-origin (relative) Location keeps sensitive headers."""
+    prev = URL("https://a.example/dir/start")
+    resp = _FakeRedirectResponse({"Location": "/dir/final"})
+    headers = CIMultiDict({"Authorization": "Bearer secret"})
+    _strip_cross_origin_headers(prev, _redirect_target(prev, resp), headers)
+    assert headers.get("Authorization") == "Bearer secret"
+
+
 # ---------------------------------------------------------------------------
 # Network: cross-origin redirect credential stripping (S2)
 #
@@ -763,6 +854,18 @@ def test_credentials_redacted_in_errors(httpserver):
     assert exc_info.value.url is not None
     assert "s3cr3t" not in exc_info.value.url
     assert "TOPSECRET" not in exc_info.value.url
+
+    # The FULL formatted traceback (which walks __cause__/__context__) must not
+    # leak credentials either: the credential-bearing aiohttp/fsspec exception is
+    # broken out of the displayed chain (raised `from None`).
+    e = exc_info.value
+    formatted = "".join(traceback.format_exception(type(e), e, e.__traceback__))
+    assert "s3cr3t" not in formatted
+    assert "TOPSECRET" not in formatted
+    # The explicit cause is dropped and the implicit context is suppressed so
+    # the formatter never reaches the raw exception.
+    assert e.__cause__ is None
+    assert e.__suppress_context__ is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -1,0 +1,412 @@
+"""Non-network unit tests for sleap_io.io._remote.
+
+Network and security (cross-origin redirect) tests live in a later step; these
+tests exercise only the pure / local-filesystem logic.
+"""
+
+import asyncio
+import os
+import time
+import warnings
+from pathlib import Path
+
+import aiohttp
+import pytest
+from aiohttp.client_reqrep import ConnectionKey
+
+from sleap_io.io._remote import (
+    _CACHE_MARKER_NAME,
+    RemoteIOError,
+    _identify_magic,
+    _is_url,
+    _raise_remote,
+    _redact_url,
+    _require_package,
+    _warn_if_old_aiohttp,
+    clear_remote_cache,
+)
+
+# ---------------------------------------------------------------------------
+# _is_url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        # Windows absolute paths -> not URLs (scheme is the drive letter).
+        ("C:/Users/foo.slp", False),
+        ("C:\\Users\\foo.slp", False),
+        ("D:\\data\\labels.slp", False),
+        # Relative / bare local paths.
+        ("./labels.slp", False),
+        ("../data/labels.slp", False),
+        ("labels.slp", False),
+        ("/abs/unix/path.slp", False),
+        # Remote schemes.
+        ("http://example.com/x.slp", True),
+        ("https://slp.sh/4M16VD/labels.slp", True),
+        ("s3://bucket/key.slp", True),
+        ("gs://bucket/key.slp", True),
+        ("gcs://bucket/key.slp", True),
+        ("az://container/key.slp", True),
+        ("abfs://container/key.slp", True),
+        # Unsupported scheme.
+        ("ftp://host/x.slp", False),
+        ("file:///tmp/x.slp", False),
+        # Edge cases.
+        ("", False),
+    ],
+)
+def test_is_url_boundaries(value, expected):
+    """_is_url distinguishes remote URLs from local/Windows paths."""
+    assert _is_url(value) is expected
+
+
+def test_is_url_case_insensitive():
+    """Scheme matching is case-insensitive."""
+    assert _is_url("S3://bucket/key") is True
+    assert _is_url("HTTPS://host/x") is True
+    assert _is_url("Https://host/x") is True
+
+
+def test_is_url_pathlike():
+    """os.PathLike inputs are handled and treated as local paths."""
+    assert _is_url(Path("C:/Users/foo.slp")) is False
+    assert _is_url(Path("labels.slp")) is False
+
+
+def test_is_url_non_string_non_pathlike():
+    """Non str/PathLike inputs return False rather than raising."""
+    assert _is_url(123) is False  # type: ignore[arg-type]
+    assert _is_url(None) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _redact_url
+# ---------------------------------------------------------------------------
+
+
+def test_redact_url_userinfo():
+    """Userinfo (user:pass@) is replaced with ***:***."""
+    out = _redact_url("https://user:pass@host.example/path/labels.slp")
+    assert "user" not in out
+    assert "pass" not in out
+    assert "***:***@host.example" in out
+    assert out.startswith("https://")
+    assert out.endswith("/path/labels.slp")
+
+
+def test_redact_url_token_query_params():
+    """Token-like query parameters have their values redacted."""
+    out = _redact_url("https://host/x?token=SECRET&access_token=ABC&sig=XYZ&keep=ok")
+    assert "SECRET" not in out
+    assert "ABC" not in out
+    assert "XYZ" not in out
+    # Non-sensitive params are preserved.
+    assert "keep=ok" in out
+
+
+def test_redact_url_no_credentials_unchanged():
+    """A URL with no credentials is returned essentially unchanged."""
+    url = "https://host.example/path/labels.slp"
+    assert _redact_url(url) == url
+
+
+def test_redact_url_userinfo_and_token_combined():
+    """Both userinfo and token query params are redacted together."""
+    out = _redact_url("https://u:p@host/x?x-amz-security-token=TOK&sas=SAS")
+    assert "u:p" not in out
+    assert "TOK" not in out
+    assert "SAS" not in out
+    assert "***:***@host" in out
+
+
+# ---------------------------------------------------------------------------
+# _identify_magic
+# ---------------------------------------------------------------------------
+
+
+def test_identify_magic_hdf5():
+    """The HDF5 superblock signature classifies as hdf5."""
+    assert _identify_magic(b"\x89HDF\r\n\x1a\n\x00\x00\x00\x00") == "hdf5"
+
+
+def test_identify_magic_json_object():
+    """A leading '{' classifies as json."""
+    assert _identify_magic(b'{"version": 1}') == "json"
+
+
+def test_identify_magic_json_array():
+    """A leading '[' classifies as json."""
+    assert _identify_magic(b"[1, 2, 3]") == "json"
+
+
+def test_identify_magic_zip():
+    r"""The PK\x03\x04 signature classifies as zip."""
+    assert _identify_magic(b"PK\x03\x04rest-of-zip") == "zip"
+
+
+def test_identify_magic_csv():
+    """ASCII-printable bytes with a comma classify as csv."""
+    assert _identify_magic(b"a,b,c\n1,2,3") == "csv"
+
+
+def test_identify_magic_garbage_unknown():
+    """Binary garbage classifies as unknown."""
+    assert _identify_magic(b"\x00\x01\x02\xff\xfe") == "unknown"
+
+
+def test_identify_magic_empty_unknown():
+    """Empty head is unknown (not spuriously csv)."""
+    assert _identify_magic(b"") == "unknown"
+
+
+def test_identify_magic_ascii_no_comma_unknown():
+    """ASCII without a comma is not csv."""
+    assert _identify_magic(b"hello world\n") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# RemoteIOError
+# ---------------------------------------------------------------------------
+
+
+def test_remote_io_error_is_oserror():
+    """RemoteIOError subclasses OSError for graceful degradation."""
+    assert issubclass(RemoteIOError, OSError)
+
+
+def test_remote_io_error_carries_status_and_redacted_url():
+    """RemoteIOError stores the status and a redacted URL."""
+    err = RemoteIOError(
+        "file not found",
+        url="https://user:pass@host/x?token=SECRET",
+        status=404,
+    )
+    assert err.status == 404
+    assert err.url is not None
+    assert "user" not in err.url
+    assert "pass" not in err.url
+    assert "SECRET" not in err.url
+    msg = str(err)
+    assert "status=404" in msg
+    assert "SECRET" not in msg
+    assert "pass" not in msg
+
+
+def test_remote_io_error_no_url_no_status():
+    """RemoteIOError with neither url nor status has a clean message."""
+    err = RemoteIOError("boom")
+    assert err.url is None
+    assert err.status is None
+    assert str(err) == "boom"
+
+
+def test_remote_io_error_preserves_cause():
+    """The underlying cause is preserved as __cause__."""
+    cause = ValueError("inner")
+    err = RemoteIOError("wrap", cause=cause)
+    assert err.__cause__ is cause
+
+
+# ---------------------------------------------------------------------------
+# _raise_remote mapping
+# ---------------------------------------------------------------------------
+
+
+def _make_response_error(status: int) -> aiohttp.ClientResponseError:
+    """Construct a real aiohttp.ClientResponseError with the given status."""
+    return aiohttp.ClientResponseError(
+        request_info=None, history=(), status=status, message="err"
+    )
+
+
+def test_raise_remote_maps_404():
+    """Aiohttp 404 maps to RemoteIOError(status=404)."""
+    with pytest.raises(RemoteIOError) as ei:
+        _raise_remote(_make_response_error(404), url="https://host/x")
+    assert ei.value.status == 404
+    assert "file not found" in str(ei.value)
+
+
+def test_raise_remote_maps_416():
+    """Aiohttp 416 maps to RemoteIOError(status=416)."""
+    with pytest.raises(RemoteIOError) as ei:
+        _raise_remote(_make_response_error(416), url="https://host/x")
+    assert ei.value.status == 416
+    assert "range past end of file" in str(ei.value)
+
+
+def test_raise_remote_maps_generic_5xx():
+    """An unmapped status maps to a generic RemoteIOError carrying the status."""
+    with pytest.raises(RemoteIOError) as ei:
+        _raise_remote(_make_response_error(503), url="https://host/x")
+    assert ei.value.status == 503
+    assert "HTTP 503" in str(ei.value)
+
+
+def test_raise_remote_maps_connector_error():
+    """aiohttp.ClientConnectorError maps to a connection-error RemoteIOError."""
+    key = ConnectionKey("host.example", 443, True, None, None, None, None)
+    cce = aiohttp.ClientConnectorError(key, OSError("dns fail"))
+    with pytest.raises(RemoteIOError) as ei:
+        _raise_remote(cce, url="https://host/x")
+    assert ei.value.status is None
+    assert "connection error" in str(ei.value)
+
+
+def test_raise_remote_maps_timeout():
+    """asyncio.TimeoutError maps to a timeout RemoteIOError."""
+    with pytest.raises(RemoteIOError) as ei:
+        _raise_remote(asyncio.TimeoutError(), url="https://host/x")
+    assert ei.value.status is None
+    assert "timeout" in str(ei.value)
+
+
+def test_raise_remote_passthrough_remote_io_error():
+    """An existing RemoteIOError is re-raised unchanged."""
+    original = RemoteIOError("already wrapped", status=418)
+    with pytest.raises(RemoteIOError) as ei:
+        _raise_remote(original, url="https://host/x")
+    assert ei.value is original
+
+
+def test_raise_remote_unknown_exception():
+    """An unrecognized exception is wrapped as an unexpected RemoteIOError."""
+    with pytest.raises(RemoteIOError) as ei:
+        _raise_remote(KeyError("nope"), url="https://host/x")
+    assert ei.value.status is None
+    assert "unexpected error" in str(ei.value)
+
+
+def test_raise_remote_redacts_url_in_error():
+    """Credentials in the URL are redacted in the raised error."""
+    with pytest.raises(RemoteIOError) as ei:
+        _raise_remote(
+            _make_response_error(404),
+            url="https://user:pass@host/x?token=SECRET",
+        )
+    assert "pass" not in str(ei.value)
+    assert "SECRET" not in str(ei.value)
+
+
+# ---------------------------------------------------------------------------
+# _require_package
+# ---------------------------------------------------------------------------
+
+
+def test_require_package_missing_raises_with_cloud_hint():
+    """A genuinely-absent package raises ImportError with the cloud hint."""
+    pkg = "definitely_not_installed_pkg_xyz_12345"
+    with pytest.raises(ImportError) as ei:
+        _require_package(pkg, scheme="s3")
+    msg = str(ei.value)
+    assert pkg in msg
+    assert "sleap-io[cloud]" in msg
+    assert "s3://" in msg
+
+
+def test_require_package_present_no_raise():
+    """An installed package imports without raising."""
+    # 'json' is always present in the stdlib.
+    _require_package("json", scheme="s3")
+
+
+# ---------------------------------------------------------------------------
+# _warn_if_old_aiohttp
+# ---------------------------------------------------------------------------
+
+
+def test_warn_if_old_aiohttp_warns_on_old_version():
+    """An aiohttp version below the minimum triggers a RuntimeWarning."""
+    with pytest.warns(RuntimeWarning, match="below sleap-io's minimum"):
+        _warn_if_old_aiohttp("3.13.0")
+
+
+def test_warn_if_old_aiohttp_silent_on_new_version():
+    """A version at or above the minimum produces no warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_if_old_aiohttp("3.13.5")
+        _warn_if_old_aiohttp("4.0.0")
+
+
+# ---------------------------------------------------------------------------
+# clear_remote_cache
+# ---------------------------------------------------------------------------
+
+
+def test_clear_remote_cache_requires_explicit_storage():
+    """clear_remote_cache requires an explicit cache_storage path."""
+    with pytest.raises(RuntimeError) as ei:
+        clear_remote_cache()
+    assert "cache_storage" in str(ei.value)
+
+
+def test_clear_remote_cache_refuses_without_marker(tmp_path):
+    """clear_remote_cache refuses a directory lacking the marker file."""
+    with pytest.raises(RuntimeError) as ei:
+        clear_remote_cache(cache_storage=tmp_path)
+    assert "marker" in str(ei.value).lower()
+
+
+def test_clear_remote_cache_refuses_home_dir():
+    """clear_remote_cache refuses to operate on $HOME (forbidden path)."""
+    with pytest.raises(RuntimeError) as ei:
+        clear_remote_cache(cache_storage=Path.home())
+    assert "forbidden" in str(ei.value).lower()
+
+
+def test_clear_remote_cache_deletes_only_cache_key_files(tmp_path):
+    """Only files matching the cache-key pattern are deleted; others remain."""
+    (tmp_path / _CACHE_MARKER_NAME).touch()
+    # Cache-key-pattern files (sha-style hex hashes, optional .tags sidecar).
+    cache_a = tmp_path / ("a" * 32)
+    cache_b = tmp_path / ("b" * 64)
+    cache_tags = tmp_path / (("c" * 40) + ".tags")
+    for p in (cache_a, cache_b, cache_tags):
+        p.write_bytes(b"x")
+    # Unrelated files that must NOT be deleted.
+    unrelated_named = tmp_path / "important.txt"
+    unrelated_short = tmp_path / ("d" * 8)  # too short to match pattern
+    unrelated_named.write_bytes(b"keep")
+    unrelated_short.write_bytes(b"keep")
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+
+    deleted = clear_remote_cache(cache_storage=tmp_path)
+
+    assert deleted == 3
+    assert not cache_a.exists()
+    assert not cache_b.exists()
+    assert not cache_tags.exists()
+    assert unrelated_named.exists()
+    assert unrelated_short.exists()
+    assert subdir.exists()
+    # Marker itself is preserved (does not match the cache-key pattern).
+    assert (tmp_path / _CACHE_MARKER_NAME).exists()
+
+
+def test_clear_remote_cache_honors_older_than(tmp_path):
+    """older_than only deletes files older than the threshold."""
+    (tmp_path / _CACHE_MARKER_NAME).touch()
+    old_file = tmp_path / ("a" * 32)
+    new_file = tmp_path / ("b" * 32)
+    old_file.write_bytes(b"x")
+    new_file.write_bytes(b"x")
+    # Backdate old_file's mtime by 1 hour.
+    old_time = time.time() - 3600
+    os.utime(old_file, (old_time, old_time))
+
+    deleted = clear_remote_cache(cache_storage=tmp_path, older_than=1800)
+
+    assert deleted == 1
+    assert not old_file.exists()
+    assert new_file.exists()
+
+
+def test_clear_remote_cache_empty_dir_with_marker(tmp_path):
+    """A marked dir with no cache files deletes nothing and returns 0."""
+    (tmp_path / _CACHE_MARKER_NAME).touch()
+    assert clear_remote_cache(cache_storage=tmp_path) == 0

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -7992,3 +7992,63 @@ def test_slp_undistributed_annotations_roundtrip(tmp_path):
     assert len(lf0.centroids) == 0
     assert len(lf0.bboxes) == 0
     assert len(lf0.masks) == 0
+
+
+def test_read_tracks_with_open_file(slp_typical):
+    """`read_tracks` reads from a passed-in open handle without closing it."""
+    with h5py.File(slp_typical, "r") as f:
+        tracks_passed = read_tracks(slp_typical, _hdf5_file=f)
+        # Handle must remain usable after the read (helper must not close it).
+        assert f.id.valid
+        assert "tracks_json" in f
+
+    tracks_default = read_tracks(slp_typical)
+    assert [t.name for t in tracks_passed] == [t.name for t in tracks_default]
+
+
+def test_read_metadata_with_open_file(slp_typical):
+    """`read_metadata` reads from a passed-in open handle without closing it."""
+    with h5py.File(slp_typical, "r") as f:
+        md_passed = read_metadata(slp_typical, _hdf5_file=f)
+        assert f.id.valid
+
+    md_default = read_metadata(slp_typical)
+    assert isinstance(md_passed, dict)
+    assert md_passed == md_default
+
+
+def test_read_videos_with_open_file(slp_minimal_pkg):
+    """`read_videos` reads (and threads the handle into make_video) correctly."""
+    with h5py.File(slp_minimal_pkg, "r") as f:
+        videos_passed = read_videos(slp_minimal_pkg, open_backend=False, _hdf5_file=f)
+        # Handle must remain usable after the read.
+        assert f.id.valid
+
+    videos_default = read_videos(slp_minimal_pkg, open_backend=False)
+    assert len(videos_passed) == len(videos_default)
+    assert [str(v.filename) for v in videos_passed] == [
+        str(v.filename) for v in videos_default
+    ]
+
+
+def test_read_labels_threads_single_open(slp_minimal_pkg):
+    """`read_labels` opens the backing HDF5 file only a small number of times.
+
+    Counts real `h5py.File` opens during a single `read_labels` call. Because the
+    orchestrator opens once and threads that handle through every helper, the only
+    extra open is `read_label_images`' long-lived second handle (when present), so
+    the total must be small (<= 3).
+    """
+    real_h5py_file = h5py.File
+    open_count = 0
+
+    def counting_h5py_file(*args, **kwargs):
+        nonlocal open_count
+        open_count += 1
+        return real_h5py_file(*args, **kwargs)
+
+    with mock.patch("sleap_io.io.slp.h5py.File", side_effect=counting_h5py_file):
+        labels = read_labels(slp_minimal_pkg)
+
+    assert type(labels) is Labels
+    assert open_count <= 3

--- a/tests/io/test_utils.py
+++ b/tests/io/test_utils.py
@@ -31,6 +31,26 @@ def test_read_hdf5_dataset(hdf5_file):
     np.testing.assert_array_equal(read_hdf5_dataset(hdf5_file, "ds1"), [0, 1, 2])
 
 
+def test_read_hdf5_dataset_positional_still_works(hdf5_file):
+    """Test `read_hdf5_dataset` still works with positional args (backcompat)."""
+    np.testing.assert_array_equal(read_hdf5_dataset(hdf5_file, "ds1"), [0, 1, 2])
+    np.testing.assert_array_equal(read_hdf5_dataset(hdf5_file, "grp/ds2"), [3, 4, 5])
+
+
+def test_read_hdf5_dataset_with_open_file(hdf5_file):
+    """Test `read_hdf5_dataset` reads from a passed open file and leaves it open."""
+    with h5py.File(hdf5_file, "r") as f:
+        np.testing.assert_array_equal(
+            read_hdf5_dataset(hdf5_file, "ds1", _hdf5_file=f), [0, 1, 2]
+        )
+        np.testing.assert_array_equal(
+            read_hdf5_dataset(hdf5_file, "grp/ds2", _hdf5_file=f), [3, 4, 5]
+        )
+        # The passed handle must remain usable (i.e. not closed by the call).
+        assert f.id.valid
+        np.testing.assert_array_equal(f["ds1"][()], [0, 1, 2])
+
+
 def test_write_hdf5_dataset(hdf5_file):
     """Test `write_hdf5_dataset` can write hdf5 datasets."""
 
@@ -53,6 +73,18 @@ def test_read_hdf5_group(hdf5_file):
     np.testing.assert_array_equal(data["/ds1"], [0, 1, 2])
     np.testing.assert_array_equal(data["/grp/ds2"], [3, 4, 5])
     assert len(data.keys()) == 2
+
+
+def test_read_hdf5_group_with_open_file(hdf5_file):
+    """Test `read_hdf5_group` reads from a passed open file and leaves it open."""
+    with h5py.File(hdf5_file, "r") as f:
+        data = read_hdf5_group(hdf5_file, group="/", _hdf5_file=f)
+        np.testing.assert_array_equal(data["/ds1"], [0, 1, 2])
+        np.testing.assert_array_equal(data["/grp/ds2"], [3, 4, 5])
+        assert len(data.keys()) == 2
+        # The passed handle must remain usable (i.e. not closed by the call).
+        assert f.id.valid
+        np.testing.assert_array_equal(f["ds1"][()], [0, 1, 2])
 
 
 def test_write_hdf5_group(hdf5_file):
@@ -116,6 +148,24 @@ def test_read_hdf5_attrs(hdf5_file):
     assert read_hdf5_attrs(hdf5_file, dataset="/", attribute="attr2") == 1
     attrs = read_hdf5_attrs(hdf5_file, dataset="/")
     assert attrs == {"attr1": 0, "attr2": 1}
+
+
+def test_read_hdf5_attrs_with_open_file(hdf5_file):
+    """Test `read_hdf5_attrs` reads from a passed open file and leaves it open."""
+    with h5py.File(hdf5_file, "r") as f:
+        assert (
+            read_hdf5_attrs(hdf5_file, dataset="/", attribute="attr1", _hdf5_file=f)
+            == 0
+        )
+        assert (
+            read_hdf5_attrs(hdf5_file, dataset="/", attribute="attr2", _hdf5_file=f)
+            == 1
+        )
+        attrs = read_hdf5_attrs(hdf5_file, dataset="/", _hdf5_file=f)
+        assert attrs == {"attr1": 0, "attr2": 1}
+        # The passed handle must remain usable (i.e. not closed by the call).
+        assert f.id.valid
+        assert dict(f["/"].attrs) == {"attr1": 0, "attr2": 1}
 
 
 def test_write_hdf5_attrs(hdf5_file):

--- a/tests/io/test_video_reading.py
+++ b/tests/io/test_video_reading.py
@@ -303,6 +303,53 @@ def test_hdf5video_url_reads_frames(httpserver, slp_minimal_pkg):
     assert_equal(frame, local[0])
 
 
+def test_hdf5video_post_init_closes_probe_handle_local(slp_minimal_pkg):
+    """`__attrs_post_init__` does not leak the probe HDF5 handle (local).
+
+    Re-running the heuristic probe must leave no open h5py file handle behind:
+    the probe handle is closed in a `finally` block regardless of early returns.
+    """
+    backend = HDF5Video(filename=slp_minimal_pkg, dataset=None, keep_open=False)
+    # The post-init probe ran during construction; it must not have stashed an
+    # open file handle (local files have no cached `_url_file`).
+    assert backend._url_file is None
+    # Re-running the probe explicitly must also leave nothing dangling.
+    backend.__attrs_post_init__()
+    assert backend._url_file is None
+    # Opening a fresh handle and checking the file object closes cleanly proves
+    # the probe did not hold the file open exclusively.
+    with h5py.File(slp_minimal_pkg, "r") as f:
+        assert "video0/video" in f
+
+
+def test_hdf5video_post_init_releases_probe_url_file(httpserver, slp_minimal_pkg):
+    """`__attrs_post_init__` releases a URL file-like opened solely to probe.
+
+    A probe-time open must not leak the cached fsspec `_url_file`, so that a
+    later (possibly authenticated) read reopens cleanly rather than reusing the
+    probe handle.
+    """
+    file_bytes = Path(slp_minimal_pkg).read_bytes()
+    httpserver.expect_request("/labels.pkg.slp").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.pkg.slp")
+
+    backend = HDF5Video(filename=url, dataset=None, keep_open=False)
+    object.__setattr__(backend, "_url_stream_mode", "download")
+    object.__setattr__(backend, "_url_file", None)
+
+    backend.__attrs_post_init__()
+    # The probe detected the embedded dataset...
+    assert backend.dataset == "video0/video"
+    # ...but did not leave the cached fsspec file-like dangling.
+    assert backend._url_file is None
+
+    # A subsequent read still works (reopens the URL lazily).
+    frame = backend[0]
+    assert frame.shape == (384, 384, 1)
+
+
 def test_hdf5video_get_frame_raw_bytes_fixed_length(tmpdir):
     """Test get_frame_raw_bytes() with fixed-length dataset (strips trailing zeros)."""
     import cv2

--- a/tests/io/test_video_reading.py
+++ b/tests/io/test_video_reading.py
@@ -1,5 +1,6 @@
 """Tests for methods in the sleap_io.io.video_reading file."""
 
+import pickle
 from pathlib import Path
 
 import h5py
@@ -240,6 +241,66 @@ def test_hdf5video_get_frame_raw_bytes_keep_open_false(slp_minimal_pkg):
     # Verify PNG magic bytes
     png_magic = raw_bytes[:4].view(np.uint8)
     assert list(png_magic) == [137, 80, 78, 71]
+
+
+def test_hdf5video_pickle_drops_reader(slp_minimal_pkg):
+    """Pickling an HDF5Video drops the open reader and stays readable."""
+    backend = VideoBackend.from_filename(slp_minimal_pkg)
+    assert type(backend) is HDF5Video
+
+    # Force the cached reader handle to be populated by reading a frame.
+    _ = backend[0]
+    assert backend._open_reader is not None
+
+    restored = pickle.loads(pickle.dumps(backend))
+    assert type(restored) is HDF5Video
+
+    # The unpicklable h5py handle must not survive the round-trip.
+    assert restored._open_reader is None
+    assert restored._url_file is None
+
+    # Shape (and lazy reopening) still works after unpickling.
+    assert restored.shape == backend.shape
+    assert_equal(restored[0], backend[0])
+
+
+def test_hdf5video_url_reads_frames(httpserver, slp_minimal_pkg):
+    """An HDF5Video with a URL filename reads frames via fsspec over HTTP.
+
+    The fixture is served with a plain 200 (no Range/206 support) to confirm
+    small files load via a full read.
+    """
+    file_bytes = Path(slp_minimal_pkg).read_bytes()
+    httpserver.expect_request("/labels.pkg.slp").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.pkg.slp")
+
+    # Construct the HDF5Video directly against the URL and exercise _open_h5.
+    # Use the "download" stream mode (full read into memory) so it works against
+    # a server that only returns 200 with no Range support.
+    backend = HDF5Video(filename=url, dataset=None, keep_open=False)
+    object.__setattr__(backend, "_url_stream_mode", "download")
+    object.__setattr__(backend, "_url_file", None)
+    assert type(backend) is HDF5Video
+
+    # Re-run heuristic detection over the URL now that download mode is set so
+    # the embedded image format/dataset are read from the remote file.
+    backend.__attrs_post_init__()
+    assert backend.dataset == "video0/video"
+    assert backend.has_embedded_images
+
+    # _open_h5() should open the remote file and yield a usable handle.
+    with backend._open_h5() as f:
+        assert "video0/video" in f
+
+    # Reading the first frame should pull bytes over HTTP and decode them.
+    frame = backend[0]
+    assert frame.shape == (384, 384, 1)
+
+    # Compare against a local read of the same fixture for parity.
+    local = HDF5Video(filename=slp_minimal_pkg, dataset="video0/video", keep_open=False)
+    assert_equal(frame, local[0])
 
 
 def test_hdf5video_get_frame_raw_bytes_fixed_length(tmpdir):

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -187,6 +187,61 @@ def test_safe_video_open(slp_minimal_pkg):
     assert not video.is_open
 
 
+def _count_requests(httpserver, path: str) -> int:
+    """Count the requests in the server log matching the given path."""
+    return sum(1 for req, _ in httpserver.log if req.path == path)
+
+
+def test_video_exists_url_cached_within_ttl(httpserver):
+    """A URL `exists()` probes the server once and reuses the cache within TTL."""
+    httpserver.expect_request("/labels.slp").respond_with_data(
+        b"hello world data", content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.slp")
+
+    video = Video(filename=url, open_backend=False)
+
+    assert video.exists() is True
+    first = _count_requests(httpserver, "/labels.slp")
+    assert first == 1
+
+    # Second call within the TTL must NOT hit the server again.
+    assert video.exists() is True
+    second = _count_requests(httpserver, "/labels.slp")
+    assert second == first
+
+
+def test_video_exists_url_404(httpserver):
+    """A URL that 404s returns False from `exists()`."""
+    httpserver.expect_request("/missing.slp").respond_with_data("nope", status=404)
+    url = httpserver.url_for("/missing.slp")
+
+    video = Video(filename=url, open_backend=False)
+    assert video.exists() is False
+
+
+def test_video_exists_replace_filename_clears_cache(httpserver, monkeypatch):
+    """`replace_filename` clears the cached URL existence result."""
+    # Force a short TTL so we control caching behavior deterministically.
+    monkeypatch.setenv("SLEAP_IO_EXISTS_TTL", "1000")
+    httpserver.expect_request("/labels.slp").respond_with_data(
+        b"hello world data", content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.slp")
+
+    video = Video(filename=url, open_backend=False)
+    assert video.exists() is True
+    assert video._exists_cache  # populated
+
+    # Replacing the filename must invalidate the cache.
+    video.replace_filename(url, open=False)
+    assert video._exists_cache == {}
+
+    # The next call re-probes the server (a second request appears).
+    assert video.exists() is True
+    assert _count_requests(httpserver, "/labels.slp") == 2
+
+
 def test_video_set_plugin(centered_pair_low_quality_path):
     """Test Video.set_video_plugin() method."""
     import sleap_io as sio

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -242,6 +242,24 @@ def test_video_exists_replace_filename_clears_cache(httpserver, monkeypatch):
     assert _count_requests(httpserver, "/labels.slp") == 2
 
 
+def test_video_exists_url_malformed_ttl_env(httpserver, monkeypatch):
+    """A malformed `SLEAP_IO_EXISTS_TTL` must not break the never-raise contract.
+
+    `exists()` (and `is_open`, which a GUI render loop polls) is contractually a
+    bool predicate; a bad env value should fall back to the default TTL rather
+    than raising `ValueError`.
+    """
+    monkeypatch.setenv("SLEAP_IO_EXISTS_TTL", "notanumber")
+    httpserver.expect_request("/labels.slp").respond_with_data(
+        b"hello world data", content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.slp")
+
+    video = Video(filename=url, open_backend=False)
+    # Must return a bool, not raise.
+    assert video.exists() is True
+
+
 def test_video_set_plugin(centered_pair_low_quality_path):
     """Test Video.set_video_plugin() method."""
     import sleap_io as sio


### PR DESCRIPTION
## Summary

First PR in a stack implementing remote data loading for sleap-io (part of #51). Adds direct loading of `.slp` / `.pkg.slp` from **HTTP(S) URLs and cloud buckets** (`s3://`, `gs://`, `gcs://`, `az://`, `abfs://`) using **lazy HTTP Range reads**, so a 77 MB `pkg.slp` loads by pulling only ~9% of the file in 8 requests — faster than a full download.

> **Stacked PR 1 of 3 — do not merge to `main` yet.** Based on `main`; follow-ups stack on top of this branch:
> - **PR 2** — remote video (`load_video(url)` via PyAV)
> - **PR 3** — Google Drive URL resolver
>
> Together the stack addresses #51 (URLs, Google Drive links, cloud buckets).

**Backend decision:** after a *fair* re-benchmark (table below), we use **fsspec `HTTPFileSystem` with `cache_type='blockcache'`** instead of a hand-vendored Range reader — identical bytes/requests, ~25% faster wall time (aiohttp pooling), and no HTTP client code to maintain. fsspec also lights up the cloud schemes for free.

## Key changes

- **New internal module `sleap_io/io/_remote.py`** — URL detection (`_is_url`, robust against Windows paths) + redaction, fsspec filesystem builder with a cross-origin credential-stripping trace hook, `open_url` (blockcache / cache / filecache / download modes), magic-byte format sniff, `clear_remote_cache`, and `RemoteIOError`.
- **`load_slp(url, ...)`** — new keyword-only `headers`, `stream_mode`, `cache_storage`, `cache_expiry`, `block_size`, `max_blocks`, `retries`. The existing `open_videos` and `lazy=` params and **all local-path behavior are preserved exactly**; URL kwargs are no-ops for local paths.
- **`load_file(url, sniff=...)`** — URL branch with 1-RTT magic-byte sniff for ambiguous extensions (`.h5`/`.json`/`.csv`); all existing local format detection is untouched.
- **`load_video(url)`** — raises a clear `NotImplementedError` pointing at PR 2 (with a redacted URL).
- **`_hdf5_file=` refactor** — keyword-only/private kwarg threaded through `utils.py` (3 helpers) and `slp.py` (17 read helpers + **both** the eager `read_labels` and lazy `_read_labels_lazy` orchestrators) so a remote `.slp` is parsed from a *single* open HDF5 handle instead of ~15. All existing positional callers keep working.
- **URL-aware `HDF5Video`** — `_open_h5()` streams embedded `pkg.slp` frames over fsspec; `__getstate__/__setstate__` pickle hooks on `VideoBackend`/`HDF5Video` (this also **fixes a pre-existing bug**: `HDF5Video` with an open reader was un-picklable, breaking `DataLoader`/`multiprocessing` workers).
- **`Video.exists()` URL fast-path** — TTL-cached HEAD probe (60 s default, `SLEAP_IO_EXISTS_TTL` override) inserted *before* `is_file_accessible` (which would otherwise short-circuit URLs to `False`); cache cleared on `replace_filename`. Protects the GUI `is_open` hot path.
- **Deps** — base `fsspec>=2024.10.0`, `aiohttp>=3.13.5` (the floor where aiohttp strips `Authorization`+`Cookie`+`Proxy-Authorization` on cross-origin redirect); new `[cloud]` extra = `s3fs`/`gcsfs`/`adlfs` (one install enables all three); dev `pytest-httpserver`.
- **Top-level re-exports** — `clear_remote_cache`, `RemoteIOError`.

## Example usage

```python
import sleap_io as sio

# HTTPS — works out of the box (lazy range reads)
labels = sio.load_slp("https://slp.sh/4M16VD/labels.slp")

# Cloud schemes (pip install 'sleap-io[cloud]')
labels = sio.load_slp("s3://my-bucket/labels.slp")

# Authenticated URL (header stripped on cross-origin redirect)
labels = sio.load_slp("https://org.io/private.slp",
                      headers={"Authorization": "Bearer secret"})

# Persistent, ETag-revalidated cache for repeated opens
labels = sio.load_slp("https://slp.sh/4M16VD/labels.slp",
                      stream_mode="filecache", cache_expiry=86400)

sio.clear_remote_cache(older_than=7 * 86400)
```

## Benchmark — 77 MB `pkg.slp`, median of 5 trials

| Approach | Bytes pulled | % of file | HTTP reqs | Wall |
|---|---:|---:|---:|---:|
| **fsspec `blockcache`, 1 MiB (chosen)** | **7.4 MB** | **9.4%** | **8** | **1.47 s** |
| Vendored RangeFile (v1 proposal) | 7.4 MB | 9.4% | 8 | 1.96 s |
| fsspec default (`bytes` read-ahead) | 20.8 MB | 26.2% | 13 | 2.54 s |
| `simplecache::` (full DL, persistent) | 79 MB | 100% | 1 | 1.70 s |
| obstore `open_reader` | 0.44 MB | 0.6% | 32 | 6.02 s |
| Full download (control) | 79 MB | 100% | 1 | 2.59 s |

Validated across 5 CDNs (slp.sh, AWS S3, GCS, GitHub releases, HuggingFace); `blockcache` worked on every host without per-host tuning.

## Security

| # | Guarantee |
|---|---|
| S1 | `aiohttp>=3.13.5` base dep — full cross-origin sensitive-header stripping |
| S2 | Belt-and-suspenders `on_request_redirect` hook re-strips `Authorization`/`Cookie`/`Proxy-Authorization` on cross-origin redirect (tested) |
| S3 | TLS verification always on; no public `verify=False` |
| S4 | URLs redacted (userinfo + token query params) in all errors/`RemoteIOError` |
| S5 | `Accept-Encoding: identity` on every request (avoids gzip+Range ambiguity) |
| S6 | `clear_remote_cache` refuses dirs lacking a marker; only deletes cache-key-pattern files |

## API changes / backcompat

- **No public API removed; no SemVer break.** All new kwargs are keyword-only with defaults; new top-level exports are additive.
- `_hdf5_file=` is keyword-only and underscore-private — third-party `read_hdf5_dataset(path, dataset)` callers are unaffected.
- **Behavior changes (CHANGELOG):** `HDF5Video` is now picklable when a reader is open (bug fix); `Video.exists()` now does a cached HEAD probe for URL filenames (previously always returned `False`).

## Testing

- `tests/io/test_remote.py`: **100 tests** (+1 live self-skipping test); **`_remote.py` at 100% coverage** (248 stmts / 92 branches).
- Cross-origin auth/cookie stripping, same-origin retention, credential redaction, error mapping (404/416/5xx-after-retries, `Retry-After`), HEAD-405→Range fallback, and cache-dir guards — all via `pytest-httpserver`.
- Full suite: **3091 passed, 24 skipped** locally. (One failure, `test_merging_integration.py::...test_samefile_with_symlink`, is a pre-existing Windows symlink-privilege issue in a file byte-identical to `main` — not a regression.)

## Design decisions

- **fsspec over a vendored RangeFile** — fair re-benchmark erased v1's claimed gap; fsspec matches bytes/requests and is faster, with multi-cloud + `simplecache`/`filecache` for free.
- **`cache_type='blockcache'`** — LRU over fixed blocks is the right shape for h5py's scattered random reads (the default read-ahead cache refetches metadata on backward seeks).
- **`stream_mode='auto'` = `blockcache`** — a threshold sweep found no size-based crossover justifying auto-switching; users opt into `cache`/`filecache`/`download`.
- **Cloud via a single `[cloud]` extra**; **magic-byte sniff default-on** for ambiguous URL extensions.

Full empirical investigation (benchmarks, multi-CDN probe, threshold sweep, architecture validation) lives in a gitignored scratch folder and is summarized above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
