### PR TITLE
feat(model): warn on spatially-divergent track-name merge collisions (#425)

### DIFF
--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -3498,6 +3498,13 @@ class Labels:
                     self.tracks.append(other_track)
                     track_map[other_track] = other_track
 
+            # Warn (diagnostic only) if any name-matched track pair carries
+            # instances that diverge spatially on every shared frame. This does
+            # not alter track_map or any merge result.
+            self._warn_track_name_divergence(
+                other, video_map, track_map, track_matcher, instance_matcher
+            )
+
             # Step 4: Merge frames
             total_frames = len(other.labeled_frames)
 
@@ -3661,6 +3668,108 @@ class Labels:
             progress_callback(total_frames, total_frames, "Merge complete")
 
         return result
+
+    def _warn_track_name_divergence(
+        self,
+        other: "Labels",
+        video_map: dict,
+        track_map: dict,
+        track_matcher: "TrackMatcher",
+        instance_matcher: "InstanceMatcher",
+    ) -> None:
+        """Warn when name-matched tracks diverge spatially on all shared frames.
+
+        Name-based track merging silently coalesces tracks that share a name
+        across two ``Labels``. If those tracks actually label different animals,
+        this can glue distinct tracks together. This helper emits a diagnostic
+        ``UserWarning`` (purely additive; it never changes the merge result) when
+        a track pair matched by name carries instances on overlapping frames that
+        do not spatially correspond under the merge's instance matcher.
+
+        The check is a no-op unless track matching is by ``NAME`` (divergence is
+        meaningless for identity/object track matching) and the instance matcher
+        is spatial (``SPATIAL`` or ``IOU``). A warning fires at most once per
+        colliding ``(self_track, other_track)`` pair, only when the pair has at
+        least one shared frame with instances on both sides and zero spatial
+        instance matches across all such frames.
+
+        Args:
+            other: The other ``Labels`` being merged into ``self``.
+            video_map: Mapping from ``other`` videos to the matched ``self``
+                videos, as built in ``merge()``.
+            track_map: Mapping from ``other`` tracks to the matched ``self``
+                tracks (or back to themselves if appended as new), as built in
+                ``merge()``.
+            track_matcher: The ``TrackMatcher`` used for the merge. The check is
+                skipped unless its method is ``NAME``.
+            instance_matcher: The ``InstanceMatcher`` used for the merge. Reused
+                here as the divergence primitive (no new threshold introduced).
+                Skipped when its method is ``IDENTITY`` (see below).
+        """
+        import warnings
+
+        from sleap_io.model.matching import InstanceMatchMethod, TrackMatchMethod
+
+        # Only name-based merging can silently glue distinct tracks together.
+        if track_matcher.method != TrackMatchMethod.NAME:
+            return
+
+        # Divergence is a spatial question. An ``IDENTITY`` instance matcher
+        # compares track-object identity, which is always False across a name
+        # collision (the tracks are distinct objects by definition), so it cannot
+        # assess spatial divergence and would warn unconditionally. Skip it.
+        if instance_matcher.method == InstanceMatchMethod.IDENTITY:
+            return
+
+        # Select true name collisions: an other_track coalesced onto a distinct
+        # self_track object with an equal name (not a track appended as new).
+        colliding_pairs = [
+            (other_track, self_track)
+            for other_track, self_track in track_map.items()
+            if self_track is not other_track and self_track.name == other_track.name
+        ]
+        if not colliding_pairs:
+            return
+
+        for other_track, self_track in colliding_pairs:
+            n_shared = 0
+            n_matches = 0
+            divergent_video = None
+
+            for other_frame in other.labeled_frames:
+                mapped_video = video_map.get(other_frame.video, other_frame.video)
+                matching_frames = self.find(mapped_video, other_frame.frame_idx)
+                if len(matching_frames) == 0:
+                    continue
+
+                self_insts = [
+                    inst
+                    for frame in matching_frames
+                    for inst in frame.instances
+                    if inst.track is self_track
+                ]
+                other_insts = [
+                    inst for inst in other_frame.instances if inst.track is other_track
+                ]
+                if len(self_insts) == 0 or len(other_insts) == 0:
+                    continue
+
+                n_shared += 1
+                n_matches += len(instance_matcher.find_matches(self_insts, other_insts))
+                if divergent_video is None:
+                    divergent_video = mapped_video
+
+            if n_shared >= 1 and n_matches == 0:
+                warnings.warn(
+                    f"Track {self_track.name!r} was merged by name across labels "
+                    f"that share video {divergent_video!r}, but instances on that "
+                    f"track diverge spatially on all {n_shared} overlapping "
+                    f"frame(s) (no instance matched under the merge's instance "
+                    f"matcher). If these tracking runs label different animals, "
+                    f"name-based merging may glue distinct tracks together. "
+                    f"Review the merge or resolve tracks at the instance level.",
+                    stacklevel=2,
+                )
 
     @staticmethod
     def _remap_frame_annotations(

--- a/tests/model/test_merging_integration.py
+++ b/tests/model/test_merging_integration.py
@@ -1,6 +1,9 @@
 """Integration tests for the merging functionality."""
 
+import warnings
+
 import numpy as np
+import pytest
 
 from sleap_io import Labels, Skeleton
 from sleap_io.model.instance import Instance, PredictedInstance, Track
@@ -9,6 +12,8 @@ from sleap_io.model.matching import (
     InstanceMatcher,
     InstanceMatchMethod,
     MergeResult,
+    TrackMatcher,
+    TrackMatchMethod,
 )
 from sleap_io.model.video import Video
 
@@ -1883,3 +1888,271 @@ class TestMergeOriginalVideoLogic:
             "Chain: final.pkg.slp → intermediate.pkg.slp → /data/video.mp4"
         )
         assert labels.labeled_frames[0].video is base_video
+
+
+def _make_run(track_name, points, frame_idx=0, *, skeleton=None, video=None):
+    """Build a single-frame, single-instance Labels for divergence tests.
+
+    Args:
+        track_name: Name for the instance's track.
+        points: ``(n_nodes, 2)`` array of point coordinates.
+        frame_idx: Frame index for the labeled frame.
+        skeleton: Skeleton to use. A 2-node skeleton is created if None.
+        video: Video to use. A ``test.mp4`` video is created if None.
+
+    Returns:
+        A ``Labels`` with one ``LabeledFrame`` holding one tracked ``Instance``.
+    """
+    if skeleton is None:
+        skeleton = Skeleton(["head", "tail"])
+    if video is None:
+        video = Video(filename="test.mp4", open_backend=False)
+    labels = Labels()
+    frame = LabeledFrame(video=video, frame_idx=frame_idx)
+    inst = Instance.from_numpy(
+        np.asarray(points, dtype="float64"),
+        skeleton=skeleton,
+        track=Track(name=track_name),
+    )
+    frame.instances = [inst]
+    labels.append(frame)
+    return labels
+
+
+class TestTrackNameDivergenceWarning:
+    """Tests for the name-collision divergence warning in ``Labels.merge``."""
+
+    def test_warns_on_spatial_divergence(self):
+        """Warns when same-named tracks are far apart on the shared frame."""
+        skeleton = Skeleton(["head", "tail"])
+        run1 = _make_run("track_0", [[10, 10], [20, 20]], skeleton=skeleton)
+        run2 = _make_run("track_0", [[500, 500], [510, 510]], skeleton=skeleton)
+
+        with pytest.warns(UserWarning, match=r"track_0.*diverge spatially"):
+            result = run1.merge(run2, track="name")
+
+        assert result.successful
+        # Diagnostic only: tracks still collapse by name.
+        assert len(run1.tracks) == 1
+
+    def test_no_warning_when_instances_overlap(self):
+        """No divergence warning when same-named tracks overlap spatially."""
+        skeleton = Skeleton(["head", "tail"])
+        run1 = _make_run("track_0", [[10, 10], [20, 20]], skeleton=skeleton)
+        run2 = _make_run("track_0", [[11, 11], [21, 21]], skeleton=skeleton)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = run1.merge(run2, track="name")
+
+        assert result.successful
+        assert not any("diverge spatially" in str(w.message) for w in caught)
+        assert len(run1.tracks) == 1
+
+    def test_skipped_for_identity_track_method(self):
+        """No divergence check when track matching is by identity, not name."""
+        skeleton = Skeleton(["head", "tail"])
+        run1 = _make_run("track_0", [[10, 10], [20, 20]], skeleton=skeleton)
+        run2 = _make_run("track_0", [[500, 500], [510, 510]], skeleton=skeleton)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            run1.merge(run2, track="identity")
+
+        assert not any("diverge spatially" in str(w.message) for w in caught)
+
+    def test_skipped_for_custom_identity_matcher(self):
+        """No divergence check for a custom non-NAME TrackMatcher."""
+        skeleton = Skeleton(["head", "tail"])
+        run1 = _make_run("track_0", [[10, 10], [20, 20]], skeleton=skeleton)
+        run2 = _make_run("track_0", [[500, 500], [510, 510]], skeleton=skeleton)
+
+        matcher = TrackMatcher(method=TrackMatchMethod.IDENTITY)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            run1.merge(run2, track=matcher)
+
+        assert not any("diverge spatially" in str(w.message) for w in caught)
+
+    def test_skipped_for_identity_instance_matcher(self):
+        """No divergence check when the instance matcher is identity-based.
+
+        Identity instance matching compares track-object identity, which is
+        always False across a name collision, so it cannot assess spatial
+        divergence and must not warn unconditionally (even on divergent points).
+        """
+        skeleton = Skeleton(["head", "tail"])
+        run1 = _make_run("track_0", [[10, 10], [20, 20]], skeleton=skeleton)
+        run2 = _make_run("track_0", [[500, 500], [510, 510]], skeleton=skeleton)
+
+        matcher = InstanceMatcher(method=InstanceMatchMethod.IDENTITY)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            run1.merge(run2, track="name", instance=matcher)
+
+        assert not any("diverge spatially" in str(w.message) for w in caught)
+
+    def test_no_warning_without_shared_frames(self):
+        """No warning when same-named tracks never co-occur on a frame."""
+        skeleton = Skeleton(["head", "tail"])
+        run1 = _make_run(
+            "track_0", [[10, 10], [20, 20]], frame_idx=0, skeleton=skeleton
+        )
+        run2 = _make_run(
+            "track_0", [[500, 500], [510, 510]], frame_idx=5, skeleton=skeleton
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            run1.merge(run2, track="name")
+
+        assert not any("diverge spatially" in str(w.message) for w in caught)
+
+    def test_no_warning_when_track_not_on_shared_frame(self):
+        """No warning when the colliding track has no instance on a shared frame."""
+        skeleton = Skeleton(["head", "tail"])
+        video = Video(filename="test.mp4", open_backend=False)
+
+        # run1 has track_0 on frame 0.
+        run1 = _make_run(
+            "track_0", [[10, 10], [20, 20]], skeleton=skeleton, video=video
+        )
+
+        # run2 has both track_0 and track_1 in its track list (so track_0
+        # collides), but on the shared frame 0 only a track_1 instance appears.
+        run2 = Labels()
+        track0 = Track(name="track_0")
+        track1 = Track(name="track_1")
+        # Frame 0 (shared): only a track_1 instance.
+        f0 = LabeledFrame(video=video, frame_idx=0)
+        f0.instances = [
+            Instance.from_numpy(
+                np.array([[500.0, 500.0], [510.0, 510.0]]),
+                skeleton=skeleton,
+                track=track1,
+            )
+        ]
+        # Frame 5 (not shared): a track_0 instance, so track_0 is in run2.tracks.
+        f5 = LabeledFrame(video=video, frame_idx=5)
+        f5.instances = [
+            Instance.from_numpy(
+                np.array([[500.0, 500.0], [510.0, 510.0]]),
+                skeleton=skeleton,
+                track=track0,
+            )
+        ]
+        run2.append(f0)
+        run2.append(f5)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            run1.merge(run2, track="name")
+
+        assert not any("diverge spatially" in str(w.message) for w in caught)
+
+    def test_no_warning_for_appended_new_track(self):
+        """No warning when the incoming track is new (appended, not collided)."""
+        skeleton = Skeleton(["head", "tail"])
+        run1 = _make_run("track_0", [[10, 10], [20, 20]], skeleton=skeleton)
+        run2 = _make_run("track_2", [[500, 500], [510, 510]], skeleton=skeleton)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            run1.merge(run2, track="name")
+
+        assert not any("diverge spatially" in str(w.message) for w in caught)
+        # The new track is appended.
+        assert len(run1.tracks) == 2
+
+    def test_warns_once_per_pair_across_multiple_frames(self):
+        """Warning fires once per pair even with several divergent frames."""
+        skeleton = Skeleton(["head", "tail"])
+        video = Video(filename="test.mp4", open_backend=False)
+
+        # One Track object per run, reused across all frames, so the same
+        # (self_track, other_track) pair spans every shared frame.
+        run1 = Labels()
+        run2 = Labels()
+        self_track = Track(name="track_0")
+        other_track = Track(name="track_0")
+        for idx in range(3):
+            f1 = LabeledFrame(video=video, frame_idx=idx)
+            f1.instances = [
+                Instance.from_numpy(
+                    np.array([[10.0, 10.0], [20.0, 20.0]]),
+                    skeleton=skeleton,
+                    track=self_track,
+                )
+            ]
+            run1.append(f1)
+
+            f2 = LabeledFrame(video=video, frame_idx=idx)
+            f2.instances = [
+                Instance.from_numpy(
+                    np.array([[500.0, 500.0], [510.0, 510.0]]),
+                    skeleton=skeleton,
+                    track=other_track,
+                )
+            ]
+            run2.append(f2)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            run1.merge(run2, track="name")
+
+        divergence = [w for w in caught if "diverge spatially" in str(w.message)]
+        assert len(divergence) == 1
+        assert "3 overlapping" in str(divergence[0].message)
+
+    def test_many_to_one_collision_warns_per_other_track(self):
+        """Two incoming same-named tracks colliding onto one self track."""
+        skeleton = Skeleton(["head", "tail"])
+        video = Video(filename="test.mp4", open_backend=False)
+
+        run1 = _make_run(
+            "track_0", [[10, 10], [20, 20]], skeleton=skeleton, video=video
+        )
+
+        # run2: two distinct Track objects both named track_0 on distinct frames.
+        run2 = Labels()
+        track_a = Track(name="track_0")
+        track_b = Track(name="track_0")
+        fa = LabeledFrame(video=video, frame_idx=0)
+        fa.instances = [
+            Instance.from_numpy(
+                np.array([[500.0, 500.0], [510.0, 510.0]]),
+                skeleton=skeleton,
+                track=track_a,
+            )
+        ]
+        fb = LabeledFrame(video=video, frame_idx=0)
+        fb.instances = [
+            Instance.from_numpy(
+                np.array([[600.0, 600.0], [610.0, 610.0]]),
+                skeleton=skeleton,
+                track=track_b,
+            )
+        ]
+        # Distinct frame_idx so both frames coexist in run2.
+        fb.frame_idx = 1
+        run1_extra = LabeledFrame(video=video, frame_idx=1)
+        run1_extra.instances = [
+            Instance.from_numpy(
+                np.array([[10.0, 10.0], [20.0, 20.0]]),
+                skeleton=skeleton,
+                track=run1.tracks[0],
+            )
+        ]
+        run1.append(run1_extra)
+        run2.append(fa)
+        run2.append(fb)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = run1.merge(run2, track="name")
+
+        assert result.successful
+        divergence = [w for w in caught if "diverge spatially" in str(w.message)]
+        # Both incoming track_0 objects collide onto self's single track_0 and
+        # both diverge, so one warning per colliding other_track (two total).
+        assert len(divergence) == 2


### PR DESCRIPTION
## Summary

Addresses #425 (the minimal "at minimum, a warning" increment; the larger options are deferred — see below).

`Labels.merge(other, track="name")` (the default) collapses tracks purely on string name. That is correct for the common HITL workflow, but in the **multi-tracking-run-on-the-same-video** scenario two runs can each produce `track_0` referring to *different* animals, and name-based merging **silently** glues them together (residual edge case from talmolab/sleap#1083). This PR makes that case **non-silent** with a diagnostic warning, without changing any merge result.

## Key Changes

- **`sleap_io/model/labels.py`**: new private helper `Labels._warn_track_name_divergence(...)`, called once at the Step-3/Step-4 boundary of `merge()` (after `track_map` is built, before frames are merged). It emits a `UserWarning` once per name-collision track pair when **all** of these hold:
  1. track matching is by `NAME`;
  2. the two `Labels` share ≥1 `(video, frame_idx)` frame carrying instances on *both* the matched `self_track` and `other_track`;
  3. those instances fail to spatially correspond on **every** shared frame under the merge's own instance matcher.
- **`tests/model/test_merging_integration.py`**: `TestTrackNameDivergenceWarning` (10 tests) + a `_make_run` synthetic-Labels helper.

## Example

```python
import sleap_io as sio
# run1 and run2 both have a "track_0", but on the same video they label
# different animals (instances are far apart on shared frames):
run1.merge(run2, track="name")
# UserWarning: Track 'track_0' was merged by name across labels that share video
# Video(...), but instances on that track diverge spatially on all 12 overlapping
# frame(s) (no instance matched under the merge's instance matcher). If these
# tracking runs label different animals, name-based merging may glue distinct
# tracks together. Review the merge or resolve tracks at the instance level.
```

## API Changes

- **None.** No new public kwargs, no matcher-interface change, no change to merge *results* (`track_map`, `tracks`, instance assignments are identical). The change is purely an additive `UserWarning`.

## Design Decisions

- **Reuse the merge's existing `instance_matcher` as the divergence primitive** (default `SPATIAL`/5px). This introduces no new threshold and no new public surface — exactly the issue author's "at minimum, a warning" suggestion.
- **Skipped for `IDENTITY` track matching** (divergence is meaningless for object-identity matching) **and for `IDENTITY` instance matching** — the latter compares track-object identity, which is always false across a name collision (the tracks are distinct objects by definition), so it cannot assess spatial divergence and would otherwise warn unconditionally. Both are early-returns.
- **Fires at most once per colliding `(self_track, other_track)` pair**, never per-frame; many-to-one collisions warn per other-track.
- **Contained**: reuses only objects already in scope in `merge()`; mutates nothing.

## Deferred (out of scope — need a maintainer design decision)

The two larger options from #425 change behavior / add permanent public API and were intentionally **not** included here:
- a `TrackMatchMethod.SPATIAL` that maps tracks by instance overlap on shared frames (cannot fit the current `TrackMatcher.match(t1, t2)` interface, which has no frame access);
- a `track_resolver` callback / matcher hook.

I'm leaving #425 **open** so these remain tracked. Merging this PR does not auto-close it.

## Testing

- `TestTrackNameDivergenceWarning` (10 tests): fires on divergence; silent when instances overlap, when no frames are shared, when the track is absent on a shared frame, and for appended-new tracks; skipped for identity track and identity instance matchers; warns once per pair across multiple frames; many-to-one collisions warn per other-track.
- Full `tests/` suite: **3248 passed** (the only failure is a pre-existing Windows-only symlink-privilege issue unrelated to this change). `ruff format`/`ruff check` clean. **100% patch coverage** on the new helper and call site (all branches, including both early-return guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
