### PR TITLE
feat(io): Google Drive share-link loading (PR 3/3)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -708,6 +708,46 @@ the install hint above.
       credentials, restricted network, and a non-privileged user) and keep
       FFmpeg/pyav up to date.
 
+### Google Drive
+
+Google Drive file share links are recognized and resolved to a direct download
+automatically, so you can pass a Drive URL straight to
+[`load_slp`][sleap_io.load_slp] or [`load_file`][sleap_io.load_file]:
+
+```python
+import sleap_io as sio
+
+# Any of these Drive share-link shapes work:
+labels = sio.load_slp("https://drive.google.com/file/d/<FILE_ID>/view")
+labels = sio.load_slp("https://drive.google.com/uc?id=<FILE_ID>&export=download")
+labels = sio.load_slp("https://drive.google.com/open?id=<FILE_ID>")
+
+# load_file resolves the Drive link, sniffs the content, and routes it:
+labels = sio.load_file("https://drive.google.com/file/d/<FILE_ID>/view")
+```
+
+The file must be shared as **"Anyone with the link"** (no sign-in required).
+Because Drive download links carry no file extension and reject the `HEAD`/range
+requests that lazy streaming relies on, a Drive file is **fully downloaded into
+memory** during resolution (the `stream_mode`/cache keyword arguments do not
+apply). The two-hop "can't scan for viruses" confirmation page that Drive serves
+for larger files is handled transparently.
+
+Some limitations:
+
+- **Folder links are not supported** — pass a single-file share link
+  (`…/file/d/<FILE_ID>/view`), not a `…/drive/folders/<ID>` URL. A folder URL
+  raises a `ValueError`.
+- **Drive videos are not supported** — `load_video(<drive url>)` raises a
+  `NotImplementedError`. Download the video file first, then load it locally.
+- **Quota / permission errors** — if Drive returns its "too many users have
+  viewed or downloaded this file recently" page, a `RemoteIOError` is raised;
+  retry later or re-check the file's sharing settings.
+
+For `load_file`, the format is detected from the downloaded bytes (which costs
+one extra fetch). Pass an explicit `format=` (e.g. `format="slp"`) to skip the
+detection download.
+
 ### Supported schemes and install matrix
 
 | Scheme | Requires | Notes |
