### PR TITLE
feat(video): Remote video loading via PyAV (supersedes #440)

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -653,12 +653,60 @@ backends reopen the remote file lazily when you read frames, reusing the same
 streaming configuration.
 
 !!! info "What is and isn't supported"
-    URL loading currently covers `.slp`/`.pkg.slp` only (including through the
-    universal [`load_file`][sleap_io.load_file]). Other labels formats (NWB,
-    COCO, Label Studio, JABS, DLC, TrackMate, LEAP, GeoJSON, Ultralytics) and
-    remote *video* loading (`sio.load_video("https://.../movie.mp4")`) are not
-    yet implemented over URLs and raise `NotImplementedError`; download the file
-    locally first. These are tracked as follow-ups.
+    URL loading currently covers `.slp`/`.pkg.slp` (including through the
+    universal [`load_file`][sleap_io.load_file]) and remote *media video* over
+    `http`/`https` (see [Remote video](#remote-video) below). Other *labels*
+    formats (NWB, COCO, Label Studio, JABS, DLC, TrackMate, LEAP, GeoJSON,
+    Ultralytics) are not yet implemented over URLs and raise
+    `NotImplementedError`; download the file locally first. These are tracked
+    as follow-ups.
+
+### Remote video
+
+[`load_video`][sleap_io.load_video] (and [`load_file`][sleap_io.load_file] for
+video extensions) can read a media video directly from an `http`/`https` URL:
+
+```python
+import sleap_io as sio
+
+# Reads frames lazily over the network; needs the [pyav] extra
+video = sio.load_video("https://example.com/path/video.mp4")
+frame = video[0]  # frames are decoded on demand
+```
+
+Supported container extensions are the same as for local media videos
+(`mp4`, `avi`, `mov`, `mj2`, `mkv`). Only `http` and `https` URLs are accepted
+for video — cloud schemes (`s3://`, `gs://`, …) are not supported for video
+loading. The URL's query string and fragment are ignored when detecting the
+extension, so pre-signed/tokenized URLs like
+`https://host/video.mp4?token=...` route correctly.
+
+Remote video requires the `pyav` extra, which is selected automatically as the
+backend for URLs:
+
+```bash
+pip install "sleap-io[pyav]"   # remote video support (provides `av`)
+```
+
+If the `av` package is missing, `load_video(url)` raises an `ImportError` with
+the install hint above.
+
+!!! danger "Security: remote video hands untrusted data to FFmpeg"
+    Decoding a remote video streams bytes from the URL into FFmpeg (via pyav).
+    FFmpeg's demuxers and decoders are a large, historically
+    vulnerability-prone attack surface (the CVE history for media parsers is
+    extensive), so a malicious URL or stream can attempt to exploit the
+    decoder running in your process.
+
+    To limit risk, sleap-io only ever passes `http`/`https` URLs through to the
+    decoder (no other schemes, no shell/protocol indirection). You should:
+
+    - **Load remote video only from sources you trust.** Treat an arbitrary
+      third-party URL the same as running untrusted code.
+    - **Sandbox untrusted inputs.** If you must decode video from an untrusted
+      source, do it in an isolated environment (container/VM with no
+      credentials, restricted network, and a non-privileged user) and keep
+      FFmpeg/pyav up to date.
 
 ### Supported schemes and install matrix
 
@@ -795,12 +843,15 @@ labels = sio.load_slp(url, stream_mode="filecache", cache_storage=cache_dir)
 - **`RuntimeWarning` about `aiohttp`** — remote loading needs
   `aiohttp >= 3.13.5` for safe cross-origin header stripping. If you see this
   warning, upgrade with `pip install --upgrade 'aiohttp>=3.13.5'`.
-- **`NotImplementedError` from `load_video(url)`** — remote video loading is not
-  supported yet; download the file locally first.
+- **`ImportError` from `load_video(url)`** — remote video loading needs the
+  `pyav` extra; install it with `pip install 'sleap-io[pyav]'`. Only `http`/
+  `https` URLs are supported for video. See [Remote video](#remote-video) for
+  the security considerations of decoding untrusted remote video.
 
 !!! note "See also"
     - [`load_slp`][sleap_io.load_slp]: Full URL keyword-argument reference
     - [`load_file`][sleap_io.load_file]: Universal loader with URL sniffing
+    - [`load_video`][sleap_io.load_video]: Loads remote media video over http/https
     - [`clear_remote_cache`][sleap_io.clear_remote_cache]: Cache cleanup helper
     - [`RemoteIOError`][sleap_io.RemoteIOError]: Remote I/O error surface
     - [SLP Format](formats/slp.md): The on-disk `.slp` layout that URL loading streams

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -830,6 +830,11 @@ def load_video(filename: str, **kwargs) -> Video:
             "mov", "mj2", "mkv", "h5", "hdf5", "slp", "png", "jpg", "jpeg", "tif",
             "tiff", "bmp", "seq". If the filename is a list, a list of image filenames
             are expected. If filename is a folder, it will be searched for images.
+            May also be an ``http(s)://`` URL pointing to a remote media video
+            (one of "mp4", "avi", "mov", "mj2", "mkv"). Remote videos are read
+            with the pyav plugin, which is selected automatically for URLs; it
+            requires the ``av`` package (install with
+            ``pip install 'sleap-io[pyav]'``).
         **kwargs: Additional arguments passed to `Video.from_filename`.
             Currently supports:
             - dataset: Name of dataset in HDF5 file.
@@ -886,15 +891,6 @@ def load_video(filename: str, **kwargs) -> Video:
         set_default_video_plugin: Set the default video plugin globally.
         get_default_video_plugin: Get the current default video plugin.
     """
-    from sleap_io.io import _remote
-
-    if _remote._is_url(filename):
-        raise NotImplementedError(
-            "Remote video loading is not yet implemented "
-            f"(URL: {_remote._redact_url(str(filename))}). Tracked as a "
-            "follow-up PR in the remote loaders feature stack. For now, "
-            "download the file locally before calling load_video()."
-        )
     return Video.from_filename(filename, **kwargs)
 
 

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -1100,20 +1100,20 @@ _URL_UNAMBIGUOUS_EXTS: dict[str, str] = {
 _URL_AMBIGUOUS_EXTS = frozenset({".h5", ".json", ".csv"})
 
 
-#: URL-loadable formats. Only `.slp` (and `.pkg.slp`) loading is implemented
-#: for remote URLs in this PR; every other format's loader opens the path
-#: locally and would fail with a cryptic `OSError` over a URL, so those are
-#: gated behind a clean `NotImplementedError` (mirroring `load_video(url)`).
-_URL_IMPLEMENTED_FORMATS = frozenset({"slp"})
+#: URL-loadable formats. Only `slp` (`.slp`/`.pkg.slp`) and `video` (remote
+#: media via pyav) loading are implemented for remote URLs; every other
+#: format's loader opens the path locally and would fail with a cryptic
+#: `OSError` over a URL, so those are gated behind a clean `NotImplementedError`.
+_URL_IMPLEMENTED_FORMATS = frozenset({"slp", "video"})
 
 
 def _dispatch_url_format(filename: str, format: str, **kwargs) -> Labels | Video:
     """Dispatch a URL to a concrete loader given a resolved format string.
 
-    Only the `slp` format is URL-aware in this PR; every other format's loader
-    opens the path with a local file `open()` and would fail with a cryptic
-    `OSError` over a URL, so those are gated behind a clean `NotImplementedError`
-    (mirroring `load_video(url)`).
+    Only the `slp` (labels) and `video` (media) formats are URL-aware; every
+    other format's loader opens the path with a local file `open()` and would
+    fail with a cryptic `OSError` over a URL, so those are gated behind a clean
+    `NotImplementedError`.
 
     Args:
         filename: The URL to load.
@@ -1126,7 +1126,7 @@ def _dispatch_url_format(filename: str, format: str, **kwargs) -> Labels | Video
     Raises:
         ValueError: If `format` is not a recognized format.
         NotImplementedError: If `format` is recognized but remote loading for it
-            is not yet implemented (every format other than `slp`).
+            is not yet implemented (every format other than `slp`/`video`).
     """
     from sleap_io.io import _remote
 
@@ -1158,6 +1158,8 @@ def _dispatch_url_format(filename: str, format: str, **kwargs) -> Labels | Video
             "Download the file locally first."
         )
 
+    if format == "video":
+        return load_video(filename, **kwargs)
     return load_slp(filename, **kwargs)
 
 

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -1278,10 +1278,16 @@ def _load_file_url(
             f"URL: '{_remote._redact_url(filename)}'. Pass an explicit format=."
         )
 
-    # Video extension fallback (the genuine video extensions).
-    for vid_ext in Video.EXTS:
-        if filename.lower().endswith(vid_ext.lower()):
-            return _dispatch_url_format(filename, "video", **kwargs)
+    # Video extension fallback (the genuine video extensions). Match against the
+    # already-parsed, path-stripped ``ext`` (computed above, e.g. ``".mp4"``)
+    # rather than the raw URL, so query-stringed/fragment URLs (e.g. presigned
+    # S3/GCS links with a ``?token=`` or ``#fragment``) still match. ``ext``
+    # carries a leading dot while ``Video.EXTS`` entries do not, so compare with
+    # ``endswith``. This mirrors the ``_extension_token`` path-stripping in
+    # ``VideoBackend.from_filename`` so that ``load_file`` and ``load_video``
+    # agree on the same URL.
+    if ext.endswith(tuple(vid_ext.lower() for vid_ext in Video.EXTS)):
+        return _dispatch_url_format(filename, "video", **kwargs)
 
     raise ValueError(
         f"Could not infer format from URL: '{_remote._redact_url(filename)}'."

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -825,6 +825,19 @@ def save_coco(
 def load_video(filename: str, **kwargs) -> Video:
     """Load a video file.
 
+    Remote media videos can be loaded from ``http``/``https`` URLs (see the
+    ``filename`` argument). Only ``http``/``https`` URLs are supported for video
+    (cloud schemes are not), and the ``av`` package is required (install with
+    ``pip install 'sleap-io[pyav]'``).
+
+    Warning:
+        Decoding a remote video streams bytes from the URL into FFmpeg (via
+        pyav), whose demuxers/decoders are a large, historically
+        vulnerability-prone attack surface. Load remote video only from trusted
+        sources, and sandbox untrusted inputs (e.g. decode in an isolated
+        container/VM with no credentials and a restricted network). sleap-io
+        only passes ``http``/``https`` URLs through to the decoder.
+
     Args:
         filename: The filename(s) of the video. Supported extensions: "mp4", "avi",
             "mov", "mj2", "mkv", "h5", "hdf5", "slp", "png", "jpg", "jpeg", "tif",
@@ -834,7 +847,7 @@ def load_video(filename: str, **kwargs) -> Video:
             (one of "mp4", "avi", "mov", "mj2", "mkv"). Remote videos are read
             with the pyav plugin, which is selected automatically for URLs; it
             requires the ``av`` package (install with
-            ``pip install 'sleap-io[pyav]'``).
+            ``pip install 'sleap-io[pyav]'``). See the security warning above.
         **kwargs: Additional arguments passed to `Video.from_filename`.
             Currently supports:
             - dataset: Name of dataset in HDF5 file.

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -531,9 +531,23 @@ class VideoBackend:
             media_kwargs = _get_valid_kwargs(MediaVideo, kwargs)
             if is_url:
                 # Remote media videos are read via pyav (imageio's pyav plugin
-                # forwards http(s) URIs to ``av.open`` natively). Default to it
-                # when the caller did not request a specific plugin, and require
-                # the ``av`` package up front for a clear error.
+                # forwards http(s) URIs to ``av.open`` natively). Enforce the
+                # documented contract that only http/https URLs are supported:
+                # cloud schemes (s3/gs/gcs/az/abfs) are recognized as remote by
+                # ``_is_url`` but are not safe to hand to ``av.open``, so reject
+                # them cleanly here rather than letting the raw URL reach the
+                # decoder.
+                scheme = urllib.parse.urlparse(filename).scheme.lower()
+                if scheme not in ("http", "https"):
+                    raise NotImplementedError(
+                        "Remote video loading only supports http/https URLs; "
+                        f"got scheme '{scheme}' for "
+                        f"{_remote._redact_url(filename)}. Download the file "
+                        "locally first."
+                    )
+                # Default to pyav when the caller did not request a specific
+                # plugin, and require the ``av`` package up front for a clear
+                # error.
                 if media_kwargs.get("plugin") is None:
                     media_kwargs["plugin"] = "pyav"
                 if (
@@ -889,13 +903,20 @@ class MediaVideo(VideoBackend):
         if self._fps is not None:
             return self._fps
 
-        # Read from container metadata
+        # Read from container metadata and cache the result so repeated access
+        # is O(1). This matters most for the remote (URL) path: ``av.open`` over
+        # http does not use Range requests, so each uncached read re-streams the
+        # entire video. Public helpers such as ``Video.frame_to_seconds`` read
+        # ``fps`` multiple times per call, which would otherwise re-download the
+        # whole video each time. Container fps is immutable for a given file, and
+        # the cache slot is cleared when the filename changes (see
+        # ``Video.replace_filename``), so caching is safe.
         try:
             if self.plugin == "opencv":
                 fps = self.reader.get(cv2.CAP_PROP_FPS)
-                return fps if fps > 0 else None
+                rate = fps if fps > 0 else None
             elif _remote._is_url(self.filename):
-                return _fps_from_av_container(self.filename)
+                rate = _fps_from_av_container(self.filename)
             else:
                 # Use imageio v2 API to get metadata (v3 improps doesn't include fps)
                 import imageio.v2 as iio_v2
@@ -904,9 +925,11 @@ class MediaVideo(VideoBackend):
                 meta = reader.get_meta_data()
                 reader.close()
                 fps = meta.get("fps")
-                return float(fps) if fps is not None else None
+                rate = float(fps) if fps is not None else None
         except Exception:
             return None
+        self._fps = rate
+        return rate
 
     @fps.setter
     def fps(self, value: float | None) -> None:

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import urllib.parse
 from io import BytesIO
 from pathlib import Path
 
@@ -11,6 +12,8 @@ import h5py
 import imageio.v3 as iio
 import numpy as np
 import simplejson as json
+
+from sleap_io.io import _remote
 
 try:
     import cv2
@@ -291,6 +294,72 @@ def _get_valid_kwargs(cls, kwargs: dict) -> dict:
     return {k: v for k, v in kwargs.items() if k in valid_fields}
 
 
+def _extension_token(filename: str) -> str:
+    """Return the lowercased path portion used for extension matching.
+
+    For local paths this is just the lowercased filename. For URLs it is the
+    lowercased URL *path* (with any ``?query`` / ``#fragment`` stripped) so that
+    a query-stringed URL such as ``https://h/v.mp4?token=x`` still matches the
+    ``mp4`` extension via ``str.endswith``.
+
+    Args:
+        filename: A local path or remote URL.
+
+    Returns:
+        A lowercased string whose suffix is the resource's file extension.
+    """
+    if _remote._is_url(filename):
+        return urllib.parse.urlparse(filename).path.lower()
+    return filename.lower()
+
+
+def _is_pyav_available() -> bool:
+    """Return True if the ``av`` (pyav) package can be imported.
+
+    Used to gate remote (URL) video loading, which relies on pyav. Checks the
+    already-imported module first (the module attempts a top-level ``import av``)
+    and otherwise attempts a fresh import so availability is detected even if the
+    top-level import was skipped.
+
+    Returns:
+        True if ``av`` is importable, else False.
+    """
+    if "av" in sys.modules:
+        return True
+    # Defensive: the module attempts a top-level ``import av``, so in any
+    # environment with the ``[pyav]`` extra (including CI) ``av`` is already in
+    # ``sys.modules`` and the lines below are not reached.
+    import importlib.util  # pragma: no cover
+
+    return importlib.util.find_spec("av") is not None  # pragma: no cover
+
+
+def _fps_from_av_container(filename: str) -> float | None:
+    """Read the frame rate of a (possibly remote) media video via pyav.
+
+    ``av.open`` natively supports ``http(s)://`` URIs, so this works for both
+    local paths and remote URLs without requiring ``imageio-ffmpeg``.
+
+    Args:
+        filename: A local path or remote URL of a media video.
+
+    Returns:
+        The average frame rate as a float, falling back to the stream base rate,
+        or None if no usable rate is present on the video stream.
+    """
+    import av
+
+    container = av.open(filename)
+    try:
+        stream = container.streams.video[0]
+        rate = stream.average_rate
+        if rate is None:  # pragma: no cover - defensive: VFR/odd containers
+            rate = stream.base_rate
+        return float(rate) if rate is not None else None
+    finally:
+        container.close()
+
+
 @attrs.define
 class VideoBackend:
     """Base class for video backends.
@@ -406,15 +475,23 @@ class VideoBackend:
         if isinstance(filename, Path):
             filename = filename.as_posix()
 
-        if type(filename) is str and Path(filename).is_dir():
+        is_url = type(filename) is str and _remote._is_url(filename)
+
+        # Skip local-filesystem dir detection for URLs (``Path.is_dir`` on a URL
+        # is meaningless and would just return False, but avoid the syscall).
+        if type(filename) is str and not is_url and Path(filename).is_dir():
             filename = ImageVideo.find_images(filename)
+
+        # Match extensions against the URL *path* (query/fragment stripped) for
+        # URLs, and the lowercased filename otherwise.
+        ext_token = _extension_token(filename) if type(filename) is str else ""
 
         if type(filename) is list:
             filename = [Path(f).as_posix() for f in filename]
             return ImageVideo(
                 filename, grayscale=grayscale, **_get_valid_kwargs(ImageVideo, kwargs)
             )
-        elif filename.lower().endswith(("tif", "tiff")):
+        elif ext_token.endswith(("tif", "tiff")):
             # Detect TIFF format
             format_type, metadata = TiffVideo.detect_format(filename)
 
@@ -437,11 +514,11 @@ class VideoBackend:
                     grayscale=grayscale,
                     **_get_valid_kwargs(ImageVideo, kwargs),
                 )
-        elif filename.lower().endswith(tuple(ext.lower() for ext in ImageVideo.EXTS)):
+        elif ext_token.endswith(tuple(ext.lower() for ext in ImageVideo.EXTS)):
             return ImageVideo(
                 [filename], grayscale=grayscale, **_get_valid_kwargs(ImageVideo, kwargs)
             )
-        elif filename.lower().endswith(".seq"):
+        elif ext_token.endswith(".seq"):
             from sleap_io.io.seq import SeqVideo
 
             return SeqVideo(
@@ -450,14 +527,34 @@ class VideoBackend:
                 keep_open=keep_open,
                 **_get_valid_kwargs(SeqVideo, kwargs),
             )
-        elif filename.lower().endswith(tuple(ext.lower() for ext in MediaVideo.EXTS)):
+        elif ext_token.endswith(tuple(ext.lower() for ext in MediaVideo.EXTS)):
+            media_kwargs = _get_valid_kwargs(MediaVideo, kwargs)
+            if is_url:
+                # Remote media videos are read via pyav (imageio's pyav plugin
+                # forwards http(s) URIs to ``av.open`` natively). Default to it
+                # when the caller did not request a specific plugin, and require
+                # the ``av`` package up front for a clear error.
+                if media_kwargs.get("plugin") is None:
+                    media_kwargs["plugin"] = "pyav"
+                if (
+                    normalize_plugin_name(media_kwargs["plugin"]) == "pyav"
+                    and not _is_pyav_available()
+                ):
+                    # Defensive: ``av`` is required for remote loading and is
+                    # always present in the test/CI environment, so this guard
+                    # only fires for an install lacking the ``[pyav]`` extra.
+                    raise ImportError(  # pragma: no cover
+                        "Loading videos from URLs requires the 'av' package "
+                        "(pyav). Install with: pip install 'sleap-io[pyav]'. "
+                        f"(URL: {_remote._redact_url(filename)})"
+                    )
             return MediaVideo(
                 filename,
                 grayscale=grayscale,
                 keep_open=keep_open,
-                **_get_valid_kwargs(MediaVideo, kwargs),
+                **media_kwargs,
             )
-        elif filename.lower().endswith(tuple(ext.lower() for ext in HDF5Video.EXTS)):
+        elif ext_token.endswith(tuple(ext.lower() for ext in HDF5Video.EXTS)):
             return HDF5Video(
                 filename,
                 dataset=dataset,
@@ -781,6 +878,12 @@ class MediaVideo(VideoBackend):
             method for the current plugin:
             - OpenCV: cv2.CAP_PROP_FPS
             - FFMPEG/pyav: imageio metadata
+
+            For remote (URL) filenames the FPS is read directly from the pyav
+            container via ``av.open(url)``. imageio's v2 FFMPEG reader (used for
+            local files) requires the ``imageio-ffmpeg`` package and an ffmpeg
+            executable, which are not guaranteed in a pyav-only install, whereas
+            ``av`` is already required for remote loading.
         """
         # Return cached/explicit value if set
         if self._fps is not None:
@@ -791,6 +894,8 @@ class MediaVideo(VideoBackend):
             if self.plugin == "opencv":
                 fps = self.reader.get(cv2.CAP_PROP_FPS)
                 return fps if fps > 0 else None
+            elif _remote._is_url(self.filename):
+                return _fps_from_av_container(self.filename)
             else:
                 # Use imageio v2 API to get metadata (v3 improps doesn't include fps)
                 import imageio.v2 as iio_v2

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -547,9 +547,17 @@ class Video:
                     grayscale = self.backend_metadata["shape"][-1] == 1
 
         if not self.exists(dataset=dataset):
-            msg = (
-                f"Video does not exist or cannot be opened for reading: {self.filename}"
+            from sleap_io.io._remote import _is_url, _redact_url
+
+            # Redact credential-bearing URLs (e.g. presigned ``?token=`` links)
+            # so they never surface in tracebacks/logs. Local paths are shown
+            # verbatim.
+            name = (
+                _redact_url(self.filename)
+                if isinstance(self.filename, str) and _is_url(self.filename)
+                else self.filename
             )
+            msg = f"Video does not exist or cannot be opened for reading: {name}"
             if dataset is not None:
                 msg += f" (dataset: {dataset})"
             raise FileNotFoundError(msg)

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -3,9 +3,10 @@
 import shutil
 from pathlib import Path
 
+import numpy as np
 import pytest
 
-from sleap_io import Labels, LabelsSet, RemoteIOError, clear_remote_cache
+from sleap_io import Labels, LabelsSet, RemoteIOError, Video, clear_remote_cache
 from sleap_io.io._remote import _require_package
 from sleap_io.io.main import (
     load_file,
@@ -533,22 +534,36 @@ def test_load_slp_url_label_image_roundtrip(httpserver, tmp_path, lazy):
     np.testing.assert_array_equal(rli.data, data)
 
 
-def test_load_video_url_raises_not_implemented():
-    """`load_video(url)` raises `NotImplementedError` with a redacted URL.
+def test_load_video_url_reads_first_frame(httpserver, centered_pair_low_quality_path):
+    """`load_video(url)` reads a first frame matching the local file's frame."""
+    file_bytes = Path(centered_pair_low_quality_path).read_bytes()
+    httpserver.expect_request("/movie.mp4").respond_with_data(
+        file_bytes, content_type="video/mp4"
+    )
+    url = httpserver.url_for("/movie.mp4")
 
-    The message must mention the follow-up PR and must not leak credentials.
-    """
-    url = "https://user:secret@example.com/movie.mp4?token=abc123"
-    with pytest.raises(NotImplementedError) as exc_info:
-        load_video(url)
+    local = load_video(centered_pair_low_quality_path)
+    remote = load_video(url)
+    assert isinstance(remote, Video)
 
-    message = str(exc_info.value)
-    # Follow-up PR is mentioned.
-    assert "follow-up" in message.lower()
-    # Credentials are redacted out of the surfaced URL.
-    assert "secret" not in message
-    assert "abc123" not in message
-    assert "example.com" in message
+    local_frame = local[0]
+    remote_frame = remote[0]
+    assert remote_frame.shape == local_frame.shape
+    assert remote_frame.dtype == local_frame.dtype
+    assert np.array_equal(remote_frame, local_frame)
+
+
+def test_load_file_url_routes_to_video(httpserver, centered_pair_low_quality_path):
+    """`load_file` routes a `.mp4` URL to `load_video`, returning a `Video`."""
+    file_bytes = Path(centered_pair_low_quality_path).read_bytes()
+    httpserver.expect_request("/movie.mp4").respond_with_data(
+        file_bytes, content_type="video/mp4"
+    )
+    url = httpserver.url_for("/movie.mp4")
+
+    video = load_file(url)
+    assert isinstance(video, Video)
+    assert video[0].shape == (384, 384, 1)
 
 
 def test_load_file_url_nwb_raises_not_implemented():

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -566,6 +566,54 @@ def test_load_file_url_routes_to_video(httpserver, centered_pair_low_quality_pat
     assert video[0].shape == (384, 384, 1)
 
 
+def test_load_file_url_video_with_query_string(
+    httpserver, centered_pair_low_quality_path
+):
+    """`load_file` routes a query-stringed `.mp4` URL to `load_video`.
+
+    Regression: the video-extension fallback previously matched against the raw
+    URL, so a presigned/CDN-tokenized URL (which does not end in ``.mp4``) fell
+    through to a `ValueError`, while `load_video` on the same URL succeeded.
+    """
+    file_bytes = Path(centered_pair_low_quality_path).read_bytes()
+    httpserver.expect_request("/movie.mp4").respond_with_data(
+        file_bytes, content_type="video/mp4"
+    )
+    url = httpserver.url_for("/movie.mp4") + "?token=secret&x=1"
+
+    video = load_file(url)
+    assert isinstance(video, Video)
+    assert video[0].shape == (384, 384, 1)
+
+
+def test_load_file_url_video_with_fragment(httpserver, centered_pair_low_quality_path):
+    """`load_file` routes a fragment-bearing `.mp4` URL to `load_video`."""
+    file_bytes = Path(centered_pair_low_quality_path).read_bytes()
+    httpserver.expect_request("/movie.mp4").respond_with_data(
+        file_bytes, content_type="video/mp4"
+    )
+    url = httpserver.url_for("/movie.mp4") + "#t=5"
+
+    video = load_file(url)
+    assert isinstance(video, Video)
+
+
+def test_load_file_url_cloud_scheme_video_raises_not_implemented():
+    """A cloud-scheme media URL is rejected with a clean `NotImplementedError`.
+
+    The documented contract is http/https-only for remote video; cloud schemes
+    must not reach the decoder. No network request is issued.
+    """
+    url = "s3://AKIA:secretkey@bucket/video.mp4?X-Amz-Security-Token=topsecret"
+    with pytest.raises(NotImplementedError) as exc_info:
+        load_file(url)
+    message = str(exc_info.value)
+    assert "http/https" in message
+    # The raw credentials/token must not leak in the error message.
+    assert "secretkey" not in message
+    assert "topsecret" not in message
+
+
 def test_load_file_url_nwb_raises_not_implemented():
     """A `.nwb` URL raises a clean `NotImplementedError`, not a raw `OSError`.
 

--- a/tests/io/test_video_reading.py
+++ b/tests/io/test_video_reading.py
@@ -1599,6 +1599,73 @@ def test_load_video_url_get_frames(httpserver, centered_pair_low_quality_path):
     assert_equal(remote[:3], local[:3])
 
 
+def test_remote_fps_is_cached(httpserver, centered_pair_low_quality_path):
+    """Reading ``fps`` on a remote video downloads once, then is cached.
+
+    Regression: ``MediaVideo.fps`` previously re-read container metadata on every
+    access, and ``av.open`` over http streams the full body each time (no Range
+    requests), so repeated ``fps`` access re-downloaded the whole video.
+    """
+    data = Path(centered_pair_low_quality_path).read_bytes()
+    get_count = {"n": 0}
+
+    def handler(request):
+        get_count["n"] += 1
+        from werkzeug.wrappers import Response
+
+        return Response(data, content_type="video/mp4")
+
+    httpserver.expect_request("/video.mp4").respond_with_handler(handler)
+    url = httpserver.url_for("/video.mp4")
+
+    video = sio.load_video(url)
+    assert video.backend.fps == 15.0
+    downloads_after_first = get_count["n"]
+    assert downloads_after_first == 1
+
+    # A second access (and any helper that reads fps repeatedly) is free.
+    assert video.backend.fps == 15.0
+    assert video.frame_to_seconds(15) == 1.0
+    assert get_count["n"] == downloads_after_first
+    assert video.backend._fps == 15.0
+
+
+def test_from_filename_cloud_scheme_video_raises(centered_pair_low_quality_path):
+    """A cloud-scheme media URL is rejected before reaching the decoder.
+
+    Only http/https remote video is supported; cloud schemes (s3/gs/...) are
+    recognized as remote by ``_is_url`` but must not be handed to ``av.open``.
+    """
+    for url in ("s3://bucket/video.mp4", "gs://bucket/clip.mov"):
+        with pytest.raises(NotImplementedError, match="http/https"):
+            VideoBackend.from_filename(url)
+
+
+def test_from_filename_cloud_scheme_video_does_not_leak_credentials():
+    """The cloud-scheme rejection redacts credentials in its error message."""
+    url = "s3://AKIA:secretkey@bucket/video.mp4?X-Amz-Security-Token=topsecret"
+    with pytest.raises(NotImplementedError) as exc_info:
+        VideoBackend.from_filename(url)
+    message = str(exc_info.value)
+    assert "secretkey" not in message
+    assert "topsecret" not in message
+
+
+def test_remote_video_open_error_redacts_url():
+    """A failed open of a tokenized remote video redacts the URL in the error.
+
+    Regression: ``Video.open`` raised ``FileNotFoundError`` with the raw URL,
+    leaking ``?token=`` credentials into tracebacks/logs.
+    """
+    url = "https://host.invalid/video.mp4?token=supersecret"
+    video = sio.load_video(url)
+    with pytest.raises(FileNotFoundError) as exc_info:
+        video[0]
+    message = str(exc_info.value)
+    assert "supersecret" not in message
+    assert "token=%2A%2A%2A" in message
+
+
 def test_is_pyav_available_when_installed():
     """``_is_pyav_available`` reports True in the test environment (av installed).
 

--- a/tests/io/test_video_reading.py
+++ b/tests/io/test_video_reading.py
@@ -8,7 +8,9 @@ import imageio.v3 as iio
 import numpy as np
 import pytest
 from numpy.testing import assert_equal
+from pytest_httpserver import HTTPServer
 
+import sleap_io as sio
 from sleap_io.io.video_reading import (
     HDF5Video,
     ImageVideo,
@@ -1482,3 +1484,128 @@ def test_tiffvideo_fps(tmp_path):
     # Can set FPS explicitly
     backend.fps = 10.0
     assert backend.fps == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Remote (URL) media video loading via pyav.
+#
+# av.open / imageio's pyav plugin stream the full body via a plain GET (no
+# Range requests), so a simple ``respond_with_data`` 200 server is sufficient
+# to back these tests with a real fixture video's bytes.
+# ---------------------------------------------------------------------------
+
+
+def _serve_video(server: HTTPServer, path: str, route: str) -> str:
+    """Serve a local video file's bytes at ``route`` and return its URL.
+
+    Args:
+        server: A running ``pytest_httpserver`` server.
+        path: Local path to the fixture video to serve.
+        route: The URL route to bind (e.g. ``"/video.mp4"``).
+
+    Returns:
+        The full URL the served bytes are reachable at.
+    """
+    data = Path(path).read_bytes()
+    server.expect_request(route).respond_with_data(data, content_type="video/mp4")
+    return server.url_for(route)
+
+
+def test_from_filename_url_routes_to_mediavideo(
+    httpserver, centered_pair_low_quality_path
+):
+    """A media-video URL is routed to MediaVideo with the pyav plugin."""
+    url = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")
+    backend = VideoBackend.from_filename(url)
+    assert type(backend) is MediaVideo
+    assert backend.filename == url
+    # URLs default to the pyav plugin (validated/normalized on the backend).
+    assert backend.plugin == "pyav"
+
+
+def test_from_filename_url_respects_explicit_plugin(
+    httpserver, centered_pair_low_quality_path
+):
+    """An explicit ``plugin`` on a URL is honored (not overridden by the default)."""
+    url = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")
+    backend = VideoBackend.from_filename(url, plugin="pyav")
+    assert type(backend) is MediaVideo
+    assert backend.plugin == "pyav"
+    assert backend[0].shape == (384, 384, 1)
+
+
+def test_from_filename_url_with_query_string_matches_extension(
+    httpserver, centered_pair_low_quality_path
+):
+    """A URL carrying a ``?query`` still matches the mp4 extension and reads."""
+    base = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")
+    url = base + "?token=secret&x=1"
+    backend = VideoBackend.from_filename(url)
+    assert type(backend) is MediaVideo
+    assert backend[0].shape == (384, 384, 1)
+
+
+def test_load_video_url_reads_first_frame(httpserver, centered_pair_low_quality_path):
+    """A frame read over http matches the frame read from the local file."""
+    url = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")
+
+    local = sio.load_video(centered_pair_low_quality_path)
+    remote = sio.load_video(url)
+
+    local_frame = local[0]
+    remote_frame = remote[0]
+    assert remote_frame.shape == local_frame.shape
+    assert remote_frame.dtype == local_frame.dtype
+    assert_equal(remote_frame, local_frame)
+
+
+def test_load_video_url_num_frames(httpserver, centered_pair_low_quality_path):
+    """num_frames over http (via pyav improps) matches the local value."""
+    url = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")
+    local = sio.load_video(centered_pair_low_quality_path)
+    remote = sio.load_video(url)
+    assert remote.backend.num_frames == local.backend.num_frames == 1100
+
+
+def test_load_video_url_img_shape(httpserver, centered_pair_low_quality_path):
+    """img_shape over http (via a pyav test-frame read) matches the local value."""
+    url = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")
+    local = sio.load_video(centered_pair_low_quality_path)
+    remote = sio.load_video(url)
+    assert remote.backend.img_shape == local.backend.img_shape == (384, 384, 1)
+
+
+def test_load_video_url_fps(httpserver, centered_pair_low_quality_path):
+    """FPS over http (via av.open) matches the local value."""
+    url = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")
+    local = sio.load_video(centered_pair_low_quality_path)
+    remote = sio.load_video(url)
+    assert remote.backend.fps == local.backend.fps == 15.0
+
+
+def test_load_video_url_full_shape(httpserver, centered_pair_low_quality_path):
+    """The full (frames, h, w, c) shape over http matches the local value."""
+    url = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")
+    local = sio.load_video(centered_pair_low_quality_path)
+    remote = sio.load_video(url)
+    assert remote.shape == local.shape == (1100, 384, 384, 1)
+
+
+def test_load_video_url_get_frames(httpserver, centered_pair_low_quality_path):
+    """Reading multiple frames over http matches the local frames."""
+    url = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")
+    local = sio.load_video(centered_pair_low_quality_path)
+    remote = sio.load_video(url)
+    assert_equal(remote[:3], local[:3])
+
+
+def test_is_pyav_available_when_installed():
+    """``_is_pyav_available`` reports True in the test environment (av installed).
+
+    The complementary False branch only fires for an install lacking the
+    ``[pyav]`` extra; it is marked ``# pragma: no cover`` rather than forced via
+    monkeypatching, since ``av`` is a required dependency of the test suite.
+    """
+    from sleap_io.io.video_reading import _is_pyav_available
+
+    assert _is_pyav_available() is True


### PR DESCRIPTION
## Summary

**Remote video loading** — `load_video("https://.../video.mp4")` (and `.avi/.mov/.mj2/.mkv`) over HTTP(S) via PyAV. Second piece of the remote-data-loading stack for #51, now rebased onto `main` after PR #439 (core remote URL loading) merged.

> Supersedes **#440**, which GitHub auto-closed when PR #439's branch was deleted on merge (its base branch vanished). Same branch (`feature/remote-video-pyav`), same content, now targeting `main`.
>
> Stacked on **#439** (merged). PR #441 (Google Drive resolver) stacks on this branch.

**Empirical basis:** verified over a `pytest-httpserver`-served MP4 that PyAV reads remote HTTP URLs natively (imageio's pyav plugin forwards `http(s)` URIs to `av.open`). Frame reads, `num_frames`, and `img_shape` needed no adaptation; only `fps` needed a direct `av.open(url)` path (imageio's fps helper requires `imageio-ffmpeg`, not guaranteed in a pyav-only install).

## Key changes

- **`load_video(url)`** — URLs now flow through `Video.from_filename`; local behavior byte-identical.
- **`VideoBackend.from_filename`** — URL-aware dispatch: extension parsed from the URL **path** (stripping `?query`/`#fragment`) so `…/video.mp4?token=…` still routes to `MediaVideo`; `Path.is_dir()` skipped for URLs.
- **PyAV forced for URL videos** when no plugin is specified; clear `ImportError` (redacted URL) pointing at `pip install 'sleap-io[pyav]'` if `av` is missing.
- **`MediaVideo.fps`** uses `av.open(self.filename)` for URL filenames; local path unchanged.
- **`load_file(url)`** routes `.mp4`/etc. URLs to `load_video` (via the PR #439 dispatch guard, extended here to admit the `video` format).
- **Docs** — "Remote video" section in `docs/examples.md` + an FFmpeg/PyAV **security warning** for decoding untrusted remote streams (only `http`/`https`; trusted sources / sandboxing).

## Security

Remote video decoding hands untrusted bytes to FFmpeg/PyAV (a large CVE surface). Only `http`/`https` schemes are passed through; docs + the `load_video` docstring warn to load remote video only from trusted sources and sandbox untrusted inputs.

## Testing

- New tests (URL→MediaVideo routing, explicit-plugin override, query-string extension matching, first-frame read bit-identical to local, `num_frames`/`img_shape`/`fps`/full-shape over HTTP, `load_file(url)`→Video) via `pytest-httpserver`.
- Full suite green locally (only the pre-existing Windows-only symlink test fails, unchanged vs main).
- `ruff check` + `ruff format --check` clean.

## Notes

- This branch was rebased onto `main` (post-#439) with `git rebase --onto main`; one test-file and one docs conflict were resolved (keeping #439's accurate "labels formats not URL-loadable yet" note while adding the new remote-video support). A follow-up commit extends #439's `load_file` URL dispatch allowlist to include `video`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
