### PR TITLE
fix(io): raise helpful error when SLP metadata JSON attribute is missing (#429)

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1496,8 +1496,28 @@ def read_metadata(labels_path: str, *, _hdf5_file: h5py.File | None = None) -> d
 
     Returns:
         A dict containing the metadata from a SLEAP labels file.
+
+    Raises:
+        ValueError: If the ``metadata`` group is missing its ``json`` attribute
+            (or the group itself is absent), indicating the file is likely
+            corrupt.
     """
-    md = read_hdf5_attrs(labels_path, "metadata", "json", _hdf5_file=_hdf5_file)
+    try:
+        md = read_hdf5_attrs(labels_path, "metadata", "json", _hdf5_file=_hdf5_file)
+    except KeyError as e:
+        raise ValueError(
+            f"The SLEAP labels file {labels_path!r} is missing its required "
+            "metadata JSON blob (the 'metadata' HDF5 group has no readable 'json' "
+            "attribute) and is likely corrupt. If you have a working .slp file "
+            "with the same skeleton, you can copy the attribute into a BACKUP "
+            "COPY of the corrupt file with h5py (back up first):\n"
+            "    import h5py\n"
+            "    with h5py.File('working.slp', 'r') as src, "
+            "h5py.File('corrupt_copy.slp', 'a') as dst:\n"
+            "        dst['metadata'].attrs['json'] = src['metadata'].attrs['json']\n"
+            "Only do this if the skeletons match exactly, otherwise the loaded "
+            "data will be wrong."
+        ) from e
     if isinstance(md, bytes):
         md = md.decode()
     elif isinstance(md, np.ndarray):

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -5414,6 +5414,55 @@ def test_read_metadata_ndarray(tmp_path):
     assert result == metadata
 
 
+def test_read_metadata_missing_json_attr_raises_valueerror(tmp_path):
+    """Test read_metadata raises ValueError when 'json' attr is missing."""
+    path = str(tmp_path / "missing_json.slp")
+    with h5py.File(path, "w") as f:
+        grp = f.require_group("metadata")
+        # Group exists but has no 'json' attribute (only an unrelated attr).
+        grp.attrs["format_id"] = 1.1
+
+    with pytest.raises(ValueError, match="missing its required metadata JSON blob"):
+        read_metadata(path)
+
+
+def test_read_labels_missing_json_attr_raises_valueerror(slp_minimal, tmp_path):
+    """Test ValueError propagates to read_labels when 'json' attr is missing."""
+    # Start from a real .slp file so all other datasets are present, then
+    # corrupt a copy by deleting only the 'metadata/json' attribute.
+    path = str(tmp_path / "corrupt.slp")
+    shutil.copy(slp_minimal, path)
+    with h5py.File(path, "a") as f:
+        del f["metadata"].attrs["json"]
+
+    with pytest.raises(ValueError, match="likely corrupt"):
+        read_labels(path)
+
+
+def test_read_metadata_missing_metadata_group_raises_valueerror(tmp_path):
+    """Test read_metadata raises ValueError when 'metadata' group is absent."""
+    path = str(tmp_path / "no_metadata_group.slp")
+    with h5py.File(path, "w") as f:
+        # No 'metadata' group at all.
+        f.require_group("other")
+
+    with pytest.raises(ValueError, match="likely corrupt"):
+        read_metadata(path)
+
+
+def test_read_metadata_malformed_json_not_remasked(tmp_path):
+    """Test malformed (present) JSON surfaces as a decode error, not corruption."""
+    path = str(tmp_path / "malformed_json.slp")
+    with h5py.File(path, "w") as f:
+        grp = f.require_group("metadata")
+        grp.attrs["json"] = b"{not valid json"
+
+    # The corruption message must NOT be raised here; json parsing should fail.
+    with pytest.raises(ValueError) as exc_info:
+        read_metadata(path)
+    assert "missing its required metadata JSON blob" not in str(exc_info.value)
+
+
 def test_read_h5wasm_instances_float64_indices(tmp_path):
     """Test that float64 index values from h5wasm are handled in read_instances."""
     path = str(tmp_path / "instances.h5")


### PR DESCRIPTION
## Summary

Closes #429.

`read_metadata` (and therefore `read_labels` / `load_slp`) previously raised a raw, contextless h5py `KeyError` when an `.slp` file's `metadata` HDF5 group exists but is missing its `json` attribute:

```
KeyError: "Can't open attribute (can't locate attribute: 'json')"
```

This was hit in the wild on user-corrupted files where only `format_id` survived in the `metadata` group (see [talmolab/sleap#2146](https://github.com/talmolab/sleap/issues/2146)). The error told the user nothing about *which* file was bad, *what* was wrong, or how to recover. This PR replaces it with a typed, actionable `ValueError`.

## Key Changes

- **`sleap_io/io/slp.py` — `read_metadata`**: wrap *only* the `read_hdf5_attrs(...)` call in a single `try/except KeyError` and re-raise as `ValueError(...) from e`. The message names the offending file, states it is likely corrupt, and includes an h5py recovery snippet (copy `metadata.attrs["json"]` from a working file with the same skeleton **into a backup copy** of the corrupt file). A `Raises:` section was added to the docstring.
- **`tests/io/test_slp.py`**: four focused tests (missing-attribute, missing-group, `read_labels` propagation, malformed-blob-not-remasked).

## Example Usage

```python
import sleap_io as sio

sio.load_slp("corrupt.slp")
# ValueError: The SLEAP labels file 'corrupt.slp' is missing its required
# metadata JSON blob (the 'metadata' HDF5 group has no readable 'json'
# attribute) and is likely corrupt. If you have a working .slp file with the
# same skeleton, you can copy the attribute into a BACKUP COPY of the corrupt
# file with h5py (back up first):
#     import h5py
#     with h5py.File('working.slp', 'r') as src, h5py.File('corrupt_copy.slp', 'a') as dst:
#         dst['metadata'].attrs['json'] = src['metadata'].attrs['json']
# Only do this if the skeletons match exactly, otherwise the loaded data will be wrong.
```

## API Changes

- No signature changes. `read_metadata` now raises `ValueError` (with the original `KeyError` chained via `from e`) instead of letting a bare `KeyError` escape. This propagates unchanged through `read_skeletons` → `read_labels`, so callers can catch a single `ValueError` type.

## Testing

- 4 new tests added; full `tests/io/test_slp.py` suite passes (263 passed).
- `ruff format --check` and `ruff check` clean.
- Patch coverage: 100% — the new `try`/`read`/`except`/`raise` lines (slp.py:1505–1508) are all exercised; the except→raise branch is covered by the missing-attribute and missing-group tests.

## Design Decisions

- **Wrap only the `read_hdf5_attrs` call, not the decode/`json.loads`.** `json.JSONDecodeError` is a subclass of `ValueError`; a present-but-*malformed* blob is a different failure mode and is intentionally left to surface as its own decode error rather than being mislabeled as "missing/corrupt". The `test_read_metadata_malformed_json_not_remasked` test locks this in.
- **Blanket `except KeyError` (no h5py message string-matching, no separate group-existence probe).** A fully-absent `metadata` group also raises `KeyError` (at `f[dataset]`); the unified "likely corrupt" wording stays accurate for both cases, keeping the patch minimal and avoiding brittle version-specific string parsing.
- **No wrapping added in `read_labels`/`read_skeletons`.** The `ValueError` already propagates through the existing call chain, so extra handling would only risk double-wrapping.
- **Recovery hint targets a backup copy of the broken file as the write destination** (donor opened read-only), with explicit "back up first" and "skeletons must match exactly" warnings, so a mis-read hint can't nudge users into clobbering a good file or silently importing a mismatched skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
