### PR TITLE
docs: content & format-reference corrections (0.8.0 audit)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2726,7 +2726,7 @@ sio --version
 **Example output:**
 
 ```
-sleap-io 0.6.0
+sleap-io 0.8.0
 python 3.12.11
 
 Core:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1094,6 +1094,11 @@ How to match track identities:
 | `identity` | Match by track object identity (default). Correctness-first: never collapses distinct tracks by arbitrary tracker-assigned names |
 | `name` | Match tracks with identical names. Opt-in for semantically meaningful names (user-assigned identities or identity-classification model outputs) |
 
+!!! warning "Breaking change in 0.8.0"
+    The default changed from `name` to `identity` in v0.8.0 — tracks that merely
+    share an arbitrary name (e.g. `track_0`) are no longer merged. Pass
+    `--track name` to restore the pre-0.8.0 behavior.
+
 #### Frame Strategy (`--frame`)
 
 How to handle overlapping frames (same video and frame index in both files):

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -121,9 +121,9 @@ bbox = sio.UserBoundingBox(x1=10, y1=20, x2=100, y2=200, category="mouse")
 bbox = sio.UserBoundingBox.from_xywh(10, 20, 90, 180)  # same box
 
 # Query geometric properties
-bbox.xyxy         # (10.0, 20.0, 100.0, 200.0)
-bbox.xywh         # (10.0, 20.0, 90.0, 180.0)
-bbox.area         # 16200.0
+bbox.xyxy         # (10, 20, 100, 200)  (ints preserved from int inputs)
+bbox.xywh         # (10, 20, 90, 180)
+bbox.area         # 16200
 bbox.centroid_xy  # (55.0, 110.0)
 
 # Predictions carry a score (and optional tracking_score)

--- a/docs/formats/analysis_h5.md
+++ b/docs/formats/analysis_h5.md
@@ -37,17 +37,25 @@ analysis.h5
 │
 ├── track_names               # Dataset: Track name strings
 ├── node_names                # Dataset: Node/keypoint name strings
+├── edge_names                # Dataset: Skeleton edge name pairs
+├── edge_inds                 # Dataset: Skeleton edge node-index pairs
 ├── video_path                # Dataset: Source video path
+├── video_ind                 # Dataset: Source video index
+├── labels_path               # Dataset: Original labels file path
+├── provenance                # Dataset: Source file provenance (JSON)
 │
 ├── @format                   # Attribute: "analysis" (format identifier)
 ├── @sleap_io_version         # Attribute: sleap-io package version
 ├── @preset                   # Attribute: Axis ordering preset
-├── @provenance               # Attribute: Source file provenance (JSON)
-├── @skeleton_name            # Attribute: Skeleton name
-├── @skeleton_edges           # Attribute: Edge list (JSON)
-├── @skeleton_symmetries      # Attribute: Symmetry pairs (JSON)
-└── @labels_path              # Attribute: Original labels file path
+├── @skeleton_name            # Attribute: Skeleton name (save_metadata=True)
+├── @skeleton_symmetries      # Attribute: Symmetry pairs, JSON (save_metadata=True)
+└── @video_backend_metadata   # Attribute: Video backend metadata, JSON (save_metadata=True)
 ```
+
+!!! warning "`provenance`, `labels_path`, and the skeleton edges are datasets, not attributes"
+    Read them as `f["provenance"]`, `f["labels_path"]`, `f["edge_names"]`, and
+    `f["edge_inds"]` — **not** `f.attrs[...]`. There is no `skeleton_edges`
+    attribute.
 
 ## Axis Ordering Presets
 
@@ -121,11 +129,11 @@ Dense array of pose coordinates. Missing data is represented as `NaN`.
 
 ### `track_occupancy`
 
-Boolean array indicating which tracks have valid data per frame.
+Array indicating which tracks have valid data per frame (values are `0`/`1`).
 
 | Property | Value |
 |----------|-------|
-| Dtype | `bool` |
+| Dtype | `uint8` |
 | Shape | `(n_frames, n_tracks)` |
 
 ### `point_scores`
@@ -134,7 +142,7 @@ Per-point confidence scores from the pose estimation model.
 
 | Property | Value |
 |----------|-------|
