### PR TITLE
fix(docs): repair non-runnable examples and guard pycon blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -27,6 +28,13 @@ jobs:
               - 'tests/**'
               - '.github/workflows/ci.yml'
               - 'pyproject.toml'
+            docs:
+              - 'docs/**'
+              - 'hooks/**'
+              - 'mkdocs.yml'
+              - 'scripts/**'
+              - 'tests/test_docs.py'
+              - '.github/workflows/ci.yml'
 
   # Lint with ruff
   lint:
@@ -111,12 +119,35 @@ jobs:
           verbose: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # Fast guard: every docs ``pycon`` block must render without a traceback, so the
+  # published docs never ship a NameError/exception. Runs on docs changes (the full
+  # test matrix above only runs on code changes), keeping doc-only PRs cheap.
+  docs-guard:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
+    name: Docs guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run docs pycon guard
+        run: uv run pytest tests/test_docs.py -q
+
   # This job aggregates all CI results into a single check for branch protection.
   # It succeeds if all jobs passed OR were correctly skipped (e.g., docs-only changes).
   ci:
     name: CI
     if: always()
-    needs: [changes, lint, tests]
+    needs: [changes, lint, tests, docs-guard]
     runs-on: ubuntu-latest
     steps:
       - name: Check CI status
@@ -124,6 +155,7 @@ jobs:
           echo "changes: ${{ needs.changes.result }}"
           echo "lint: ${{ needs.lint.result }}"
           echo "tests: ${{ needs.tests.result }}"
+          echo "docs-guard: ${{ needs.docs-guard.result }}"
 
           # Fail if any job failed or was cancelled
           if [[ "${{ needs.changes.result }}" == "failure" || "${{ needs.changes.result }}" == "cancelled" ]]; then
@@ -136,6 +168,10 @@ jobs:
           fi
           if [[ "${{ needs.tests.result }}" == "failure" || "${{ needs.tests.result }}" == "cancelled" ]]; then
             echo "::error::tests job failed or was cancelled"
