### PR TITLE
chore(release): Bump version to 0.8.0

### DIFF
--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -3,4 +3,4 @@
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release
 # version.
-__version__ = "0.7.1"
+__version__ = "0.8.0"


### PR DESCRIPTION
@
## Summary

Bumps the package version from `0.7.1` to `0.8.0` in `sleap_io/version.py` to cut a new minor release.

The minor bump reflects new features and a behavior-changing default landed since `v0.7.1`.

## Changes since v0.7.1

**Features**
- Import DLC project metadata — edges, source videos, splits (#450)
- Default `Labels.merge` track matching to identity, not name (#449) — ⚠️ behavior change
- Warn on spatially-divergent track-name merge collisions (#448)
- Load `.slp` from URLs and cloud buckets via fsspec (#439)
- Remote video loading via PyAV (#442)
- Google Drive share-link loading (#441)

**Fixes**
- Structural skeleton dedup in `Labels.update/append/extend` (#447)
- Raise helpful error when SLP metadata JSON attribute is missing (#446)
- Harden remote URL loading — auth, handle lifecycle, Drive caps, fsspec cache (#445)
- Preserve edge-less nodes in `SkeletonEncoder` JSON output (#438)

**Docs**
- Add Remote loading guide — URLs, cloud, Google Drive, video (#444)

## Testing

Version is read dynamically by setuptools via `pyproject.toml` (`version = {attr = "sleap_io.version.__version__"}`); no functional code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@