-| Dtype | `float32` |
+| Dtype | `float64` |
 | Range | 0.0 to 1.0 |
 | Missing | `NaN` |
 
@@ -144,7 +152,7 @@ Per-instance confidence scores (average of point scores).
 
 | Property | Value |
 |----------|-------|
-| Dtype | `float32` |
+| Dtype | `float64` |
 | Range | 0.0 to 1.0 |
 | Missing | `NaN` |
 
@@ -154,9 +162,9 @@ Per-instance tracking confidence (from identity tracking models).
 
 | Property | Value |
 |----------|-------|
-| Dtype | `float32` |
+| Dtype | `float64` |
 | Range | 0.0 to 1.0 |
-| Default | 0.0 for user instances |
+| Missing/default | `NaN` (including user instances without a tracking score) |
 
 ### `track_names`
 
@@ -201,11 +209,11 @@ Source video file path.
 | `format` | string | Always `"analysis"` |
 | `sleap_io_version` | string | sleap-io package version that wrote the file |
 | `preset` | string | Axis ordering: `"matlab"`, `"standard"`, or `"custom"` |
-| `provenance` | JSON string | Source file and creation metadata |
-| `skeleton_name` | string | Skeleton name |
-| `skeleton_edges` | JSON string | Edge list as `[[src, dst], ...]` |
-| `skeleton_symmetries` | JSON string | Symmetry pairs as `[["left", "right"], ...]` |
-| `labels_path` | string | Original labels file path (optional) |
+| `skeleton_name` | string | Skeleton name (written only when `save_metadata=True`, the default) |
+| `skeleton_symmetries` | JSON string | Symmetry pairs as `[["left", "right"], ...]` (written only when `save_metadata=True`) |
+| `video_backend_metadata` | JSON string | Per-video backend metadata (written only when `save_metadata=True`) |
+
+`provenance`, `labels_path`, and the skeleton edges (`edge_names`, `edge_inds`) are stored as **datasets**, not attributes — see the [HDF5 Layout](#hdf5-layout) above.
 
 !!! note "`sleap_io_version` is a provenance stamp, not a format gate"
     This attribute records the `sleap-io` package version that wrote the file (the value of `sleap_io.__version__` at save time). It is **not** a file-format version — the Analysis HDF5 layout itself is not versioned. Downstream tools should not use this value as a semver gate for structural changes; check the presence of specific datasets or `@preset` instead.

--- a/docs/formats/csv.md
+++ b/docs/formats/csv.md
@@ -180,38 +180,35 @@ sio.save_csv(labels, "data.csv", save_metadata=True)
 
 ```json
 {
-    "format_version": "1.0",
-    "csv_format": "frames",
-    "skeleton": {
-        "name": "Skeleton-0",
-        "nodes": ["nose", "head", "neck", "tail"],
-        "edges": [[0, 1], [1, 2], [2, 3]],
-        "symmetries": []
-    },
+    "version": "1.0",
     "videos": [
         {
             "filename": "video.mp4",
-            "shape": [1000, 480, 640, 3]
+            "backend_metadata": {}
+        }
+    ],
+    "skeletons": [
+        {
+            "name": "Skeleton-0",
+            "nodes": ["nose", "head", "neck", "tail"],
+            "edges": [[0, 1], [1, 2], [2, 3]],
+            "symmetries": []
         }
     ],
     "tracks": ["mouse_1", "mouse_2"],
     "suggestions": [],
-    "provenance": {
-        "source_file": "labels.slp",
-        "sleap_io_version": "0.6.0"
-    }
+    "provenance": {}
 }
 ```
 
 | Field | Description |
 |-------|-------------|
-| `format_version` | Metadata format version |
-| `csv_format` | CSV format used (`sleap`, `dlc`, `points`, etc.) |
-| `skeleton` | Full skeleton definition with nodes, edges, symmetries |
-| `videos` | Video metadata (filename, shape) |
+| `version` | Metadata schema version (currently `"1.0"`) |
+| `videos` | Video metadata; each entry has `filename` and a backend-specific `backend_metadata` object (e.g. `shape`, `dataset`, `grayscale`) |
+| `skeletons` | List of skeleton definitions, each with `nodes`, `edges`, and `symmetries` |
 | `tracks` | Track names in order |
 | `suggestions` | Suggested frame indices |
-| `provenance` | Source file and version information |
+| `provenance` | Source-file / creation metadata, mirroring `labels.provenance` |
 
 ## Loading CSV Files
 

--- a/docs/formats/index.md
+++ b/docs/formats/index.md
@@ -403,6 +403,12 @@ labels = sio.load_dlc("project/labeled-data/vid1/CollectedData_Scorer.csv")
 labels = sio.load_dlc("project/labeled-data/vid1/CollectedData_Scorer.csv", config=False)
 ```
 
+!!! note "Unannotated rows become empty frames"
+    Every CSV row (image) is loaded as a `LabeledFrame`, including rows with no
+    labeled bodyparts (all-NaN) — these become **empty** `LabeledFrame`s, so the
+    frame count matches the input. Drop them with
+    [`Labels.clean()`](../model/labels.md) if you don't want them.
+
 ::: sleap_io.io.main.load_dlc
 
 #### Loading a whole DLC project
@@ -557,6 +563,14 @@ Load predictions from [LEAP](https://github.com/talmo/leap), a SLEAP predecessor
 ### COCO Format (.json)
 
 [COCO](https://cocodataset.org/) (Common Objects in Context) format is widely used in computer vision and pose estimation. sleap-io provides full read and write support, making it compatible with tools like [mmpose](https://github.com/open-mmlab/mmpose), [CVAT](https://www.cvat.ai/), and other COCO-compatible frameworks.
+
+!!! note "Unannotated images become empty frames"
+    `load_coco` creates a `LabeledFrame` for every entry in the `images` array,
+    including images with zero annotations — these become **empty**
+    `LabeledFrame`s, so the frame count matches the input and unannotated images
+    round-trip losslessly. One caveat: an image whose file path cannot be resolved
+    is skipped, so a 0-annotation image with a missing file is dropped rather than
+    preserved.
 
 ::: sleap_io.io.main.load_coco
 

--- a/docs/formats/tiff.md
+++ b/docs/formats/tiff.md
@@ -21,13 +21,16 @@ When writing, a JSON sidecar file is created alongside the TIFF at `{path}.meta.
 ```json
 {
   "format": "sleap-io-label-image-meta",
-  "version": 1,
+  "version": 3,
+  "axes": "YX",
   "objects": {
     "1": {"track": "cell_1", "category": "neuron"},
     "2": {"track": "cell_2", "category": "glia"}
   }
 }
 ```
+
+`axes` is `"YX"` for a single label image and `"TYX"` for a multi-frame stack; the reader uses it as the authoritative layout hint. Optional `scale` and `offset` keys are added when any label image carries a spatial transform.
 
 On read, the sidecar is loaded automatically if present. Without it, tracks are auto-created with the label ID as the name and categories are left empty.
 
@@ -68,7 +71,7 @@ sio.save_label_images("output.tif", label_images, stack=True)
 
 # Write as per-frame files in a directory
 sio.save_label_images("output_dir/", label_images, stack=False)
-# Creates: output_dir/0.tif, output_dir/1.tif, ... + output_dir/.meta.json
+# Creates: output_dir/0.tif, output_dir/1.tif, ... + output_dir.meta.json (sibling of the dir)
 ```
 
 ## Cellpose Workflow Example

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,9 +61,10 @@ labels = sio.load_file("predictions.slp")
 labels.save("predictions.nwb")
 
 # Convert to NumPy arrays
-trx = labels.numpy()  # (n_frames, n_tracks, n_nodes, 2); n_frames == len(video)
+trx = labels.numpy()  # (n_frames, n_tracks, n_nodes, 2); n_frames spans up to the last labeled frame
 
-# Merge annotations from multiple sources
+# Merge annotations from multiple sources (track matching defaults to identity;
+# pass track="name" to merge tracks by name — see the Merging guide)
 base = sio.load_file("manual_annotations.slp")
 base.merge(sio.load_file("predictions.slp"))
 base.save("merged.slp")

--- a/docs/install.md
+++ b/docs/install.md
@@ -315,7 +315,7 @@ uv sync --all-extras
 
 This installs:
 
-- All optional dependencies (`opencv`, `pyav`, `mat`, `polars`)
+- All optional dependencies (`opencv`, `pyav`, `mat`, `polars`, `cloud`)
 - Development tools (`pytest`, `ruff`, `mkdocs`)
 - The package in editable mode
 
@@ -324,8 +324,15 @@ This installs:
 === "pip editable install"
 
     ```bash
-    pip install -e .[dev,all]
+    pip install -e ".[all]"   # runtime + optional extras
+    pip install --group dev   # dev tools (pytest, ruff, mkdocs)
     ```
+
+    !!! note
+        `dev` is a [PEP 735](https://peps.python.org/pep-0735/) dependency-group,
+        not a pip extra — `pip install -e ".[dev,all]"` installs `[all]` but
+        silently skips the dev tools (pip warns and ignores the unknown `dev`
+        extra). Install the group separately with `pip install --group dev`.
 
 === "conda + pip"
 

--- a/docs/merging.md
+++ b/docs/merging.md
@@ -377,6 +377,13 @@ base.merge(other, video="basename")  # Match by filename only
 
 Tracks represent identities (e.g., individual animals) that persist across frames. During merge, tracks from the incoming dataset are matched to tracks in the base dataset.
 
+!!! warning "Breaking change in 0.8.0"
+    The default track matching changed from `"name"` to `"identity"` in v0.8.0.
+    Independently loaded files no longer collapse tracks that merely share a name
+    (e.g. an arbitrary `"track_0"`). **To restore the pre-0.8.0 behavior, pass
+    `track="name"`** (Python) or `--track name` (CLI). This also affects
+    [`Labels.match()`](#matching-without-merging), `TrackMatcher`, and `sio merge`.
+
 ### Matching methods
 
 | Method | Behavior | Use case |
@@ -388,10 +395,13 @@ If no match is found, the track is added as new to the base dataset.
 
 !!! note "Asymmetry of errors"
     Name-based **over-merge** (gluing two different animals together because both
-    happen to be named `"track_0"`) is silent and unrecoverable, while
+    happen to be named `"track_0"`) is harder to detect and undo than
     identity-based **under-merge** (keeping tracks separate that you wanted
-    combined) is visible and recoverable. The default therefore favors
-    under-merge; opt in to `"name"` only when track names are meaningful.
+    combined), which is visible and recoverable. The default therefore favors
+    under-merge; opt in to `"name"` only when track names are meaningful. When you
+    do use `"name"`, `merge()` emits a
+    [divergence warning](#divergence-warning-for-name-based-merges) if same-named
+    tracks appear to be distinct animals.
 
 ### String configuration
 
@@ -415,6 +425,24 @@ from sleap_io.model.matching import TrackMatcher
 matcher = TrackMatcher(method="name")
 base.merge(other, track=matcher)
 ```
+
+### Divergence warning for name-based merges {#divergence-warning-for-name-based-merges}
+
+When matching by name (`track="name"`), `merge()` emits a `UserWarning` if two
+same-named tracks collide on a shared `(video, frame)` yet their instances fail
+to correspond spatially on **every** overlapping frame — a strong signal that
+name-based matching is about to glue distinct tracks together:
+
+```text
+UserWarning: Track 'track_0' was merged by name across labels that share video
+'...', but instances on that track diverge spatially on all N overlapping
+frame(s) ... name-based merging may glue distinct tracks together. Review the
+merge or resolve tracks at the instance level.
+```
+
+The warning is diagnostic only — the merge still proceeds. It fires at most once
+per colliding track, requires a spatial/IoU instance matcher (it is skipped for
+`instance="identity"`), and never fires for the default `track="identity"`.
 
 ---
 

--- a/docs/model/labels.md
+++ b/docs/model/labels.md
@@ -56,6 +56,16 @@ You do not need to manually specify `videos` and `skeletons` — they are automa
 >>> print(labels.skeletons)
 ```
 
+!!! tip "Structural skeleton deduplication"
+    When you add frames with [`Labels.update()`](#sleap_io.Labels.update),
+    [`Labels.append()`](#sleap_io.Labels.append), or
+    [`Labels.extend()`](#sleap_io.Labels.extend), a skeleton that is
+    *structurally equal* (same nodes and edges, in the same order) to one already
+    on the `Labels` is deduplicated — the existing `Skeleton` is reused and the
+    duplicate is dropped (no point data moves). Skeletons that differ in node or
+    edge order are kept distinct. See
+    [`Skeleton.matches`](poses.md#sleap_io.Skeleton.matches).
+
 ### Loading from file
 
 Load labels from any supported format. The format is detected automatically from the file extension:

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -683,7 +683,7 @@ This saves a preview PNG to `/tmp/sio_preview.png` showing the transformed frame
 
 ## Metadata & Provenance
 
-By default, transform metadata is automatically embedded in the output SLP file. This preserves a record of how the data was transformed for reproducibility and debugging.
+By default, the `sio transform` **CLI** embeds transform metadata in the output SLP file, preserving a record of how the data was transformed for reproducibility and debugging. The Python [`transform_labels()`][sleap_io.transform_labels] API does **not** populate this automatically (see the note below).
 
 ### Embedded provenance format
 
@@ -725,6 +725,14 @@ source_path = transform_info["source"]
 # Get transform matrix for coordinate conversion
 matrix = transform_info["videos"]["0"]["coordinate_transform"]["matrix"]
 ```
+
+!!! note "CLI vs. Python API"
+    The `transform` provenance key is written by the `sio transform` CLI (enabled
+    by default; disable with `--no-embed-provenance`). The Python
+    `sio.transform_labels()` does **not** embed provenance, so
+    `labels.provenance.get("transform")` returns `None` for API-produced output —
+    set it yourself before saving if you need it (e.g.
+    `labels.provenance["transform"] = {...}`).
 
 To disable provenance embedding:
 


### PR DESCRIPTION
## Summary

Corrects user-facing documentation that was inaccurate, undocumented, or stale — found during the 0.8.0 docs audit. All format-spec claims were re-verified against the **actual writer output**.

> ⚠️ Stacked on #454 → #453. GitHub auto-retargets to `main` as each merges. Review/merge in order.

## Commits

**1. Document 0.8.0 behavior changes**
- `merging.md` / `cli.md`: breaking-change banner for the merge-default flip `name`→`identity` with a migration note (`track="name"` / `--track name`); document the new spatial-divergence `UserWarning`; soften the now-stale "silent and unrecoverable" wording.
- `index.md`: identity-default note on the quick-start `merge()`; qualify the `n_frames == len(video)` comment (holds only when the video length resolves).
- `formats/index.md`: `load_dlc`/`load_coco` now retain unannotated rows/images as empty `LabeledFrame`s (+ COCO missing-file caveat).
- `labels.md`: structural skeleton dedup in `update`/`append`/`extend`.

**2. Correct format reference specs** (each verified against real output)
- `analysis_h5.md`: `track_occupancy` is `uint8` not `bool`; scores are `float64` not `float32`; `tracking_scores` default is `NaN` not `0.0`; remove the fictional `@skeleton_edges`; `provenance`/`labels_path` are **datasets** not attributes; add real `edge_names`/`edge_inds`/`video_ind`/`@video_backend_metadata`; note `save_metadata` gating.
- `csv.md`: sidecar uses `version` (not `format_version`), no `csv_format`, plural `skeletons`, `backend_metadata` (not top-level `shape`), no injected `sleap_io_version`.
- `tiff.md`: sidecar is `version: 3` with the required `axes` key; directory-mode sidecar is the **sibling** `<dir>.meta.json`.

**3. Transforms / install / freshness**
- `transforms.md`: auto provenance embedding is a **CLI** behavior; `transform_labels()` does not embed it.
- `install.md`: `dev` is a PEP 735 group, not a pip extra (`.[dev,all]` silently skips dev tools → use `--group dev`); add `cloud` to the `uv sync` description.
- `examples.md`: bbox accessors preserve int inputs (`16200`, not `16200.0`).
- `cli.md`: `sio --version` output `0.6.0` → `0.8.0`.

## Testing

- `mkdocs build` (EAGER_IMPORT=1): exit 0, **no broken links or missing anchors** from the new cross-references.
- `pytest tests/test_docs.py`: 73 passed.

## Not included (follow-ups)

- **N2** (`transforms.md` examples pass `str` where `output_path: Path` is required → `AttributeError`): best fixed by coercing `str`→`Path` inside `transform_labels()` (a library change + test), tracked separately rather than wrapping ~19 example paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)