### PR TITLE
feat(model)!: default Labels.merge track matching to identity, not name (#425)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1043,7 +1043,7 @@ Merged 2 files:
 | `-o, --output` | (required) | Output labels file |
 | `--skeleton` | `structure` | Skeleton matching method |
 | `--video` | `auto` | Video matching method |
-| `--track` | `name` | Track matching method |
+| `--track` | `identity` | Track matching method |
 | `--frame` | `auto` | Frame merge strategy |
 | `--instance` | `spatial` | Instance matching method |
 | `--embed` | (none) | Embed frames in output (`user`, `all`, `suggestions`, `source`) |
@@ -1091,8 +1091,8 @@ How to match track identities:
 
 | Method | Behavior |
 |--------|----------|
-| `name` | Match tracks with identical names (default) |
-| `identity` | Match by track object identity |
+| `identity` | Match by track object identity (default). Correctness-first: never collapses distinct tracks by arbitrary tracker-assigned names |
+| `name` | Match tracks with identical names. Opt-in for semantically meaningful names (user-assigned identities or identity-classification model outputs) |
 
 #### Frame Strategy (`--frame`)
 

--- a/docs/merging.md
+++ b/docs/merging.md
@@ -32,7 +32,7 @@ These options are controlled via parameters to [`Labels.merge()`](#sleap_io.mode
 |-----------|----------|---------|
 | `skeleton` | How skeletons are matched | [`"structure"`](#skeleton-matching) (default), [`"subset"`](#skeleton-matching), [`"overlap"`](#skeleton-matching), [`"exact"`](#skeleton-matching) |
 | `video` | How videos are matched | [`"auto"`](#how-auto-matching-works) (default), [`"path"`](#other-video-matching-methods), [`"basename"`](#other-video-matching-methods), [`"content"`](#other-video-matching-methods), [`"shape"`](#other-video-matching-methods), [`"image_dedup"`](#other-video-matching-methods) |
-| `track` | How tracks are matched | [`"name"`](#track-matching) (default), [`"identity"`](#track-matching) |
+| `track` | How tracks are matched | [`"identity"`](#track-matching) (default), [`"name"`](#track-matching) (opt-in) |
 | `frame` | How overlapping frames are combined | [`"auto"`](#auto-default) (default), [`"replace_predictions"`](#replace_predictions), [`"keep_original"`](#other-frame-strategies), [`"keep_new"`](#other-frame-strategies), [`"keep_both"`](#other-frame-strategies), [`"update_tracks"`](#other-frame-strategies) |
 | `instance` | How instances are paired within frames | [`"spatial"`](#instance-matching) (default), [`"identity"`](#instance-matching), [`"iou"`](#instance-matching) |
 
@@ -381,19 +381,27 @@ Tracks represent identities (e.g., individual animals) that persist across frame
 
 | Method | Behavior | Use case |
 |--------|----------|----------|
-| `"name"` | Match tracks with identical names | **Default.** Named individuals |
-| `"identity"` | Match by track object identity | Same `Track` object in memory |
+| `"identity"` | Match by track object identity (same `Track` instance). **Default** — correctness-first; never collapses distinct tracks by arbitrary tracker-assigned names | Independently loaded files whose track names (e.g. `"track_0"`) are positional/arbitrary |
+| `"name"` | Match tracks with identical names. Opt-in for semantically meaningful names (user-assigned or identity-classification models) | Named individuals; identity-model outputs |
 
 If no match is found, the track is added as new to the base dataset.
+
+!!! note "Asymmetry of errors"
+    Name-based **over-merge** (gluing two different animals together because both
+    happen to be named `"track_0"`) is silent and unrecoverable, while
+    identity-based **under-merge** (keeping tracks separate that you wanted
+    combined) is visible and recoverable. The default therefore favors
+    under-merge; opt in to `"name"` only when track names are meaningful.
 
 ### String configuration
 
 ```python
-# Default: match by track name
-base.merge(other, track="name")
+# Default: match by track object identity (same Track instance).
+base.merge(other)
+base.merge(other, track="identity")  # explicit default
 
-# Match by object identity (same Track instance)
-base.merge(other, track="identity")
+# Opt-in: match by track name (collapses distinct same-named tracks).
+base.merge(other, track="name")
 ```
 
 ### Object configuration

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -2674,8 +2674,10 @@ def unsplit(
         frames_before = len(labels)
 
         # Merge with automatic video matching (uses original_video provenance)
-        # and keep_both frame strategy (splits have no overlapping frames)
-        labels.merge(other, video="auto", frame="keep_both")
+        # and keep_both frame strategy (splits have no overlapping frames).
+        # Splits provably originate from one project, so name-coalescing is the
+        # correct intent (track="name"); the library default is "identity".
+        labels.merge(other, video="auto", frame="keep_both", track="name")
 
         frames_added = len(labels) - frames_before
         click.echo(f"  +{frames_added} frames -> {len(labels)} total")
@@ -2748,7 +2750,7 @@ def unsplit(
 @click.option(
     "--track",
     type=click.Choice(["name", "identity"]),
-    default="name",
+    default="identity",
     show_default=True,
     help="Track matching method.",
 )

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -3083,8 +3083,15 @@ class Labels:
             skeleton: Skeleton matching method. Can be a string ("structure",
                 "subset", "overlap", "exact") or a SkeletonMatcher object.
                 Default is "structure".
-            track: Track matching method. Can be a string ("name", "identity") or
-                a TrackMatcher object. Default is "name".
+            track: Track matching method. Can be a string ("identity", "name") or
+                a TrackMatcher object. Default is "identity", which matches tracks
+                only by object identity (the same Track instance) and appends all
+                other tracks as new -- a correctness-first default that never
+                collapses distinct tracks by their (often arbitrary,
+                tracker-assigned) names. Pass "name" to match tracks by their name
+                attribute instead, for cases where track names are semantically
+                meaningful (e.g. user-assigned identities or identity-classification
+                model outputs).
 
         Returns:
             MatchResult object containing correspondence maps.
@@ -3213,8 +3220,15 @@ class Labels:
             video: Video matching method. Can be a string ("auto", "path",
                 "basename", "content", "shape", "image_dedup") or a VideoMatcher
                 object for advanced configuration. Default is "auto".
-            track: Track matching method. Can be a string ("name", "identity") or
-                a TrackMatcher object. Default is "name".
+            track: Track matching method. Can be a string ("identity", "name") or
+                a TrackMatcher object. Default is "identity", which matches tracks
+                only by object identity (the same Track instance) and appends all
+                other tracks as new -- a correctness-first default that never
+                collapses distinct tracks by their (often arbitrary,
+                tracker-assigned) names. Pass "name" to match tracks by their name
+                attribute instead, for cases where track names are semantically
+                meaningful (e.g. user-assigned identities or identity-classification
+                model outputs).
             frame: Frame merge strategy. One of "auto", "keep_original",
                 "keep_new", "keep_both", "update_tracks", "replace_predictions".
                 Default is "auto".

--- a/sleap_io/model/matching.py
+++ b/sleap_io/model/matching.py
@@ -777,11 +777,13 @@ class TrackMatcher:
 
     Attributes:
         method: The matching method to use. Can be a TrackMatchMethod enum value
-            or a string that will be converted to the enum. Default is NAME.
+            or a string that will be converted to the enum. Default is IDENTITY
+            (matches only the same Track object; correctness-first). Use NAME to
+            match by track name.
     """
 
     method: TrackMatchMethod | str = attrs.field(
-        default=TrackMatchMethod.NAME,
+        default=TrackMatchMethod.IDENTITY,
         converter=lambda x: TrackMatchMethod(x) if isinstance(x, str) else x,
     )
 

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -7785,6 +7785,55 @@ def test_slp_bbox_tracking_score_none_roundtrip(tmp_path):
     assert loaded.bboxes[0].tracking_score is None
 
 
+def test_duplicate_track_name_roundtrip(tmp_path):
+    """Two distinct same-named tracks round-trip losslessly through SLP.
+
+    The identity-default merge makes duplicate-name Labels more common, so verify
+    that the SLP reader/writer (which keys tracks by positional index, with Track
+    eq=False) preserves two distinct ``track_0`` tracks rather than collapsing
+    them into one.
+    """
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+
+    track_a = Track(name="track_0")
+    track_b = Track(name="track_0")  # Same name, distinct object.
+
+    inst_a = Instance.from_numpy(
+        np.array([[1.0, 2.0]]), skeleton=skeleton, track=track_a
+    )
+    inst_b = Instance.from_numpy(
+        np.array([[3.0, 4.0]]), skeleton=skeleton, track=track_b
+    )
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst_a, inst_b])
+    labels = Labels(
+        labeled_frames=[lf],
+        videos=[video],
+        skeletons=[skeleton],
+        tracks=[track_a, track_b],
+    )
+
+    path = str(tmp_path / "dup_track_names.slp")
+    save_slp(labels, path)
+    loaded = load_slp(path)
+
+    # Both distinct tracks survive with the same name.
+    assert len(loaded.tracks) == 2
+    assert [t.name for t in loaded.tracks] == ["track_0", "track_0"]
+
+    # Per-instance track references resolve to distinct positional indices.
+    loaded_lf = loaded.labeled_frames[0]
+    track_indices = sorted(
+        loaded.tracks.index(inst.track) for inst in loaded_lf.instances
+    )
+    assert track_indices == [0, 1]
+
+    # Points are exact and correctly associated with their (distinct) track.
+    by_index = {loaded.tracks.index(inst.track): inst for inst in loaded_lf.instances}
+    np.testing.assert_allclose(by_index[0].numpy(), np.array([[1.0, 2.0]]))
+    np.testing.assert_allclose(by_index[1].numpy(), np.array([[3.0, 4.0]]))
+
+
 def test_slp_centroid_low_level(tmp_path):
     """Test low-level read_centroids/write_centroids."""
     video = Video(filename="test.mp4")

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -4880,7 +4880,10 @@ def test_labels_match_track_matching():
     gt_labels = Labels(videos=[video], skeletons=[skeleton], tracks=[track_gt])
     pred_labels = Labels(videos=[video], skeletons=[skeleton], tracks=[track_pred])
 
-    result = gt_labels.match(pred_labels)
+    # Opt in to name-based matching: these are two distinct Track objects with
+    # the same name, which only coalesce under track="name" (the identity
+    # default would keep them as separate tracks).
+    result = gt_labels.match(pred_labels, track="name")
 
     # Track should match by name
     assert result.all_tracks_matched
@@ -7331,7 +7334,9 @@ def test_merge_remaps_annotation_tracks():
         labeled_frames=[lf], videos=[video], skeletons=[skeleton], tracks=[track_other]
     )
 
-    self_labels.merge(other_labels)
+    # track="name" so the two distinct same-named Track objects coalesce and the
+    # annotation track is remapped (the identity default would keep them separate).
+    self_labels.merge(other_labels, track="name")
 
     # The centroid's track should now reference track_self (the matched track)
     merged_lf = self_labels.find(video, 0)[0]
@@ -7375,7 +7380,9 @@ def test_merge_remaps_annotations_existing_frame():
         tracks=[track_other],
     )
 
-    self_labels.merge(other_labels, frame="keep_both")
+    # track="name" so the two distinct same-named Track objects coalesce and the
+    # incoming centroid's track is remapped (the identity default would not).
+    self_labels.merge(other_labels, frame="keep_both", track="name")
 
     # Both centroids should be on the frame
     assert len(lf0.centroids) == 2
@@ -7407,11 +7414,122 @@ def test_merge_remaps_label_image_tracks():
         tracks=[track_other],
     )
 
-    self_labels.merge(other_labels)
+    # track="name" so the two distinct same-named Track objects coalesce and the
+    # label_image track reference is remapped (the identity default would not).
+    self_labels.merge(other_labels, track="name")
 
     merged_lf = self_labels.find(video, 0)[0]
     assert len(merged_lf.label_images) == 1
     assert merged_lf.label_images[0].objects[1].track is track_self
+
+
+def test_merge_default_keeps_same_named_distinct_tracks_separate():
+    """Default merge (identity) keeps distinct same-named tracks as separate tracks.
+
+    This locks in the correctness-first identity default: two independently loaded
+    files often have positionally-named tracks (e.g. "track_0") that are *different*
+    animals, so the default must NOT collapse them by name.
+    """
+    skeleton = Skeleton(["A"])
+    video = Video(filename="v.mp4", open_backend=False)
+
+    track_self = Track(name="track_0")
+    track_other = Track(name="track_0")  # Same name, distinct object.
+
+    inst_self = Instance.from_numpy(
+        np.array([[1.0, 2.0]]), skeleton=skeleton, track=track_self
+    )
+    self_labels = Labels(
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0, instances=[inst_self])],
+        videos=[video],
+        skeletons=[skeleton],
+        tracks=[track_self],
+    )
+
+    inst_other = Instance.from_numpy(
+        np.array([[3.0, 4.0]]), skeleton=skeleton, track=track_other
+    )
+    other_labels = Labels(
+        labeled_frames=[LabeledFrame(video=video, frame_idx=1, instances=[inst_other])],
+        videos=[video],
+        skeletons=[skeleton],
+        tracks=[track_other],
+    )
+
+    self_labels.merge(other_labels)
+
+    # No silent collapse: both distinct tracks survive as the original objects.
+    assert len(self_labels.tracks) == 2
+    assert self_labels.tracks[0] is track_self
+    assert self_labels.tracks[1] is track_other
+    # The incoming instance keeps its own (distinct) track; nothing was rebound.
+    assert inst_other.track is track_other
+
+
+def test_merge_track_name_opt_in_collapses_and_warns():
+    """track="name" still collapses same-named tracks and still warns on divergence.
+
+    Mirrors the divergence-warning fixture: two distinct ``track_0`` tracks whose
+    instances are spatially far apart. The explicit name opt-in must (a) coalesce
+    them into a single track and (b) emit the spatial-divergence warning.
+    """
+    skeleton = Skeleton(["head", "tail"])
+    video = Video(filename="v.mp4", open_backend=False)
+
+    track_self = Track(name="track_0")
+    track_other = Track(name="track_0")
+
+    inst_self = Instance.from_numpy(
+        np.array([[10.0, 10.0], [20.0, 20.0]]), skeleton=skeleton, track=track_self
+    )
+    self_labels = Labels(
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0, instances=[inst_self])],
+        videos=[video],
+        skeletons=[skeleton],
+        tracks=[track_self],
+    )
+
+    inst_other = Instance.from_numpy(
+        np.array([[500.0, 500.0], [510.0, 510.0]]), skeleton=skeleton, track=track_other
+    )
+    other_labels = Labels(
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0, instances=[inst_other])],
+        videos=[video],
+        skeletons=[skeleton],
+        tracks=[track_other],
+    )
+
+    with pytest.warns(UserWarning, match=r"track_0.*diverge spatially"):
+        self_labels.merge(other_labels, frame="keep_both", track="name")
+
+    # Opt-in name matching collapses the two same-named tracks into one.
+    assert len(self_labels.tracks) == 1
+
+
+def test_match_default_keeps_same_named_distinct_tracks_unmatched():
+    """match() default (identity) does not match distinct same-named tracks.
+
+    Locks match()/merge() consistency: both resolve ``track=None`` to a bare
+    ``TrackMatcher()`` and therefore share the identity default. ``track="name"``
+    is the opt-in that matches by name.
+    """
+    skeleton = Skeleton(["A"])
+    video = Video(filename="v.mp4", open_backend=False)
+
+    track_gt = Track(name="track_0")
+    track_pred = Track(name="track_0")  # Same name, distinct object.
+
+    gt_labels = Labels(videos=[video], skeletons=[skeleton], tracks=[track_gt])
+    pred_labels = Labels(videos=[video], skeletons=[skeleton], tracks=[track_pred])
+
+    # Default identity: distinct objects do not match (track_map maps to None).
+    result = gt_labels.match(pred_labels)
+    assert result.track_map[track_pred] is not track_gt
+    assert result.track_map[track_pred] is None
+
+    # Opt-in name matching: they match.
+    result_named = gt_labels.match(pred_labels, track="name")
+    assert result_named.track_map[track_pred] is track_gt
 
 
 def test_clean_removes_orphaned_annotation_tracks():
@@ -7573,7 +7691,9 @@ def test_merge_remaps_annotations_with_different_videos():
         tracks=[track_other],
     )
 
-    self_labels.merge(other_labels, frame="keep_both")
+    # track="name" so the two distinct same-named Track objects coalesce and the
+    # incoming label_image track is remapped (the identity default would not).
+    self_labels.merge(other_labels, frame="keep_both", track="name")
 
     # Both label_images should be on the frame
     assert len(lf0.label_images) == 2


### PR DESCRIPTION
## Summary

Implements **Option 3** from #425: flip the default track-matching method in `Labels.merge()` / `Labels.match()` from `"name"` to `"identity"` (correctness-first). **This is a breaking change.**

Tracker-assigned track names like `track_0` are positional and arbitrary — which animal lands on which index can change between runs — so name-based matching could **silently** glue instances of *different* animals onto one track. By the asymmetry of errors, over-merge is silent and unrecoverable while under-merge is visible and recoverable, so the safe default matches tracks only by object identity and appends all others as new.

## Key Changes

- **`sleap_io/model/matching.py`** — flip the single `TrackMatcher` class default `NAME → IDENTITY`. Both `Labels.merge()` and `Labels.match()` inherit it via their bare `TrackMatcher()` resolution, so they stay consistent and can't diverge.
- **`sleap_io/model/labels.py`** — updated `merge()` and `match()` `track` docstrings (default is now `"identity"`, with the rationale and the `"name"` opt-in).
- **`sleap_io/io/cli.py`** — `sio merge --track` default flips to `identity`; the `unsplit` command is pinned to `track="name"` (splits provably originate from one project, so name-coalescing is the correct intent — the only non-test library caller relying on the old default).
- The track-name spatial-divergence warning (added for #425 in #448) now self-guards to the `track="name"` opt-in path.
- **`docs/merging.md`, `docs/cli.md`** — document the new default, the opt-in, and an "asymmetry of errors" note.

## Migration

```python
# Previous default behavior (match tracks by name) is now opt-in:
base.merge(other, track="name")
base.match(other, track="name")
# sio merge --track name
```

## API Changes

- `Labels.merge(track=...)` and `Labels.match(track=...)` default `"name"` → `"identity"`.
- `sio merge --track` default `"name"` → `"identity"`.
- No signatures change; `"name"` remains fully supported as an explicit value.

## Testing

- Migrated 5 existing tests that exercised name-dedup to pass `track="name"` explicitly (intent preserved, assertions unchanged).
- Added 4 tests: default keeps same-named distinct tracks separate; `track="name"` still collapses them **and** still emits the divergence warning; `match()`/`merge()` default consistency; duplicate-track-name SLP round-trip (lossless — SLP stores tracks positionally with `eq=False`).
- Full `tests/` suite: **3252 passed** (the only failure is the pre-existing Windows-only `test_samefile_with_symlink`, `WinError 1314`, environmental). `ruff format`/`check` clean. Patch coverage on the executable changed lines confirmed.

## Design Decisions

- **Used the existing `IDENTITY` method, not a new `NONE`.** Identity already gives the exact correctness-first semantics (only the same `Track` object collapses; distinct objects append as new) and is already implemented/tested; a new method would re-append even genuinely-shared `Track` objects and add enum/doc/test surface for no benefit.
- **Single class-default change** rather than hardcoding the method at the two call sites, so `merge()` and `match()` can never silently diverge.
- **`unsplit` pinned to `track="name"`** because splits are guaranteed to come from one project.

## Follow-up

Addresses #425 (closing it). The upstream consumer fix — having SLEAP's HITL merge pick the track-matching method based on tracker/model type (generic tracker → identity/propagate tracks; identity-classification model → name) — is tracked in a new issue on talmolab/sleap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