+            exit 1
+          fi
+          if [[ "${{ needs.docs-guard.result }}" == "failure" || "${{ needs.docs-guard.result }}" == "cancelled" ]]; then
+            echo "::error::docs-guard job failed or was cancelled"
             exit 1
           fi
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -37,7 +37,7 @@ video = sio.load_video("test.mp4")
 
 # Create instance from numpy array
 instance = sio.Instance.from_numpy(
-    points=np.array([
+    points_data=np.array([
         [10.2, 20.4],  # head
         [5.8, 15.1],   # thorax
         [0.3, 10.6],   # abdomen

--- a/docs/install.md
+++ b/docs/install.md
@@ -513,7 +513,7 @@ Check installed backends:
 ```bash
 sio --version
 # Or in Python:
-python -c "import sleap_io; print(sleap_io.Video.backend_plugins)"
+python -c "import sleap_io; print(sleap_io.get_available_video_backends())"
 ```
 
 Install missing backends:

--- a/docs/model/regions.md
+++ b/docs/model/regions.md
@@ -732,13 +732,19 @@ Use `label_ids` to control pixel values explicitly — useful when objects
 appear/disappear across frames and you need consistent values per track:
 
 ```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> mask_a = np.zeros((64, 64), dtype=bool)
+>>> mask_b = np.zeros((64, 64), dtype=bool)
+>>> mask_a[10:30, 10:30] = True
+>>> mask_b[40:60, 40:60] = True
 >>> li = sio.PredictedLabelImage.from_binary_masks(
 ...     [mask_a, mask_b],
 ...     label_ids=[5, 10],
 ...     scores=[0.95, 0.87],
 ... )
 >>> print(li.label_ids)
-array([ 5, 10])
+[ 5 10]
 
 ```
 
@@ -806,9 +812,17 @@ Index with a `Track` to get the binary mask for that object:
 Test containment, iterate objects, or get a union mask by category:
 
 ```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> data = np.zeros((64, 64), dtype=np.int32)
+>>> data[10:30, 10:30] = 1
+>>> track = sio.Track(name="cell_A")
+>>> li = sio.UserLabelImage.from_numpy(data, tracks={1: track})
 >>> print(track in li)
+True
 >>> for track, category, mask in li.items():
 ...     print(f"{track.name}: {category}, {mask.sum()} px")
+cell_A: , 400 px
 
 ```
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,71 @@
+"""Guard tests for executable documentation code blocks.
+
+The docs build executes every ```pycon``` block via ``markdown-exec`` and the
+``hooks/markdown_exec_pycon.py`` hook, rendering the interleaved output -- including
+any *traceback* -- directly into the published HTML. Each block runs with a fresh
+set of globals, so a block that references a name defined in a previous block
+silently ships a ``NameError`` traceback to readers (see the regression where two
+``regions.md`` blocks rendered ``NameError`` into the docs).
+
+This module fails CI on a pull request if any docs ``pycon`` block raises, catching
+the regression before it reaches the (push/release-only) docs build.
+"""
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = REPO_ROOT / "docs"
+HOOK_PATH = REPO_ROOT / "hooks" / "markdown_exec_pycon.py"
+_PYCON_BLOCK = re.compile(r"```pycon\n(.*?)```", re.DOTALL)
+_TRACEBACK_MARKER = "Traceback (most recent call last)"
+
+
+def _load_pycon_hook():
+    """Import ``hooks/markdown_exec_pycon.py`` (not an installed package)."""
+    spec = importlib.util.spec_from_file_location("markdown_exec_pycon", HOOK_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _collect_pycon_blocks() -> list[tuple[Path, int, str]]:
+    """Return ``(md_file, block_index, code)`` for every docs ``pycon`` block."""
+    blocks = []
+    for md_file in sorted(DOCS_DIR.glob("**/*.md")):
+        source = md_file.read_text(encoding="utf-8")
+        for index, match in enumerate(_PYCON_BLOCK.finditer(source)):
+            blocks.append((md_file, index, match.group(1)))
+    return blocks
+
+
+_BLOCKS = _collect_pycon_blocks()
+_BLOCK_IDS = [
+    f"{md.relative_to(REPO_ROOT).as_posix()}#block{idx}" for md, idx, _ in _BLOCKS
+]
+
+
+def test_docs_have_pycon_blocks():
+    """Sanity check that block discovery is wired up (guards against a no-op suite)."""
+    assert _BLOCKS, "No docs pycon blocks found -- discovery is broken."
+
+
+@pytest.mark.parametrize("md_file, block_index, code", _BLOCKS, ids=_BLOCK_IDS)
+def test_pycon_block_renders_without_traceback(md_file, block_index, code, monkeypatch):
+    """Each docs ``pycon`` block must execute without rendering a traceback.
+
+    Blocks load fixtures via paths relative to the repo root (e.g.
+    ``tests/data/...``), so execution is pinned to the repo root, matching the
+    docs-build working directory.
+    """
+    monkeypatch.chdir(REPO_ROOT)
+    hook = _load_pycon_hook()
+    rendered = hook._run_pycon_interleaved(code)
+    assert _TRACEBACK_MARKER not in rendered, (
+        f"{md_file.relative_to(REPO_ROOT).as_posix()} pycon block #{block_index} "
+        f"renders a traceback into the published docs. Make the block self-contained "
+        f"(each block runs with fresh globals).\n\nRendered output:\n{rendered}"
+    )


### PR DESCRIPTION
## Summary

Fixes three published documentation examples that were broken, and adds a CI guard so this class of regression is caught on PRs. Found during the 0.8.0 docs audit.

## Key Changes

| Page | Bug | Fix |
|------|-----|-----|
| `docs/examples.md` | The **first** hands-on snippet called `Instance.from_numpy(points=...)` — the parameter is `points_data`, so it raised `TypeError` on copy-paste. | `points=` → `points_data=` |
| `docs/model/regions.md` | Two `pycon` blocks (label-image `from_binary_masks` / `items()`) referenced names defined only in *prior* blocks. Each `pycon` block runs with **fresh globals** (`hooks/markdown_exec_pycon.py`), so they rendered `NameError` **tracebacks directly into the published HTML**. | Made both blocks self-contained |
| `docs/install.md` | Troubleshooting told users to run `print(sleap_io.Video.backend_plugins)` — a non-existent attribute (`AttributeError`). | `get_available_video_backends()` |

## New guard

`tests/test_docs.py` discovers every `pycon` block across `docs/**/*.md`, runs each through the actual build hook, and fails if any renders `Traceback (most recent call last)`. This runs in the normal pytest CI (the `Docs` workflow only builds on push/release, so it wouldn't catch this on a PR).

## Testing

- `pytest tests/test_docs.py` → **73 passed** (72 blocks + discovery sanity check), 0.65s.
- Verified the two `regions.md` blocks produced real `NameError` tracebacks through the hook *before* the fix, and 0 tracebacks after.
- All 72 blocks execute with **zero stray files** created.

## Notes

This is the first of several focused PRs from the 0.8.0 docs audit. `regions.md` will be restructured in a follow-up (split into Centroids/Boxes/ROIs/Segmentation); this fix is decoupled because it's release-blocking and keeps the new guard green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)