### PR TITLE
feat(io): import DLC project metadata — edges, source videos, splits (#424)

### DIFF
--- a/docs/formats/index.md
+++ b/docs/formats/index.md
@@ -365,9 +365,70 @@ with h5py.File("output.h5", "r") as f:
 
 ### DeepLabCut Format (.h5, .csv)
 
-Load predictions from [DeepLabCut](http://www.mackenziemathislab.org/deeplabcut), a popular markerless pose estimation tool.
+Load annotations from [DeepLabCut](http://www.mackenziemathislab.org/deeplabcut), a popular markerless pose estimation tool.
+
+`load_dlc` reads a single DLC annotation CSV. When a project `config.yaml` is
+available — either passed explicitly via `config=` or auto-discovered by walking
+up from the CSV — the following extra metadata is imported:
+
+- **Skeleton edges** from the config `skeleton:` list. Edges that reference
+  bodyparts not present in the labeled data are dropped with a warning.
+- **Source videos**: each `labeled-data/<video>/` image folder is linked back to
+  its original video file (from the config `video_sets`) via `Video.source_video`,
+  matched by filename stem. The link is best-effort and left unset on a stem
+  mismatch or missing file.
+
+Pass `config=False` to disable config use entirely and reproduce the legacy,
+config-free output. Cropping/ROI metadata (`video_sets[...].crop`) is not yet
+imported.
+
+```python
+import sleap_io as sio
+
+# Single CSV; auto-discovers config.yaml for edges + source-video links.
+labels = sio.load_dlc("project/labeled-data/vid1/CollectedData_Scorer.csv")
+
+# Strict legacy output (no edges/links), even inside a project.
+labels = sio.load_dlc("project/labeled-data/vid1/CollectedData_Scorer.csv", config=False)
+```
 
 ::: sleap_io.io.main.load_dlc
+
+#### Loading a whole DLC project
+
+`load_dlc_project` loads every `labeled-data/<video>/` folder in a project at
+once and merges them into a single `Labels` that shares one `Skeleton` (with
+edges) and one set of `Track`s, recording provenance under the `dlc_project`,
+`dlc_scorer`, and `dlc_task` keys. A project directory or its `config.yaml` can
+also be passed to `load_file`, which routes it here automatically.
+
+```python
+labels = sio.load_dlc_project("path/to/dlc_project")  # dir or config.yaml
+labels = sio.load_file("path/to/dlc_project")          # auto-routed
+```
+
+::: sleap_io.io.main.load_dlc_project
+
+#### Importing train/test splits
+
+`load_dlc_splits` recovers the train/test splits created by DLC's
+`create_training_dataset`, reading the positional indices stored in the project's
+`Documentation_data-*.pickle` and reconstructing DLC's globally, lexicographically
+sorted merge of all per-video annotations. It returns a
+[`LabelsSet`](../model/index.md) with `"train"` and `"test"` keys.
+
+Splits require the labeled images to be present on disk. For non-zero-padded
+image filenames a warning is emitted, since DLC's lexicographic ordering (e.g.
+`img10` < `img2`) differs from numeric ordering and could otherwise cause silent
+train/test mis-assignment. If a project has multiple training fractions or
+shuffles, pass `train_fraction=` and/or `shuffle=` to disambiguate.
+
+```python
+splits = sio.load_dlc_splits("path/to/dlc_project", shuffle=1)
+train, test = splits["train"], splits["test"]
+```
+
+::: sleap_io.io.main.load_dlc_splits
 
 ### CSV Format (.csv)
 

--- a/docs/formats/index.md
+++ b/docs/formats/index.md
@@ -379,8 +379,19 @@ up from the CSV — the following extra metadata is imported:
   mismatch or missing file.
 
 Pass `config=False` to disable config use entirely and reproduce the legacy,
-config-free output. Cropping/ROI metadata (`video_sets[...].crop`) is not yet
-imported.
+config-free output.
+
+!!! note "Cropping is not yet applied"
+    DeepLabCut's `video_sets[...].crop` is a *virtual* read-time crop (an ROI
+    that DLC's video reader slices out of each full frame on the fly). When a
+    project uses cropping, the images under `labeled-data/<video>/` are the
+    cropped region and the labels are stored in **cropped-frame coordinates**,
+    whereas the linked `source_video` points at the original, **uncropped**
+    video. sleap-io does not yet apply this crop, so for cropped projects the
+    labels are offset from the source video by the crop origin `(x1, y1)`.
+    Reconciling the two requires virtual ROI-cropping of a `Video` on read,
+    which is planned future work. For the common case of no cropping (the DLC
+    default is the full frame), there is no offset and the link is exact.
 
 ```python
 import sleap_io as sio

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -20,6 +20,8 @@ __getattr__, __dir__, __all__ = lazy.attach(
             "load_coco",
             "load_csv",
             "load_dlc",
+            "load_dlc_project",
+            "load_dlc_splits",
             "load_file",
             "load_geojson",
             "load_jabs",

--- a/sleap_io/io/dlc.py
+++ b/sleap_io/io/dlc.py
@@ -14,7 +14,14 @@ imported:
   to its original video file (from the config ``video_sets``) via
   `Video.source_video`, matched by filename stem.
 
-Cropping/ROI metadata (``video_sets[...].crop``) is not yet imported.
+DLC's ``video_sets[...].crop`` is a *virtual* read-time crop (an ROI sliced out
+of each full frame by DLC's video reader). When a project uses cropping, the
+``labeled-data`` images are the cropped region and labels are in cropped-frame
+coordinates, while the linked ``source_video`` is the original, *uncropped*
+video -- so labels are offset from the source video by the crop origin. This
+crop is not yet applied on import; reconciling the two coordinate systems
+requires virtual ROI-cropping of a `Video` on read, which is planned future
+work. With no cropping (the DLC default), there is no offset.
 """
 
 from __future__ import annotations

--- a/sleap_io/io/dlc.py
+++ b/sleap_io/io/dlc.py
@@ -1,16 +1,37 @@
-"""This module handles direct I/O operations for working with DeepLabCut (DLC) files."""
+"""This module handles direct I/O operations for working with DeepLabCut (DLC) files.
+
+In addition to reading a single DLC annotation CSV (`load_dlc`), this module can
+import an entire DLC *project* from its `config.yaml` (`load_dlc_project`) and
+recover the train/test splits stored by `create_training_dataset`
+(`load_dlc_splits`).
+
+When a project `config.yaml` is available, the following extra metadata is
+imported:
+
+- **Skeleton edges** from the config ``skeleton:`` list (edges referencing
+  bodyparts that were not labeled are dropped with a warning).
+- **Source videos**: each ``labeled-data/<video>/`` image folder is linked back
+  to its original video file (from the config ``video_sets``) via
+  `Video.source_video`, matched by filename stem.
+
+Cropping/ROI metadata (``video_sets[...].crop``) is not yet imported.
+"""
 
 from __future__ import annotations
 
+import pickle
 import re
+import warnings
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import yaml
 
 from sleap_io.model.instance import Instance, Track
 from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
+from sleap_io.model.labels_set import LabelsSet
 from sleap_io.model.skeleton import Node, Skeleton
 from sleap_io.model.video import Video
 
@@ -46,55 +67,353 @@ def is_dlc_file(filename: str | Path) -> bool:
         return False
 
 
+# -----------------------------------------------------------------------------
+# Config parsing and discovery
+# -----------------------------------------------------------------------------
+
+#: Keys that identify a mapping as a DLC project ``config.yaml``.
+_DLC_CONFIG_KEYS = (
+    "video_sets",
+    "bodyparts",
+    "scorer",
+    "Task",
+    "skeleton",
+    "individuals",
+)
+
+
+def _read_dlc_config(path: str | Path) -> dict | None:
+    """Read a DLC project ``config.yaml`` into a dictionary.
+
+    Args:
+        path: Path to the config YAML file.
+
+    Returns:
+        The parsed config as a dictionary, or `None` if the file is missing or
+        cannot be parsed as a YAML mapping. A warning is emitted on failure so
+        that a malformed or foreign config never breaks plain CSV loading.
+    """
+    path = Path(path)
+    if not path.is_file():
+        warnings.warn(f"DLC config file not found: {path}")
+        return None
+    try:
+        with open(path, "r") as f:
+            cfg = yaml.safe_load(f)
+    except Exception as e:  # pragma: no cover - defensive
+        warnings.warn(f"Failed to parse DLC config {path}: {e}")
+        return None
+    if not isinstance(cfg, dict):
+        warnings.warn(f"DLC config {path} did not parse to a mapping.")
+        return None
+    return cfg
+
+
+def _looks_like_dlc_config(cfg: dict) -> bool:
+    """Return whether a parsed mapping looks like a DLC project config.
+
+    Args:
+        cfg: A parsed YAML mapping.
+
+    Returns:
+        True if at least two characteristic DLC config keys are present. This
+        guards auto-discovery against picking up an unrelated ``config.yaml``.
+    """
+    if not isinstance(cfg, dict):
+        return False
+    return sum(key in cfg for key in _DLC_CONFIG_KEYS) >= 2
+
+
+def _discover_config(csv_path: str | Path, max_levels: int = 3) -> Path | None:
+    """Search upward from a CSV for a DLC project ``config.yaml``.
+
+    DLC projects store annotations at ``<project>/labeled-data/<video>/`` with
+    ``config.yaml`` at the project root, so the config typically sits two
+    directories above the CSV.
+
+    Args:
+        csv_path: Path to a DLC annotation CSV.
+        max_levels: Maximum number of parent directories to search.
+
+    Returns:
+        The path to a validated DLC ``config.yaml``, or `None` if none is found
+        within `max_levels` levels.
+    """
+    start = Path(csv_path).resolve().parent
+    for d in [start, *start.parents][: max_levels + 1]:
+        candidate = d / "config.yaml"
+        if candidate.is_file():
+            cfg = _read_dlc_config(candidate)
+            if cfg is not None and _looks_like_dlc_config(cfg):
+                return candidate
+    return None
+
+
+def _resolve_config(
+    csv_path: str | Path, config: str | Path | bool | None
+) -> dict | None:
+    """Resolve the ``config`` argument of `load_dlc` to a parsed config dict.
+
+    Args:
+        csv_path: Path to the DLC CSV being loaded (used for auto-discovery).
+        config: Either `None` (auto-discover ``config.yaml`` by walking up from
+            the CSV), `False` (disable config entirely for strict legacy
+            output), or an explicit path to a ``config.yaml``.
+
+    Returns:
+        The parsed config dictionary, or `None` if disabled or not found.
+    """
+    if config is False:
+        return None
+    if config is None:
+        discovered = _discover_config(csv_path)
+        return _read_dlc_config(discovered) if discovered is not None else None
+    return _read_dlc_config(config)
+
+
+def _is_dlc_project_path(filename: str | Path) -> bool:
+    """Return whether a path refers to a DLC project (for `load_file` routing).
+
+    Args:
+        filename: A directory or a ``config.yaml`` path.
+
+    Returns:
+        True if `filename` is a directory containing both ``config.yaml`` and
+        ``labeled-data/``, or a ``config.yaml`` file that validates as a DLC
+        project config.
+    """
+    p = Path(filename)
+    if p.is_dir():
+        return (p / "config.yaml").is_file() and (p / "labeled-data").is_dir()
+    if p.name == "config.yaml" and p.is_file():
+        cfg = _read_dlc_config(p)
+        return cfg is not None and _looks_like_dlc_config(cfg)
+    return False
+
+
+def _attach_config_skeleton(skeleton: Skeleton, cfg: dict) -> None:
+    """Attach skeleton edges (and name) from a DLC config to a `Skeleton`.
+
+    Edges referencing bodyparts that are not present in the skeleton's nodes are
+    dropped with a warning. Resolution is strictly name-based to avoid corrupting
+    edges when the node order differs from the config.
+
+    Args:
+        skeleton: The `Skeleton` to mutate in place.
+        cfg: A parsed DLC config dictionary.
+    """
+    task = cfg.get("Task")
+    if task and skeleton.name is None:
+        skeleton.name = str(task)
+
+    raw_edges = cfg.get("skeleton") or []
+    node_names = set(skeleton.node_names)
+    valid: list[tuple[str, str]] = []
+    dropped: list = []
+    for entry in raw_edges:
+        if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+            dropped.append(entry)
+            continue
+        src, dst = str(entry[0]), str(entry[1])
+        if src in node_names and dst in node_names:
+            valid.append((src, dst))
+        else:
+            dropped.append((src, dst))
+
+    if valid:
+        skeleton.add_edges(valid)
+    if dropped:
+        warnings.warn(
+            f"Dropped {len(dropped)} DLC skeleton edge(s) referencing bodyparts "
+            f"not present in the labeled data: {dropped}"
+        )
+
+
+def _video_sets_stem_map(cfg: dict) -> dict[str, str]:
+    """Map video filename stems to original video paths from config ``video_sets``.
+
+    Paths are normalized so Windows-style backslash separators are handled on any
+    OS. Placeholder entries (e.g. DLC demo templates) are skipped.
+
+    Args:
+        cfg: A parsed DLC config dictionary.
+
+    Returns:
+        A dictionary mapping each video's filename stem to its original path
+        string (preserving config order).
+    """
+    out: dict[str, str] = {}
+    video_sets = cfg.get("video_sets") or {}
+    for key in video_sets.keys():
+        key_str = str(key)
+        if "WILL BE AUTOMATICALLY UPDATED" in key_str:
+            continue
+        name = key_str.replace("\\", "/").rsplit("/", 1)[-1]
+        stem = name.rsplit(".", 1)[0] if "." in name else name
+        if stem:
+            out[stem] = key_str
+    return out
+
+
+def _set_source_video(
+    video: Video,
+    folder_name: str,
+    stem_map: dict[str, str],
+    video_search_paths: list[str | Path] | None = None,
+) -> None:
+    """Link an image-folder `Video` back to its original source video.
+
+    Args:
+        video: The image-sequence `Video` to annotate (mutated in place).
+        folder_name: The ``labeled-data/<folder>`` name for this video.
+        stem_map: Mapping of video stems to original paths (see
+            `_video_sets_stem_map`).
+        video_search_paths: Optional paths to search for the original video file
+            by basename (best-effort path repair).
+
+    Notes:
+        The source `Video` is created with ``open_backend=False`` so a missing
+        original file (the common case on import) never raises. On a stem
+        mismatch, `video.source_video` is left as `None`.
+    """
+    original = stem_map.get(folder_name)
+    if original is None:
+        return
+
+    path = original
+    if video_search_paths:
+        basename = original.replace("\\", "/").rsplit("/", 1)[-1]
+        for search_path in video_search_paths:
+            candidate = Path(search_path) / basename
+            if candidate.exists():
+                path = str(candidate)
+                break
+
+    video.source_video = Video(filename=path, open_backend=False)
+
+
+# -----------------------------------------------------------------------------
+# CSV reading
+# -----------------------------------------------------------------------------
+
+
+def _read_dlc_dataframe(filename: str | Path) -> tuple[pd.DataFrame, bool]:
+    """Read a DLC annotation CSV into a DataFrame with a flattened string index.
+
+    Args:
+        filename: Path to a DLC annotation CSV.
+
+    Returns:
+        A tuple of `(df, is_multianimal)` where `df` has image paths as its
+        (string) index and multi-level columns, and `is_multianimal` indicates
+        whether the file uses the multi-animal individuals/bodyparts/coords
+        layout.
+    """
+    filename = Path(filename)
+
+    # Try reading first few rows to determine format.
+    try:
+        # Try multi-animal format first (header rows 1-3, skipping scorer row).
+        peek = pd.read_csv(filename, header=[1, 2, 3], nrows=2)
+        is_multianimal = peek.columns[0][0] == "individuals"
+        is_multiindex = peek.iloc[0, 0] == "labeled-data"
+    except Exception:
+        # Fall back to single-animal format.
+        is_multianimal = False
+        is_multiindex = False
+
+    # Older DLC versions store image paths with OS-specific path separators.
+    # Newer versions store paths without separators as MultiIndex.
+    index_col = [0, 1, 2] if is_multiindex else 0
+
+    # Multi-animal format: skip scorer row, use individuals/bodyparts/coords.
+    # Single-animal format: use scorer/bodyparts/coords.
+    header = [1, 2, 3] if is_multianimal else [0, 1, 2]
+
+    df = pd.read_csv(filename, header=header, index_col=index_col)
+    # Flatten MultiIndex to match older DLC format.
+    if is_multiindex:
+        df.index = df.index.map("/".join)
+
+    return df, is_multianimal
+
+
+# -----------------------------------------------------------------------------
+# Single-CSV loading
+# -----------------------------------------------------------------------------
+
+
 def load_dlc(
     filename: str | Path,
     video_search_paths: list[str | Path] | None = None,
+    config: str | Path | bool | None = None,
     **kwargs,
 ) -> Labels:
-    """Load DeepLabCut annotations from CSV file.
+    """Load DeepLabCut annotations from a CSV file.
 
     Args:
         filename: Path to DLC CSV file.
         video_search_paths: List of paths to search for video files.
+        config: Path to a DLC project ``config.yaml``. When provided (or
+            auto-discovered), skeleton edges and source-video links are imported
+            in addition to the pose annotations. Pass `None` (the default) to
+            auto-discover ``config.yaml`` by walking up from the CSV, an explicit
+            path to force a specific config, or `False` to disable config use
+            entirely (strict legacy output).
         **kwargs: Additional arguments (unused).
 
     Returns:
         Labels object with loaded data.
+
+    Notes:
+        When a config is found, the returned `Labels` gains skeleton edges and
+        per-video `Video.source_video` links that were previously absent. Pass
+        ``config=False`` to reproduce the legacy config-free output.
+    """
+    cfg = _resolve_config(filename, config)
+    return _load_dlc_csv(filename, config=cfg, video_search_paths=video_search_paths)
+
+
+def _load_dlc_csv(
+    filename: str | Path,
+    *,
+    config: dict | None = None,
+    video_search_paths: list[str | Path] | None = None,
+    skeleton: Skeleton | None = None,
+    tracks: list[Track] | None = None,
+) -> Labels:
+    """Load a single DLC annotation CSV into a `Labels` object.
+
+    Args:
+        filename: Path to a DLC annotation CSV.
+        config: A parsed DLC config dictionary (not a path), or `None`. When
+            provided, skeleton edges and source-video links are applied.
+        video_search_paths: Optional paths to search for original video files.
+        skeleton: An optional pre-built `Skeleton` to reuse (shared across a
+            project load). When provided, structure parsing and edge attachment
+            are skipped so all frames reference the same skeleton.
+        tracks: An optional pre-built list of `Track`s to reuse alongside
+            `skeleton`.
+
+    Returns:
+        A `Labels` object for this CSV.
     """
     filename = Path(filename)
+    df, is_multianimal = _read_dlc_dataframe(filename)
 
-    # Try reading first few rows to determine format
-    try:
-        # Try multi-animal format first (header rows 1-3, skipping scorer row)
-        df = pd.read_csv(filename, header=[1, 2, 3], nrows=2)
-        is_multianimal = df.columns[0][0] == "individuals"
-        is_multiindex = df.iloc[0, 0] == "labeled-data"
-    except Exception:
-        # Fall back to single-animal format
-        is_multianimal = False
-        is_multiindex = False
-
-    # Older DLC versions store image paths with OS-specific path separators
-    # Newer versions store paths without separators as MultiIndex
-    index_col = [0, 1, 2] if is_multiindex else 0
-
-    # Multi-animal format: skip scorer row, use individuals/bodyparts/coords
-    # Single-animal format: use scorer/bodyparts/coords
-    header = [1, 2, 3] if is_multianimal else [0, 1, 2]
-
-    df = pd.read_csv(filename, header=header, index_col=index_col)
-    # Flatten MultiIndex to match older DLC format
-    if is_multiindex:
-        df.index = df.index.map("/".join)
-
-    # Parse structure based on format
-    if is_multianimal:
-        skeleton, tracks = _parse_multi_animal_structure(df)
-    else:
-        skeleton = _parse_single_animal_structure(df)
+    # Parse structure based on format (unless a shared skeleton was provided).
+    if skeleton is None:
+        if is_multianimal:
+            skeleton, tracks = _parse_multi_animal_structure(df)
+        else:
+            skeleton = _parse_single_animal_structure(df)
+            tracks = []
+        if config is not None:
+            _attach_config_skeleton(skeleton, config)
+    elif tracks is None:
         tracks = []
 
-    # First, group all image paths by their video directory
+    # First, group all image paths by their video directory.
     video_image_paths = {}
     frame_map = {}  # Maps image path to frame index
 
@@ -115,61 +434,66 @@ def load_dlc(
             video_image_paths[video_name] = []
         video_image_paths[video_name].append(img_path)
 
-    # Create one Video object per video directory
+    # Create one Video object per video directory.
     videos = {}
     for video_name, image_paths in video_image_paths.items():
-        # Sort image paths to ensure consistent ordering
+        # Sort image paths to ensure consistent ordering.
         sorted_paths = sorted(image_paths, key=lambda p: frame_map[p])
 
-        # Find the actual image files
+        # Find the actual image files.
         actual_image_files = []
         for img_path in sorted_paths:
-            # First try the full path from CSV
+            # First try the full path from CSV.
             full_path = filename.parent / img_path
             if full_path.exists():
                 actual_image_files.append(str(full_path))
             else:
-                # Try just the filename in the same directory as the CSV
+                # Try just the filename in the same directory as the CSV.
                 img_name = Path(img_path).name
                 simple_path = filename.parent / img_name
                 if simple_path.exists():
                     actual_image_files.append(str(simple_path))
                 else:
                     # Try going up one directory from CSV location
-                    # (CSV in subdir references parent/subdir/img.png)
+                    # (CSV in subdir references parent/subdir/img.png).
                     parent_path = filename.parent.parent / img_path
                     if parent_path.exists():
                         actual_image_files.append(str(parent_path))
 
-        # Only create video if we found actual images
+        # Only create video if we found actual images.
         if actual_image_files:
             videos[video_name] = Video.from_filename(actual_image_files)
 
-    # Parse the actual data rows and create labeled frames
+    # Link image folders back to their original videos from config video_sets.
+    if config is not None and videos:
+        stem_map = _video_sets_stem_map(config)
+        for video_name, video in videos.items():
+            _set_source_video(video, video_name, stem_map, video_search_paths)
+
+    # Parse the actual data rows and create labeled frames.
     labeled_frames = []
     for idx, row in df.iterrows():
-        # Get image path from index
+        # Get image path from index.
         img_path = str(idx)
-        frame_idx = _extract_frame_index(img_path)
 
-        # Determine which video this frame belongs to
+        # Determine which video this frame belongs to.
         path_parts = Path(img_path).parts
         if len(path_parts) >= 2 and path_parts[0] == "labeled-data":
             video_name = path_parts[1]
         else:
             video_name = Path(img_path).parent.name or "default"
 
-        # Skip if we don't have a video for this frame
+        # Skip if we don't have a video for this frame.
         if video_name not in videos:
             continue
 
-        # Parse instances for this frame
+        # Parse instances for this frame.
         if is_multianimal:
             instances = _parse_multi_animal_row(row, skeleton, tracks)
         else:
             instances = _parse_single_animal_row(row, skeleton)
 
-        # Get the index of this image within its video
+        # Get the index of this image within its video.
         sorted_video_paths = sorted(
             video_image_paths[video_name], key=lambda p: frame_map[p]
         )
@@ -190,6 +514,465 @@ def load_dlc(
         tracks=tracks,
         skeletons=[skeleton] if skeleton.nodes else [],
     )
+
+
+# -----------------------------------------------------------------------------
+# Project loading
+# -----------------------------------------------------------------------------
+
+
+def _resolve_project_config_path(config: str | Path) -> Path:
+    """Resolve a project argument to a ``config.yaml`` path.
+
+    Args:
+        config: A path to a ``config.yaml`` file or to a project directory
+            containing one.
+
+    Returns:
+        The path to the ``config.yaml`` file.
+
+    Raises:
+        FileNotFoundError: If a directory is given but contains no
+            ``config.yaml``.
+    """
+    p = Path(config)
+    if p.is_dir():
+        candidate = p / "config.yaml"
+        if candidate.is_file():
+            return candidate
+        raise FileNotFoundError(f"No config.yaml found in DLC project directory: {p}")
+    return p
+
+
+def _find_project_csvs(project_dir: Path, scorer: str | None) -> list[tuple[str, Path]]:
+    """Find per-video annotation CSVs under ``labeled-data/``.
+
+    Args:
+        project_dir: The DLC project root (the directory containing
+            ``config.yaml``).
+        scorer: The project scorer name (used to locate
+            ``CollectedData_<scorer>.csv``).
+
+    Returns:
+        A list of ``(folder_name, csv_path)`` tuples, sorted by folder name.
+    """
+    labeled_dir = project_dir / "labeled-data"
+    folders: list[tuple[str, Path]] = []
+    if not labeled_dir.is_dir():
+        return folders
+    for sub in sorted(labeled_dir.iterdir()):
+        if not sub.is_dir():
+            continue
+        csv = sub / f"CollectedData_{scorer}.csv"
+        if not csv.is_file():
+            # Fall back to any DLC-looking CSV in the folder.
+            candidates = [c for c in sorted(sub.glob("*.csv")) if is_dlc_file(c)]
+            if not candidates:
+                continue
+            csv = candidates[0]
+        folders.append((sub.name, csv))
+    return folders
+
+
+def load_dlc_project(
+    config: str | Path,
+    video_search_paths: list[str | Path] | None = None,
+) -> Labels:
+    """Load an entire DeepLabCut project from its ``config.yaml``.
+
+    All ``labeled-data/<video>/`` folders are loaded and merged into a single
+    `Labels` object that shares one `Skeleton` (with edges from the config) and
+    one set of `Track`s. Each per-video `Video` is linked back to its original
+    video file via `Video.source_video` when available.
+
+    Args:
+        config: Path to a DLC project ``config.yaml``, or to a project directory
+            containing one.
+        video_search_paths: Optional paths to search for original video files.
+
+    Returns:
+        A `Labels` object with frames from every labeled video in the project.
+
+    Raises:
+        ValueError: If the config cannot be read or no annotation CSVs are found.
+
+    Notes:
+        The returned `Labels` records DLC provenance under the keys
+        ``"dlc_project"``, ``"dlc_scorer"`` and ``"dlc_task"``.
+    """
+    config_path = _resolve_project_config_path(config)
+    cfg = _read_dlc_config(config_path)
+    if cfg is None:
+        raise ValueError(f"Could not read DLC config: {config_path}")
+
+    project_dir = config_path.parent
+    scorer = cfg.get("scorer")
+    folders = _find_project_csvs(project_dir, scorer)
+    if not folders:
+        raise ValueError(
+            f"No DLC annotation CSVs found under {project_dir / 'labeled-data'}"
+        )
+
+    # Build a single shared skeleton and track list across all videos so that
+    # every instance references the same objects (one skeleton, deduped tracks).
+    node_names: list[str] = []
+    track_names: list[str] = []
+    for _, csv in folders:
+        df, is_multianimal = _read_dlc_dataframe(csv)
+        if is_multianimal:
+            folder_skeleton, folder_tracks = _parse_multi_animal_structure(df)
+            for track in folder_tracks:
+                if track.name not in track_names:
+                    track_names.append(track.name)
+        else:
+            folder_skeleton = _parse_single_animal_structure(df)
+        for name in folder_skeleton.node_names:
+            if name not in node_names:
+                node_names.append(name)
+
+    shared_skeleton = Skeleton(nodes=[Node(name) for name in sorted(set(node_names))])
+    _attach_config_skeleton(shared_skeleton, cfg)
+    shared_tracks = [Track(name=name) for name in track_names]
+
+    # Load each folder using the shared skeleton/tracks and collect the frames.
+    all_frames: list[LabeledFrame] = []
+    videos: list[Video] = []
+    for _, csv in folders:
+        folder_labels = _load_dlc_csv(
+            csv,
+            config=cfg,
+            video_search_paths=video_search_paths,
+            skeleton=shared_skeleton,
+            tracks=shared_tracks,
+        )
+        all_frames.extend(folder_labels.labeled_frames)
+        videos.extend(folder_labels.videos)
+
+    labels = Labels(
+        labeled_frames=all_frames,
+        videos=videos,
+        tracks=shared_tracks,
+        skeletons=[shared_skeleton] if shared_skeleton.nodes else [],
+    )
+    labels.provenance.update(
+        {
+            "dlc_project": str(config_path),
+            "dlc_scorer": scorer,
+            "dlc_task": cfg.get("Task"),
+        }
+    )
+    return labels
+
+
+# -----------------------------------------------------------------------------
+# Training-set splits
+# -----------------------------------------------------------------------------
+
+
+def _get_training_set_folder(
+    project_dir: Path, cfg: dict, iteration: int | None
+) -> Path:
+    """Return the ``UnaugmentedDataSet`` folder for a project iteration.
+
+    Mirrors DLC's ``get_training_set_folder``: the path is
+    ``training-datasets/iteration-<iteration>/UnaugmentedDataSet_<Task><date>``
+    (note: ``Task`` and ``date`` are concatenated with no separator).
+
+    Args:
+        project_dir: The DLC project root.
+        cfg: The parsed DLC config.
+        iteration: The iteration index, or `None` to use ``cfg['iteration']``.
+
+    Returns:
+        The path to the unaugmented training-set folder.
+    """
+    it = cfg.get("iteration", 0) if iteration is None else iteration
+    task = cfg.get("Task", "")
+    date = cfg.get("date", "")
+    return (
+        project_dir
+        / "training-datasets"
+        / f"iteration-{it}"
+        / f"UnaugmentedDataSet_{task}{date}"
+    )
+
+
+def _select_documentation_pickle(
+    project_dir: Path,
+    cfg: dict,
+    train_fraction: float | None,
+    shuffle: int | None,
+    iteration: int | None,
+) -> Path:
+    """Locate the ``Documentation_data-*.pickle`` for the requested split.
+
+    Args:
+        project_dir: The DLC project root.
+        cfg: The parsed DLC config.
+        train_fraction: The training fraction to select (e.g. ``0.95``), or
+            `None` to leave unconstrained.
+        shuffle: The shuffle index to select, or `None` to leave unconstrained.
+        iteration: The iteration index, or `None` to use ``cfg['iteration']``.
+
+    Returns:
+        The path to the selected Documentation pickle.
+
+    Raises:
+        FileNotFoundError: If the training-set folder or any pickle is missing.
+        ValueError: If the selection is ambiguous (multiple pickles match).
+    """
+    trainset_dir = _get_training_set_folder(project_dir, cfg, iteration)
+    pickles = (
+        sorted(trainset_dir.glob("Documentation_data-*.pickle"))
+        if trainset_dir.is_dir()
+        else []
+    )
+    if not pickles:
+        raise FileNotFoundError(
+            f"No DLC Documentation_data-*.pickle found in {trainset_dir}. "
+            "Run create_training_dataset in DLC to generate splits."
+        )
+
+    pattern = re.compile(
+        r"Documentation_data-(?P<task>.+)_(?P<frac>\d+)shuffle(?P<shuffle>\d+)\.pickle$"
+    )
+    parsed: list[tuple[Path, int, int]] = []
+    for p in pickles:
+        m = pattern.match(p.name)
+        if m is not None:
+            parsed.append((p, int(m.group("frac")), int(m.group("shuffle"))))
+
+    if not parsed:
+        # Cannot parse selectors; only safe when unambiguous.
+        if len(pickles) == 1:
+            return pickles[0]
+        raise ValueError(
+            f"Could not parse train_fraction/shuffle from pickles in {trainset_dir}: "
+            f"{[p.name for p in pickles]}"
+        )
+
+    candidates = parsed
+    if train_fraction is not None:
+        frac_int = int(round(train_fraction * 100))
+        candidates = [c for c in candidates if c[1] == frac_int]
+    if shuffle is not None:
+        candidates = [c for c in candidates if c[2] == shuffle]
+
+    if not candidates:
+        available = [(p.name, f, s) for (p, f, s) in parsed]
+        raise FileNotFoundError(
+            f"No Documentation pickle matched train_fraction={train_fraction}, "
+            f"shuffle={shuffle}. Available: {available}"
+        )
+    if len(candidates) > 1:
+        available = [(p.name, f, s) for (p, f, s) in candidates]
+        raise ValueError(
+            "Multiple DLC splits found; specify train_fraction and/or shuffle. "
+            f"Available (name, train%, shuffle): {available}"
+        )
+    return candidates[0][0]
+
+
+def _read_dlc_split(pickle_path: str | Path) -> tuple[list[int], list[int]]:
+    """Read train/test positional indices from a DLC Documentation pickle.
+
+    The pickle is a 4-element list ``[data, trainIndices, testIndices,
+    trainFraction]``. Only ``trainIndices`` (``meta[1]``) and ``testIndices``
+    (``meta[2]``) are used; ``meta[0]`` is the lossy train-only record list and
+    is intentionally ignored.
+
+    Args:
+        pickle_path: Path to the Documentation pickle.
+
+    Returns:
+        A tuple ``(train_indices, test_indices)`` of integer positional indices
+        into the globally merged frame order.
+    """
+    with open(pickle_path, "rb") as f:
+        meta = pickle.load(f)
+    train = [int(i) for i in meta[1] if int(i) != -1]
+    test = [int(i) for i in meta[2] if int(i) != -1]
+    return train, test
+
+
+def _dlc_merged_order(project_dir: Path, cfg: dict) -> list[tuple[str, str]]:
+    """Reconstruct DLC's globally merged frame order as ``(folder, filename)``.
+
+    DLC builds its training set by concatenating each video's
+    ``CollectedData_<scorer>`` frame (in ``video_sets`` order, deduped by stem,
+    skipping folders whose annotation file is missing or labeled by a different
+    scorer) and then sorting the whole thing lexicographically with
+    ``DataFrame.sort_index()``. The train/test indices in the Documentation
+    pickle are positional indices into this merged order.
+
+    Args:
+        project_dir: The DLC project root.
+        cfg: The parsed DLC config.
+
+    Returns:
+        A list of ``(folder, filename)`` tuples in DLC's merged positional
+        order. Position ``i`` corresponds to split index ``i``.
+    """
+    scorer = cfg.get("scorer")
+    stem_map = _video_sets_stem_map(cfg)
+
+    # Determine the included folders, mirroring DLC's merge skip-rules.
+    # ``stem_map`` is keyed by stem, so stems are already unique.
+    included: list[tuple[str, Path]] = []
+    for stem in stem_map.keys():
+        csv = project_dir / "labeled-data" / stem / f"CollectedData_{scorer}.csv"
+        if not csv.is_file():
+            # Folder absent / not annotated -> skipped by DLC too.
+            continue
+        csv_scorer = _read_csv_scorer(csv)
+        if scorer is not None and csv_scorer is not None and csv_scorer != scorer:
+            warnings.warn(
+                f"Skipping {csv} labeled by '{csv_scorer}' (project scorer is "
+                f"'{scorer}'); this matches DLC's training-set merge behavior."
+            )
+            continue
+        included.append((stem, csv))
+
+    if not included:
+        # Fallback: video_sets stems did not match any labeled-data folder.
+        # Include every folder with a DLC CSV so splits remain usable.
+        for folder, csv in _find_project_csvs(project_dir, scorer):
+            included.append((folder, csv))
+
+    merged: list[tuple[str, str]] = []
+    for _, csv in included:
+        df, _ = _read_dlc_dataframe(csv)
+        for idx in df.index:
+            p = Path(str(idx))
+            merged.append((p.parent.name, p.name))
+
+    # DLC applies a global lexicographic sort_index() across all merged frames.
+    merged.sort()
+    return merged
+
+
+def _read_csv_scorer(csv: str | Path) -> str | None:
+    """Read the scorer name from the first row of a DLC CSV.
+
+    Args:
+        csv: Path to a DLC annotation CSV.
+
+    Returns:
+        The scorer name (the second field of the first line), or `None` if it
+        cannot be determined.
+    """
+    try:
+        with open(csv, "r") as f:
+            first = f.readline().strip()
+    except Exception:  # pragma: no cover - defensive
+        return None
+    parts = first.split(",")
+    return parts[1] if len(parts) > 1 else None
+
+
+def _warn_if_nonlexicographic(merged: list[tuple[str, str]]) -> None:
+    """Warn if numeric filename order differs from DLC's lexicographic order.
+
+    Args:
+        merged: The merged ``(folder, filename)`` order from `_dlc_merged_order`.
+    """
+
+    def numeric_key(key: tuple[str, str]):
+        folder, fname = key
+        nums = re.findall(r"\d+", fname)
+        return (folder, int(nums[-1]) if nums else -1, fname)
+
+    if sorted(merged) != sorted(merged, key=numeric_key):
+        warnings.warn(
+            "DLC split import: image filenames are not zero-padded, so DLC's "
+            "lexicographic ordering differs from numeric order (e.g. 'img10' < "
+            "'img2'). Train/test assignment follows DLC's lexicographic order; "
+            "verify the result."
+        )
+
+
+def load_dlc_splits(
+    config: str | Path,
+    shuffle: int | None = None,
+    train_fraction: float | None = None,
+    iteration: int | None = None,
+    video_search_paths: list[str | Path] | None = None,
+) -> LabelsSet:
+    """Load DeepLabCut train/test splits from a project's Documentation pickle.
+
+    Args:
+        config: Path to a DLC project ``config.yaml`` (or its project directory).
+        shuffle: The shuffle index to load. Required if the project has more than
+            one shuffle.
+        train_fraction: The training fraction to load (e.g. ``0.95``). Required
+            if the project has more than one training fraction.
+        iteration: The project iteration. Defaults to ``cfg['iteration']``.
+        video_search_paths: Optional paths to search for original video files.
+
+    Returns:
+        A `LabelsSet` with ``"train"`` and ``"test"`` keys, each a `Labels`
+        containing the frames assigned to that split.
+
+    Raises:
+        FileNotFoundError: If no matching Documentation pickle exists.
+        ValueError: If the config cannot be read or the split selection is
+            ambiguous.
+
+    Notes:
+        Splits require the labeled images to be present on disk so that each
+        merged frame maps to a loaded `LabeledFrame`. DLC stores split membership
+        as positional indices into a globally, lexicographically sorted merge of
+        all per-video annotations; this function reconstructs that order. For
+        non-zero-padded filenames, a warning is emitted because lexicographic and
+        numeric orderings diverge.
+    """
+    config_path = _resolve_project_config_path(config)
+    cfg = _read_dlc_config(config_path)
+    if cfg is None:
+        raise ValueError(f"Could not read DLC config: {config_path}")
+    project_dir = config_path.parent
+
+    # Load the full project, then partition its frames into train/test.
+    labels = load_dlc_project(config_path, video_search_paths=video_search_paths)
+
+    merged = _dlc_merged_order(project_dir, cfg)
+    _warn_if_nonlexicographic(merged)
+
+    pickle_path = _select_documentation_pickle(
+        project_dir, cfg, train_fraction, shuffle, iteration
+    )
+    train_indices, test_indices = _read_dlc_split(pickle_path)
+
+    # Build a lookup from (folder, filename) -> global LabeledFrame index.
+    lf_lookup: dict[tuple[str, str], int] = {}
+    for global_idx, lf in enumerate(labels.labeled_frames):
+        fname = lf.video.filename
+        if isinstance(fname, list):
+            fname = fname[lf.frame_idx]
+        p = Path(str(fname))
+        lf_lookup[(p.parent.name, p.name)] = global_idx
+
+    def map_indices(indices: list[int]) -> list[int]:
+        out: list[int] = []
+        for i in indices:
+            if 0 <= i < len(merged):
+                global_idx = lf_lookup.get(merged[i])
+                if global_idx is not None:
+                    out.append(global_idx)
+        return out
+
+    train_global = map_indices(train_indices)
+    test_global = map_indices(test_indices)
+
+    train_labels = labels.extract(train_global, copy=True)
+    test_labels = labels.extract(test_global, copy=True)
+
+    return LabelsSet({"train": train_labels, "test": test_labels})
+
+
+# -----------------------------------------------------------------------------
+# Structure / row parsing (unchanged behavior)
+# -----------------------------------------------------------------------------
 
 
 def _parse_multi_animal_structure(df: pd.DataFrame) -> tuple[Skeleton, list[Track]]:

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -430,13 +430,21 @@ def save_jabs(labels: Labels, pose_version: int, root_folder: str | None = None)
 
 
 def load_dlc(
-    filename: str, video_search_paths: list[str | Path] | None = None, **kwargs
+    filename: str,
+    video_search_paths: list[str | Path] | None = None,
+    config: str | Path | bool | None = None,
+    **kwargs,
 ) -> Labels:
     """Read DeepLabCut annotations from a CSV file and return a `Labels` object.
 
     Args:
         filename: Path to DLC CSV file with annotations.
         video_search_paths: Optional list of paths to search for video files.
+        config: Path to a DLC project ``config.yaml``. When provided (or
+            auto-discovered), skeleton edges and source-video links are imported.
+            Pass `None` (the default) to auto-discover ``config.yaml`` by walking
+            up from the CSV, an explicit path to force a specific config, or
+            `False` to disable config use entirely (strict legacy output).
         **kwargs: Additional arguments passed to DLC loader.
 
     Returns:
@@ -444,7 +452,66 @@ def load_dlc(
     """
     from sleap_io.io import dlc
 
-    return dlc.load_dlc(filename, video_search_paths=video_search_paths, **kwargs)
+    return dlc.load_dlc(
+        filename, video_search_paths=video_search_paths, config=config, **kwargs
+    )
+
+
+def load_dlc_project(
+    config: str | Path,
+    video_search_paths: list[str | Path] | None = None,
+    **kwargs,
+) -> Labels:
+    """Read an entire DeepLabCut project from its ``config.yaml``.
+
+    All ``labeled-data/<video>/`` folders are loaded and merged into a single
+    `Labels` sharing one `Skeleton` (with edges from the config) and one set of
+    `Track`s, with each video linked back to its original via
+    `Video.source_video`.
+
+    Args:
+        config: Path to a DLC project ``config.yaml`` (or the project directory
+            containing one).
+        video_search_paths: Optional list of paths to search for video files.
+        **kwargs: Additional arguments passed to the DLC project loader.
+
+    Returns:
+        Parsed labels as a `Labels` instance.
+    """
+    from sleap_io.io import dlc
+
+    return dlc.load_dlc_project(config, video_search_paths=video_search_paths, **kwargs)
+
+
+def load_dlc_splits(
+    config: str | Path,
+    shuffle: int | None = None,
+    train_fraction: float | None = None,
+    iteration: int | None = None,
+    video_search_paths: list[str | Path] | None = None,
+) -> "LabelsSet":
+    """Read DeepLabCut train/test splits from a project's Documentation pickle.
+
+    Args:
+        config: Path to a DLC project ``config.yaml`` (or the project directory).
+        shuffle: The shuffle index to load. Required if more than one exists.
+        train_fraction: The training fraction to load (e.g. ``0.95``). Required
+            if more than one exists.
+        iteration: The project iteration. Defaults to ``cfg['iteration']``.
+        video_search_paths: Optional list of paths to search for video files.
+
+    Returns:
+        A `LabelsSet` with ``"train"`` and ``"test"`` keys.
+    """
+    from sleap_io.io import dlc
+
+    return dlc.load_dlc_splits(
+        config,
+        shuffle=shuffle,
+        train_fraction=train_fraction,
+        iteration=iteration,
+        video_search_paths=video_search_paths,
+    )
 
 
 def load_trackmate(
@@ -1068,6 +1135,11 @@ def load_file(
             Path(filename).is_dir() and (Path(filename) / "data.yaml").exists()
         ):
             format = "ultralytics"
+        elif filename.endswith("config.yaml") or Path(filename).is_dir():
+            from sleap_io.io import dlc
+
+            if dlc._is_dlc_project_path(filename):
+                format = "dlc_project"
         elif filename.lower().endswith(".csv"):
             from sleap_io.io import dlc, trackmate
 
@@ -1105,6 +1177,8 @@ def load_file(
             return load_jabs(filename, **kwargs)
     elif format == "dlc":
         return load_dlc(filename, **kwargs)
+    elif format == "dlc_project":
+        return load_dlc_project(filename, **kwargs)
     elif format == "csv":
         return load_csv(filename, **kwargs)
     elif format == "trackmate":

--- a/tests/io/test_dlc.py
+++ b/tests/io/test_dlc.py
@@ -1,10 +1,138 @@
 """Tests for DeepLabCut I/O operations."""
 
+import pickle
+from pathlib import Path
+
 import numpy as np
 import pytest
+import yaml
 
 import sleap_io as sio
 from sleap_io.io import dlc
+from sleap_io.model.labels_set import LabelsSet
+
+
+def make_dlc_project(
+    root,
+    *,
+    scorer="LM",
+    task="proj",
+    date="Jan1",
+    iteration=0,
+    bodyparts=("snout", "leftear", "rightear"),
+    skeleton=(("snout", "leftear"), ("snout", "rightear")),
+    folders=None,
+    video_sets=None,
+    make_images=True,
+    train_indices=None,
+    test_indices=None,
+    train_fraction=0.8,
+    shuffle=1,
+    csv_scorer=None,
+):
+    """Build a minimal synthetic single-animal DLC project under ``root``.
+
+    Args:
+        root: Project root directory (created if needed).
+        scorer: Project scorer name (used for config and CSV filenames).
+        task: DLC ``Task`` name.
+        date: DLC ``date`` string.
+        iteration: DLC ``iteration`` index.
+        bodyparts: Bodypart names.
+        skeleton: Iterable of ``(src, dst)`` edge name pairs for the config.
+        folders: Mapping of ``labeled-data`` folder name to a list of image
+            basenames (without extension). Defaults to two videos.
+        video_sets: Optional explicit ``video_sets`` mapping. If `None`, built
+            from `folders` so each folder stem matches a ``<folder>.mp4`` entry.
+        make_images: Whether to write dummy image files.
+        train_indices: If given (with `test_indices`), write a Documentation
+            pickle encoding these positional split indices.
+        test_indices: Positional test indices for the Documentation pickle.
+        train_fraction: Training fraction for the pickle name/contents.
+        shuffle: Shuffle index for the pickle name.
+        csv_scorer: Scorer name written into the CSV header (defaults to
+            `scorer`); set differently to simulate a scorer mismatch.
+
+    Returns:
+        The path to the project's ``config.yaml``.
+    """
+    root = Path(root)
+    if folders is None:
+        folders = {"vid1": ["img000", "img001", "img002"], "vid2": ["img000", "img001"]}
+    csv_scorer = scorer if csv_scorer is None else csv_scorer
+
+    nbp = len(bodyparts)
+    scorer_row = "scorer," + ",".join([csv_scorer] * (2 * nbp))
+    bp_row = "bodyparts," + ",".join(bp for bp in bodyparts for _ in range(2))
+    coord_row = "coords," + ",".join(["x", "y"] * nbp)
+
+    for folder, imgs in folders.items():
+        d = root / "labeled-data" / folder
+        d.mkdir(parents=True, exist_ok=True)
+        lines = [scorer_row, bp_row, coord_row]
+        for i, img in enumerate(imgs):
+            vals = ",".join(str(v) for v in range(i * 100, i * 100 + 2 * nbp))
+            lines.append(f"labeled-data/{folder}/{img}.png,{vals}")
+        (d / f"CollectedData_{scorer}.csv").write_text("\n".join(lines) + "\n")
+        if make_images:
+            for img in imgs:
+                (d / f"{img}.png").write_text("dummy")
+
+    if video_sets is None:
+        video_sets = {
+            str(root / "videos" / f"{folder}.mp4"): {"crop": "0, 100, 0, 100"}
+            for folder in folders
+        }
+
+    cfg = {
+        "Task": task,
+        "scorer": scorer,
+        "date": date,
+        "iteration": iteration,
+        "multianimalproject": False,
+        "video_sets": video_sets,
+        "bodyparts": list(bodyparts),
+        "skeleton": [list(e) for e in skeleton],
+        "TrainingFraction": [train_fraction],
+    }
+    (root / "config.yaml").write_text(yaml.safe_dump(cfg))
+
+    if train_indices is not None and test_indices is not None:
+        tdir = (
+            root
+            / "training-datasets"
+            / f"iteration-{iteration}"
+            / f"UnaugmentedDataSet_{task}{date}"
+        )
+        tdir.mkdir(parents=True, exist_ok=True)
+        first_folder = list(folders)[0]
+        data = [
+            {"image": ("labeled-data", first_folder, f"{folders[first_folder][0]}.png")}
+        ]
+        name = (
+            f"Documentation_data-{task}_{int(round(train_fraction * 100))}"
+            f"shuffle{shuffle}.pickle"
+        )
+        with open(tdir / name, "wb") as f:
+            pickle.dump(
+                [data, list(train_indices), list(test_indices), train_fraction],
+                f,
+                pickle.HIGHEST_PROTOCOL,
+            )
+
+    return root / "config.yaml"
+
+
+def _frame_keys(labels):
+    """Return sorted ``(folder, filename)`` keys for a Labels' frames."""
+    keys = []
+    for lf in labels.labeled_frames:
+        fname = lf.video.filename
+        if isinstance(fname, list):
+            fname = fname[lf.frame_idx]
+        p = Path(str(fname))
+        keys.append((p.parent.name, p.name))
+    return sorted(keys)
 
 
 def test_is_dlc_file(dlc_maudlc_testdata, dlc_testdata):
@@ -341,3 +469,652 @@ def test_dlc_with_nested_path_structure(tmp_path):
     labels2 = sio.load_file(csv_parent_path)
     assert len(labels2.labeled_frames) == 3
     assert len(labels2.videos) == 1
+
+
+# -----------------------------------------------------------------------------
+# Config parsing and discovery
+# -----------------------------------------------------------------------------
+
+
+def test_read_dlc_config_valid(dlc_config):
+    """Reading a valid DLC config returns the expected mapping."""
+    cfg = dlc._read_dlc_config(dlc_config)
+    assert isinstance(cfg, dict)
+    assert cfg["Task"] == "maudlc_2.3.0"
+    assert "video_sets" in cfg
+    assert cfg["skeleton"] == [["A", "B"], ["B", "C"], ["A", "C"]]
+
+
+def test_read_dlc_config_missing(tmp_path):
+    """A missing config file warns and returns None."""
+    with pytest.warns(UserWarning):
+        assert dlc._read_dlc_config(tmp_path / "nope.yaml") is None
+
+
+def test_read_dlc_config_non_mapping(tmp_path):
+    """A YAML file that is not a mapping warns and returns None."""
+    bad = tmp_path / "config.yaml"
+    bad.write_text("- just\n- a\n- list\n")
+    with pytest.warns(UserWarning):
+        assert dlc._read_dlc_config(bad) is None
+
+
+def test_looks_like_dlc_config():
+    """DLC config detection requires multiple characteristic keys."""
+    assert dlc._looks_like_dlc_config({"video_sets": {}, "bodyparts": []})
+    assert not dlc._looks_like_dlc_config({"bodyparts": []})
+    assert not dlc._looks_like_dlc_config(["not", "a", "dict"])
+
+
+def test_discover_config_walks_up(tmp_path):
+    """Auto-discovery finds config.yaml two levels above the CSV."""
+    config_path = make_dlc_project(tmp_path)
+    csv = tmp_path / "labeled-data" / "vid1" / "CollectedData_LM.csv"
+    found = dlc._discover_config(csv)
+    assert found is not None
+    assert Path(found) == Path(config_path)
+
+
+def test_discover_config_none_when_absent(tmp_path):
+    """Auto-discovery returns None when no config.yaml is in range."""
+    csv = tmp_path / "labeled-data" / "vid1" / "data.csv"
+    csv.parent.mkdir(parents=True)
+    csv.write_text("scorer,A\n")
+    assert dlc._discover_config(csv) is None
+
+
+def test_discover_config_rejects_non_dlc_yaml(tmp_path):
+    """A config.yaml that is not a DLC config is rejected by discovery."""
+    (tmp_path / "config.yaml").write_text(yaml.safe_dump({"unrelated": 1}))
+    csv = tmp_path / "labeled-data" / "vid1" / "data.csv"
+    csv.parent.mkdir(parents=True)
+    csv.write_text("scorer,A\n")
+    assert dlc._discover_config(csv) is None
+
+
+# -----------------------------------------------------------------------------
+# Item 4: skeleton edges from config
+# -----------------------------------------------------------------------------
+
+
+def test_load_dlc_edges_from_explicit_config(dlc_maudlc_testdata, dlc_config):
+    """Skeleton edges are imported from an explicit config; nodes unchanged."""
+    labels = sio.load_dlc(dlc_maudlc_testdata, config=dlc_config)
+    skel = labels.skeleton
+    assert set(skel.node_names) == {"A", "B", "C", "D", "E"}  # nodes unchanged
+    assert skel.edge_names == [("A", "B"), ("B", "C"), ("A", "C")]
+    assert skel.name == "maudlc_2.3.0"
+
+
+def test_load_dlc_no_config_has_no_edges(dlc_maudlc_testdata):
+    """Without a config, no edges are added (backward compatible)."""
+    labels = sio.load_dlc(dlc_maudlc_testdata, config=False)
+    assert labels.skeleton.edges == []
+
+
+def test_load_dlc_config_false_disables_discovery(tmp_path):
+    """config=False reproduces legacy output even inside a project."""
+    make_dlc_project(tmp_path)
+    csv = tmp_path / "labeled-data" / "vid1" / "CollectedData_LM.csv"
+    labels = sio.load_dlc(csv, config=False)
+    assert labels.skeleton.edges == []
+
+
+def test_load_dlc_autodiscovers_config(tmp_path):
+    """config=None auto-discovers config.yaml and attaches edges."""
+    make_dlc_project(tmp_path)
+    csv = tmp_path / "labeled-data" / "vid1" / "CollectedData_LM.csv"
+    labels = sio.load_dlc(csv)  # default config=None -> auto-discover
+    assert labels.skeleton.edge_names == [("snout", "leftear"), ("snout", "rightear")]
+
+
+def test_edges_referencing_absent_bodypart_dropped(tmp_path):
+    """Edges naming a bodypart absent from the data are dropped with a warning."""
+    config_path = make_dlc_project(
+        tmp_path,
+        skeleton=(("snout", "leftear"), ("snout", "ghost")),
+    )
+    with pytest.warns(UserWarning, match="ghost"):
+        labels = sio.load_dlc_project(config_path)
+    assert labels.skeleton.edge_names == [("snout", "leftear")]
+
+
+def test_empty_skeleton_config_no_edges(tmp_path):
+    """An empty config skeleton yields no edges and no error."""
+    config_path = make_dlc_project(tmp_path, skeleton=())
+    labels = sio.load_dlc_project(config_path)
+    assert labels.skeleton.edges == []
+
+
+def test_malformed_skeleton_entry_skipped(tmp_path):
+    """Malformed skeleton entries (not 2-tuples) are skipped defensively."""
+    skel = sio.Skeleton(nodes=["snout", "leftear"])
+    cfg = {
+        "Task": "t",
+        "skeleton": [["snout", "leftear"], ["snout"], "bad", ["a", "b", "c"]],
+    }
+    with pytest.warns(UserWarning):
+        dlc._attach_config_skeleton(skel, cfg)
+    assert skel.edge_names == [("snout", "leftear")]
+
+
+# -----------------------------------------------------------------------------
+# Item 3: source video links from video_sets
+# -----------------------------------------------------------------------------
+
+
+def test_source_video_linked_by_stem(tmp_path):
+    """Each image folder is linked to its source video matched by stem."""
+    config_path = make_dlc_project(tmp_path)
+    labels = sio.load_dlc_project(config_path)
+    by_folder = {Path(v.filename[0]).parent.name: v for v in labels.videos}
+    assert by_folder["vid1"].source_video is not None
+    assert Path(by_folder["vid1"].source_video.filename).name == "vid1.mp4"
+    assert by_folder["vid1"].original_video is not None
+
+
+def test_source_video_none_on_stem_mismatch(tmp_path):
+    """A folder whose name does not match any video stem gets no source link."""
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"video": ["img000", "img001"]},
+        video_sets={str(tmp_path / "videos" / "different_name.mp4"): {}},
+    )
+    labels = sio.load_dlc_project(config_path)
+    assert labels.videos[0].source_video is None
+
+
+def test_source_video_placeholder_skipped(tmp_path):
+    """Placeholder video_sets entries are skipped."""
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000"]},
+        video_sets={
+            "WILL BE AUTOMATICALLY UPDATED BY DEMO CODE": {"crop": "0, 1, 0, 1"}
+        },
+    )
+    labels = sio.load_dlc_project(config_path)
+    assert labels.videos[0].source_video is None
+
+
+def test_source_video_windows_path_stem(tmp_path):
+    """Windows backslash video paths have their stem extracted correctly."""
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000"]},
+        video_sets={r"D:\data\videos\vid1.mp4": {"crop": "0, 1, 0, 1"}},
+    )
+    labels = sio.load_dlc_project(config_path)
+    assert labels.videos[0].source_video is not None
+    assert labels.videos[0].source_video.filename == r"D:\data\videos\vid1.mp4"
+
+
+def test_source_video_search_path_repair(tmp_path):
+    """video_search_paths repairs the original path by basename when present."""
+    vids = tmp_path / "found_videos"
+    vids.mkdir()
+    (vids / "vid1.mp4").write_text("dummy")
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000"]},
+        video_sets={r"X:\missing\vid1.mp4": {}},
+    )
+    labels = sio.load_dlc_project(config_path, video_search_paths=[vids])
+    assert Path(labels.videos[0].source_video.filename) == vids / "vid1.mp4"
+
+
+# -----------------------------------------------------------------------------
+# load_dlc_project + load_file routing
+# -----------------------------------------------------------------------------
+
+
+def test_load_dlc_project_merges_videos(tmp_path):
+    """A multi-video project merges into one Labels with a single skeleton."""
+    config_path = make_dlc_project(tmp_path)
+    labels = sio.load_dlc_project(config_path)
+    assert len(labels.skeletons) == 1
+    # Edges deduped to the config's 2 edges, not duplicated per video.
+    assert len(labels.skeleton.edges) == 2
+    assert len(labels.videos) == 2
+    assert len(labels.labeled_frames) == 5  # 3 + 2
+    assert labels.provenance["dlc_scorer"] == "LM"
+    assert labels.provenance["dlc_task"] == "proj"
+    assert "dlc_project" in labels.provenance
+
+
+def test_load_dlc_project_from_directory(tmp_path):
+    """A project directory can be passed directly."""
+    make_dlc_project(tmp_path)
+    labels = sio.load_dlc_project(tmp_path)
+    assert len(labels.videos) == 2
+
+
+def test_load_dlc_project_directory_no_config(tmp_path):
+    """A directory without config.yaml raises a clear error."""
+    with pytest.raises(FileNotFoundError):
+        dlc._resolve_project_config_path(tmp_path)
+
+
+def test_load_dlc_project_no_csvs(tmp_path):
+    """A project with no annotation CSVs raises a clear error."""
+    (tmp_path / "labeled-data").mkdir()
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"Task": "t", "scorer": "LM", "video_sets": {}, "bodyparts": []})
+    )
+    with pytest.raises(ValueError, match="No DLC annotation CSVs"):
+        sio.load_dlc_project(tmp_path / "config.yaml")
+
+
+def test_load_dlc_project_skips_non_dlc_csv(tmp_path):
+    """A non-DLC CSV in a labeled-data folder is ignored during discovery."""
+    config_path = make_dlc_project(tmp_path, folders={"vid1": ["img000"]})
+    # Drop a non-DLC CSV into a new folder with a non-standard scorer name.
+    extra = tmp_path / "labeled-data" / "vid2"
+    extra.mkdir()
+    (extra / "notes.csv").write_text("a,b,c\n1,2,3\n")
+    labels = sio.load_dlc_project(config_path)
+    # Only the real DLC folder is loaded.
+    assert len(labels.videos) == 1
+
+
+def test_load_file_routes_dlc_project_dir(tmp_path):
+    """load_file routes a DLC project directory to load_dlc_project."""
+    make_dlc_project(tmp_path)
+    labels = sio.load_file(str(tmp_path))
+    assert isinstance(labels, sio.Labels)
+    assert len(labels.videos) == 2
+    assert len(labels.skeleton.edges) == 2
+
+
+def test_load_file_routes_config_yaml(tmp_path):
+    """load_file routes a config.yaml path to load_dlc_project."""
+    config_path = make_dlc_project(tmp_path)
+    labels = sio.load_file(str(config_path))
+    assert isinstance(labels, sio.Labels)
+    assert len(labels.videos) == 2
+
+
+def test_is_dlc_project_path(tmp_path):
+    """Project path detection accepts dirs and config.yaml, rejects others."""
+    config_path = make_dlc_project(tmp_path)
+    assert dlc._is_dlc_project_path(tmp_path)
+    assert dlc._is_dlc_project_path(config_path)
+    assert not dlc._is_dlc_project_path(tmp_path / "labeled-data" / "vid1")
+    # A non-config file and a nonexistent path are not DLC projects.
+    other = tmp_path / "notes.txt"
+    other.write_text("hi")
+    assert not dlc._is_dlc_project_path(other)
+    assert not dlc._is_dlc_project_path(tmp_path / "does_not_exist")
+
+
+# -----------------------------------------------------------------------------
+# Item 1: training-set splits
+# -----------------------------------------------------------------------------
+
+
+def test_load_dlc_splits_maps_frames(tmp_path):
+    """Train/test indices map to the correct frames via the merged order."""
+    # Merged lexicographic order of (folder, filename):
+    #   0:(vid1,img000) 1:(vid1,img001) 2:(vid1,img002) 3:(vid2,img000) 4:(vid2,img001)
+    config_path = make_dlc_project(
+        tmp_path, train_indices=[0, 2, 4], test_indices=[1, 3]
+    )
+    splits = sio.load_dlc_splits(config_path)
+    assert isinstance(splits, LabelsSet)
+    assert set(splits.labels.keys()) == {"train", "test"}
+    assert _frame_keys(splits["train"]) == [
+        ("vid1", "img000.png"),
+        ("vid1", "img002.png"),
+        ("vid2", "img001.png"),
+    ]
+    assert _frame_keys(splits["test"]) == [
+        ("vid1", "img001.png"),
+        ("vid2", "img000.png"),
+    ]
+
+
+def test_load_dlc_splits_filters_negative_indices(tmp_path):
+    """Sentinel -1 indices are filtered out of the splits."""
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+        train_indices=[0, -1],
+        test_indices=[1],
+    )
+    splits = sio.load_dlc_splits(config_path)
+    assert _frame_keys(splits["train"]) == [("vid1", "img000.png")]
+    assert _frame_keys(splits["test"]) == [("vid1", "img001.png")]
+
+
+def test_load_dlc_splits_lexicographic_order(tmp_path):
+    """Non-zero-padded filenames follow DLC's lexicographic order, with a warning."""
+    # Lexicographically, "img10.png" < "img2.png", so position 0 is img10.
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img2", "img10"]},
+        video_sets={str(tmp_path / "videos" / "vid1.mp4"): {}},
+        train_indices=[0],
+        test_indices=[1],
+    )
+    with pytest.warns(UserWarning, match="lexicographic"):
+        splits = sio.load_dlc_splits(config_path)
+    assert _frame_keys(splits["train"]) == [("vid1", "img10.png")]
+    assert _frame_keys(splits["test"]) == [("vid1", "img2.png")]
+
+
+def test_load_dlc_splits_missing_pickle(tmp_path):
+    """A project without a Documentation pickle raises FileNotFoundError."""
+    config_path = make_dlc_project(tmp_path)  # no train/test indices -> no pickle
+    with pytest.raises(FileNotFoundError):
+        sio.load_dlc_splits(config_path)
+
+
+def test_load_dlc_splits_ambiguous_requires_selector(tmp_path):
+    """Multiple shuffles require an explicit selector."""
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+        train_indices=[0],
+        test_indices=[1],
+        shuffle=1,
+    )
+    # Add a second shuffle pickle.
+    make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+        train_indices=[1],
+        test_indices=[0],
+        shuffle=2,
+    )
+    with pytest.raises(ValueError, match="Multiple DLC splits"):
+        sio.load_dlc_splits(config_path)
+    # Selecting a shuffle disambiguates.
+    splits = sio.load_dlc_splits(config_path, shuffle=2)
+    assert _frame_keys(splits["train"]) == [("vid1", "img001.png")]
+
+
+def test_load_dlc_splits_selector_no_match(tmp_path):
+    """A selector that matches nothing raises FileNotFoundError."""
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+        train_indices=[0],
+        test_indices=[1],
+        shuffle=1,
+    )
+    with pytest.raises(FileNotFoundError):
+        sio.load_dlc_splits(config_path, shuffle=99)
+
+
+def test_read_dlc_split_reads_indices(tmp_path):
+    """_read_dlc_split returns train/test indices from meta[1]/meta[2]."""
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+        train_indices=[0],
+        test_indices=[1],
+    )
+    project_dir = Path(config_path).parent
+    cfg = dlc._read_dlc_config(config_path)
+    pkl = dlc._select_documentation_pickle(project_dir, cfg, None, None, None)
+    train, test = dlc._read_dlc_split(pkl)
+    assert train == [0]
+    assert test == [1]
+
+
+def test_dlc_merged_order_skips_scorer_mismatch(tmp_path):
+    """Folders labeled by a different scorer are skipped in the merged order."""
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+    )
+    # Add a second folder whose CSV scorer does not match the project scorer.
+    make_dlc_project(
+        tmp_path,
+        folders={"vid2": ["img000"]},
+        video_sets={
+            str(tmp_path / "videos" / "vid1.mp4"): {},
+            str(tmp_path / "videos" / "vid2.mp4"): {},
+        },
+        csv_scorer="OtherScorer",
+    )
+    cfg = dlc._read_dlc_config(config_path)
+    with pytest.warns(UserWarning, match="different scorer|OtherScorer|scorer"):
+        merged = dlc._dlc_merged_order(tmp_path, cfg)
+    # Only vid1's two frames are included; vid2 (mismatched scorer) is skipped.
+    assert ("vid2", "img000.png") not in merged
+    assert ("vid1", "img000.png") in merged
+
+
+def make_dlc_ma_project(
+    root,
+    *,
+    scorer="LM",
+    task="maproj",
+    date="Jan1",
+    folders=None,
+    train_indices=None,
+    test_indices=None,
+):
+    """Build a minimal synthetic multi-animal DLC project under ``root``."""
+    root = Path(root)
+    if folders is None:
+        folders = {"m1": ["img000", "img001"], "m2": ["img000"]}
+    individuals = ["Animal1", "Animal2"]
+    bodyparts = ["A", "B"]
+
+    scorer_cells, ind_cells, bp_cells, coord_cells = [], [], [], []
+    for ind in individuals:
+        for bp in bodyparts:
+            for c in ["x", "y"]:
+                scorer_cells.append(scorer)
+                ind_cells.append(ind)
+                bp_cells.append(bp)
+                coord_cells.append(c)
+    ncol = len(scorer_cells)
+    rows = [
+        "scorer," + ",".join(scorer_cells),
+        "individuals," + ",".join(ind_cells),
+        "bodyparts," + ",".join(bp_cells),
+        "coords," + ",".join(coord_cells),
+    ]
+
+    for folder, imgs in folders.items():
+        d = root / "labeled-data" / folder
+        d.mkdir(parents=True, exist_ok=True)
+        lines = list(rows)
+        for i, img in enumerate(imgs):
+            vals = ",".join(str(v) for v in range(i * 100, i * 100 + ncol))
+            lines.append(f"labeled-data/{folder}/{img}.png,{vals}")
+        (d / f"CollectedData_{scorer}.csv").write_text("\n".join(lines) + "\n")
+        for img in imgs:
+            (d / f"{img}.png").write_text("dummy")
+
+    cfg = {
+        "Task": task,
+        "scorer": scorer,
+        "date": date,
+        "iteration": 0,
+        "multianimalproject": True,
+        "video_sets": {str(root / "videos" / f"{f}.mp4"): {} for f in folders},
+        "individuals": individuals,
+        "multianimalbodyparts": bodyparts,
+        "bodyparts": "MULTI!",
+        "skeleton": [["A", "B"]],
+        "TrainingFraction": [0.8],
+    }
+    (root / "config.yaml").write_text(yaml.safe_dump(cfg))
+
+    if train_indices is not None and test_indices is not None:
+        tdir = (
+            root
+            / "training-datasets"
+            / "iteration-0"
+            / f"UnaugmentedDataSet_{task}{date}"
+        )
+        tdir.mkdir(parents=True)
+        with open(tdir / f"Documentation_data-{task}_80shuffle1.pickle", "wb") as f:
+            pickle.dump(
+                [[], list(train_indices), list(test_indices), 0.8],
+                f,
+                pickle.HIGHEST_PROTOCOL,
+            )
+    return root / "config.yaml"
+
+
+def test_load_dlc_csv_shared_skeleton_default_tracks(tmp_path):
+    """_load_dlc_csv with a shared skeleton but no tracks defaults tracks to []."""
+    make_dlc_project(tmp_path, folders={"vid1": ["img000"]})
+    skel = sio.Skeleton(nodes=["leftear", "rightear", "snout"])
+    csv = tmp_path / "labeled-data" / "vid1" / "CollectedData_LM.csv"
+    labels = dlc._load_dlc_csv(csv, skeleton=skel)
+    assert labels.skeleton is skel
+    assert labels.tracks == []
+
+
+def test_load_dlc_project_multianimal(tmp_path):
+    """A multi-animal project loads with shared skeleton, edges, and tracks."""
+    config_path = make_dlc_ma_project(tmp_path)
+    labels = sio.load_dlc_project(config_path)
+    assert len(labels.skeletons) == 1
+    assert set(labels.skeleton.node_names) == {"A", "B"}
+    assert labels.skeleton.edge_names == [("A", "B")]
+    assert {t.name for t in labels.tracks} == {"Animal1", "Animal2"}
+    assert len(labels.videos) == 2
+
+
+def test_load_dlc_splits_multianimal(tmp_path):
+    """Splits work for a multi-animal project."""
+    # Merged order: 0:(m1,img000) 1:(m1,img001) 2:(m2,img000)
+    config_path = make_dlc_ma_project(tmp_path, train_indices=[0, 2], test_indices=[1])
+    splits = sio.load_dlc_splits(config_path)
+    assert _frame_keys(splits["train"]) == [("m1", "img000.png"), ("m2", "img000.png")]
+    assert _frame_keys(splits["test"]) == [("m1", "img001.png")]
+
+
+def test_load_dlc_splits_fallback_when_stems_mismatch(tmp_path):
+    """When video_sets stems match no folder, merged order falls back to CSVs."""
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vidA": ["img000", "img001"]},
+        video_sets={str(tmp_path / "videos" / "unrelated.mp4"): {}},
+        train_indices=[0],
+        test_indices=[1],
+    )
+    splits = sio.load_dlc_splits(config_path)
+    assert _frame_keys(splits["train"]) == [("vidA", "img000.png")]
+    assert _frame_keys(splits["test"]) == [("vidA", "img001.png")]
+
+
+def test_load_dlc_splits_select_by_train_fraction(tmp_path):
+    """A train_fraction selector filters the available pickles."""
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+        train_indices=[0],
+        test_indices=[1],
+        train_fraction=0.8,
+    )
+    splits = sio.load_dlc_splits(config_path, train_fraction=0.8)
+    assert _frame_keys(splits["train"]) == [("vid1", "img000.png")]
+
+
+def test_select_documentation_pickle_unparseable_single(tmp_path):
+    """A single pickle with an unparseable name is returned as-is."""
+    config_path = make_dlc_project(tmp_path, folders={"vid1": ["img000"]})
+    cfg = dlc._read_dlc_config(config_path)
+    tdir = (
+        tmp_path / "training-datasets" / "iteration-0" / "UnaugmentedDataSet_projJan1"
+    )
+    tdir.mkdir(parents=True)
+    p = tdir / "Documentation_data-weirdname.pickle"
+    with open(p, "wb") as f:
+        pickle.dump([[], [0], [], 0.8], f)
+    assert dlc._select_documentation_pickle(tmp_path, cfg, None, None, None) == p
+
+
+def test_select_documentation_pickle_unparseable_ambiguous(tmp_path):
+    """Multiple pickles with unparseable names raise a clear error."""
+    config_path = make_dlc_project(tmp_path, folders={"vid1": ["img000"]})
+    cfg = dlc._read_dlc_config(config_path)
+    tdir = (
+        tmp_path / "training-datasets" / "iteration-0" / "UnaugmentedDataSet_projJan1"
+    )
+    tdir.mkdir(parents=True)
+    for name in ["Documentation_data-a.pickle", "Documentation_data-b.pickle"]:
+        with open(tdir / name, "wb") as f:
+            pickle.dump([[], [0], [], 0.8], f)
+    with pytest.raises(ValueError, match="Could not parse"):
+        dlc._select_documentation_pickle(tmp_path, cfg, None, None, None)
+
+
+def test_find_project_csvs_fallback_nonstandard_name(tmp_path):
+    """A DLC CSV not named CollectedData_<scorer> is found via glob fallback."""
+    config_path = make_dlc_project(tmp_path, folders={"vid1": ["img000"]})
+    d = tmp_path / "labeled-data" / "vid2"
+    d.mkdir()
+    (d / "img000.png").write_text("dummy")
+    (d / "mydata.csv").write_text(
+        "scorer,LM,LM,LM,LM,LM,LM\n"
+        "bodyparts,snout,snout,leftear,leftear,rightear,rightear\n"
+        "coords,x,y,x,y,x,y\n"
+        "labeled-data/vid2/img000.png,0,1,2,3,4,5\n"
+    )
+    labels = sio.load_dlc_project(config_path)
+    assert len(labels.videos) == 2
+
+
+def test_find_project_csvs_skips_files_in_labeled_data(tmp_path):
+    """Stray files directly under labeled-data/ are ignored."""
+    config_path = make_dlc_project(tmp_path, folders={"vid1": ["img000"]})
+    (tmp_path / "labeled-data" / "stray.txt").write_text("ignore me")
+    labels = sio.load_dlc_project(config_path)
+    assert len(labels.videos) == 1
+
+
+def test_load_dlc_project_unreadable_config(tmp_path):
+    """A config.yaml that is not a mapping raises a clear error."""
+    (tmp_path / "labeled-data").mkdir()
+    (tmp_path / "config.yaml").write_text("- a\n- b\n")
+    with pytest.warns(UserWarning):
+        with pytest.raises(ValueError, match="Could not read DLC config"):
+            sio.load_dlc_project(tmp_path / "config.yaml")
+
+
+def test_load_dlc_project_no_labeled_data_dir(tmp_path):
+    """A project with no labeled-data directory raises a clear error."""
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump({"Task": "t", "scorer": "LM", "video_sets": {}, "bodyparts": []})
+    )
+    with pytest.raises(ValueError, match="No DLC annotation CSVs"):
+        sio.load_dlc_project(tmp_path / "config.yaml")
+
+
+def test_load_dlc_splits_unreadable_config(tmp_path):
+    """load_dlc_splits raises a clear error when the config is not a mapping."""
+    (tmp_path / "labeled-data").mkdir()
+    (tmp_path / "config.yaml").write_text("- a\n- b\n")
+    with pytest.warns(UserWarning):
+        with pytest.raises(ValueError, match="Could not read DLC config"):
+            sio.load_dlc_splits(tmp_path / "config.yaml")
+
+
+def test_load_dlc_image_resolved_from_parent_dir(tmp_path):
+    """Images one directory above the CSV are resolved (parent-path fallback)."""
+    # CSV lives in a subdir; images live under <project>/labeled-data/session1/.
+    (tmp_path / "labeled-data" / "session1").mkdir(parents=True)
+    for i in range(2):
+        (tmp_path / "labeled-data" / "session1" / f"img{i:03d}.png").write_text("x")
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    csv = subdir / "data.csv"
+    csv.write_text(
+        "scorer,S,S,S,S,S,S\n"
+        "bodyparts,A,A,B,B,C,C\n"
+        "coords,x,y,x,y,x,y\n"
+        "labeled-data/session1/img000.png,0,1,2,3,4,5\n"
+        "labeled-data/session1/img001.png,6,7,8,9,10,11\n"
+    )
+    labels = sio.load_dlc(csv, config=False)
+    assert len(labels.labeled_frames) == 2
+    assert len(labels.videos) == 1

--- a/tests/io/test_dlc.py
+++ b/tests/io/test_dlc.py
@@ -1019,8 +1019,8 @@ def test_load_dlc_splits_select_by_train_fraction(tmp_path):
     assert _frame_keys(splits["train"]) == [("vid1", "img000.png")]
 
 
-def test_select_documentation_pickle_unparseable_single(tmp_path):
-    """A single pickle with an unparseable name is returned as-is."""
+def test_select_documentation_pickle_unparsable_single(tmp_path):
+    """A single pickle with an unparsable name is returned as-is."""
     config_path = make_dlc_project(tmp_path, folders={"vid1": ["img000"]})
     cfg = dlc._read_dlc_config(config_path)
     tdir = (
@@ -1033,8 +1033,8 @@ def test_select_documentation_pickle_unparseable_single(tmp_path):
     assert dlc._select_documentation_pickle(tmp_path, cfg, None, None, None) == p
 
 
-def test_select_documentation_pickle_unparseable_ambiguous(tmp_path):
-    """Multiple pickles with unparseable names raise a clear error."""
+def test_select_documentation_pickle_unparsable_ambiguous(tmp_path):
+    """Multiple pickles with unparsable names raise a clear error."""
     config_path = make_dlc_project(tmp_path, folders={"vid1": ["img000"]})
     cfg = dlc._read_dlc_config(config_path)
     tdir = (


### PR DESCRIPTION
## Summary

Implements items **1, 3, and 4** of #424, improving DeepLabCut project import. When a DLC project `config.yaml` is available, `load_dlc` now imports additional project metadata, and two new entry points load whole projects and their training splits.

Addresses items 1, 3, 4 of #424. **Item 2 (cropping) is deferred** — DLC's `video_sets[...].crop` is a *virtual read-time crop* (an ROI sliced out of each full frame by DLC's video reader). sleap-io already has the `ROI` primitive; what it lacks is the ability to apply an ROI as a virtual crop on a `Video` on read. Until that lands, this PR imports the source-video link but not the crop (see the caveat under Item 3 below).

## Key Changes

### Item 4 — Skeleton edges from `config.yaml`
Edges in the config `skeleton:` list are parsed onto the imported `Skeleton`. Resolution is strictly **name-based**, and edges referencing bodyparts not present in the labeled data are **dropped with a warning** (nodes are never injected, so point-array alignment is preserved).

### Item 3 — Link image folders back to original videos
Each `labeled-data/<video>/` image folder is linked to its original video file from the config `video_sets` via `Video.source_video`, matched by filename **stem**. The link is best-effort: it's left unset on a stem mismatch, placeholder entry, or missing file, and uses `Video(open_backend=False)` so a missing `.mp4` never raises at import. Windows-style paths in `video_sets` are handled.

> **Cropping caveat.** `source_video` points at the original, **uncropped** video. For projects that use `video_sets` cropping, the `labeled-data` images are the cropped region and the labels are in cropped-frame coordinates, so they are offset from the source video by the crop origin `(x1, y1)`. The crop itself is **not** applied (item 2 — virtual ROI cropping). For the common no-crop case (the DLC default is the full frame), there is no offset and the link is exact.

### Item 1 — Train/test splits
`load_dlc_splits()` recovers the splits created by DLC's `create_training_dataset`. DLC stores split membership as **positional indices into a globally, lexicographically `sort_index()`-ed merge** of all per-video annotations, so the importer reconstructs that exact order (replicating DLC's merge skip-rules: config order, skipping folders whose annotation file is missing or is labeled by a different scorer) and maps the indices from `Documentation_data-*.pickle` (`meta[1]`/`meta[2]`) to a `LabelsSet`. `meta[0]` is intentionally ignored (it's the lossy train-only record list). A warning is emitted for non-zero-padded filenames, where lexicographic and numeric orderings diverge.

### Supporting changes
- New `load_dlc_project(config)` loads and merges a whole project into one `Labels` sharing a single `Skeleton` (with edges) and `Track` set, recording provenance (`dlc_project`, `dlc_scorer`, `dlc_task`).
- `load_dlc` gains a `config` keyword: `None` (default) auto-discovers `config.yaml` by walking up from the CSV; an explicit path forces a config; `False` reproduces strict legacy output.
- `load_file` now detects and routes DLC project directories / `config.yaml` to `load_dlc_project`.
- New top-level exports: `sio.load_dlc_project`, `sio.load_dlc_splits`.

## Example Usage

```python
import sleap_io as sio

# Single CSV — auto-discovers config.yaml for edges + source-video links.
labels = sio.load_dlc("project/labeled-data/vid1/CollectedData_Scorer.csv")

# Strict legacy output (no edges/links).
labels = sio.load_dlc(csv_path, config=False)

# Whole project (dir or config.yaml); also works via load_file.
labels = sio.load_dlc_project("path/to/dlc_project")
labels = sio.load_file("path/to/dlc_project")

# Train/test splits -> LabelsSet.
splits = sio.load_dlc_splits("path/to/dlc_project", shuffle=1)
train, test = splits["train"], splits["test"]
```

## API Changes

- `load_dlc(filename, video_search_paths=None, config=None, **kwargs)` — added `config` keyword. **Behavior change:** when a config is found (default auto-discovery), the returned `Labels` now gains skeleton edges and `Video.source_video` links that were previously absent. Pass `config=False` for the prior behavior.
- New `load_dlc_project(config, video_search_paths=None) -> Labels`.
- New `load_dlc_splits(config, shuffle=None, train_fraction=None, iteration=None, video_search_paths=None) -> LabelsSet`.
- `load_file` routes DLC project directories and `config.yaml` files.

## Testing

- All 21 pre-existing DLC tests pass unchanged (the no-config path is behavior-preserving).
- Added focused tests covering config parsing/discovery, edges (incl. drop-and-warn and empty/malformed configs), source-video linking (stem match/mismatch, placeholder, Windows paths, search-path repair), project loading + `load_file` routing (single- and multi-animal), and splits (frame-mapping correctness, lexicographic vs numeric ordering, `-1` filtering, scorer-mismatch skip, selector disambiguation, missing pickle).
- `sleap_io/io/dlc.py` coverage 97.3% (remaining misses are pre-existing defensive branches in the unchanged pose-parsing helpers).
- Fixtures are **synthesized** (config + labeled-data tree + byte-authentic `Documentation` pickle via pure `pandas`/`numpy`/`pickle`) — no DLC install needed, and no LGPL example data vendored into this BSD-3 repo.

## Design Decisions

- **Filter-and-warn for edges** rather than passing edges to the `Skeleton` constructor (which raises on an unknown endpoint) or `add_edges` blindly (which would inject phantom nodes and break point-array alignment).
- **Reconstruct DLC's merged order** for splits rather than trusting `meta[0]`; the split indices are positional into the global `sort_index()` merge, which is incompatible with the loader's per-video numeric frame ordering.
- **`load_dlc_splits` returns a `LabelsSet`** (mirroring `make_training_splits`) instead of overloading `load_dlc_project`'s return type.
- **Synthesized fixtures** chosen over vendoring DeepLabCut's example projects, since DLC is LGPL-3.0 and sleap-io is BSD-3-Clause, and the examples ship no `Documentation` pickle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