@@ -847,6 +887,10 @@ labels = sio.load_slp(url, stream_mode="filecache", cache_storage=cache_dir)
   `pyav` extra; install it with `pip install 'sleap-io[pyav]'`. Only `http`/
   `https` URLs are supported for video. See [Remote video](#remote-video) for
   the security considerations of decoding untrusted remote video.
+- **Google Drive errors** — a `ValueError` means the link is a folder (pass a
+  `…/file/d/<ID>/view` file link) or the file ID could not be parsed; a
+  `RemoteIOError` mentioning a quota/permission page means the file is not shared
+  publicly or Drive is rate-limiting downloads. See [Google Drive](#google-drive).
 
 !!! note "See also"
     - [`load_slp`][sleap_io.load_slp]: Full URL keyword-argument reference

--- a/sleap_io/io/_gdrive.py
+++ b/sleap_io/io/_gdrive.py
@@ -28,14 +28,21 @@ import re
 import urllib.parse
 from html.parser import HTMLParser
 
-from sleap_io.io._remote import RemoteIOError, _redact_url
+from sleap_io.io._remote import (
+    _GDRIVE_HOSTS,
+    RemoteIOError,
+    _is_gdrive_url,
+    _redact_url,
+)
+
+# Re-export the pure-stdlib Drive detection helpers (defined in ``_remote`` so
+# they are importable without this heavier resolver module). Keeping them in the
+# ``_gdrive`` namespace preserves the import sites in ``main``/``video_reading``.
+__all__ = ["_GDRIVE_HOSTS", "_is_gdrive_url"]
 
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-#: Hostnames recognized as Google Drive / Docs share links.
-_GDRIVE_HOSTS = frozenset({"drive.google.com", "docs.google.com"})
 
 #: Base used to absolutize a relative ``href="/uc?export=download…"`` link.
 _DOCS_BASE = "https://docs.google.com"
@@ -77,23 +84,10 @@ _ERROR_SUBCAPTION_RE = re.compile(
 
 # ---------------------------------------------------------------------------
 # URL detection + file-id parsing
+#
+# ``_is_gdrive_url`` / ``_GDRIVE_HOSTS`` are imported from ``_remote`` above and
+# re-exported here (see ``__all__``).
 # ---------------------------------------------------------------------------
-
-
-def _is_gdrive_url(url: str) -> bool:
-    """Return True if ``url`` is a Google Drive / Docs share link.
-
-    Args:
-        url: The candidate URL.
-
-    Returns:
-        True if the hostname is ``drive.google.com`` or ``docs.google.com``.
-    """
-    try:
-        host = urllib.parse.urlparse(url).hostname
-    except (ValueError, TypeError):  # pragma: no cover - urlparse is permissive
-        return False
-    return host in _GDRIVE_HOSTS
 
 
 def _parse_gdrive(url: str) -> tuple[str, bool]:

--- a/sleap_io/io/_gdrive.py
+++ b/sleap_io/io/_gdrive.py
@@ -30,6 +30,7 @@ from html.parser import HTMLParser
 
 from sleap_io.io._remote import (
     _GDRIVE_HOSTS,
+    _SENSITIVE_HEADERS,
     RemoteIOError,
     _is_gdrive_url,
     _redact_url,
@@ -58,6 +59,17 @@ _BROWSER_UA = (
 #: module-level constant so tests can repoint the resolver at a local
 #: ``pytest-httpserver`` without touching real Google Drive.
 _UC_URL_TEMPLATE = "https://drive.google.com/uc?id={file_id}"
+
+#: Exact hostnames a resolved download URL is permitted to target. Drive serves
+#: the interstitial from ``drive.google.com``/``docs.google.com`` and the actual
+#: bytes from ``drive.usercontent.google.com``.
+_DOWNLOAD_HOSTS = frozenset(
+    {"drive.google.com", "docs.google.com", "drive.usercontent.google.com"}
+)
+
+#: The file often downloads from a per-region ``*.googleusercontent.com`` host,
+#: so any subdomain of this suffix is also permitted.
+_DOWNLOAD_HOST_SUFFIX = ".googleusercontent.com"
 
 #: Maximum number of interstitial hops to follow before giving up.
 _MAX_HOPS = 4
@@ -139,6 +151,66 @@ def _parse_gdrive(url: str) -> tuple[str, bool]:
         "Could not parse a Google Drive file ID from the URL; expected an "
         "'id=' query parameter or a '/file/d/<FILE_ID>/view' path "
         f"(got: {_redact_url(url)})."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Download-host allowlist (SSRF guard for scraped next-hop URLs)
+# ---------------------------------------------------------------------------
+
+
+def _allowed_download_hosts() -> frozenset[str]:
+    """Return the set of exact hostnames a download hop may target.
+
+    This is :data:`_DOWNLOAD_HOSTS` unioned with the hostname of the current
+    :data:`_UC_URL_TEMPLATE`. In production the template host is
+    ``drive.google.com`` (already in :data:`_DOWNLOAD_HOSTS`), so the union is a
+    no-op. The tests, however, repoint :data:`_UC_URL_TEMPLATE` at a loopback
+    ``pytest-httpserver`` that serves both the interstitial and the download
+    form-action on the same host; including the template host keeps that test
+    seam working without exposing a second seam or hardcoding a loopback address.
+
+    Returns:
+        The frozenset of permitted exact hostnames.
+    """
+    template_host = urllib.parse.urlparse(_UC_URL_TEMPLATE).hostname
+    if template_host is None:  # pragma: no cover - template always has a host
+        return _DOWNLOAD_HOSTS
+    return _DOWNLOAD_HOSTS | {template_host}
+
+
+def _check_download_host(url: str) -> None:
+    """Reject a download/next-hop URL that does not target a Google host.
+
+    Guards against SSRF and credential exfiltration: the resolution loop follows
+    URLs scraped out of attacker-influenceable interstitial HTML (the
+    ``#download-form`` action and the ``"downloadUrl"`` JSON variant). Without
+    this check, a malicious or compromised interstitial could redirect the
+    cookie- and header-carrying session at an arbitrary host.
+
+    A URL is permitted only when its scheme is ``http``/``https`` and its
+    hostname is in :func:`_allowed_download_hosts` or is a subdomain of
+    :data:`_DOWNLOAD_HOST_SUFFIX`.
+
+    Args:
+        url: The candidate URL to validate before issuing a GET.
+
+    Raises:
+        RemoteIOError: If the URL's scheme or host is not allowed. The URL is
+            redacted by :class:`~sleap_io.io._remote.RemoteIOError` before
+            display.
+    """
+    parsed = urllib.parse.urlparse(url)
+    hostname = parsed.hostname
+    if parsed.scheme in ("http", "https") and hostname is not None:
+        if hostname in _allowed_download_hosts() or hostname.endswith(
+            _DOWNLOAD_HOST_SUFFIX
+        ):
+            return
+    raise RemoteIOError(
+        "Refusing to follow a Google Drive redirect to an unexpected host "
+        "(only Google download hosts are allowed).",
+        url=url,
     )
 
 
@@ -301,7 +373,13 @@ async def _resolve_and_fetch(file_id: str, headers: dict[str, str] | None) -> by
     """
     import aiohttp
 
-    request_headers = {"User-Agent": _BROWSER_UA, **(headers or {})}
+    # Public Drive-link downloads never need credentials; strip any sensitive
+    # user headers (Authorization/Cookie/Proxy-Authorization) before they can be
+    # attached to the session and sent to a scraped next-hop host.
+    safe = {
+        k: v for k, v in (headers or {}).items() if k.lower() not in _SENSITIVE_HEADERS
+    }
+    request_headers = {"User-Agent": _BROWSER_UA, **safe}
     url = _UC_URL_TEMPLATE.format(file_id=file_id)
 
     # ``unsafe=True`` lets the jar keep cookies set by IP-address hosts (Drive
@@ -312,6 +390,9 @@ async def _resolve_and_fetch(file_id: str, headers: dict[str, str] | None) -> by
         headers=request_headers, cookie_jar=cookie_jar
     ) as session:
         for _ in range(_MAX_HOPS):
+            # Validate the initial uc URL and every scraped next-hop before
+            # issuing a GET that carries the session's cookies/headers.
+            _check_download_host(url)
             async with session.get(url, allow_redirects=True) as resp:
                 resp.raise_for_status()
                 content_type = resp.headers.get("Content-Type", "")
@@ -351,7 +432,7 @@ def _open_gdrive(url: str, *, headers: dict[str, str] | None = None) -> io.Bytes
         An :class:`io.BytesIO` positioned at the start of the downloaded bytes.
 
     Raises:
-        ValueError: For folder URLs, unparseable file IDs, or confirmation
+        ValueError: For folder URLs, unparsable file IDs, or confirmation
             pages with no download link.
         RemoteIOError: For HTTP failures, quota/permission pages, or
             non-convergent resolution.

--- a/sleap_io/io/_gdrive.py
+++ b/sleap_io/io/_gdrive.py
@@ -62,10 +62,13 @@ _UC_URL_TEMPLATE = "https://drive.google.com/uc?id={file_id}"
 #: Maximum number of interstitial hops to follow before giving up.
 _MAX_HOPS = 4
 
-#: Path regexes that yield a Drive file ID (``/file/d/<ID>/view|edit`` and the
-#: ``/file/u/<n>/d/<ID>/…`` per-account variant).
-_FILE_PATH_RE = re.compile(r"^/file/d/(.+?)/(?:edit|view)$")
-_FILE_PATH_U_RE = re.compile(r"^/file/u/[0-9]+/d/(.+?)/(?:edit|view)$")
+#: Path regex that yields a Drive file ID. Accepts the ``/file/d/<ID>/…`` share
+#: path with an optional ``/u/<n>/`` per-account prefix and an optional trailing
+#: action segment (``/view``, ``/edit``, ``/preview``, or none). Using
+#: ``[^/]+`` for the ID segment keeps multi-segment paths from being misparsed.
+_FILE_PATH_RE = re.compile(
+    r"^/file/(?:u/[0-9]+/)?d/(?P<id>[^/]+)(?:/(?:edit|view|preview))?/?$"
+)
 
 #: Marks a folder share link (unsupported -- sleap-io loads single files).
 _FOLDER_RE = re.compile(r"/(?:drive/)?folders/")
@@ -94,9 +97,10 @@ def _parse_gdrive(url: str) -> tuple[str, bool]:
     """Extract the file ID from a Google Drive share URL.
 
     Supports the ``id=`` query parameter (``/open?id=…``,
-    ``/uc?id=…&export=download``), the ``/file/d/<ID>/view`` (and
-    ``/file/d/<ID>/edit``) path form, and the ``/file/u/<n>/d/<ID>/…``
-    per-account variant.
+    ``/uc?id=…&export=download``) and the ``/file/d/<ID>/…`` path form. The
+    trailing action segment is optional and may be ``/view``, ``/edit``,
+    ``/preview``, or absent (a bare ``/file/d/<ID>``); the ``/file/u/<n>/d/<ID>``
+    per-account prefix is also accepted.
 
     Args:
         url: A Google Drive share URL.
@@ -127,9 +131,9 @@ def _parse_gdrive(url: str) -> tuple[str, bool]:
         return query["id"][0], False
 
     # 2) Path-based forms.
-    match = _FILE_PATH_RE.match(path) or _FILE_PATH_U_RE.match(path)
+    match = _FILE_PATH_RE.match(path)
     if match:
-        return match.group(1), False
+        return match.group("id"), False
 
     raise ValueError(
         "Could not parse a Google Drive file ID from the URL; expected an "

--- a/sleap_io/io/_gdrive.py
+++ b/sleap_io/io/_gdrive.py
@@ -1,0 +1,374 @@
+"""Google Drive share-link resolution for remote loading.
+
+Google Drive share URLs (``https://drive.google.com/file/d/<ID>/view``,
+``https://drive.google.com/uc?id=<ID>``, ``…/open?id=<ID>``) do not point at the
+file bytes directly: Drive serves an HTML "interstitial" confirmation page for
+anything large enough to skip its virus scan, and the real download URL lives
+inside that page's ``#download-form`` (or, for small files, behind a
+``Content-Disposition`` header on the first response). This module ports the
+minimal subset of `gdown <https://github.com/wkentaro/gdown>`_'s resolution
+logic needed by sleap-io, using only the standard library
+(:mod:`html.parser` + :mod:`re`) for HTML parsing -- no ``gdown`` or
+``beautifulsoup4`` dependency.
+
+The resolver (:func:`_open_gdrive`) is **notebook-safe**: it performs its HTTP
+GETs on fsspec's background event-loop thread via :func:`fsspec.asyn.sync`, so
+it does not call :func:`asyncio.run` (which raises "event loop is already
+running" inside a Jupyter kernel). Because Drive rejects ``HEAD`` with 405
+(which breaks fsspec's lazy size-probe) and its download quota can interrupt a
+transfer mid-stream, the resolver fully prefetches the resolved bytes within a
+single cookie-carrying session and returns an :class:`io.BytesIO`.
+"""
+
+from __future__ import annotations
+
+import html
+import io
+import re
+import urllib.parse
+from html.parser import HTMLParser
+
+from sleap_io.io._remote import RemoteIOError, _redact_url
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Hostnames recognized as Google Drive / Docs share links.
+_GDRIVE_HOSTS = frozenset({"drive.google.com", "docs.google.com"})
+
+#: Base used to absolutize a relative ``href="/uc?export=download…"`` link.
+_DOCS_BASE = "https://docs.google.com"
+
+#: Browser-like User-Agent. Drive serves the interstitial HTML (rather than a
+#: terse bot response) when it believes a browser is asking.
+_BROWSER_UA = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+
+#: Template for the initial resolution URL given a file ID. Exposed as a
+#: module-level constant so tests can repoint the resolver at a local
+#: ``pytest-httpserver`` without touching real Google Drive.
+_UC_URL_TEMPLATE = "https://drive.google.com/uc?id={file_id}"
+
+#: Maximum number of interstitial hops to follow before giving up.
+_MAX_HOPS = 4
+
+#: Path regexes that yield a Drive file ID (``/file/d/<ID>/view|edit`` and the
+#: ``/file/u/<n>/d/<ID>/…`` per-account variant).
+_FILE_PATH_RE = re.compile(r"^/file/d/(.+?)/(?:edit|view)$")
+_FILE_PATH_U_RE = re.compile(r"^/file/u/[0-9]+/d/(.+?)/(?:edit|view)$")
+
+#: Marks a folder share link (unsupported -- sleap-io loads single files).
+_FOLDER_RE = re.compile(r"/(?:drive/)?folders/")
+
+#: ``href="/uc?export=download…"`` small-file variant.
+_HREF_RE = re.compile(r'href="(/uc\?export=download[^"]+)"')
+
+#: ``"downloadUrl":"…"`` JSON variant (escaped ``=``/``&``).
+_DOWNLOAD_URL_RE = re.compile(r'"downloadUrl":"([^"]+)"')
+
+#: ``<p class="uc-error-subcaption">…</p>`` quota / permission error caption.
+_ERROR_SUBCAPTION_RE = re.compile(
+    r'<p class="uc-error-subcaption">(.*?)</p>', re.DOTALL
+)
+
+
+# ---------------------------------------------------------------------------
+# URL detection + file-id parsing
+# ---------------------------------------------------------------------------
+
+
+def _is_gdrive_url(url: str) -> bool:
+    """Return True if ``url`` is a Google Drive / Docs share link.
+
+    Args:
+        url: The candidate URL.
+
+    Returns:
+        True if the hostname is ``drive.google.com`` or ``docs.google.com``.
+    """
+    try:
+        host = urllib.parse.urlparse(url).hostname
+    except (ValueError, TypeError):  # pragma: no cover - urlparse is permissive
+        return False
+    return host in _GDRIVE_HOSTS
+
+
+def _parse_gdrive(url: str) -> tuple[str, bool]:
+    """Extract the file ID from a Google Drive share URL.
+
+    Supports the ``id=`` query parameter (``/open?id=…``,
+    ``/uc?id=…&export=download``), the ``/file/d/<ID>/view`` (and
+    ``/file/d/<ID>/edit``) path form, and the ``/file/u/<n>/d/<ID>/…``
+    per-account variant.
+
+    Args:
+        url: A Google Drive share URL.
+
+    Returns:
+        A ``(file_id, is_folder)`` tuple. ``is_folder`` is always False on
+        return because folder URLs raise (see below); it is part of the
+        signature for callers that want to branch before catching.
+
+    Raises:
+        ValueError: If the URL is a folder share link, or if no file ID can be
+            parsed from it.
+    """
+    parsed = urllib.parse.urlparse(url)
+    path = parsed.path
+
+    if _FOLDER_RE.search(path):
+        raise ValueError(
+            "Google Drive folder URLs are not supported; pass a single-file "
+            "share link of the form "
+            "https://drive.google.com/file/d/<FILE_ID>/view "
+            f"(got: {_redact_url(url)})."
+        )
+
+    # 1) ``id`` query parameter (covers /open?id=, /uc?id=…, both orderings).
+    query = urllib.parse.parse_qs(parsed.query)
+    if "id" in query and query["id"]:
+        return query["id"][0], False
+
+    # 2) Path-based forms.
+    match = _FILE_PATH_RE.match(path) or _FILE_PATH_U_RE.match(path)
+    if match:
+        return match.group(1), False
+
+    raise ValueError(
+        "Could not parse a Google Drive file ID from the URL; expected an "
+        "'id=' query parameter or a '/file/d/<FILE_ID>/view' path "
+        f"(got: {_redact_url(url)})."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Interstitial HTML scraping (stdlib only -- no bs4)
+# ---------------------------------------------------------------------------
+
+
+class _DownloadFormParser(HTMLParser):
+    """Extract the ``#download-form`` action + hidden inputs from Drive HTML.
+
+    Drive's large-file interstitial wraps the real download in a
+    ``<form id="download-form" action="https://drive.usercontent.google.com/
+    download" method="get">`` whose hidden ``<input>`` elements carry the
+    ``id``/``export``/``confirm``/``uuid`` parameters that must be merged into
+    the action's query string.
+
+    Attributes:
+        action: The form's ``action`` URL, or None if no download form was seen.
+        params: Hidden input ``{name: value}`` pairs collected from the form.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the parser with no form found yet."""
+        super().__init__(convert_charrefs=True)
+        self.action: str | None = None
+        self.params: dict[str, str] = {}
+        self._in_form = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        """Track the download form and collect its hidden inputs.
+
+        Args:
+            tag: The lowercased tag name.
+            attrs: The tag's ``(name, value)`` attribute pairs.
+        """
+        attr = {k: v for k, v in attrs}
+        if tag == "form" and attr.get("id") == "download-form":
+            self._in_form = True
+            self.action = attr.get("action")
+        elif tag == "input" and self._in_form:
+            name = attr.get("name")
+            if name is not None:
+                self.params[name] = attr.get("value") or ""
+
+    def handle_endtag(self, tag: str) -> None:
+        """Close the form-tracking state on the form's end tag.
+
+        Args:
+            tag: The lowercased tag name.
+        """
+        if tag == "form" and self._in_form:
+            self._in_form = False
+
+
+def _url_from_download_form(form_html: str) -> str | None:
+    """Resolve the ``#download-form`` to a direct download URL, if present.
+
+    Args:
+        form_html: The interstitial HTML.
+
+    Returns:
+        The merged download URL (form action query + hidden inputs), or None if
+        the HTML has no ``#download-form`` with an action.
+    """
+    parser = _DownloadFormParser()
+    parser.feed(form_html)
+    if not parser.action:
+        return None
+
+    parsed_action = urllib.parse.urlparse(parser.action)
+    # Start from any params already on the action URL, then overlay the hidden
+    # inputs (id/export/confirm/uuid) which take precedence.
+    merged: dict[str, str] = dict(
+        urllib.parse.parse_qsl(parsed_action.query, keep_blank_values=True)
+    )
+    merged.update(parser.params)
+    new_query = urllib.parse.urlencode(merged)
+    return urllib.parse.urlunparse(parsed_action._replace(query=new_query))
+
+
+def _url_from_confirmation(confirmation_html: str) -> str:
+    """Scrape the next download URL out of a Drive interstitial page.
+
+    Ports gdown's ``download.py`` confirmation logic with the standard library.
+    Tries, in order: the small-file ``href="/uc?export=download…"`` link, the
+    large-file ``#download-form``, and the ``"downloadUrl":"…"`` JSON variant.
+    If none match but the page carries a ``uc-error-subcaption`` (quota /
+    permission failure), a clear :class:`~sleap_io.io._remote.RemoteIOError` is
+    raised.
+
+    Args:
+        confirmation_html: The interstitial HTML returned by Drive.
+
+    Returns:
+        The next URL to GET in the resolution loop.
+
+    Raises:
+        RemoteIOError: If the page is a quota/permission error page.
+        ValueError: If no download URL could be extracted from the page.
+    """
+    # (a) Small-file relative href.
+    href_match = _HREF_RE.search(confirmation_html)
+    if href_match:
+        return _DOCS_BASE + href_match.group(1).replace("&amp;", "&")
+
+    # (b) Large-file #download-form (the dominant current path).
+    form_url = _url_from_download_form(confirmation_html)
+    if form_url is not None:
+        return form_url
+
+    # (c) "downloadUrl":"…" JSON variant.
+    json_match = _DOWNLOAD_URL_RE.search(confirmation_html)
+    if json_match:
+        return json_match.group(1).replace("\\u003d", "=").replace("\\u0026", "&")
+
+    # (d) Quota / permission error page.
+    error_match = _ERROR_SUBCAPTION_RE.search(confirmation_html)
+    if error_match:
+        caption = re.sub(r"<[^>]+>", "", error_match.group(1)).strip()
+        caption = html.unescape(caption)
+        raise RemoteIOError(
+            "Google Drive refused the download: "
+            f"{caption} "
+            "(if this is a quota error, try again later; if it is a permission "
+            "error, set the file's sharing to 'Anyone with the link')."
+        )
+
+    raise ValueError(
+        "Could not find a Google Drive download link in the confirmation page; "
+        "the file may be inaccessible or Drive's page format may have changed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Notebook-safe resolution loop (runs on fsspec's event-loop thread)
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_and_fetch(file_id: str, headers: dict[str, str] | None) -> bytes:
+    """Run the Drive GET loop and return the resolved file bytes.
+
+    This coroutine is driven from :func:`_open_gdrive` via
+    :func:`fsspec.asyn.sync` on fsspec's background event loop, so it is safe to
+    call from inside a running asyncio loop (e.g. a Jupyter kernel). A single
+    :class:`aiohttp.ClientSession` is used so Drive's interstitial cookies are
+    carried across the hop automatically.
+
+    Args:
+        file_id: The Google Drive file ID.
+        headers: Optional extra HTTP headers (merged over the browser default).
+
+    Returns:
+        The fully-downloaded file bytes.
+
+    Raises:
+        RemoteIOError: For quota/permission pages or if resolution does not
+            converge on a downloadable response within :data:`_MAX_HOPS`.
+        ValueError: If a confirmation page yields no download link.
+    """
+    import aiohttp
+
+    request_headers = {"User-Agent": _BROWSER_UA, **(headers or {})}
+    url = _UC_URL_TEMPLATE.format(file_id=file_id)
+
+    # ``unsafe=True`` lets the jar keep cookies set by IP-address hosts (Drive
+    # uses a domain so this is a no-op there, but it is needed to carry the
+    # interstitial cookie across the hop against a loopback test server).
+    cookie_jar = aiohttp.CookieJar(unsafe=True)
+    async with aiohttp.ClientSession(
+        headers=request_headers, cookie_jar=cookie_jar
+    ) as session:
+        for _ in range(_MAX_HOPS):
+            async with session.get(url, allow_redirects=True) as resp:
+                resp.raise_for_status()
+                content_type = resp.headers.get("Content-Type", "")
+                has_disposition = "Content-Disposition" in resp.headers
+                is_html = "text/html" in content_type.lower()
+
+                # A Content-Disposition header (or any non-HTML body) means we
+                # have reached the file itself: read it fully in this session.
+                if has_disposition or not is_html:
+                    return await resp.read()
+
+                # Otherwise this is the interstitial HTML; scrape the next URL.
+                page = await resp.text()
+            url = _url_from_confirmation(page)
+
+    raise RemoteIOError(
+        "Google Drive resolution did not converge on a downloadable file "
+        f"within {_MAX_HOPS} hops; the link may be invalid or require sign-in.",
+        url=url,
+    )
+
+
+def _open_gdrive(url: str, *, headers: dict[str, str] | None = None) -> io.BytesIO:
+    """Resolve a Google Drive share URL and return its bytes as a BytesIO.
+
+    The Drive download URL carries no file extension and Drive rejects ``HEAD``
+    with 405, both of which break the lazy fsspec open path; the resolved bytes
+    are therefore fully prefetched here (within one cookie-carrying session) and
+    returned as an in-memory :class:`io.BytesIO`, mirroring ``open_url``'s
+    ``stream_mode="download"`` shape.
+
+    Args:
+        url: A Google Drive / Docs share URL.
+        headers: Optional extra HTTP headers to forward.
+
+    Returns:
+        An :class:`io.BytesIO` positioned at the start of the downloaded bytes.
+
+    Raises:
+        ValueError: For folder URLs, unparseable file IDs, or confirmation
+            pages with no download link.
+        RemoteIOError: For HTTP failures, quota/permission pages, or
+            non-convergent resolution.
+    """
+    import fsspec.asyn
+
+    file_id, _is_folder = _parse_gdrive(url)
+
+    loop = fsspec.asyn.get_loop()
+    try:
+        data = fsspec.asyn.sync(loop, _resolve_and_fetch, file_id, headers)
+    except (RemoteIOError, ValueError):
+        raise
+    except Exception as e:  # noqa: BLE001 - normalize transport errors
+        from sleap_io.io._remote import _raise_remote
+
+        _raise_remote(e, url=url)
+    return io.BytesIO(data)

--- a/sleap_io/io/_remote.py
+++ b/sleap_io/io/_remote.py
@@ -591,6 +591,15 @@ def open_url(
         ImportError: For cloud schemes when the extra is not installed.
         ValueError: For an unrecognized ``stream_mode``.
     """
+    # Google Drive share links resolve through a two-hop interstitial flow and
+    # are full-prefetched into memory (Drive's HEAD 405 + quota-mid-stream
+    # behavior makes lazy range reads unreliable). The streaming kwargs above
+    # (stream_mode/cache/block_size/...) do not apply to this branch.
+    from sleap_io.io._gdrive import _is_gdrive_url, _open_gdrive
+
+    if _is_gdrive_url(url):
+        return _open_gdrive(url, headers=headers)
+
     parsed = urllib.parse.urlparse(url)
     scheme = parsed.scheme.lower()
     fs = _build_fsspec_filesystem(

--- a/sleap_io/io/_remote.py
+++ b/sleap_io/io/_remote.py
@@ -50,6 +50,11 @@ _CLOUD_PROTOCOL_TO_PACKAGE = {
     "abfs": "adlfs",
 }
 
+#: Hostnames recognized as Google Drive / Docs share links. Detection lives
+#: here (pure stdlib) so it is reachable without importing the heavier
+#: :mod:`sleap_io.io._gdrive` resolver; the resolver re-exports this symbol.
+_GDRIVE_HOSTS = frozenset({"drive.google.com", "docs.google.com"})
+
 #: HTTP headers stripped on cross-origin redirect (case-insensitive).
 _SENSITIVE_HEADERS = frozenset({"authorization", "cookie", "proxy-authorization"})
 
@@ -182,6 +187,26 @@ def _is_url(filename: str | os.PathLike) -> bool:
         return False
     scheme = urllib.parse.urlparse(s).scheme.lower()
     return scheme in _URL_SCHEMES
+
+
+def _is_gdrive_url(url: str) -> bool:
+    """Return True if ``url`` is a Google Drive / Docs share link.
+
+    Lives in this module (alongside :func:`_is_url`) so the cheap, pure-stdlib
+    Drive detection is importable without pulling in the heavier
+    :mod:`sleap_io.io._gdrive` resolver; that module re-exports this function.
+
+    Args:
+        url: The candidate URL.
+
+    Returns:
+        True if the hostname is ``drive.google.com`` or ``docs.google.com``.
+    """
+    try:
+        host = urllib.parse.urlparse(url).hostname
+    except (ValueError, TypeError):  # pragma: no cover - urlparse is permissive
+        return False
+    return host in _GDRIVE_HOSTS
 
 
 def _redact_url(url: str) -> str:
@@ -594,10 +619,12 @@ def open_url(
     # Google Drive share links resolve through a two-hop interstitial flow and
     # are full-prefetched into memory (Drive's HEAD 405 + quota-mid-stream
     # behavior makes lazy range reads unreliable). The streaming kwargs above
-    # (stream_mode/cache/block_size/...) do not apply to this branch.
-    from sleap_io.io._gdrive import _is_gdrive_url, _open_gdrive
-
+    # (stream_mode/cache/block_size/...) do not apply to this branch. Detection
+    # (``_is_gdrive_url``) is local + pure stdlib; the resolver is imported
+    # lazily only when a Drive URL is actually seen.
     if _is_gdrive_url(url):
+        from sleap_io.io._gdrive import _open_gdrive
+
         return _open_gdrive(url, headers=headers)
 
     parsed = urllib.parse.urlparse(url)

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -1243,8 +1243,12 @@ def _dispatch_gdrive_url_format(filename: str, **kwargs) -> Labels | Video:
 
     Raises:
         ValueError: If the content type cannot be recognized.
+        NotImplementedError: If the sniffed format is recognized but remote
+            loading for it is not yet implemented (every format other than
+            `slp`/`video`).
         RemoteIOError: For HTTP / resolution failures.
     """
+    from sleap_io.io import _remote
     from sleap_io.io._gdrive import _open_gdrive
 
     headers = kwargs.get("headers")
@@ -1254,6 +1258,19 @@ def _dispatch_gdrive_url_format(filename: str, **kwargs) -> Labels | Video:
     finally:
         file_like.close()
     fmt = _gdrive_format_from_bytes(data)
+
+    # The bytes were already fully downloaded to sniff the format above, so the
+    # generic `_dispatch_url_format` "Download the file locally first." message
+    # would be misleading here (the download cost was already paid). Raise a
+    # Drive-specific message instead for unsupported formats.
+    if fmt not in _URL_IMPLEMENTED_FORMATS:
+        raise NotImplementedError(
+            f"The Google Drive file was detected as '{fmt}' after a full "
+            f"download, but remote loading for '{fmt}' is not yet implemented "
+            f"(URL: {_remote._redact_url(filename)}); only 'slp' and 'video' "
+            "are supported over URLs. Save the bytes to a local file and load "
+            "that path instead."
+        )
     return _dispatch_url_format(filename, fmt, **kwargs)
 
 

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -851,6 +851,10 @@ def load_video(filename: str, **kwargs) -> Video:
             with the pyav plugin, which is selected automatically for URLs; it
             requires the ``av`` package (install with
             ``pip install 'sleap-io[pyav]'``). See the security warning above.
+            Google Drive share links are **not** supported for video (Drive
+            download links carry no file extension and reject the range
+            requests video streaming relies on); download the video file first,
+            then load it locally.
         **kwargs: Additional arguments passed to `Video.from_filename`.
             Currently supports:
             - dataset: Name of dataset in HDF5 file.
@@ -902,6 +906,10 @@ def load_video(filename: str, **kwargs) -> Video:
 
     Returns:
         A `Video` object.
+
+    Raises:
+        NotImplementedError: If ``filename`` is a Google Drive share link
+            (Drive video loading is not supported; download the file first).
 
     See Also:
         set_default_video_plugin: Set the default video plugin globally.

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -44,7 +44,10 @@ def load_slp(
     Args:
         filename: Path to a SLEAP labels file (`.slp`), or a URL. Supported URL
             schemes: `http`, `https`, `s3`, `gs`, `gcs`, `az`, `abfs`. Cloud
-            schemes require `pip install 'sleap-io[cloud]'`.
+            schemes require `pip install 'sleap-io[cloud]'`. Google Drive share
+            links (`https://drive.google.com/file/d/<ID>/view`) are also
+            supported and resolved to a direct download automatically (the file
+            is fully downloaded into memory; folder links are not supported).
         open_videos: If `True` (the default), attempt to open the video backend for
             I/O. If `False`, the backend will not be opened (useful for reading metadata
             when the video files are not available).
@@ -967,7 +970,9 @@ def load_file(
 
     Args:
         filename: Path to a file, or a URL (`http`, `https`, `s3`, `gs`, `gcs`,
-            `az`, `abfs`).
+            `az`, `abfs`). Google Drive file share links are also supported; the
+            file is downloaded and its format detected from the content (pass an
+            explicit `format=` to skip the detection download).
         format: Optional format to load as. If not provided, will be inferred from the
             file extension. Available formats are: "slp", "nwb", "geojson",
             "alphatracker", "labelstudio", "coco", "jabs", "analysis_h5", "dlc",
@@ -1163,6 +1168,87 @@ def _dispatch_url_format(filename: str, format: str, **kwargs) -> Labels | Video
     return load_slp(filename, **kwargs)
 
 
+def _gdrive_format_from_bytes(data: bytes) -> str:
+    """Resolve a format name from the first bytes of a Drive download.
+
+    Drive download URLs have no extension, so the format is inferred from the
+    magic bytes (and, for HDF5, the top-level group structure).
+
+    Args:
+        data: The fully-downloaded file bytes.
+
+    Returns:
+        A format name suitable for `_dispatch_url_format` (e.g. ``"slp"``,
+        ``"analysis_h5"``, ``"jabs"``, ``"coco"``, ``"labelstudio"``,
+        ``"alphatracker"``, ``"csv"``).
+
+    Raises:
+        ValueError: If the content type cannot be recognized.
+    """
+    import io
+    import json
+
+    from sleap_io.io import _remote
+
+    family = _remote._identify_magic(data[:16])
+    if family == "hdf5":
+        import h5py
+
+        with h5py.File(io.BytesIO(data), "r") as f:
+            if "track_occupancy" in f:
+                return "analysis_h5"
+            if "metadata" in f:
+                return "slp"
+            return "jabs"
+    if family == "json":
+        try:
+            parsed = json.loads(data)
+        except Exception:
+            parsed = None
+        if _is_alphatracker_data(parsed):
+            return "alphatracker"
+        if _is_coco_data(parsed):
+            return "coco"
+        return "labelstudio"
+    if family == "csv":
+        return "csv"
+    raise ValueError(
+        f"Could not determine the format of the Google Drive file (sniffed "
+        f"'{family}'). Pass an explicit format= (e.g. 'slp')."
+    )
+
+
+def _dispatch_gdrive_url_format(filename: str, **kwargs) -> Labels | Video:
+    """Resolve + sniff a Google Drive URL, then dispatch to the right loader.
+
+    The Drive bytes are fetched once to sniff the format; the chosen loader
+    then re-resolves the URL to read it. Pass an explicit ``format=`` to skip
+    this detection fetch entirely.
+
+    Args:
+        filename: The Google Drive URL.
+        **kwargs: Forwarded to the underlying loader (URL streaming kwargs such
+            as ``headers`` flow through to `load_slp`).
+
+    Returns:
+        The loaded `Labels` or `Video` object.
+
+    Raises:
+        ValueError: If the content type cannot be recognized.
+        RemoteIOError: For HTTP / resolution failures.
+    """
+    from sleap_io.io._gdrive import _open_gdrive
+
+    headers = kwargs.get("headers")
+    file_like = _open_gdrive(filename, headers=headers)
+    try:
+        data = file_like.read()
+    finally:
+        file_like.close()
+    fmt = _gdrive_format_from_bytes(data)
+    return _dispatch_url_format(filename, fmt, **kwargs)
+
+
 def _resolve_hdf5_url_format(
     url: str,
     headers: dict[str, str] | None,
@@ -1235,6 +1321,20 @@ def _load_file_url(
     # Explicit format always wins, bypassing detection entirely.
     if format is not None:
         return _dispatch_url_format(filename, format, **kwargs)
+
+    # Google Drive share links carry no usable file extension, so resolve +
+    # sniff the bytes to pick a format. `sniff=False` disables this since there
+    # is no extension to fall back on.
+    from sleap_io.io._gdrive import _is_gdrive_url
+
+    if _is_gdrive_url(filename):
+        if sniff is False:
+            raise ValueError(
+                "Cannot infer format for a Google Drive URL when sniff=False "
+                f"(Drive links carry no file extension): '{filename}'. Pass an "
+                "explicit format= (e.g. 'slp')."
+            )
+        return _dispatch_gdrive_url_format(filename, **kwargs)
 
     parsed = urllib.parse.urlparse(filename)
     ext = "".join(Path(parsed.path).suffixes[-1:]).lower()

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -477,6 +477,22 @@ class VideoBackend:
 
         is_url = type(filename) is str and _remote._is_url(filename)
 
+        if is_url:
+            from sleap_io.io._gdrive import _is_gdrive_url
+
+            if _is_gdrive_url(filename):
+                # Drive download URLs carry no extension and Drive rejects the
+                # range/HEAD requests video decoding relies on, so streaming a
+                # Drive video is not supported. Drive *labels* (.slp) loading is
+                # supported via load_slp/load_file.
+                raise NotImplementedError(
+                    "Loading videos directly from Google Drive URLs is not "
+                    "supported (Drive download links carry no file extension and "
+                    "reject the range requests video decoding needs). Download "
+                    "the video file first, or load Drive .slp label files with "
+                    f"load_slp/load_file. (URL: {_remote._redact_url(filename)})"
+                )
+
         # Skip local-filesystem dir detection for URLs (``Path.is_dir`` on a URL
         # is meaningless and would just return False, but avoid the syscall).
         if type(filename) is str and not is_url and Path(filename).is_dir():

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -893,6 +893,58 @@ def test_load_video_gdrive_url_not_supported():
         load_video("https://drive.google.com/file/d/FILEID/view")
 
 
+def _serve_gdrive_bytes(httpserver, body):
+    """Wire a two-hop Drive flow serving arbitrary ``body`` bytes.
+
+    Args:
+        httpserver: The `pytest-httpserver` instance to configure.
+        body: The raw bytes served at the usercontent `/download` hop.
+    """
+    from werkzeug.wrappers import Response
+
+    download_url = httpserver.url_for("/download")
+    form = (
+        f'<html><body><form id="download-form" action="{download_url}" '
+        'method="get">'
+        '<input type="hidden" name="id" value="FILEID">'
+        '<input type="hidden" name="export" value="download">'
+        '<input type="hidden" name="confirm" value="t">'
+        "</form></body></html>"
+    )
+
+    def _download_handler(request):
+        resp = Response(body, status=200)
+        resp.headers["Content-Disposition"] = 'attachment; filename="data.bin"'
+        return resp
+
+    httpserver.expect_request("/uc").respond_with_data(form, content_type="text/html")
+    httpserver.expect_request("/download").respond_with_handler(_download_handler)
+
+
+def test_load_file_gdrive_url_unsupported_format_message(gdrive_uc_template):
+    """A Drive file sniffed as a non-slp/video format raises a Drive-specific error.
+
+    The bytes are already fully downloaded to sniff the format, so the generic
+    "Download the file locally first." wording would be misleading. The
+    Drive-sniff path must instead say the download cost was already paid and
+    point at saving the bytes locally.
+    """
+    buf = io.BytesIO()
+    with h5py.File(buf, "w") as f:
+        f.create_dataset("track_occupancy", data=np.zeros((1, 1)))
+    _serve_gdrive_bytes(gdrive_uc_template, buf.getvalue())
+
+    with pytest.raises(NotImplementedError) as ei:
+        load_file("https://drive.google.com/file/d/FILEID/view")
+
+    msg = str(ei.value)
+    assert "analysis_h5" in msg
+    assert "after a full download" in msg
+    # Must not reuse the misleading generic "Download the file locally first."
+    # wording (the user already paid the download cost).
+    assert "Download the file locally first." not in msg
+
+
 def test_gdrive_format_from_bytes_hdf5_slp():
     """An HDF5 body with a `metadata` group is classified as slp."""
     buf = io.BytesIO()

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -1,14 +1,18 @@
 """Tests for functions in the sleap_io.io.main file."""
 
+import io
+import json
 import shutil
 from pathlib import Path
 
+import h5py
 import numpy as np
 import pytest
 
 from sleap_io import Labels, LabelsSet, RemoteIOError, Video, clear_remote_cache
 from sleap_io.io._remote import _require_package
 from sleap_io.io.main import (
+    _gdrive_format_from_bytes,
     load_file,
     load_jabs,
     load_labels_set,
@@ -772,3 +776,192 @@ def test_imports_clear_remote_cache_at_top_level():
     assert sio.RemoteIOError is RemoteIOError
     assert issubclass(RemoteIOError, OSError)
     assert callable(clear_remote_cache)
+
+
+# ---------------------------------------------------------------------------
+# Google Drive URL loading (PR 3)
+#
+# These simulate Drive's two-hop interstitial flow on the loopback
+# pytest-httpserver and repoint the resolver at it by overriding the
+# `_gdrive._UC_URL_TEMPLATE` constant. No request reaches real Google Drive.
+# ---------------------------------------------------------------------------
+
+
+def _serve_gdrive_slp(httpserver, slp_path):
+    """Wire a two-hop Drive flow serving a real `.slp` fixture's bytes.
+
+    Args:
+        httpserver: The `pytest-httpserver` instance to configure.
+        slp_path: Path to a `.slp` fixture whose bytes are served at the
+            usercontent `/download` hop.
+    """
+    from werkzeug.wrappers import Response
+
+    file_bytes = Path(slp_path).read_bytes()
+    download_url = httpserver.url_for("/download")
+    form = (
+        f'<html><body><form id="download-form" action="{download_url}" '
+        'method="get">'
+        '<input type="hidden" name="id" value="FILEID">'
+        '<input type="hidden" name="export" value="download">'
+        '<input type="hidden" name="confirm" value="t">'
+        "</form></body></html>"
+    )
+
+    def _download_handler(request):
+        resp = Response(file_bytes, status=200)
+        resp.headers["Content-Disposition"] = 'attachment; filename="labels.slp"'
+        return resp
+
+    httpserver.expect_request("/uc").respond_with_data(form, content_type="text/html")
+    httpserver.expect_request("/download").respond_with_handler(_download_handler)
+
+
+@pytest.fixture
+def gdrive_uc_template(monkeypatch, httpserver):
+    """Repoint the Drive resolver's start URL at the loopback test server.
+
+    Overrides the `_gdrive._UC_URL_TEMPLATE` module constant so the resolver
+    starts its GET loop at the local `/uc` endpoint. No real Drive request is
+    made.
+
+    Yields:
+        The httpserver (already installed as the resolver start host).
+    """
+    import sleap_io.io._gdrive as gdrive_mod
+
+    template = httpserver.url_for("/uc") + "?id={file_id}"
+    monkeypatch.setattr(gdrive_mod, "_UC_URL_TEMPLATE", template)
+    return httpserver
+
+
+def test_load_slp_gdrive_url(gdrive_uc_template, slp_minimal):
+    """`load_slp(<drive /file/d/ID/view url>)` returns a `Labels` object.
+
+    The `.slp` bytes are served at the usercontent hop; `load_slp` resolves the
+    Drive share link, downloads, and parses it like any other URL.
+    """
+    _serve_gdrive_slp(gdrive_uc_template, slp_minimal)
+
+    labels = load_slp("https://drive.google.com/file/d/FILEID/view")
+    assert type(labels) is Labels
+    assert len(labels) == 1
+
+
+def test_load_slp_gdrive_open_id_url(gdrive_uc_template, slp_minimal):
+    """`load_slp` also accepts the `/open?id=` Drive share shape."""
+    _serve_gdrive_slp(gdrive_uc_template, slp_minimal)
+
+    labels = load_slp("https://drive.google.com/open?id=FILEID")
+    assert type(labels) is Labels
+    assert len(labels) == 1
+
+
+def test_load_file_gdrive_url_sniffs_slp(gdrive_uc_template, slp_minimal):
+    """`load_file` resolves a Drive URL, sniffs the bytes, and routes to slp."""
+    _serve_gdrive_slp(gdrive_uc_template, slp_minimal)
+
+    labels = load_file("https://drive.google.com/file/d/FILEID/view")
+    assert type(labels) is Labels
+    assert len(labels) == 1
+
+
+def test_load_file_gdrive_url_explicit_format(gdrive_uc_template, slp_minimal):
+    """An explicit `format='slp'` dispatches a Drive URL without a sniff fetch."""
+    _serve_gdrive_slp(gdrive_uc_template, slp_minimal)
+
+    labels = load_file("https://drive.google.com/file/d/FILEID/view", format="slp")
+    assert type(labels) is Labels
+    assert len(labels) == 1
+
+
+def test_load_file_gdrive_url_sniff_false_raises(slp_minimal):
+    """`load_file(drive_url, sniff=False)` raises (no extension to fall back on)."""
+    with pytest.raises(ValueError, match="Cannot infer format for a Google Drive"):
+        load_file("https://drive.google.com/file/d/FILEID/view", sniff=False)
+
+
+def test_load_slp_gdrive_folder_url_raises(slp_minimal):
+    """A Drive folder share link raises a clear ValueError."""
+    with pytest.raises(ValueError, match="folder URLs are not supported"):
+        load_slp("https://drive.google.com/drive/folders/FOLDERID")
+
+
+def test_load_video_gdrive_url_not_supported():
+    """`load_video` on a Drive URL raises a clear NotImplementedError."""
+    with pytest.raises(NotImplementedError, match="Google Drive"):
+        load_video("https://drive.google.com/file/d/FILEID/view")
+
+
+def test_gdrive_format_from_bytes_hdf5_slp():
+    """An HDF5 body with a `metadata` group is classified as slp."""
+    buf = io.BytesIO()
+    with h5py.File(buf, "w") as f:
+        f.create_group("metadata")
+    assert _gdrive_format_from_bytes(buf.getvalue()) == "slp"
+
+
+def test_gdrive_format_from_bytes_hdf5_analysis():
+    """An HDF5 body with `track_occupancy` is classified as analysis_h5."""
+    buf = io.BytesIO()
+    with h5py.File(buf, "w") as f:
+        f.create_dataset("track_occupancy", data=np.zeros((1, 1)))
+    assert _gdrive_format_from_bytes(buf.getvalue()) == "analysis_h5"
+
+
+def test_gdrive_format_from_bytes_hdf5_jabs():
+    """A bare HDF5 body (no slp/analysis markers) falls back to jabs."""
+    buf = io.BytesIO()
+    with h5py.File(buf, "w") as f:
+        f.create_group("poseest")
+    assert _gdrive_format_from_bytes(buf.getvalue()) == "jabs"
+
+
+def test_gdrive_format_from_bytes_json_labelstudio():
+    """A generic JSON object is classified as labelstudio."""
+    assert _gdrive_format_from_bytes(b'{"some": "labelstudio"}') == "labelstudio"
+
+
+def test_gdrive_format_from_bytes_json_coco():
+    """A COCO-pose JSON object is classified as coco."""
+    coco = json.dumps(
+        {
+            "images": [],
+            "annotations": [],
+            "categories": [{"keypoints": ["a", "b"]}],
+        }
+    ).encode()
+    assert _gdrive_format_from_bytes(coco) == "coco"
+
+
+def test_gdrive_format_from_bytes_json_alphatracker():
+    """An AlphaTracker JSON array is classified as alphatracker."""
+    at = json.dumps(
+        [
+            {
+                "filename": "f.png",
+                "class": "image",
+                "annotations": [
+                    {"class": "Face"},
+                    {"class": "point", "x": 1, "y": 2},
+                ],
+            }
+        ]
+    ).encode()
+    assert _gdrive_format_from_bytes(at) == "alphatracker"
+
+
+def test_gdrive_format_from_bytes_json_malformed_is_labelstudio():
+    """Malformed JSON (starts with `{`) is not alphatracker/coco -> labelstudio."""
+    assert _gdrive_format_from_bytes(b"{not valid json") == "labelstudio"
+
+
+def test_gdrive_format_from_bytes_csv():
+    """CSV-looking bytes are classified as csv."""
+    assert _gdrive_format_from_bytes(b"a,b,c\n1,2,3\n") == "csv"
+
+
+def test_gdrive_format_from_bytes_unknown_raises():
+    """Unrecognizable bytes raise a clear ValueError."""
+    with pytest.raises(ValueError, match="Could not determine the format"):
+        _gdrive_format_from_bytes(b"\x00\x01\x02\xff\xfe")

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -14,6 +14,7 @@ import asyncio
 import os
 import time
 import traceback
+import urllib.parse
 import warnings
 from pathlib import Path
 
@@ -24,6 +25,12 @@ from multidict import CIMultiDict
 from werkzeug.wrappers import Response
 from yarl import URL
 
+from sleap_io.io._gdrive import (
+    _is_gdrive_url,
+    _open_gdrive,
+    _parse_gdrive,
+    _url_from_confirmation,
+)
 from sleap_io.io._remote import (
     _CACHE_MARKER_NAME,
     _RETRY_BACKOFF_BASE,
@@ -1205,6 +1212,347 @@ def test_open_url_blockcache_explicit_max_blocks(httpserver):
         assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
     finally:
         file_like.close()
+
+
+# ---------------------------------------------------------------------------
+# Google Drive: URL detection + file-id parsing (pure, no server)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://drive.google.com/file/d/ABC123/view", True),
+        ("https://drive.google.com/uc?id=ABC123&export=download", True),
+        ("https://docs.google.com/uc?id=ABC123", True),
+        ("https://DRIVE.GOOGLE.COM/file/d/ABC/view", True),
+        ("https://example.com/file/d/ABC/view", False),
+        ("https://storage.googleapis.com/bucket/x.slp", False),
+        ("s3://bucket/key.slp", False),
+        ("not a url at all", False),
+    ],
+)
+def test_is_gdrive_url(url, expected):
+    """`_is_gdrive_url` recognizes drive/docs hostnames only."""
+    assert _is_gdrive_url(url) is expected
+
+
+@pytest.mark.parametrize(
+    "url,expected_id",
+    [
+        # /file/d/<ID>/view (+ ?usp=sharing in the query).
+        ("https://drive.google.com/file/d/FILEID/view", "FILEID"),
+        ("https://drive.google.com/file/d/FILEID/view?usp=sharing", "FILEID"),
+        ("https://drive.google.com/file/d/FILEID/edit", "FILEID"),
+        # /file/u/<n>/d/<ID>/view per-account variant.
+        ("https://drive.google.com/file/u/0/d/FILEID/view", "FILEID"),
+        # id= query param, both orderings + /open?id=.
+        ("https://drive.google.com/uc?id=FILEID&export=download", "FILEID"),
+        ("https://drive.google.com/uc?export=download&id=FILEID", "FILEID"),
+        ("https://drive.google.com/open?id=FILEID", "FILEID"),
+    ],
+)
+def test_parse_gdrive_extracts_file_id(url, expected_id):
+    """`_parse_gdrive` extracts the file ID from every supported URL shape."""
+    file_id, is_folder = _parse_gdrive(url)
+    assert file_id == expected_id
+    assert is_folder is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://drive.google.com/drive/folders/FOLDERID",
+        "https://drive.google.com/folders/FOLDERID",
+        "https://drive.google.com/drive/folders/FOLDERID?usp=sharing",
+    ],
+)
+def test_parse_gdrive_folder_raises(url):
+    """Folder share links raise a clear ValueError."""
+    with pytest.raises(ValueError, match="folder URLs are not supported"):
+        _parse_gdrive(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://drive.google.com/",
+        "https://drive.google.com/something/else",
+        "https://drive.google.com/file/d/ABC",  # missing /view|/edit suffix
+    ],
+)
+def test_parse_gdrive_unparseable_raises(url):
+    """A URL with no recoverable file ID raises a clear ValueError."""
+    with pytest.raises(ValueError, match="Could not parse a Google Drive file ID"):
+        _parse_gdrive(url)
+
+
+def test_parse_gdrive_redacts_credentials_in_error():
+    """A token in an unparseable URL is redacted in the raised error."""
+    with pytest.raises(ValueError) as ei:
+        _parse_gdrive("https://drive.google.com/nope?token=SECRET")
+    assert "SECRET" not in str(ei.value)
+
+
+# ---------------------------------------------------------------------------
+# Google Drive: confirmation-page scraping (pure, no server)
+# ---------------------------------------------------------------------------
+
+
+def test_url_from_confirmation_download_form_merges_params():
+    """The #download-form action is merged with all hidden inputs."""
+    html = (
+        '<html><body><form id="download-form" '
+        'action="https://drive.usercontent.google.com/download" method="get">'
+        '<input type="hidden" name="id" value="FILEID">'
+        '<input type="hidden" name="export" value="download">'
+        '<input type="hidden" name="confirm" value="t">'
+        '<input type="hidden" name="uuid" value="u-1-2-3">'
+        "</form></body></html>"
+    )
+    url = _url_from_confirmation(html)
+    parsed = urllib.parse.urlparse(url)
+    assert parsed.netloc == "drive.usercontent.google.com"
+    assert parsed.path == "/download"
+    params = dict(urllib.parse.parse_qsl(parsed.query))
+    assert params == {
+        "id": "FILEID",
+        "export": "download",
+        "confirm": "t",
+        "uuid": "u-1-2-3",
+    }
+
+
+def test_url_from_confirmation_download_form_skips_nameless_input():
+    """Hidden inputs without a `name` attribute are ignored, not crashed on."""
+    html = (
+        '<form id="download-form" '
+        'action="https://drive.usercontent.google.com/download" method="get">'
+        '<input type="hidden" value="orphan">'  # no name= attribute
+        '<input type="hidden" name="id" value="FILEID">'
+        "</form>"
+    )
+    url = _url_from_confirmation(html)
+    params = dict(urllib.parse.parse_qsl(urllib.parse.urlparse(url).query))
+    assert params == {"id": "FILEID"}
+
+
+def test_url_from_confirmation_href_variant():
+    """The small-file href variant is absolutized and unescaped."""
+    html = '<a href="/uc?export=download&amp;id=ABC&amp;confirm=t">Download</a>'
+    url = _url_from_confirmation(html)
+    assert url == "https://docs.google.com/uc?export=download&id=ABC&confirm=t"
+
+
+def test_url_from_confirmation_json_variant():
+    r"""The "downloadUrl":"…" JSON variant unescapes =/&."""
+    html = r'window.x = {"downloadUrl":"https://h/p?a=1&b=2=x"};'
+    url = _url_from_confirmation(html)
+    assert url == "https://h/p?a=1&b=2=x"
+
+
+def test_url_from_confirmation_quota_error_raises():
+    """A uc-error-subcaption quota page raises a clear RemoteIOError."""
+    html = (
+        '<p class="uc-error-subcaption">Too many users have viewed or '
+        "downloaded this file recently.</p>"
+    )
+    with pytest.raises(RemoteIOError, match="Google Drive refused the download"):
+        _url_from_confirmation(html)
+
+
+def test_url_from_confirmation_no_link_raises():
+    """A page with no recognizable download link raises ValueError."""
+    with pytest.raises(ValueError, match="Could not find a Google Drive"):
+        _url_from_confirmation("<html><body>nothing here</body></html>")
+
+
+def test_url_from_confirmation_href_precedence_over_form():
+    """When both an href and a form are present, the href wins (gdown order)."""
+    html = (
+        '<a href="/uc?export=download&amp;id=HREFID">link</a>'
+        '<form id="download-form" action="https://drive.usercontent.google.com/'
+        'download"><input name="id" value="FORMID"></form>'
+    )
+    url = _url_from_confirmation(html)
+    assert "HREFID" in url
+    assert "FORMID" not in url
+
+
+# ---------------------------------------------------------------------------
+# Google Drive: end-to-end two-hop resolution against pytest-httpserver
+#
+# The resolver hardcodes the start host (drive.google.com); these tests repoint
+# it at the loopback test server by overriding the `_UC_URL_TEMPLATE` constant
+# (the documented test seam) so NO request ever reaches real Google Drive.
+# ---------------------------------------------------------------------------
+
+
+def _serve_gdrive_two_hop(
+    httpserver,
+    *,
+    file_bytes: bytes,
+    set_cookie: str | None = None,
+    cookie_seen: list[str | None] | None = None,
+):
+    """Wire a two-hop Drive flow (`/uc` interstitial -> `/download`) on a server.
+
+    Args:
+        httpserver: The `pytest-httpserver` instance to configure.
+        file_bytes: The bytes served at the `/download` (usercontent) hop.
+        set_cookie: If given, a `Set-Cookie` value emitted by the `/uc` hop.
+        cookie_seen: If given, the `Cookie` header value received at `/download`
+            is appended to this list (to assert cookie carry across the hop).
+
+    Returns:
+        The `/uc?id=...` start URL (a Drive-looking template is installed on
+        `_gdrive._UC_URL_TEMPLATE` separately by the caller via the fixture).
+    """
+    download_url = httpserver.url_for("/download")
+    form = (
+        f'<html><body><form id="download-form" action="{download_url}" '
+        'method="get">'
+        '<input type="hidden" name="id" value="FILEID">'
+        '<input type="hidden" name="export" value="download">'
+        '<input type="hidden" name="confirm" value="t">'
+        '<input type="hidden" name="uuid" value="u-1-2-3">'
+        "</form></body></html>"
+    )
+
+    def _uc_handler(request):
+        resp = Response(form, status=200, content_type="text/html")
+        if set_cookie is not None:
+            resp.headers["Set-Cookie"] = set_cookie
+        return resp
+
+    def _download_handler(request):
+        if cookie_seen is not None:
+            cookie_seen.append(request.headers.get("Cookie"))
+        resp = Response(file_bytes, status=200)
+        resp.headers["Content-Disposition"] = 'attachment; filename="data.bin"'
+        return resp
+
+    httpserver.expect_request("/uc").respond_with_handler(_uc_handler)
+    httpserver.expect_request("/download").respond_with_handler(_download_handler)
+
+
+@pytest.fixture
+def gdrive_uc_template(monkeypatch, httpserver):
+    """Repoint the Drive resolver's start URL at the loopback test server.
+
+    Overrides the `_gdrive._UC_URL_TEMPLATE` module constant so
+    `_open_gdrive(...)` begins its GET loop at the local `pytest-httpserver`'s
+    `/uc` endpoint instead of `https://drive.google.com/uc`. This is the
+    documented test seam from the resolver spec; no real Drive request is made.
+
+    Yields:
+        The httpserver (already installed as the resolver start host).
+    """
+    import sleap_io.io._gdrive as gdrive_mod
+
+    template = httpserver.url_for("/uc") + "?id={file_id}"
+    monkeypatch.setattr(gdrive_mod, "_UC_URL_TEMPLATE", template)
+    return httpserver
+
+
+def test_open_gdrive_two_hop_download_form(gdrive_uc_template):
+    """`_open_gdrive` follows the interstitial #download-form to the bytes."""
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=_HDF5_BODY)
+
+    bio = _open_gdrive("https://drive.google.com/file/d/FILEID/view")
+    assert bio.read() == _HDF5_BODY
+
+
+def test_open_gdrive_carries_cookie_across_hop(gdrive_uc_template):
+    """The interstitial Set-Cookie is echoed back on the second (download) hop."""
+    cookie_seen: list[str | None] = []
+    _serve_gdrive_two_hop(
+        gdrive_uc_template,
+        file_bytes=_HDF5_BODY,
+        set_cookie="download_warning=xyz; Path=/",
+        cookie_seen=cookie_seen,
+    )
+
+    bio = _open_gdrive("https://drive.google.com/file/d/FILEID/view")
+    assert bio.read() == _HDF5_BODY
+    assert cookie_seen, "download hop was never reached"
+    assert cookie_seen[0] is not None
+    assert "download_warning=xyz" in cookie_seen[0]
+
+
+def test_open_gdrive_direct_content_disposition_first_hop(gdrive_uc_template):
+    """A first hop that already carries Content-Disposition returns immediately."""
+
+    def _handler(request):
+        resp = Response(_HDF5_BODY, status=200)
+        resp.headers["Content-Disposition"] = 'attachment; filename="small.bin"'
+        return resp
+
+    gdrive_uc_template.expect_request("/uc").respond_with_handler(_handler)
+
+    bio = _open_gdrive("https://drive.google.com/uc?id=FILEID")
+    assert bio.read() == _HDF5_BODY
+
+
+def test_open_gdrive_non_html_first_hop(gdrive_uc_template):
+    """A non-HTML first response is treated as the direct file."""
+    gdrive_uc_template.expect_request("/uc").respond_with_data(
+        _HDF5_BODY, content_type="application/octet-stream"
+    )
+
+    bio = _open_gdrive("https://drive.google.com/uc?id=FILEID")
+    assert bio.read() == _HDF5_BODY
+
+
+def test_open_gdrive_quota_page_raises(gdrive_uc_template):
+    """A quota interstitial surfaces as a RemoteIOError, not file bytes."""
+    quota_html = (
+        '<html><body><p class="uc-error-subcaption">Too many users have '
+        "viewed or downloaded this file recently.</p></body></html>"
+    )
+    gdrive_uc_template.expect_request("/uc").respond_with_data(
+        quota_html, content_type="text/html"
+    )
+
+    with pytest.raises(RemoteIOError, match="Google Drive refused the download"):
+        _open_gdrive("https://drive.google.com/file/d/FILEID/view")
+
+
+def test_open_gdrive_folder_url_raises():
+    """`_open_gdrive` on a folder URL raises ValueError before any request."""
+    with pytest.raises(ValueError, match="folder URLs are not supported"):
+        _open_gdrive("https://drive.google.com/drive/folders/FID")
+
+
+def test_open_gdrive_http_error_maps_to_remote_io_error(gdrive_uc_template):
+    """A non-2xx first hop is normalized to a RemoteIOError with the status."""
+    gdrive_uc_template.expect_request("/uc").respond_with_data("nope", status=404)
+
+    with pytest.raises(RemoteIOError) as ei:
+        _open_gdrive("https://drive.google.com/file/d/FILEID/view")
+    assert ei.value.status == 404
+
+
+def test_open_gdrive_non_convergent_raises(gdrive_uc_template):
+    """If every hop returns interstitial HTML, resolution fails after the bound.
+
+    The `/uc` interstitial's #download-form points back at `/uc` itself (a
+    self-referential interstitial), so the loop runs out its hop budget and
+    raises rather than spinning forever.
+    """
+    uc_url = gdrive_uc_template.url_for("/uc")
+    loop_html = (
+        f'<form id="download-form" action="{uc_url}" method="get">'
+        '<input type="hidden" name="id" value="FILEID"></form>'
+    )
+
+    def _handler(request):
+        return Response(loop_html, status=200, content_type="text/html")
+
+    gdrive_uc_template.expect_request("/uc").respond_with_handler(_handler)
+
+    with pytest.raises(RemoteIOError, match="did not converge"):
+        _open_gdrive("https://drive.google.com/file/d/FILEID/view")
 
 
 @pytest.mark.live

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -1244,8 +1244,15 @@ def test_is_gdrive_url(url, expected):
         ("https://drive.google.com/file/d/FILEID/view", "FILEID"),
         ("https://drive.google.com/file/d/FILEID/view?usp=sharing", "FILEID"),
         ("https://drive.google.com/file/d/FILEID/edit", "FILEID"),
-        # /file/u/<n>/d/<ID>/view per-account variant.
+        # /file/d/<ID>/preview (in-browser preview address-bar shape).
+        ("https://drive.google.com/file/d/FILEID/preview", "FILEID"),
+        # Bare /file/d/<ID> with no trailing action segment (+ trailing slash).
+        ("https://drive.google.com/file/d/FILEID", "FILEID"),
+        ("https://drive.google.com/file/d/FILEID/", "FILEID"),
+        # /file/u/<n>/d/<ID>/view per-account variant (+ /preview, bare).
         ("https://drive.google.com/file/u/0/d/FILEID/view", "FILEID"),
+        ("https://drive.google.com/file/u/0/d/FILEID/preview", "FILEID"),
+        ("https://drive.google.com/file/u/0/d/FILEID", "FILEID"),
         # id= query param, both orderings + /open?id=.
         ("https://drive.google.com/uc?id=FILEID&export=download", "FILEID"),
         ("https://drive.google.com/uc?export=download&id=FILEID", "FILEID"),
@@ -1278,7 +1285,8 @@ def test_parse_gdrive_folder_raises(url):
     [
         "https://drive.google.com/",
         "https://drive.google.com/something/else",
-        "https://drive.google.com/file/d/ABC",  # missing /view|/edit suffix
+        # A trailing path segment past the ID is not a recognized action.
+        "https://drive.google.com/file/d/ABC/view/extra",
     ],
 )
 def test_parse_gdrive_unparseable_raises(url):

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -22,6 +22,7 @@ import aiohttp
 import pytest
 from aiohttp.client_reqrep import ConnectionKey
 from multidict import CIMultiDict
+from pytest_httpserver import HTTPServer
 from werkzeug.wrappers import Response
 from yarl import URL
 
@@ -1289,14 +1290,14 @@ def test_parse_gdrive_folder_raises(url):
         "https://drive.google.com/file/d/ABC/view/extra",
     ],
 )
-def test_parse_gdrive_unparseable_raises(url):
+def test_parse_gdrive_unparsable_raises(url):
     """A URL with no recoverable file ID raises a clear ValueError."""
     with pytest.raises(ValueError, match="Could not parse a Google Drive file ID"):
         _parse_gdrive(url)
 
 
 def test_parse_gdrive_redacts_credentials_in_error():
-    """A token in an unparseable URL is redacted in the raised error."""
+    """A token in an unparsable URL is redacted in the raised error."""
     with pytest.raises(ValueError) as ei:
         _parse_gdrive("https://drive.google.com/nope?token=SECRET")
     assert "SECRET" not in str(ei.value)
@@ -1577,6 +1578,111 @@ def test_open_gdrive_non_convergent_raises(gdrive_uc_template):
 
     with pytest.raises(RemoteIOError, match="did not converge"):
         _open_gdrive("https://drive.google.com/file/d/FILEID/view")
+
+
+def test_gdrive_rejects_foreign_host_next_hop(gdrive_uc_template):
+    """A scraped `#download-form` action on a foreign host is refused (SSRF).
+
+    The `/uc` interstitial (served on the allowed loopback template host) points
+    its download form at a *different* host. The resolver must reject the hop
+    with a `RemoteIOError` before issuing any GET, and the foreign host must
+    never receive the user's `Authorization` header.
+    """
+    # A second server bound to `127.0.0.1` -- a different *hostname* than the
+    # `localhost` template host, so it is NOT in the download-host allowlist.
+    foreign = HTTPServer(host="127.0.0.1", port=0)
+    foreign.start()
+    auth_seen_at_foreign: list[str | None] = []
+
+    def _foreign_handler(request):
+        auth_seen_at_foreign.append(request.headers.get("Authorization"))
+        return Response(_HDF5_BODY, status=200)
+
+    try:
+        foreign.expect_request("/steal").respond_with_handler(_foreign_handler)
+        foreign_url = foreign.url_for("/steal")
+        form = (
+            f'<html><body><form id="download-form" action="{foreign_url}" '
+            'method="get"><input type="hidden" name="id" value="FILEID"></form>'
+            "</body></html>"
+        )
+        gdrive_uc_template.expect_request("/uc").respond_with_data(
+            form, content_type="text/html"
+        )
+
+        with pytest.raises(RemoteIOError, match="unexpected host"):
+            _open_gdrive(
+                "https://drive.google.com/file/d/FILEID/view",
+                headers={"Authorization": "Bearer SECRET"},
+            )
+
+        assert auth_seen_at_foreign == [], (
+            "the foreign host was contacted; the SSRF guard did not fire"
+        )
+    finally:
+        foreign.clear()
+        if foreign.is_running():
+            foreign.stop()
+
+
+def test_gdrive_strips_sensitive_user_headers(gdrive_uc_template):
+    """Authorization/Cookie are stripped; a non-sensitive header is forwarded.
+
+    Drives a successful two-hop resolve with sensitive user headers and asserts
+    neither the `/uc` interstitial nor the `/download` hop on the loopback Drive
+    server received `Authorization`/`Cookie`, while a custom `X-Test` header is
+    forwarded to both hops.
+    """
+    seen_auth: list[str | None] = []
+    seen_cookie: list[str | None] = []
+    seen_xtest: list[str | None] = []
+
+    def _record(request):
+        seen_auth.append(request.headers.get("Authorization"))
+        seen_cookie.append(request.headers.get("Cookie"))
+        seen_xtest.append(request.headers.get("X-Test"))
+
+    download_url = gdrive_uc_template.url_for("/download")
+    form = (
+        f'<html><body><form id="download-form" action="{download_url}" '
+        'method="get"><input type="hidden" name="id" value="FILEID">'
+        '<input type="hidden" name="confirm" value="t"></form></body></html>'
+    )
+
+    def _uc_handler(request):
+        _record(request)
+        return Response(form, status=200, content_type="text/html")
+
+    def _download_handler(request):
+        _record(request)
+        resp = Response(_HDF5_BODY, status=200)
+        resp.headers["Content-Disposition"] = 'attachment; filename="data.bin"'
+        return resp
+
+    gdrive_uc_template.expect_request("/uc").respond_with_handler(_uc_handler)
+    gdrive_uc_template.expect_request("/download").respond_with_handler(
+        _download_handler
+    )
+
+    bio = _open_gdrive(
+        "https://drive.google.com/file/d/FILEID/view",
+        headers={
+            "Authorization": "Bearer SECRET",
+            "Cookie": "x=1",
+            "X-Test": "keep-me",
+        },
+    )
+
+    assert bio.read() == _HDF5_BODY
+    assert seen_auth and all(a is None for a in seen_auth), (
+        "Authorization was forwarded to the Drive server (not stripped)"
+    )
+    assert seen_cookie and all(c is None for c in seen_cookie), (
+        "Cookie was forwarded to the Drive server (not stripped)"
+    )
+    assert seen_xtest == ["keep-me", "keep-me"], (
+        "a non-sensitive custom header should be forwarded to both hops"
+    )
 
 
 @pytest.mark.live

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -1463,6 +1463,22 @@ def test_open_gdrive_two_hop_download_form(gdrive_uc_template):
     assert bio.read() == _HDF5_BODY
 
 
+def test_open_url_routes_gdrive_to_resolver(gdrive_uc_template):
+    """`open_url` detects a Drive link and routes it through the resolver.
+
+    Exercises the Google Drive branch of `open_url` itself (not just the
+    `_open_gdrive` helper): a `drive.google.com` URL is recognized by
+    `_is_gdrive_url`, the streaming kwargs are bypassed, and the resolved bytes
+    come back as a BytesIO.
+    """
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=_HDF5_BODY)
+
+    file_like = open_url(
+        "https://drive.google.com/file/d/FILEID/view", stream_mode="blockcache"
+    )
+    assert file_like.read() == _HDF5_BODY
+
+
 def test_open_gdrive_carries_cookie_across_hop(gdrive_uc_template):
     """The interstitial Set-Cookie is echoed back on the second (download) hop."""
     cookie_seen: list[str | None] = []


### PR DESCRIPTION
## Summary

**Stacked PR 3 of 3** for remote data loading (the final piece of #51). Adds **Google Drive share-link support** so `sio.load_slp("https://drive.google.com/file/d/<ID>/view")` works directly — including the large-file "can't scan for viruses" confirm-token flow.

> **Base branch: `feature/remote-video-pyav` (PR #440).** Review/merge PR 1 (#439) and PR 2 (#440) first. Together the stack addresses #51 (URLs, cloud buckets, Google Drive links, remote video).

The resolver is a dependency-free port of the **current** `gdown` v6.0.0 flow (verified against upstream): it does NOT add `gdown` or `beautifulsoup4`.

## Key changes

- **New `sleap_io/io/_gdrive.py`** — Drive URL detection + file-id parsing (`/file/d/<ID>/view`, `/open?id=`, `/uc?id=`), folder-URL rejection, and a two-hop resolver that scrapes the confirm-token interstitial (the modern `#download-form` → `drive.usercontent.google.com/download` form, plus the legacy `href`/`downloadUrl` variants) and detects the quota/permission error page. HTML is parsed with the **stdlib** (`html.parser` + `re`), not `bs4`.
- **Notebook-safe** — the resolver drives its `aiohttp` requests via `fsspec.asyn.sync()` on fsspec's background event loop, so it works inside Jupyter/Colab (where a loop is already running) with **no bare `asyncio.run()`** in library code. The interstitial cookie carries across the hop within one session.
- **Wired into the loaders** — `_remote.open_url` detects Drive URLs first and returns a fully-prefetched `BytesIO` (Drive's `HEAD` returns 405, which breaks fsspec's lazy size probe, so full-prefetch is the robust default). `load_slp(drive_url)` and `load_file(drive_url)` (with magic-byte sniff, since Drive URLs carry no extension) both work.
- **`load_video(drive_url)`** raises a clear `NotImplementedError` (Drive URLs have no extension and the resolved endpoint isn't reliably Range-capable for streaming video); documented in the guide and docstring.
- **Docs** — a "Google Drive" subsection in the Loading-from-URLs guide covering the `Anyone with the link` requirement and the limitations (folders unsupported, per-file daily quota, full in-memory prefetch).

## Example usage

```python
import sleap_io as sio

# Any of these share-link shapes work (sharing = "Anyone with the link"):
labels = sio.load_slp("https://drive.google.com/file/d/FILEID/view?usp=sharing")
labels = sio.load_slp("https://drive.google.com/open?id=FILEID")

# load_file sniffs the format from content (Drive URLs have no extension):
labels = sio.load_file("https://drive.google.com/file/d/FILEID/view")
```

## Limitations (documented)

- **Folder URLs** (`/drive/folders/<ID>`) are not supported → clear `ValueError` directing users to a file share link.
- Subject to Google Drive's **per-file daily download quota** ("too many users have viewed or downloaded this file") → surfaced as a clear `RemoteIOError`.
- Large public files are **fully prefetched into memory**, not range-streamed (Drive's endpoints reject `HEAD` and throttle).
- **Remote video from Drive** is not supported in this PR (raises `NotImplementedError`).

## API changes / backcompat

- Purely additive. No public signatures change. No new dependencies (resolver uses the already-present `aiohttp`/`fsspec` + stdlib).

## Testing

- **36 new tests** across `tests/io/test_remote.py` and `tests/io/test_main.py`: URL/file-id parsing for every share-link shape; `#download-form`, `href`, and `downloadUrl` confirm variants; quota-error page → raise; folder URL → `ValueError`; cookie carried across the hop; credential redaction; and an end-to-end `load_slp`/`load_file` over a `pytest-httpserver`-simulated two-hop Drive flow (the resolver is repointed at the test server via a documented module-constant seam — **never hits real Google Drive**).
- `_gdrive.py` at **100% coverage**.
- Full suite: **3156 passed, 24 skipped** locally (the one failure is the pre-existing Windows-only symlink-privilege test, unchanged vs the base branch — not a regression; CI is green on Windows).
- `ruff check` + `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
