### PR TITLE
fix(io): harden remote URL loading (auth, handle lifecycle, Drive caps, fsspec cache)

### DIFF
--- a/docs/remote.md
+++ b/docs/remote.md
@@ -189,7 +189,8 @@ frame = labels.videos[0][0]  # range-reads just the bytes for frame 0
 
 This means you can inspect a remote packaged project without downloading the
 whole archive — the embedded video backends reopen the remote file using the
-same streaming configuration as the initial load.
+same streaming configuration and authentication `headers=` as the initial load,
+so an auth-gated `.pkg.slp` streams its frames without re-authenticating.
 
 ---
 
@@ -241,7 +242,8 @@ labels = sio.load_slp("https://drive.google.com/file/d/<FILE_ID>/view")
 labels = sio.load_slp("https://drive.google.com/uc?id=<FILE_ID>&export=download")
 labels = sio.load_slp("https://drive.google.com/open?id=<FILE_ID>")
 
-# load_file resolves the link, sniffs the bytes, and routes it (one extra fetch):
+# load_file resolves the link, sniffs the bytes to detect the format, and routes
+# it. The sniffed bytes are reused, so the file is downloaded only once:
 labels = sio.load_file("https://drive.google.com/file/d/<FILE_ID>/view")
 ```
 
@@ -263,10 +265,14 @@ Some limitations:
   viewed or downloaded this file recently" page, a
   [`RemoteIOError`][sleap_io.RemoteIOError] is raised; retry later or re-check
   the file's sharing settings.
+- **Large files** — the in-memory prefetch is capped (8 GiB by default); a file
+  exceeding the cap raises a [`RemoteIOError`][sleap_io.RemoteIOError] instead of
+  exhausting memory.
 
 For [`load_file`][sleap_io.load_file], the format is detected from the
-downloaded bytes (costing one extra fetch). Pass an explicit `format=` (e.g.
-`format="slp"`) to skip the detection download.
+downloaded bytes, and those bytes are reused for the load — so a Drive `.slp` is
+downloaded only once whether you call `load_slp` or `load_file` (an explicit
+`format=` is optional, and skips the format-detection step).
 
 ---
 

--- a/sleap_io/io/_gdrive.py
+++ b/sleap_io/io/_gdrive.py
@@ -74,6 +74,17 @@ _DOWNLOAD_HOST_SUFFIX = ".googleusercontent.com"
 #: Maximum number of interstitial hops to follow before giving up.
 _MAX_HOPS = 4
 
+#: Default upper bound (bytes) on the in-memory Drive prefetch. The resolver
+#: fully buffers the resolved file (Drive rejects HEAD and can interrupt a
+#: ranged transfer mid-stream), so an unbounded read would let a hostile or
+#: accidentally-huge share link OOM the process. 8 GiB is well above realistic
+#: ``.slp``/``.pkg.slp`` sizes (including embedded media) while still capping the
+#: worst case.
+_DEFAULT_MAX_BYTES = 8 * 1024**3
+
+#: Chunk size (bytes) for the capped streaming read of the resolved body.
+_READ_CHUNK = 1 << 20
+
 #: Path regex that yields a Drive file ID. Accepts the ``/file/d/<ID>/…`` share
 #: path with an optional ``/u/<n>/`` per-account prefix and an optional trailing
 #: action segment (``/view``, ``/edit``, ``/preview``, or none). Using
@@ -350,7 +361,50 @@ def _url_from_confirmation(confirmation_html: str) -> str:
 # ---------------------------------------------------------------------------
 
 
-async def _resolve_and_fetch(file_id: str, headers: dict[str, str] | None) -> bytes:
+async def _read_body_capped(resp, max_bytes: int, url: str) -> bytes:
+    """Drain a response body fully while enforcing a maximum byte budget.
+
+    Drive's usercontent download responses frequently omit ``Content-Length``
+    (chunked transfer) and a hostile file could advertise a small/absent length,
+    so the cap is enforced both as a cheap pre-check against any advertised
+    ``Content-Length`` and as a running total during a chunked read.
+
+    Args:
+        resp: The aiohttp response to read.
+        max_bytes: Maximum number of bytes permitted.
+        url: The download URL (redacted on display) for the error message.
+
+    Returns:
+        The full response body.
+
+    Raises:
+        RemoteIOError: If the body exceeds ``max_bytes``. The partial buffer is
+            discarded (never returned to the caller).
+    """
+    advertised = resp.content_length
+    if advertised is not None and advertised > max_bytes:
+        raise RemoteIOError(
+            "Google Drive file exceeds the maximum in-memory download size "
+            f"(cap={max_bytes} bytes, Content-Length={advertised}); pass a "
+            "larger max_bytes or download the file manually.",
+            url=url,
+        )
+    buf = bytearray()
+    async for chunk in resp.content.iter_chunked(_READ_CHUNK):
+        buf += chunk
+        if len(buf) > max_bytes:
+            raise RemoteIOError(
+                "Google Drive file exceeds the maximum in-memory download size "
+                f"(cap={max_bytes} bytes); pass a larger max_bytes or download "
+                "the file manually.",
+                url=url,
+            )
+    return bytes(buf)
+
+
+async def _resolve_and_fetch(
+    file_id: str, headers: dict[str, str] | None, max_bytes: int | None = None
+) -> bytes:
     """Run the Drive GET loop and return the resolved file bytes.
 
     This coroutine is driven from :func:`_open_gdrive` via
@@ -362,16 +416,20 @@ async def _resolve_and_fetch(file_id: str, headers: dict[str, str] | None) -> by
     Args:
         file_id: The Google Drive file ID.
         headers: Optional extra HTTP headers (merged over the browser default).
+        max_bytes: Maximum number of bytes to buffer in memory. ``None`` uses
+            :data:`_DEFAULT_MAX_BYTES`.
 
     Returns:
         The fully-downloaded file bytes.
 
     Raises:
-        RemoteIOError: For quota/permission pages or if resolution does not
-            converge on a downloadable response within :data:`_MAX_HOPS`.
+        RemoteIOError: For quota/permission pages, an oversize file, or if
+            resolution does not converge within :data:`_MAX_HOPS`.
         ValueError: If a confirmation page yields no download link.
     """
     import aiohttp
+
+    cap = _DEFAULT_MAX_BYTES if max_bytes is None else max_bytes
 
     # Public Drive-link downloads never need credentials; strip any sensitive
     # user headers (Authorization/Cookie/Proxy-Authorization) before they can be
@@ -400,9 +458,10 @@ async def _resolve_and_fetch(file_id: str, headers: dict[str, str] | None) -> by
                 is_html = "text/html" in content_type.lower()
 
                 # A Content-Disposition header (or any non-HTML body) means we
-                # have reached the file itself: read it fully in this session.
+                # have reached the file itself: read it fully (capped) in this
+                # session.
                 if has_disposition or not is_html:
-                    return await resp.read()
+                    return await _read_body_capped(resp, cap, url)
 
                 # Otherwise this is the interstitial HTML; scrape the next URL.
                 page = await resp.text()
@@ -415,18 +474,27 @@ async def _resolve_and_fetch(file_id: str, headers: dict[str, str] | None) -> by
     )
 
 
-def _open_gdrive(url: str, *, headers: dict[str, str] | None = None) -> io.BytesIO:
+def _open_gdrive(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    max_bytes: int | None = None,
+) -> io.BytesIO:
     """Resolve a Google Drive share URL and return its bytes as a BytesIO.
 
     The Drive download URL carries no file extension and Drive rejects ``HEAD``
     with 405, both of which break the lazy fsspec open path; the resolved bytes
     are therefore fully prefetched here (within one cookie-carrying session) and
     returned as an in-memory :class:`io.BytesIO`, mirroring ``open_url``'s
-    ``stream_mode="download"`` shape.
+    ``stream_mode="download"`` shape. The prefetch is bounded by ``max_bytes``
+    (default :data:`_DEFAULT_MAX_BYTES`) so a hostile or accidentally-huge file
+    cannot exhaust memory.
 
     Args:
         url: A Google Drive / Docs share URL.
         headers: Optional extra HTTP headers to forward.
+        max_bytes: Maximum number of bytes to buffer in memory. ``None`` uses
+            :data:`_DEFAULT_MAX_BYTES`.
 
     Returns:
         An :class:`io.BytesIO` positioned at the start of the downloaded bytes.
@@ -434,8 +502,8 @@ def _open_gdrive(url: str, *, headers: dict[str, str] | None = None) -> io.Bytes
     Raises:
         ValueError: For folder URLs, unparsable file IDs, or confirmation
             pages with no download link.
-        RemoteIOError: For HTTP failures, quota/permission pages, or
-            non-convergent resolution.
+        RemoteIOError: For HTTP failures, quota/permission pages, an oversize
+            file, or non-convergent resolution.
     """
     import fsspec.asyn
 
@@ -443,7 +511,7 @@ def _open_gdrive(url: str, *, headers: dict[str, str] | None = None) -> io.Bytes
 
     loop = fsspec.asyn.get_loop()
     try:
-        data = fsspec.asyn.sync(loop, _resolve_and_fetch, file_id, headers)
+        data = fsspec.asyn.sync(loop, _resolve_and_fetch, file_id, headers, max_bytes)
     except (RemoteIOError, ValueError):
         raise
     except Exception as e:  # noqa: BLE001 - normalize transport errors

--- a/sleap_io/io/_remote.py
+++ b/sleap_io/io/_remote.py
@@ -474,9 +474,15 @@ def _build_fsspec_filesystem(
         # Always set identity encoding to avoid the gzip/content-length
         # ambiguity for ranged reads (user headers cannot override it).
         merged = _identity_headers(headers)
+        # ``skip_instance_cache`` opts out of fsspec's ``_Cached`` metaclass
+        # instance cache. That cache keys on the constructor kwargs (including
+        # the per-request ``headers`` dict) and never evicts, so a long-lived
+        # process loading many URLs with rotating tokens would otherwise
+        # accumulate one filesystem instance per distinct header set.
         return HTTPFileSystem(
             client_kwargs={"headers": merged},
             get_client=_safe_get_client,
+            skip_instance_cache=True,
         )
 
     # s3 / gs / gcs / az / abfs: fsspec's per-scheme registry handles auth via
@@ -494,7 +500,14 @@ def _http_inner_options(headers: dict[str, str] | None) -> dict[str, Any]:
         A mapping suitable for the ``http=`` kwarg of ``fsspec.open``.
     """
     merged = _identity_headers(headers)
-    return {"client_kwargs": {"headers": merged}, "get_client": _safe_get_client}
+    # ``skip_instance_cache`` keeps the inner http filesystem of a chained
+    # ``simplecache::``/``filecache::`` open out of fsspec's never-evicting
+    # per-args instance cache (see :func:`_build_fsspec_filesystem`).
+    return {
+        "client_kwargs": {"headers": merged},
+        "get_client": _safe_get_client,
+        "skip_instance_cache": True,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -659,7 +672,11 @@ def open_url(
         def _open():
             import fsspec
 
-            simplecache_opts: dict[str, Any] = {}
+            # ``skip_instance_cache`` on the outer cache filesystem too: the
+            # chained ``fsspec.open`` builds (and caches) a SimpleCacheFileSystem
+            # eagerly, so without this the outer cache grows per distinct header
+            # set even though the inner http fs is already skipped.
+            simplecache_opts: dict[str, Any] = {"skip_instance_cache": True}
             if cache_storage is not None:
                 _mark_cache_dir(cache_storage)
                 simplecache_opts["cache_storage"] = str(cache_storage)
@@ -676,7 +693,11 @@ def open_url(
             import fsspec
 
             options: dict[str, Any] = {
-                "expiry_time": cache_expiry if cache_expiry is not None else 3600
+                "expiry_time": cache_expiry if cache_expiry is not None else 3600,
+                # See the ``cache`` branch above: skip fsspec's instance cache on
+                # the outer WholeFileCacheFileSystem so it does not grow per
+                # distinct header set in a long-lived process.
+                "skip_instance_cache": True,
             }
             if cache_storage is not None:
                 _mark_cache_dir(cache_storage)

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -1273,31 +1273,27 @@ def _dispatch_gdrive_url_format(filename: str, **kwargs) -> Labels | Video:
         data = file_like.read()
         fmt = _gdrive_format_from_bytes(data)
 
-        # The bytes were already fully downloaded to sniff the format above, so
-        # the generic `_dispatch_url_format` "Download the file locally first."
-        # message would be misleading here (the download cost was already paid).
-        # Raise a Drive-specific message instead for unsupported formats.
-        if fmt not in _URL_IMPLEMENTED_FORMATS:
+        # A Drive byte-sniff only classifies labels/annotation formats, and among
+        # those only `.slp` is loadable over a URL today (Drive video is rejected
+        # earlier; video bytes are never classified as a loadable format here).
+        # The bytes were already fully downloaded to sniff, so the generic
+        # `_dispatch_url_format` "Download the file locally first." wording would
+        # misstate the cost already paid -- raise a Drive-specific message.
+        if fmt != "slp":
             raise NotImplementedError(
                 f"The Google Drive file was detected as '{fmt}' after a full "
-                f"download, but remote loading for '{fmt}' is not yet "
-                f"implemented (URL: {_remote._redact_url(filename)}); only 'slp' "
-                "and 'video' are supported over URLs. Save the bytes to a local "
-                "file and load that path instead."
+                f"download, but only '.slp' labels can be loaded over a URL "
+                f"(URL: {_remote._redact_url(filename)}). Save the bytes to a "
+                "local file and load that path instead."
             )
 
-        if fmt == "slp":
-            # Reuse the already-downloaded bytes instead of re-resolving the
-            # Drive link in load_slp (which would be a second download against
-            # Drive's per-file quota). The buffer is closed in the finally below,
-            # after load_slp has fully read it (lazy pixel/label-image access
-            # uses independent in-memory handles, not this one).
-            file_like.seek(0)
-            return load_slp(filename, _file_like=file_like, **kwargs)
-
-        # fmt == "video": Drive video is unsupported and raises cleanly in
-        # load_video; no buffer reuse is possible (decoders need range reads).
-        return _dispatch_url_format(filename, fmt, **kwargs)
+        # Reuse the already-downloaded bytes instead of re-resolving the Drive
+        # link in load_slp (which would be a second download against Drive's
+        # per-file quota). The buffer is closed in the finally below, after
+        # load_slp has fully read it (lazy pixel/label-image access uses
+        # independent in-memory handles, not this one).
+        file_like.seek(0)
+        return load_slp(filename, _file_like=file_like, **kwargs)
     finally:
         file_like.close()
 

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -125,14 +125,11 @@ def load_slp(
         finally:
             file_like.close()
 
-        # Propagate URL config to embedded HDF5Video backends so they can reopen
-        # the remote file lazily on frame reads.
-        from sleap_io.io.video_reading import HDF5Video
-
-        for video in labels.videos:
-            if isinstance(video.backend, HDF5Video):
-                object.__setattr__(video.backend, "_url_headers", headers)
-                object.__setattr__(video.backend, "_url_stream_mode", resolved_mode)
+        # The URL auth context (headers/resolved_mode) is threaded into each
+        # video backend at construction time and persisted on the Video by
+        # `make_video` (via `_read_labels_*_from_open_file` -> `read_videos`), so
+        # the embedded HDF5Video probe is authenticated and later frame reads /
+        # existence probes / reopens stay authenticated. No post-hoc backfill.
         return labels
 
     # Local path - UNCHANGED behaviour; URL-specific kwargs are no-ops.

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
 
@@ -36,6 +36,7 @@ def load_slp(
     block_size: int = 1 << 20,
     max_blocks: int = 32,
     retries: int = 3,
+    _file_like: Any | None = None,
 ) -> Labels:
     """Load a SLEAP dataset from a local path or HTTP/cloud URL.
 
@@ -93,37 +94,55 @@ def load_slp(
 
     if _remote._is_url(filename):
         url = os.fspath(filename) if isinstance(filename, os.PathLike) else filename
-        file_like = _remote.open_url(
-            url,
-            headers=headers,
-            stream_mode=stream_mode,
-            cache_storage=cache_storage,
-            cache_expiry=cache_expiry,
-            block_size=block_size,
-            max_blocks=max_blocks,
-            retries=retries,
+        # ``_file_like`` lets a caller hand in an already-resolved file-like
+        # (private; used by the Google Drive auto-detect path to reuse the bytes
+        # it had to download to sniff the format, rather than re-resolving the
+        # link a second time against Drive's per-file download quota). When
+        # provided, the caller owns closing it.
+        owns_file_like = _file_like is None
+        file_like = (
+            _remote.open_url(
+                url,
+                headers=headers,
+                stream_mode=stream_mode,
+                cache_storage=cache_storage,
+                cache_expiry=cache_expiry,
+                block_size=block_size,
+                max_blocks=max_blocks,
+                retries=retries,
+            )
+            if owns_file_like
+            else _file_like
         )
         resolved_mode = "blockcache" if stream_mode == "auto" else stream_mode
+
+        # Google Drive resolves to a full in-memory BytesIO (no range support).
+        # Capture its bytes once so the long-lived label-image reopen reuses them
+        # instead of re-resolving (and re-downloading) the Drive link.
+        from sleap_io.io._gdrive import _is_gdrive_url
+
+        url_bytes = None
+        if _is_gdrive_url(url) and hasattr(file_like, "getvalue"):
+            url_bytes = file_like.getvalue()
+
         try:
             with h5py.File(file_like, "r") as f:
-                if lazy:
-                    labels = slp._read_labels_lazy_from_open_file(
-                        url,
-                        f,
-                        open_videos=open_videos,
-                        _url_headers=headers,
-                        _url_stream_mode=resolved_mode,
-                    )
-                else:
-                    labels = slp._read_labels_from_open_file(
-                        url,
-                        f,
-                        open_videos=open_videos,
-                        _url_headers=headers,
-                        _url_stream_mode=resolved_mode,
-                    )
+                reader = (
+                    slp._read_labels_lazy_from_open_file
+                    if lazy
+                    else slp._read_labels_from_open_file
+                )
+                labels = reader(
+                    url,
+                    f,
+                    open_videos=open_videos,
+                    _url_headers=headers,
+                    _url_stream_mode=resolved_mode,
+                    _url_bytes=url_bytes,
+                )
         finally:
-            file_like.close()
+            if owns_file_like:
+                file_like.close()
 
         # The URL auth context (headers/resolved_mode) is threaded into each
         # video backend at construction time and persisted on the Video by
@@ -1252,23 +1271,35 @@ def _dispatch_gdrive_url_format(filename: str, **kwargs) -> Labels | Video:
     file_like = _open_gdrive(filename, headers=headers)
     try:
         data = file_like.read()
+        fmt = _gdrive_format_from_bytes(data)
+
+        # The bytes were already fully downloaded to sniff the format above, so
+        # the generic `_dispatch_url_format` "Download the file locally first."
+        # message would be misleading here (the download cost was already paid).
+        # Raise a Drive-specific message instead for unsupported formats.
+        if fmt not in _URL_IMPLEMENTED_FORMATS:
+            raise NotImplementedError(
+                f"The Google Drive file was detected as '{fmt}' after a full "
+                f"download, but remote loading for '{fmt}' is not yet "
+                f"implemented (URL: {_remote._redact_url(filename)}); only 'slp' "
+                "and 'video' are supported over URLs. Save the bytes to a local "
+                "file and load that path instead."
+            )
+
+        if fmt == "slp":
+            # Reuse the already-downloaded bytes instead of re-resolving the
+            # Drive link in load_slp (which would be a second download against
+            # Drive's per-file quota). The buffer is closed in the finally below,
+            # after load_slp has fully read it (lazy pixel/label-image access
+            # uses independent in-memory handles, not this one).
+            file_like.seek(0)
+            return load_slp(filename, _file_like=file_like, **kwargs)
+
+        # fmt == "video": Drive video is unsupported and raises cleanly in
+        # load_video; no buffer reuse is possible (decoders need range reads).
+        return _dispatch_url_format(filename, fmt, **kwargs)
     finally:
         file_like.close()
-    fmt = _gdrive_format_from_bytes(data)
-
-    # The bytes were already fully downloaded to sniff the format above, so the
-    # generic `_dispatch_url_format` "Download the file locally first." message
-    # would be misleading here (the download cost was already paid). Raise a
-    # Drive-specific message instead for unsupported formats.
-    if fmt not in _URL_IMPLEMENTED_FORMATS:
-        raise NotImplementedError(
-            f"The Google Drive file was detected as '{fmt}' after a full "
-            f"download, but remote loading for '{fmt}' is not yet implemented "
-            f"(URL: {_remote._redact_url(filename)}); only 'slp' and 'video' "
-            "are supported over URLs. Save the bytes to a local file and load "
-            "that path instead."
-        )
-    return _dispatch_url_format(filename, fmt, **kwargs)
 
 
 def _resolve_hdf5_url_format(

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -2694,6 +2694,7 @@ def _read_labels_lazy_from_open_file(
     open_videos: bool = True,
     _url_headers: dict[str, str] | None = None,
     _url_stream_mode: str = "blockcache",
+    _url_bytes: bytes | None = None,
 ) -> Labels:
     """Build a lazy `Labels` from an already-open `h5py.File`.
 
@@ -2711,6 +2712,10 @@ def _read_labels_lazy_from_open_file(
             handle when `labels_path` is a URL. Ignored for local paths.
         _url_stream_mode: Streaming strategy for the long-lived label-image
             handle when `labels_path` is a URL. Ignored for local paths.
+        _url_bytes: Already-downloaded file bytes to reuse for the long-lived
+            label-image handle instead of re-opening `labels_path` over the
+            network (used for Google Drive, where a re-resolve is a re-download
+            against the per-file quota). Ignored for local paths.
 
     Returns:
         Labels with LazyFrameList for labeled_frames.
@@ -2775,6 +2780,7 @@ def _read_labels_lazy_from_open_file(
         _hdf5_file=f,
         _url_headers=_url_headers,
         _url_stream_mode=_url_stream_mode,
+        _url_bytes=_url_bytes,
     )
 
     # Build per-frame annotation dicts for lazy materialization
@@ -3962,6 +3968,7 @@ def read_label_images(
     _hdf5_file: h5py.File | None = None,
     _url_headers: dict[str, str] | None = None,
     _url_stream_mode: str = "blockcache",
+    _url_bytes: bytes | None = None,
 ) -> tuple[list[tuple[LabelImage, int, int]], "h5py.File | None"]:
     """Read label image annotations from a SLEAP labels file.
 
@@ -3989,6 +3996,10 @@ def read_label_images(
             Ignored for local paths.
         _url_stream_mode: Streaming strategy for the long-lived lazy-access
             handle when ``labels_path`` is a URL. Ignored for local paths.
+        _url_bytes: Already-downloaded file bytes to wrap in a fresh in-memory
+            handle for lazy pixel access, instead of re-opening ``labels_path``
+            over the network. Used for Google Drive (where a re-resolve is a
+            re-download against the per-file quota). Ignored for local paths.
 
     Returns:
         A tuple of ``(label_image_tuples, h5py_file)`` where
@@ -4012,9 +4023,15 @@ def read_label_images(
     # below capture it), so it cannot reuse `_hdf5_file`. For URL loads,
     # ``labels_path`` is the raw URL string, which ``h5py.File`` cannot open
     # directly; open a FRESH, independent fsspec file-like instead.
+    import io
+
     from sleap_io.io import _remote
 
-    if _remote._is_url(labels_path):
+    if _url_bytes is not None:
+        # Reuse already-downloaded bytes (e.g. a Google Drive prefetch) in a
+        # fresh, independent in-memory handle instead of re-resolving the URL.
+        f = h5py.File(io.BytesIO(_url_bytes), "r")
+    elif _remote._is_url(labels_path):
         f = h5py.File(
             _remote.open_url(
                 labels_path,
@@ -5355,6 +5372,7 @@ def _read_labels_from_open_file(
     open_videos: bool = True,
     _url_headers: dict[str, str] | None = None,
     _url_stream_mode: str = "blockcache",
+    _url_bytes: bytes | None = None,
 ) -> Labels:
     """Build a `Labels` from an already-open `h5py.File`.
 
@@ -5373,6 +5391,10 @@ def _read_labels_from_open_file(
             handle when `labels_path` is a URL. Ignored for local paths.
         _url_stream_mode: Streaming strategy for the long-lived label-image
             handle when `labels_path` is a URL. Ignored for local paths.
+        _url_bytes: Already-downloaded file bytes to reuse for the long-lived
+            label-image handle instead of re-opening `labels_path` over the
+            network (used for Google Drive, where a re-resolve is a re-download
+            against the per-file quota). Ignored for local paths.
 
     Returns:
         The processed `Labels` object.
@@ -5476,6 +5498,7 @@ def _read_labels_from_open_file(
         _hdf5_file=f,
         _url_headers=_url_headers,
         _url_stream_mode=_url_stream_mode,
+        _url_bytes=_url_bytes,
     )
 
     # Attach annotations to their corresponding LabeledFrames

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -187,6 +187,8 @@ def make_video(
     video_json: dict,
     open_backend: bool = True,
     _hdf5_file: h5py.File | None = None,
+    _url_headers: dict[str, str] | None = None,
+    _url_stream_mode: str = "blockcache",
 ) -> Video:
     """Create a `Video` object from a JSON dictionary.
 
@@ -198,6 +200,12 @@ def make_video(
             when the video files are not available).
         _hdf5_file: Optional already-open HDF5 file handle. For internal use to avoid
             repeatedly opening the same file when loading many embedded videos.
+        _url_headers: HTTP headers forwarded to the backend (and stored on the
+            returned `Video`) when `labels_path`/the video is a remote URL, so the
+            construction-time metadata probe and later existence probes are
+            authenticated. Private; ignored for local files.
+        _url_stream_mode: Remote streaming strategy for a URL-backed video. Private;
+            ignored for local files.
     """
     backend_metadata = video_json["backend"]
 
@@ -247,6 +255,8 @@ def make_video(
                     source_video_json,
                     open_backend=open_backend,
                     _hdf5_file=f,
+                    _url_headers=_url_headers,
+                    _url_stream_mode=_url_stream_mode,
                 )
 
             # Legacy compatibility: if original_video exists but source_video doesn't,
@@ -260,6 +270,8 @@ def make_video(
                     original_video_json,
                     open_backend=False,  # Original videos are often not available
                     _hdf5_file=f,
+                    _url_headers=_url_headers,
+                    _url_stream_mode=_url_stream_mode,
                 )
 
         if _hdf5_file is not None:
@@ -274,6 +286,8 @@ def make_video(
                 labels_path,
                 video_json["source_video"],
                 open_backend=open_backend,
+                _url_headers=_url_headers,
+                _url_stream_mode=_url_stream_mode,
             )
 
         # Legacy compatibility: if original_video exists but source_video doesn't,
@@ -283,6 +297,8 @@ def make_video(
                 labels_path,
                 video_json["original_video"],
                 open_backend=False,  # Original videos are often not available
+                _url_headers=_url_headers,
+                _url_stream_mode=_url_stream_mode,
             )
 
     # Handle ImageVideo filenames - always expand to full list regardless of
@@ -329,6 +345,8 @@ def make_video(
                 grayscale=grayscale,
                 input_format=backend_metadata.get("input_format", None),
                 format=backend_metadata.get("format", None),
+                url_headers=_url_headers,
+                url_stream_mode=_url_stream_mode,
             )
 
             # Restore FPS from metadata for backends that don't read it from file
@@ -348,13 +366,20 @@ def make_video(
             sanitize_filename(p) if isinstance(p, Path) else p for p in video_path
         ]
 
-    return Video(
+    video = Video(
         filename=video_path,
         backend=backend,
         backend_metadata=backend_metadata,
         source_video=source_video,
         open_backend=open_backend,
     )
+    # Persist the URL auth context on the Video (init=False fields) so existence
+    # probes and a later Video.open() reconstruction stay authenticated even
+    # after the backend is closed/rebuilt.
+    if _url_headers is not None or _url_stream_mode != "blockcache":
+        object.__setattr__(video, "_url_headers", _url_headers)
+        object.__setattr__(video, "_url_stream_mode", _url_stream_mode)
+    return video
 
 
 def read_videos(
@@ -362,6 +387,8 @@ def read_videos(
     open_backend: bool = True,
     *,
     _hdf5_file: h5py.File | None = None,
+    _url_headers: dict[str, str] | None = None,
+    _url_stream_mode: str = "blockcache",
 ) -> list[Video]:
     """Read `Video` dataset in a SLEAP labels file.
 
@@ -375,6 +402,11 @@ def read_videos(
             to close) and threaded into `make_video`; otherwise `labels_path` is
             opened and closed internally. This is a private argument used to thread
             a single open handle through multiple reads.
+        _url_headers: HTTP headers forwarded to each video backend when
+            `labels_path` is a URL (so the construction-time probe is
+            authenticated). Private; ignored for local files.
+        _url_stream_mode: Remote streaming strategy for URL-backed videos.
+            Private; ignored for local files.
 
     Returns:
         A list of `Video` objects.
@@ -386,7 +418,12 @@ def read_videos(
         for video_data in videos_metadata:
             video_json = json.loads(video_data)
             video = make_video(
-                labels_path, video_json, open_backend=open_backend, _hdf5_file=f
+                labels_path,
+                video_json,
+                open_backend=open_backend,
+                _hdf5_file=f,
+                _url_headers=_url_headers,
+                _url_stream_mode=_url_stream_mode,
             )
             videos.append(video)
 
@@ -2690,7 +2727,13 @@ def _read_labels_lazy_from_open_file(
     format_id = read_hdf5_attrs(labels_path, "metadata", "format_id", _hdf5_file=f)
 
     # Read metadata eagerly (these are small and needed for lazy access)
-    videos = read_videos(labels_path, open_backend=open_videos, _hdf5_file=f)
+    videos = read_videos(
+        labels_path,
+        open_backend=open_videos,
+        _hdf5_file=f,
+        _url_headers=_url_headers,
+        _url_stream_mode=_url_stream_mode,
+    )
     skeletons = read_skeletons(labels_path, _hdf5_file=f)
     tracks = read_tracks(labels_path, _hdf5_file=f)
     suggestions = read_suggestions(labels_path, videos, _hdf5_file=f)
@@ -5335,7 +5378,13 @@ def _read_labels_from_open_file(
         The processed `Labels` object.
     """
     tracks = read_tracks(labels_path, _hdf5_file=f)
-    videos = read_videos(labels_path, open_backend=open_videos, _hdf5_file=f)
+    videos = read_videos(
+        labels_path,
+        open_backend=open_videos,
+        _hdf5_file=f,
+        _url_headers=_url_headers,
+        _url_stream_mode=_url_stream_mode,
+    )
     skeletons = read_skeletons(labels_path, _hdf5_file=f)
     points = read_points(labels_path, _hdf5_file=f)
     pred_points = read_pred_points(labels_path, _hdf5_file=f)

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -435,6 +435,28 @@ class VideoBackend:
         for key, value in state.items():
             object.__setattr__(self, key, value)
 
+    def close(self) -> None:
+        """Release the cached open reader handle, if any.
+
+        Closes (``.close()``) or releases (``.release()`` for an OpenCV
+        ``VideoCapture``) the cached ``_open_reader`` and drops the reference so
+        a long-lived backend does not leak the underlying file/container handle.
+        The reader is lazily reopened on the next read, so this is safe to call
+        between reads. A no-op when nothing is cached. Subclasses that hold
+        additional handles (e.g. :class:`HDF5Video`'s URL file-like) override
+        this and call ``super().close()``.
+        """
+        reader = self._open_reader
+        self._open_reader = None
+        if reader is None:
+            return
+        closer = getattr(reader, "close", None) or getattr(reader, "release", None)
+        if closer is not None:
+            try:
+                closer()
+            except Exception:  # pragma: no cover - defensive: close should not raise
+                pass
+
     @classmethod
     def from_filename(
         cls,
@@ -1177,6 +1199,20 @@ class HDF5Video(VideoBackend):
             return h5py.File(self._url_file, "r")
         return h5py.File(self.filename, "r")
 
+    def _close_url_file(self) -> None:
+        """Close and drop the cached fsspec URL file-like, if any (idempotent).
+
+        A no-op for local files (where ``_url_file`` is never set) and when it
+        has already been closed/dropped.
+        """
+        if self._url_file is None:
+            return
+        try:
+            self._url_file.close()
+        except Exception:  # pragma: no cover - defensive: close() should not raise
+            pass
+        self._url_file = None
+
     def _release_probe_url_file(self, preexisting: bool) -> None:
         """Close and drop ``self._url_file`` if a probe opened it.
 
@@ -1189,13 +1225,20 @@ class HDF5Video(VideoBackend):
             preexisting: Whether ``self._url_file`` was already set before the
                 probe opened the file (in which case it is left untouched).
         """
-        if preexisting or self._url_file is None:
+        if preexisting:
             return
-        try:
-            self._url_file.close()
-        except Exception:  # pragma: no cover - defensive: close() should not raise
-            pass
-        self._url_file = None
+        self._close_url_file()
+
+    def close(self) -> None:
+        """Release the cached HDF5 reader and the cached fsspec URL file-like.
+
+        Extends :meth:`VideoBackend.close` (which drops the cached ``h5py.File``
+        reader) by also closing the fsspec-backed ``_url_file`` shared across
+        reads, which ``h5py.File.close()`` does not close on its own. Both are
+        lazily reopened on the next read, so this is safe to call between reads.
+        """
+        super().close()
+        self._close_url_file()
 
     def __getstate__(self) -> dict:
         """Return state for pickling/deepcopy, dropping unpicklable handles.

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -1144,6 +1144,16 @@ class HDF5Video(VideoBackend):
             "FFMPEG". If None, uses the global default or auto-detects based on
             available packages. Note that "pyav" is automatically mapped to "FFMPEG"
             since PyAV doesn't support image decoding.
+
+    Notes:
+        Concurrent reads of a single remote (URL-backed) `HDF5Video` from
+        multiple threads are safe: although all reads share one cached fsspec
+        file-like (a single byte position), h5py serializes every HDF5 C-library
+        call under a global recursive lock (`h5py._objects.phil`), so the
+        seek+read pair a frame read performs is never interleaved across threads.
+        For true read *parallelism* (rather than just safety), construct
+        independent `Video`/`HDF5Video` instances per worker; each gets its own
+        fsspec file and block cache.
     """
 
     dataset: str | None = None

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -450,12 +450,15 @@ class VideoBackend:
         self._open_reader = None
         if reader is None:
             return
+        # Every real reader is an h5py.File / imageio reader (``.close()``) or an
+        # OpenCV VideoCapture (``.release()``); the None case is purely defensive.
         closer = getattr(reader, "close", None) or getattr(reader, "release", None)
-        if closer is not None:
-            try:
-                closer()
-            except Exception:  # pragma: no cover - defensive: close should not raise
-                pass
+        if closer is None:  # pragma: no cover - defensive: reader always closeable
+            return
+        try:
+            closer()
+        except Exception:  # pragma: no cover - defensive: close should not raise
+            pass
 
     @classmethod
     def from_filename(

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -442,6 +442,8 @@ class VideoBackend:
         dataset: str | None = None,
         grayscale: bool | None = None,
         keep_open: bool = True,
+        url_headers: dict[str, str] | None = None,
+        url_stream_mode: str = "blockcache",
         **kwargs,
     ) -> "VideoBackend":
         """Create a VideoBackend from a filename.
@@ -455,6 +457,13 @@ class VideoBackend:
                 frames. If False, will close the reader after each call. If True (the
                 default), it will keep the reader open and cache it for subsequent calls
                 which may enhance the performance of reading multiple frames.
+            url_headers: HTTP headers forwarded to the remote backend when
+                ``filename`` is a URL (HDF5Video only). Set at construction so the
+                metadata probe is authenticated; ignored for local files and other
+                backends.
+            url_stream_mode: Remote streaming strategy for a URL-backed HDF5Video
+                (one of ``"blockcache"``/``"cache"``/``"filecache"``/``"download"``).
+                Ignored for local files and other backends.
             **kwargs: Additional backend-specific arguments. These are filtered to only
                 include parameters that are valid for the specific backend being
                 created:
@@ -585,11 +594,17 @@ class VideoBackend:
                 **media_kwargs,
             )
         elif ext_token.endswith(tuple(ext.lower() for ext in HDF5Video.EXTS)):
+            # Pass ``url_headers`` / ``url_stream_mode`` explicitly (not via
+            # ``_get_valid_kwargs``, which keys on the underscored field *name*
+            # and would drop the alias) so the construction-time probe in
+            # ``HDF5Video.__attrs_post_init__`` is authenticated for remote URLs.
             return HDF5Video(
                 filename,
                 dataset=dataset,
                 grayscale=grayscale,
                 keep_open=keep_open,
+                url_headers=url_headers,
+                url_stream_mode=url_stream_mode,
                 **_get_valid_kwargs(HDF5Video, kwargs),
             )
         else:
@@ -1123,12 +1138,18 @@ class HDF5Video(VideoBackend):
     _url_file: object | None = attrs.field(
         init=False, default=None, repr=False, eq=False
     )
+    # ``_url_headers`` / ``_url_stream_mode`` are ``init=True`` (attrs derives the
+    # constructor aliases ``url_headers`` / ``url_stream_mode`` by stripping the
+    # leading underscore) so the metadata probe in ``__attrs_post_init__`` runs
+    # *authenticated*: an embedded ``pkg.slp`` over an auth-gated URL would
+    # otherwise probe with no headers and silently lose the embedded-image
+    # metadata. They remain ``repr=False, eq=False`` and, because the attribute
+    # names keep the leading underscore, the name-based ``__getstate__`` pickle
+    # contract is unchanged.
     _url_headers: dict[str, str] | None = attrs.field(
-        init=False, default=None, repr=False, eq=False
+        default=None, repr=False, eq=False
     )
-    _url_stream_mode: str = attrs.field(
-        init=False, default="blockcache", repr=False, eq=False
-    )
+    _url_stream_mode: str = attrs.field(default="blockcache", repr=False, eq=False)
 
     EXTS = ("h5", "hdf5", "slp")
 

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -91,8 +91,30 @@ class Video:
     _exists_cache: dict[tuple[str, str | None], tuple[bool, float]] = attrs.field(
         init=False, factory=dict, repr=False, eq=False
     )
+    # URL auth context, threaded in by `make_video` for remote loads. Persisted
+    # on the Video (not just the backend) so existence probes and a later
+    # `open()` reconstruction stay authenticated after the backend is closed.
+    _url_headers: dict[str, str] | None = attrs.field(
+        init=False, default=None, repr=False, eq=False
+    )
+    _url_stream_mode: str = attrs.field(
+        init=False, default="blockcache", repr=False, eq=False
+    )
 
     EXTS = MediaVideo.EXTS + HDF5Video.EXTS + ImageVideo.EXTS + ("seq",)
+
+    def _backend_url_headers(self) -> dict[str, str] | None:
+        """Return the HTTP headers to authenticate remote existence probes.
+
+        Prefers the URL auth context stored on this `Video` (set by `make_video`
+        at load time); falls back to the live backend's headers when present.
+        Returns `None` for local files and unauthenticated URLs.
+        """
+        if self._url_headers is not None:
+            return self._url_headers
+        if isinstance(self.backend, HDF5Video):
+            return getattr(self.backend, "_url_headers", None)
+        return None
 
     @property
     def original_video(self) -> "Video | None":
@@ -446,7 +468,9 @@ class Video:
             return cached[0]
 
         try:
-            if not _head_or_range_probe(self.filename):
+            if not _head_or_range_probe(
+                self.filename, headers=self._backend_url_headers()
+            ):
                 result = False
             else:
                 if dataset is None or dataset == "":
@@ -482,7 +506,7 @@ class Video:
 
         from sleap_io.io._remote import open_remote_h5
 
-        url_file = open_remote_h5(self.filename)
+        url_file = open_remote_h5(self.filename, headers=self._backend_url_headers())
         try:
             with h5py.File(url_file, "r") as f:
                 return dataset in f
@@ -576,12 +600,16 @@ class Video:
         if "plugin" in self.backend_metadata:
             backend_kwargs["plugin"] = self.backend_metadata["plugin"]
 
-        # Create new backend.
+        # Create new backend. Forward the URL auth context so a reopened remote
+        # HDF5Video stays authenticated (the previous backend, and its headers,
+        # were dropped by self.close() above).
         self.backend = VideoBackend.from_filename(
             self.filename,
             dataset=dataset,
             grayscale=grayscale,
             keep_open=keep_open,
+            url_headers=self._url_headers,
+            url_stream_mode=self._url_stream_mode,
             **backend_kwargs,
         )
 

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -630,6 +630,14 @@ class Video:
             except Exception:
                 pass
 
+            # Deterministically release the backend's open handles (the cached
+            # reader and, for a remote HDF5Video, the fsspec URL file-like)
+            # rather than relying on garbage collection.
+            try:
+                self.backend.close()
+            except Exception:
+                pass
+
             del self.backend
             self.backend = None
 

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -591,6 +591,55 @@ def test_load_slp_url_embedded_pkg_wrong_token_raises(httpserver, slp_minimal_pk
         load_slp(url, headers={"Authorization": "Bearer WRONG"})
 
 
+def test_video_close_releases_remote_url_file(httpserver, slp_minimal_pkg):
+    """`Video.close()` deterministically closes the backend's URL file-like."""
+    data = Path(slp_minimal_pkg).read_bytes()
+    _serve_with_range(httpserver, "/minimal.pkg.slp", data)
+    url = httpserver.url_for("/minimal.pkg.slp")
+
+    labels = load_slp(url)
+    video = labels.videos[0]
+    assert video[0].shape == (384, 384, 1)  # opens reader + caches _url_file
+    url_file = video.backend._url_file
+    assert url_file is not None
+
+    video.close()
+    assert video.backend is None
+    assert url_file.closed is True
+
+
+def test_video_close_then_reopen_remote(httpserver, slp_minimal_pkg):
+    """After `Video.close()`, a remote video reopens and reads again."""
+    data = Path(slp_minimal_pkg).read_bytes()
+    _serve_with_range(httpserver, "/minimal.pkg.slp", data)
+    url = httpserver.url_for("/minimal.pkg.slp")
+
+    labels = load_slp(url)
+    video = labels.videos[0]
+    assert video[0].shape == (384, 384, 1)
+
+    video.close()
+    assert video.backend is None
+    # Reading again forces Video.open() to rebuild the backend over the URL.
+    frame = video[0]
+    assert frame.shape == (384, 384, 1)
+    assert video.backend._url_file is not None
+
+
+def test_video_close_twice_is_noop(httpserver, slp_minimal_pkg):
+    """Calling `Video.close()` twice does not raise."""
+    data = Path(slp_minimal_pkg).read_bytes()
+    _serve_with_range(httpserver, "/minimal.pkg.slp", data)
+    url = httpserver.url_for("/minimal.pkg.slp")
+
+    labels = load_slp(url)
+    video = labels.videos[0]
+    assert video[0].shape == (384, 384, 1)
+    video.close()
+    video.close()  # second call must be a no-op
+    assert video.backend is None
+
+
 def _make_label_image_pkg(tmp_path):
     """Build a `.pkg.slp` containing a single `UserLabelImage` and return path.
 

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -476,6 +476,121 @@ def test_load_slp_url_embedded_pkg_keeps_clean_url_and_reads_frame(
     assert frame.dtype.name == "uint8"
 
 
+def _serve_with_range_auth(httpserver, path, data, token):
+    """Serve `data` at `path` with Range support, gated on a bearer token.
+
+    Any request whose `Authorization` header does not equal `token` gets a 401,
+    so an unauthenticated probe fails exactly as an auth-gated remote would. HEAD
+    and ranged/full GET are supported for the authenticated case.
+    """
+    from werkzeug.wrappers import Response
+
+    def handler(request):
+        if request.headers.get("Authorization") != token:
+            return Response(b"unauthorized", status=401)
+        total = len(data)
+        if request.method == "HEAD":
+            resp = Response(b"", status=200)
+            resp.headers["Content-Length"] = str(total)
+            resp.headers["Accept-Ranges"] = "bytes"
+            return resp
+        rng = request.headers.get("Range")
+        if rng and rng.startswith("bytes="):
+            spec = rng.split("=", 1)[1].split(",")[0]
+            start_s, _, end_s = spec.partition("-")
+            start = int(start_s) if start_s else 0
+            end = int(end_s) if end_s else total - 1
+            end = min(end, total - 1)
+            chunk = data[start : end + 1]
+            resp = Response(chunk, status=206)
+            resp.headers["Content-Range"] = f"bytes {start}-{end}/{total}"
+        else:
+            resp = Response(data, status=200)
+        resp.headers["Accept-Ranges"] = "bytes"
+        return resp
+
+    httpserver.expect_request(path).respond_with_handler(handler)
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_load_slp_url_embedded_pkg_authenticated_reads_frame(
+    httpserver, slp_minimal_pkg, lazy
+):
+    """An auth-gated embedded ``pkg.slp`` over a URL loads embedded metadata.
+
+    The embedded ``HDF5Video`` metadata probe runs at backend *construction*
+    time; before headers were threaded to construction it ran unauthenticated
+    and silently lost the embedded-image metadata (``image_format`` stayed
+    ``"hdf5"`` -> ``has_embedded_images`` False, empty ``frame_map``). With the
+    fix it is authenticated and the embedded frame is readable.
+    """
+    data = Path(slp_minimal_pkg).read_bytes()
+    _serve_with_range_auth(httpserver, "/auth.pkg.slp", data, "Bearer SECRET")
+    url = httpserver.url_for("/auth.pkg.slp")
+
+    labels = load_slp(url, headers={"Authorization": "Bearer SECRET"}, lazy=lazy)
+    video = labels.videos[0]
+
+    # Embedded-image metadata was read by the authenticated construction probe.
+    assert video.backend.has_embedded_images is True
+    assert video.backend.image_format != "hdf5"
+    assert len(video.backend.frame_map) > 0
+
+    # And the embedded frame is readable over the authenticated URL.
+    frame = video[0]
+    assert frame.shape == (384, 384, 1)
+    assert frame.dtype.name == "uint8"
+
+
+def test_load_slp_url_embedded_pkg_authenticated_exists(httpserver, slp_minimal_pkg):
+    """`Video.exists()` forwards the backend auth headers to its remote probe."""
+    data = Path(slp_minimal_pkg).read_bytes()
+    _serve_with_range_auth(httpserver, "/auth.pkg.slp", data, "Bearer SECRET")
+    url = httpserver.url_for("/auth.pkg.slp")
+
+    labels = load_slp(url, headers={"Authorization": "Bearer SECRET"})
+    video = labels.videos[0]
+
+    # Both the root probe and the dataset-membership probe must authenticate.
+    assert video.exists() is True
+    assert video.exists(dataset=video.backend.dataset) is True
+
+
+def test_load_slp_url_embedded_pkg_reopen_stays_authenticated(
+    httpserver, slp_minimal_pkg
+):
+    """After close(), a reopened remote HDF5Video still reads authenticated.
+
+    `Video.open()` rebuilds the backend via `from_filename`; the URL auth
+    context persisted on the `Video` must be forwarded so the new backend is
+    authenticated (the old backend, and its headers, were dropped by close()).
+    """
+    data = Path(slp_minimal_pkg).read_bytes()
+    _serve_with_range_auth(httpserver, "/auth.pkg.slp", data, "Bearer SECRET")
+    url = httpserver.url_for("/auth.pkg.slp")
+
+    labels = load_slp(url, headers={"Authorization": "Bearer SECRET"})
+    video = labels.videos[0]
+    assert video[0].shape == (384, 384, 1)  # first read
+
+    video.close()
+    # Forces Video.open() -> from_filename reconstruction; must stay authed.
+    frame = video[0]
+    assert frame.shape == (384, 384, 1)
+    assert video.backend._url_headers == {"Authorization": "Bearer SECRET"}
+
+
+def test_load_slp_url_embedded_pkg_wrong_token_raises(httpserver, slp_minimal_pkg):
+    """A wrong token fails the load cleanly rather than silently degrading."""
+    data = Path(slp_minimal_pkg).read_bytes()
+    _serve_with_range_auth(httpserver, "/auth.pkg.slp", data, "Bearer SECRET")
+    url = httpserver.url_for("/auth.pkg.slp")
+
+    # RemoteIOError subclasses OSError; the top-level open is unauthenticated.
+    with pytest.raises(OSError):
+        load_slp(url, headers={"Authorization": "Bearer WRONG"})
+
+
 def _make_label_image_pkg(tmp_path):
     """Build a `.pkg.slp` containing a single `UserLabelImage` and return path.
 

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -1039,6 +1039,103 @@ def test_load_file_gdrive_url_explicit_format(gdrive_uc_template, slp_minimal):
     assert len(labels) == 1
 
 
+def _serve_gdrive_slp_counting(httpserver, slp_path):
+    """Like `_serve_gdrive_slp` but records each `/download` hit.
+
+    Returns a list appended to on every download hop so a test can assert how
+    many times the Drive file was actually downloaded.
+    """
+    from werkzeug.wrappers import Response
+
+    file_bytes = Path(slp_path).read_bytes()
+    download_url = httpserver.url_for("/download")
+    form = (
+        f'<html><body><form id="download-form" action="{download_url}" '
+        'method="get">'
+        '<input type="hidden" name="id" value="FILEID">'
+        '<input type="hidden" name="export" value="download">'
+        '<input type="hidden" name="confirm" value="t">'
+        "</form></body></html>"
+    )
+    hits: list[int] = []
+
+    def _download_handler(request):
+        hits.append(1)
+        resp = Response(file_bytes, status=200)
+        resp.headers["Content-Disposition"] = 'attachment; filename="labels.slp"'
+        return resp
+
+    httpserver.expect_request("/uc").respond_with_data(form, content_type="text/html")
+    httpserver.expect_request("/download").respond_with_handler(_download_handler)
+    return hits
+
+
+def test_load_file_gdrive_url_single_download(gdrive_uc_template, slp_minimal):
+    """`load_file` auto-detect on a Drive .slp downloads exactly once (was 2x)."""
+    hits = _serve_gdrive_slp_counting(gdrive_uc_template, slp_minimal)
+
+    labels = load_file("https://drive.google.com/file/d/FILEID/view")
+    assert type(labels) is Labels
+    assert len(hits) == 1
+
+
+def test_load_slp_gdrive_url_single_download(gdrive_uc_template, slp_minimal):
+    """Direct `load_slp` on a Drive .slp downloads exactly once."""
+    hits = _serve_gdrive_slp_counting(gdrive_uc_template, slp_minimal)
+
+    labels = load_slp("https://drive.google.com/file/d/FILEID/view")
+    assert type(labels) is Labels
+    assert len(hits) == 1
+
+
+def test_load_file_gdrive_url_explicit_format_single_download(
+    gdrive_uc_template, slp_minimal
+):
+    """`format='slp'` on a Drive URL downloads exactly once (no sniff fetch)."""
+    hits = _serve_gdrive_slp_counting(gdrive_uc_template, slp_minimal)
+
+    labels = load_file("https://drive.google.com/file/d/FILEID/view", format="slp")
+    assert type(labels) is Labels
+    assert len(hits) == 1
+
+
+def test_load_file_gdrive_url_label_image_single_download(gdrive_uc_template, tmp_path):
+    """A Drive label-image .slp via `load_file` downloads once (was 3x).
+
+    The third download came from `read_label_images` re-resolving the URL for
+    its long-lived lazy-pixel handle; it now reuses the already-downloaded bytes.
+    """
+    from sleap_io.io.main import save_slp
+    from tests.fixtures.labels import make_labels_all_annotations
+
+    path = str(tmp_path / "label_images.slp")
+    save_slp(make_labels_all_annotations(), path, embed=False)
+    with h5py.File(path, "r") as f:
+        assert "label_images" in f  # fixture must actually exercise the LI path
+    hits = _serve_gdrive_slp_counting(gdrive_uc_template, path)
+
+    labels = load_file("https://drive.google.com/file/d/FILEID/view")
+    assert type(labels) is Labels
+    assert len(hits) == 1
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_load_slp_gdrive_url_label_image_single_download(
+    gdrive_uc_template, tmp_path, lazy
+):
+    """Direct `load_slp` on a Drive label-image .slp downloads once (was 2x)."""
+    from sleap_io.io.main import save_slp
+    from tests.fixtures.labels import make_labels_all_annotations
+
+    path = str(tmp_path / "label_images.slp")
+    save_slp(make_labels_all_annotations(), path, embed=False)
+    hits = _serve_gdrive_slp_counting(gdrive_uc_template, path)
+
+    labels = load_slp("https://drive.google.com/file/d/FILEID/view", lazy=lazy)
+    assert type(labels) is Labels
+    assert len(hits) == 1
+
+
 def test_load_file_gdrive_url_sniff_false_raises(slp_minimal):
     """`load_file(drive_url, sniff=False)` raises (no extension to fall back on)."""
     with pytest.raises(ValueError, match="Cannot infer format for a Google Drive"):

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -21,6 +21,11 @@ from pathlib import Path
 import aiohttp
 import pytest
 from aiohttp.client_reqrep import ConnectionKey
+from fsspec.implementations.cached import (
+    SimpleCacheFileSystem,
+    WholeFileCacheFileSystem,
+)
+from fsspec.implementations.http import HTTPFileSystem
 from multidict import CIMultiDict
 from pytest_httpserver import HTTPServer
 from werkzeug.wrappers import Response
@@ -1213,6 +1218,104 @@ def test_open_url_blockcache_explicit_max_blocks(httpserver):
         assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
     finally:
         file_like.close()
+
+
+# ---------------------------------------------------------------------------
+# fsspec instance-cache growth guard (skip_instance_cache on header-bearing
+# filesystems so rotating per-request tokens do not accumulate fs instances).
+# ---------------------------------------------------------------------------
+
+
+def test_build_fsspec_filesystem_http_skips_instance_cache(httpserver):
+    """Distinct per-request headers do not grow `HTTPFileSystem._cache`."""
+    httpserver.expect_request("/data").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/data")
+
+    before = len(HTTPFileSystem._cache)
+    for i in range(5):
+        fs = _build_fsspec_filesystem("https", headers={"Authorization": f"Bearer t{i}"})
+        # The filesystem still works: a ranged read returns the served body.
+        with fs.open(url, mode="rb") as f:
+            assert f.read(8) == b"\x89HDF\r\n\x1a\n"
+    assert len(HTTPFileSystem._cache) == before
+
+
+def test_http_inner_options_marks_skip_instance_cache():
+    """`_http_inner_options` opts the inner http fs out of the instance cache."""
+    opts = _http_inner_options({"Authorization": "x"})
+    assert opts["skip_instance_cache"] is True
+    # The identity-encoding guarantee and client wiring are still present.
+    assert opts["client_kwargs"]["headers"]["Accept-Encoding"] == "identity"
+    assert "get_client" in opts
+
+
+def test_open_url_cache_mode_does_not_grow_instance_cache(httpserver, tmp_path):
+    """`cache` mode keeps both the SimpleCache and inner HTTP caches flat."""
+    httpserver.expect_request("/data.slp").respond_with_data(
+        _HDF5_BODY, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/data.slp")
+
+    simple_before = len(SimpleCacheFileSystem._cache)
+    http_before = len(HTTPFileSystem._cache)
+    for i in range(3):
+        file_like = open_url(
+            url,
+            stream_mode="cache",
+            cache_storage=tmp_path,
+            headers={"Authorization": f"Bearer c{i}"},
+        )
+        try:
+            assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+        finally:
+            file_like.close()
+    # Both halves of the chained simplecache::http open must stay bounded; an
+    # outer-only skip would leak the inner HTTP filesystem cache.
+    assert len(SimpleCacheFileSystem._cache) == simple_before
+    assert len(HTTPFileSystem._cache) == http_before
+
+
+def test_open_url_filecache_mode_does_not_grow_instance_cache(httpserver, tmp_path):
+    """`filecache` mode keeps the WholeFileCache and inner HTTP caches flat."""
+    httpserver.expect_request("/data.slp").respond_with_data(
+        _HDF5_BODY, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/data.slp")
+
+    whole_before = len(WholeFileCacheFileSystem._cache)
+    http_before = len(HTTPFileSystem._cache)
+    for i in range(3):
+        file_like = open_url(
+            url,
+            stream_mode="filecache",
+            cache_storage=tmp_path,
+            headers={"Authorization": f"Bearer f{i}"},
+        )
+        try:
+            assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+        finally:
+            file_like.close()
+    assert len(WholeFileCacheFileSystem._cache) == whole_before
+    assert len(HTTPFileSystem._cache) == http_before
+
+
+def test_open_url_blockcache_does_not_grow_instance_cache(httpserver):
+    """`blockcache` (auto) mode does not grow the HTTP instance cache."""
+    httpserver.expect_request("/data.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/data.slp")
+
+    before = len(HTTPFileSystem._cache)
+    for i in range(3):
+        file_like = open_url(url, headers={"Authorization": f"Bearer b{i}"})
+        try:
+            assert file_like.read(8) == b"\x89HDF\r\n\x1a\n"
+        finally:
+            file_like.close()
+    assert len(HTTPFileSystem._cache) == before
 
 
 # ---------------------------------------------------------------------------

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -1235,7 +1235,9 @@ def test_build_fsspec_filesystem_http_skips_instance_cache(httpserver):
 
     before = len(HTTPFileSystem._cache)
     for i in range(5):
-        fs = _build_fsspec_filesystem("https", headers={"Authorization": f"Bearer t{i}"})
+        fs = _build_fsspec_filesystem(
+            "https", headers={"Authorization": f"Bearer t{i}"}
+        )
         # The filesystem still works: a ranged read returns the served body.
         with fs.open(url, mode="rb") as f:
             assert f.read(8) == b"\x89HDF\r\n\x1a\n"
@@ -1665,9 +1667,7 @@ def test_open_gdrive_accepts_body_within_cap(gdrive_uc_template):
     """A body at or under the cap downloads byte-exact (chunked reassembly)."""
     _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=_HDF5_BODY)
 
-    bio = _open_gdrive(
-        "https://drive.google.com/file/d/FILEID/view", max_bytes=10_000
-    )
+    bio = _open_gdrive("https://drive.google.com/file/d/FILEID/view", max_bytes=10_000)
     assert bio.read() == _HDF5_BODY
 
 
@@ -1684,9 +1684,7 @@ def test_open_gdrive_cap_boundary_exact_passes(gdrive_uc_template):
     body = b"z" * 256
     _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=body)
 
-    bio = _open_gdrive(
-        "https://drive.google.com/file/d/FILEID/view", max_bytes=256
-    )
+    bio = _open_gdrive("https://drive.google.com/file/d/FILEID/view", max_bytes=256)
     assert bio.read() == body
 
 
@@ -1696,9 +1694,7 @@ def test_open_gdrive_cap_boundary_off_by_one_fails(gdrive_uc_template):
     _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=body)
 
     with pytest.raises(RemoteIOError, match="exceeds the maximum"):
-        _open_gdrive(
-            "https://drive.google.com/file/d/FILEID/view", max_bytes=256
-        )
+        _open_gdrive("https://drive.google.com/file/d/FILEID/view", max_bytes=256)
 
 
 def test_open_gdrive_quota_page_raises(gdrive_uc_template):

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -1632,6 +1632,75 @@ def test_open_gdrive_non_html_first_hop(gdrive_uc_template):
     assert bio.read() == _HDF5_BODY
 
 
+def test_open_gdrive_rejects_oversize_content_length(gdrive_uc_template):
+    """An advertised Content-Length over the cap is rejected before reading."""
+    # The two-hop helper's bytes download hop sets a concrete Content-Length.
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=b"x" * 1000)
+
+    with pytest.raises(RemoteIOError, match="exceeds the maximum"):
+        _open_gdrive("https://drive.google.com/file/d/FILEID/view", max_bytes=16)
+
+
+def test_open_gdrive_rejects_oversize_streamed_body(gdrive_uc_template):
+    """A body over the cap with NO Content-Length is caught by the running cap."""
+
+    def _handler(request):
+        # An iterator body makes werkzeug use chunked transfer with no
+        # Content-Length, so only the running total can catch the overflow.
+        def gen():
+            yield b"x" * 5000
+            yield b"y" * 5000
+
+        resp = Response(gen(), status=200)
+        resp.headers["Content-Disposition"] = 'attachment; filename="big.bin"'
+        return resp
+
+    gdrive_uc_template.expect_request("/uc").respond_with_handler(_handler)
+
+    with pytest.raises(RemoteIOError, match="exceeds the maximum"):
+        _open_gdrive("https://drive.google.com/uc?id=FILEID", max_bytes=8)
+
+
+def test_open_gdrive_accepts_body_within_cap(gdrive_uc_template):
+    """A body at or under the cap downloads byte-exact (chunked reassembly)."""
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=_HDF5_BODY)
+
+    bio = _open_gdrive(
+        "https://drive.google.com/file/d/FILEID/view", max_bytes=10_000
+    )
+    assert bio.read() == _HDF5_BODY
+
+
+def test_open_gdrive_default_cap_allows_small_file(gdrive_uc_template):
+    """With no explicit max_bytes the default cap is a no-op for normal files."""
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=_HDF5_BODY)
+
+    bio = _open_gdrive("https://drive.google.com/file/d/FILEID/view")
+    assert bio.read() == _HDF5_BODY
+
+
+def test_open_gdrive_cap_boundary_exact_passes(gdrive_uc_template):
+    """A body exactly equal to max_bytes is accepted (cap uses strict `>`)."""
+    body = b"z" * 256
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=body)
+
+    bio = _open_gdrive(
+        "https://drive.google.com/file/d/FILEID/view", max_bytes=256
+    )
+    assert bio.read() == body
+
+
+def test_open_gdrive_cap_boundary_off_by_one_fails(gdrive_uc_template):
+    """A body one byte over max_bytes is rejected (guards `>` vs `>=`)."""
+    body = b"z" * 257
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=body)
+
+    with pytest.raises(RemoteIOError, match="exceeds the maximum"):
+        _open_gdrive(
+            "https://drive.google.com/file/d/FILEID/view", max_bytes=256
+        )
+
+
 def test_open_gdrive_quota_page_raises(gdrive_uc_template):
     """A quota interstitial surfaces as a RemoteIOError, not file bytes."""
     quota_html = (

--- a/tests/io/test_video_reading.py
+++ b/tests/io/test_video_reading.py
@@ -347,6 +347,104 @@ def test_hdf5video_post_init_releases_probe_url_file(httpserver, slp_minimal_pkg
     # ...but did not leave the cached fsspec file-like dangling.
     assert backend._url_file is None
 
+
+def test_hdf5video_close_releases_url_file(httpserver, slp_minimal_pkg):
+    """`HDF5Video.close()` closes and drops the cached fsspec URL file-like."""
+    file_bytes = Path(slp_minimal_pkg).read_bytes()
+    httpserver.expect_request("/labels.pkg.slp").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.pkg.slp")
+
+    backend = HDF5Video(
+        filename=url, dataset=None, keep_open=True, url_stream_mode="download"
+    )
+    _ = backend[0]
+    assert backend._url_file is not None
+    assert backend._open_reader is not None
+    url_file = backend._url_file
+
+    backend.close()
+    assert backend._url_file is None
+    assert backend._open_reader is None
+    # The fsspec/BytesIO handle is deterministically closed, not left to GC.
+    assert url_file.closed is True
+
+
+def test_hdf5video_close_idempotent(httpserver, slp_minimal_pkg):
+    """`HDF5Video.close()` is safe to call twice (no raise, stays released)."""
+    file_bytes = Path(slp_minimal_pkg).read_bytes()
+    httpserver.expect_request("/labels.pkg.slp").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.pkg.slp")
+
+    backend = HDF5Video(
+        filename=url, dataset=None, keep_open=True, url_stream_mode="download"
+    )
+    _ = backend[0]
+    backend.close()
+    backend.close()  # second call must not raise
+    assert backend._url_file is None
+    assert backend._open_reader is None
+
+
+def test_hdf5video_close_local_releases_reader(slp_minimal_pkg):
+    """`HDF5Video.close()` releases the local reader; reopens lazily."""
+    backend = HDF5Video(filename=slp_minimal_pkg, dataset="video0/video")
+    _ = backend[0]
+    assert backend._open_reader is not None
+    assert backend._url_file is None  # local files have no URL file-like
+
+    backend.close()
+    assert backend._open_reader is None
+    assert backend._url_file is None
+    # The reader is lazily reopened on the next read.
+    assert backend[0].shape == (384, 384, 1)
+
+
+def test_hdf5video_close_preserves_url_context(httpserver, slp_minimal_pkg):
+    """`close()` releases handles but keeps the URL auth/stream context.
+
+    The auth headers and stream mode must survive a close so a reopened read
+    stays authenticated.
+    """
+    file_bytes = Path(slp_minimal_pkg).read_bytes()
+    httpserver.expect_request("/labels.pkg.slp").respond_with_data(
+        file_bytes, content_type="application/octet-stream"
+    )
+    url = httpserver.url_for("/labels.pkg.slp")
+
+    backend = HDF5Video(
+        filename=url,
+        dataset=None,
+        keep_open=True,
+        url_headers={"Authorization": "Bearer x"},
+        url_stream_mode="download",
+    )
+    _ = backend[0]
+    backend.close()
+    assert backend._url_headers == {"Authorization": "Bearer x"}
+    assert backend._url_stream_mode == "download"
+
+
+def test_mediavideo_close_releases_reader(centered_pair_low_quality_path):
+    """`VideoBackend.close()` releases a MediaVideo reader (close or release)."""
+    backend = VideoBackend.from_filename(centered_pair_low_quality_path, keep_open=True)
+    assert type(backend) is MediaVideo
+    _ = backend[0]
+    assert backend._open_reader is not None
+    reader = backend._open_reader
+
+    backend.close()
+    assert backend._open_reader is None
+    # An OpenCV VideoCapture is genuinely released (no longer opened); an
+    # imageio reader is closed. The duck-typed closer handles both.
+    if hasattr(reader, "isOpened"):
+        assert reader.isOpened() is False
+    # Reopens lazily on the next read.
+    assert backend[0] is not None
+
     # A subsequent read still works (reopens the URL lazily).
     frame = backend[0]
     assert frame.shape == (384, 384, 1)


### PR DESCRIPTION
## Summary

Addresses the **deferred hardening items** surfaced by the pre-merge reviews of the remote URL loading stack (#439 → #442 → #441) and tracked in #443. Each item was re-investigated against current `main` (a multi-agent adversarial pass empirically confirmed/refuted each one and designed the tests), then fixed with focused, real-server (`pytest-httpserver`, no mocking) tests.

One item — the "thread-safety of the shared fsspec file-like" concern — was **empirically disproven** and resolved as documentation: h5py serializes every HDF5 C-library call under a global recursive lock (`h5py._objects.phil`), so concurrent reads of a single remote-backed `HDF5Video` cannot interleave a seek/read pair (verified with 4-thread loopback reproductions → 0 corruptions). A runtime lock/independent-file change would have been pure overhead and would have endangered the pickle contract.

Closes the hardening checklist in #443. Tracking #51.

## Key changes (one commit per item)

| # | Item | Severity | Fix |
|---|------|----------|-----|
| 1 | Auth'd embedded `pkg.slp` probe ran **unauthenticated** | High | Thread URL auth context to backend *construction* time |
| 5 | `Video.exists()` dropped auth headers | Med | Forward stored headers to the existence probes (folded into #1) |
| 2 | Remote backend handles never closed deterministically | Med | `VideoBackend.close()` / `HDF5Video.close()`, propagated from `Video.close()` |
| 6 | Google Drive prefetch had no size cap (OOM risk) | Med | Content-Length pre-check + running-cap chunked read (8 GiB default) |
| 7 | Google Drive double/triple download on auto-detect | Med | Reuse the prefetched buffer; reuse bytes for the label-image handle |
| 4 | `HTTPFileSystem` instance-cache grew unbounded | Low | `skip_instance_cache=True` on header-bearing fs constructions |
| 3 | "thread-safety" of the shared fsspec file-like | Low | **Document-only** — h5py's global lock already serializes reads |

### #1 + #5 — authenticate the remote probe (the high-severity one)
`HDF5Video.__attrs_post_init__` runs its embedded-image metadata probe at backend *construction*, but `load_slp` previously back-filled the auth headers onto the backends *after* the whole `Labels` (and every probe) was built. For an auth-gated embedded `pkg.slp` the probe therefore 401'd and silently lost the embedded-image metadata (`image_format` stayed `"hdf5"` → `has_embedded_images` `False`, empty `frame_map`). Separately, `Video.exists()` probed with no headers (spurious `False`) and `Video.open()` rebuilt the backend without headers (reopened reads failed).

- `HDF5Video._url_headers`/`_url_stream_mode` are now `init=True` (attrs aliases `url_headers`/`url_stream_mode`) so the probe is authenticated. Field *names* keep the leading underscore, so the name-based `__getstate__` pickle contract is unchanged.
- The context is threaded `make_video` → `read_videos` → `VideoBackend.from_filename` (eager **and** lazy paths) and persisted on the `Video`, so existence probes and a later `open()` reconstruction stay authenticated.
- `load_slp` drops the now-redundant post-construction `object.__setattr__` backfill.

### #2 — deterministic close
`VideoBackend.close()` releases the cached reader (dispatching to `.close()` or an OpenCV `VideoCapture.release()`); `HDF5Video.close()` also closes the fsspec URL file-like (which `h5py.File.close()` does not). `Video.close()` now calls it. The auth/stream context is preserved so a reopen stays authenticated.

### #6 — bounded Drive prefetch
`_resolve_and_fetch` enforces a byte budget: a Content-Length pre-check plus a running total over a chunked read (Drive often omits/chunks Content-Length, so the running cap is the load-bearing guard). Over-cap → `RemoteIOError`, partial buffer discarded.

### #7 — single Drive download
A Drive `.slp` was downloaded 2–3× (sniff, then re-resolve in `load_slp`, then again for a `LabelImage` lazy-pixel handle). `load_slp` gains a private `_file_like` so the Drive auto-detect path reuses the bytes it already downloaded to sniff; those bytes are also threaded to `read_label_images` for its long-lived handle. A Drive `.slp` now downloads **exactly once** via `load_file`/`load_slp`, eager and lazy.

### #4 — bounded fsspec instance cache
`skip_instance_cache=True` on the header-bearing `HTTPFileSystem` construction and the chained `simplecache::`/`filecache::` opens (both outer and inner), so rotating per-request tokens no longer accumulate filesystem instances. Cloud branch untouched.

## API changes
- **No change to the public `load_slp` / `load_file` / `load_video` user-facing signatures.**
- `VideoBackend.from_filename(...)` gains keyword params `url_headers` / `url_stream_mode` (default `None` / `"blockcache"`; only used by `HDF5Video`).
- `HDF5Video(...)` now accepts `url_headers` / `url_stream_mode` at construction (was post-hoc `setattr`).
- New `VideoBackend.close()` / `HDF5Video.close()`; `Video.close()` now releases backend handles.
- Private/internal only: `load_slp(_file_like=...)`, `_open_gdrive(max_bytes=...)`, `read_label_images(_url_bytes=...)`, `make_video`/`read_videos` URL kwargs.

## Testing
- New real-server tests (`pytest-httpserver` loopback, auth-gating range handler, Drive `_UC_URL_TEMPLATE` seam — **no mocking**): authenticated embedded-pkg load/exists/reopen + wrong-token failure; deterministic close + reopen + idempotency (HDF5Video, MediaVideo, Video); Drive size-cap (Content-Length, streamed, exact boundary, default); Drive single-download counts (load_file/load_slp, eager/lazy, label-image); fsspec instance-cache flatness across all stream modes.
- Full suite: **3226 passed, 24 skipped** (the one deselected test is a pre-existing Windows symlink-privilege failure, unrelated; passes on CI).

## Design decisions
- **Item 3 is document-only.** The reported corruption only reproduces on a raw fsspec file driven by manual `seek`+`read`, never through h5py (whose global `phil` lock serializes the C calls). Adding a lock/independent-file would be unnecessary, would discard the warm block cache, and would risk the pickle contract (locks are unpicklable). Documented the safety guarantee instead.
- **`init=True` + alias over `_get_valid_kwargs`.** `_get_valid_kwargs` keys on the field *name* (`_url_headers`), so routing the alias through it would silently drop it; the params are passed explicitly into the `HDF5Video` branch of `from_filename`.
- **Drive embedded-video re-download is out of scope.** Frame reads over a Drive video still re-resolve on (re)open — inherent to Drive's lack of range support. The dominant sniff/label-image re-downloads are eliminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
