### PR TITLE
docs: add llms.txt + surface motion trails + rendering/cli/nav polish

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1816,6 +1816,7 @@ sio render --images frames/ --overlay masks.tif -o output.mp4
 | `--fps` | source FPS | Output video FPS. Change to slow down or speed up playback. |
 | `--crf` | 25 | Video quality (2-32, lower=better quality, larger file) |
 | `--x264-preset` | superfast | H.264 encoding speed trade-off (ultrafast to slow) |
+| `--progress` / `--no-progress` | on | Show a progress bar during video rendering |
 
 #### Appearance Options
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1371,6 +1371,30 @@ sio render -i predictions.slp --preset preview
 sio render -i predictions.slp --lf 0  # Single frame
 ```
 
+### Motion trails
+
+Draw fading trajectory trails behind each instance to visualize movement over time:
+
+```python title="render_trails.py" linenums="1"
+import sleap_io as sio
+
+labels = sio.load_slp("predictions.slp")
+
+# Trails follow track identities, so the data should be tracked.
+sio.render_video(
+    labels,
+    "trails.mp4",
+    show_trails=True,
+    trail_length=10,      # frames of history per trail
+    trail_node="centroid",  # or a node name / list of node names
+)
+```
+
+!!! note "Trails need tracks"
+    Trails are drawn per track, so untracked data produces little or no trail.
+    Run tracking first, or merge with `track="name"` if your tracks are named.
+    See [Rendering → Motion trails](rendering.md) for all `trail_*` options.
+
 ### Segmentation overlay rendering
 
 Render pose predictions on top of a segmentation mask (or render masks on bare images, no labels file needed). The overlay pipeline accepts 2-D label images, 3-D label stacks, or a directory of per-frame TIFFs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ does *not* include labeling, training, or inference.
 
 - **Multi-format I/O** -- Read and write [SLEAP](formats/index.md#sleap-native-format-slp), [NWB](formats/index.md#nwb-format-nwb), [COCO](formats/index.md#coco-format-json), [DeepLabCut](formats/index.md#deeplabcut-format-h5-csv), [Ultralytics YOLO](formats/index.md#ultralytics-yolo-format), [JABS](formats/index.md#jabs-format-h5), [Label Studio](formats/index.md#label-studio-format-json), [CSV](formats/index.md#csv-format-csv), [Analysis HDF5](formats/index.md#sleap-analysis-hdf5-format-h5), [AlphaTracker](formats/index.md#alphatracker-format), and [LEAP](formats/index.md#leap-format-mat) formats
 - **CLI tools** -- Inspect, convert, render, and transform data from the command line ([reference](cli.md))
-- **Rendering** -- Produce publication-quality videos and images with pose overlays, customizable colors, markers, and presets ([guide](rendering.md))
+- **Rendering** -- Produce publication-quality videos and images with pose overlays, customizable colors, markers, motion trails, and presets ([guide](rendering.md))
 - **Transforms** -- Crop, scale, rotate, pad, and flip videos with automatic coordinate adjustment ([guide](transforms.md))
 - **Merging** -- Combine annotations from multiple sources with flexible matching strategies ([guide](merging.md))
 - **Codecs** -- Convert to/from NumPy arrays, DataFrames (pandas/polars), and dictionaries ([guide](codecs.md))

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -29,7 +29,10 @@ This produces an MP4 video file with skeleton overlays on all labeled frames.
 
 ## Color Schemes
 
-Color scheme determines how poses are colored across instances and frames.
+Color scheme determines how poses are colored across instances and frames. The
+`color_by` parameter defaults to `"auto"`, which resolves to `"track"` when tracks
+are present, otherwise `"instance"` for a single image and `"node"` for a video or
+multi-image render. Pass an explicit value to override:
 
 ### Color by track
 
@@ -482,6 +485,9 @@ img = sio.render_image(lf, crop=(140, 120, 240, 220), scale=2.0)
 ## Background Control
 
 Control the background when rendering poses. Use `background="video"` (default) to load video frames, or specify a color to render with a solid background.
+
+!!! note "Remote video backgrounds"
+    With `background="video"`, frames are read from the underlying [`Video`](model/video.md) backend, which can be a remote/cloud/Google-Drive source (see [Remote loading](remote.md)). Rendering then incurs the same network fetch, caching, and [`RemoteIOError`](remote.md) behavior as any other frame access.
 
 ### Named color
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ plugins:
       scripts:
         - scripts/gen_ref_pages.py
         - scripts/gen_changelog.py
+        - scripts/gen_llms_txt.py
   - section-index
   - literate-nav:
       nav_file: SUMMARY.md
@@ -95,7 +96,7 @@ markdown_extensions:
   - md_in_html
   - toc:
       permalink: true
-      toc_depth: 2
+      toc_depth: 3
 
   # Python Markdown Extensions
   - pymdownx.arithmatex:

--- a/scripts/gen_llms_txt.py
+++ b/scripts/gen_llms_txt.py
@@ -1,0 +1,130 @@
+"""Generate ``llms.txt`` — a machine-readable index for LLM / agent consumers.
+
+Wired into the mkdocs ``gen-files`` plugin (see ``mkdocs.yml``). Produces an
+``llms.txt`` at the site root following the https://llmstxt.org convention: a
+one-line description, curated links to the documentation pages (the site also
+serves every page as raw markdown at the same path with a ``.md`` suffix, via
+``hooks/copy_source_markdown.py``), and the public ``sleap_io`` API surface so an
+agent can discover available functions and classes without crawling the site.
+
+Links are relative so they resolve correctly under each ``mike``-deployed version
+directory (e.g. ``/latest/examples.md``).
+"""
+
+import mkdocs_gen_files
+
+import sleap_io as sio
+
+DESCRIPTION = (
+    "Standalone Python library for reading, writing, and manipulating animal "
+    "pose-tracking data. Reads/writes SLEAP, NWB, DeepLabCut, COCO, Label Studio, "
+    "JABS, Ultralytics, TrackMate, and more, with data-structure manipulation and "
+    "video I/O. Minimal dependencies; no labeling, training, or inference."
+)
+
+GUIDES = [
+    ("Examples", "examples.md", "Practical recipes for common tasks"),
+    (
+        "Remote loading",
+        "remote.md",
+        "Load .slp and videos from URLs, S3/GCS/Azure, and Google Drive",
+    ),
+    ("Codecs", "codecs.md", "Array conversion (NumPy / pandas) formats"),
+    ("Merging", "merging.md", "Combine datasets; track / skeleton / video matching"),
+    (
+        "Rendering",
+        "rendering.md",
+        "Render videos and images with overlays, colors, and motion trails",
+    ),
+    ("Transforms", "transforms.md", "Crop, scale, rotate, and pad labels and videos"),
+]
+MODEL = [
+    (
+        "Data model overview",
+        "model/index.md",
+        "Containers and how annotations nest on frames",
+    ),
+    ("Labels", "model/labels.md", "Labels, LabeledFrame, LabelsSet containers"),
+    ("Video", "model/video.md", "Lazy video backends"),
+    ("Poses", "model/poses.md", "Skeleton, Node, Edge, Instance, Track"),
+    ("3D", "model/3d.md", "Camera, RecordingSession, 3D instances"),
+    ("Centroids", "model/centroids.md", "Point detections"),
+    ("Boxes", "model/boxes.md", "Bounding boxes"),
+    ("ROIs", "model/rois.md", "Vector polygon regions"),
+    ("Segmentation", "model/segmentation.md", "Segmentation masks and label images"),
+]
+FORMATS = [
+    (
+        "Formats overview",
+        "formats/index.md",
+        "All supported I/O formats and their limitations",
+    ),
+    ("SLP", "formats/slp.md", "Native SLEAP format"),
+    ("CSV", "formats/csv.md", "Flat tabular export/import"),
+    ("Analysis HDF5", "formats/analysis_h5.md", "SLEAP analysis arrays"),
+    ("TIFF", "formats/tiff.md", "Label images"),
+    ("TrackMate", "formats/trackmate.md", "ImageJ/Fiji point tracking"),
+]
+REFERENCE = [
+    ("Installation", "install.md", "Install options and extras"),
+    ("CLI", "cli.md", "`sio` command-line reference"),
+    ("Full API", "reference/", "Auto-generated API documentation"),
+]
+
+# Namespace re-exports that are modules, not callables/classes.
+SUBMODULES = {"io", "model", "codecs"}
+
+
+def _section(title: str, items: list[tuple[str, str, str]]) -> str:
+    lines = [f"## {title}", ""]
+    for name, url, desc in items:
+        lines.append(f"- [{name}]({url}): {desc}" if desc else f"- [{name}]({url})")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _api_section() -> str:
+    names = set(sio.__all__) - {"__version__"} - SUBMODULES
+    loaders = sorted(n for n in names if n.startswith("load_"))
+    savers = sorted(n for n in names if n.startswith("save_"))
+    remaining = names - set(loaders) - set(savers)
+    classes = sorted(n for n in remaining if n[:1].isupper())
+    functions = sorted(remaining - set(classes))
+
+    def fmt(group: list[str]) -> str:
+        return ", ".join(f"`sio.{n}`" for n in group)
+
+    return "\n".join(
+        [
+            "## Public API",
+            "",
+            "`import sleap_io as sio` exposes:",
+            "",
+            f"- **Loaders**: {fmt(loaders)}",
+            f"- **Savers**: {fmt(savers)}",
+            f"- **Classes**: {fmt(classes)}",
+            f"- **Functions**: {fmt(functions)}",
+            "",
+        ]
+    )
+
+
+content = "\n".join(
+    [
+        "# sleap-io",
+        "",
+        f"> {DESCRIPTION}",
+        "",
+        "Every documentation page is also served as raw markdown at the same path "
+        "with a `.md` suffix (e.g. `examples.md`, `model/labels.md`).",
+        "",
+        _section("Guides", GUIDES),
+        _section("Data model", MODEL),
+        _section("Formats", FORMATS),
+        _section("Reference", REFERENCE),
+        _api_section(),
+    ]
+)
+
+with mkdocs_gen_files.open("llms.txt", "w") as f:
+    f.write(content)


### PR DESCRIPTION
## Summary

Agent-accessibility and discoverability improvements from the 0.8.0 docs audit, plus surfacing the new motion-trail feature.

> ⚠️ Stacked on #455 → #454 → #453. GitHub auto-retargets to `main` as each merges. Review/merge in order.

## Key Changes

- **`llms.txt`** (M5) — new `scripts/gen_llms_txt.py`, wired into the existing `gen-files` plugin. Generates `/llms.txt` following the [llmstxt.org](https://llmstxt.org) convention: a one-line description, curated links to every docs page (also served as raw `.md` mirrors), and the **full public `sleap_io` API** grouped into loaders / savers / classes / functions — including the new 0.8.0 exports (`draw_trails`, `load_dlc_project`, `load_dlc_splits`, `clear_remote_cache`, `RemoteIOError`). This is the strongest single agent-grounding addition; the `.md`-mirror infrastructure already existed, only the index was missing.
- **Motion trails surfaced** (M7) — `index.md` Features bullet + a `render_trails.py` recipe in `examples.md` (with the "trails need tracks" caveat).
- **`rendering.md`** (N12) — document the default `color_by="auto"` and what it resolves to; note that `background="video"` reads frames from the (possibly remote/cloud) `Video` backend, with the same caching / `RemoteIOError` behavior.
- **`cli.md`** (L3) — add the `--progress` / `--no-progress` row to the render Quality Options table.
- **`mkdocs.yml`** (L9) — raise `toc_depth` to 3 so H3 anchors appear in the sidebar TOC.

## Testing

- `mkdocs build` (EAGER_IMPORT=1): exit 0, ~130s (unchanged), `llms.txt` generated (50 lines), **no new warnings** (the pre-existing `**kwargs`/`Multiple primary URLs`/`old_x` autoref notes are unrelated to this PR).
- `pytest tests/test_docs.py`: 73 passed.

## Deliberately deferred (with reasons)

- **M6 (typed signatures in the API reference):** `signature_crossrefs: true` makes the docs build **time out** (cross-referencing every type across the API), and `show_signature_annotations` alone surfaces a flood of pre-existing `**kwargs`-without-annotation warnings plus an autoref bug in the `Transform.to_matrix` docstring. Best done after the public functions' `**kwargs` are annotated and the `to_matrix` docstring matrix notation is escaped — a library/docstring cleanup, not a config flip.
- **M4 (split Formats nav into leaf pages), L4–L7 (repoint remote cross-links from `examples.md#…` to `remote.md`), L11 (Guides landing page):** lower-priority; the Formats split is a restructure on the scale of the spatial-pages split (#454) and worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)