### PR TITLE
fix(transform): accept str paths in transform_labels / transform_video

### DIFF
--- a/sleap_io/transform/video.py
+++ b/sleap_io/transform/video.py
@@ -65,7 +65,7 @@ def _get_frame_indices(video: "Video") -> list[int]:
 
 def transform_video(
     video: "Video",
-    output_path: Path,
+    output_path: str | Path,
     transform: Transform,
     fps: float | None = None,
     crf: int = 25,
@@ -78,7 +78,7 @@ def transform_video(
 
     Args:
         video: Source video object.
-        output_path: Path to save transformed video.
+        output_path: Path (or str) to save the transformed video.
         transform: Transform to apply to each frame.
         fps: Output frame rate. If None, uses source FPS.
         crf: Constant rate factor for video quality (0-51, lower is better).
@@ -95,6 +95,8 @@ def transform_video(
         For embedded HDF5 videos, use `transform_embedded_video()` instead.
     """
     from sleap_io.io.video_writing import VideoWriter
+
+    output_path = Path(output_path)
 
     # Get frame indices to iterate over
     frame_inds = _get_frame_indices(video)
@@ -355,8 +357,8 @@ def _update_videos_json(output_path: Path, videos: list["Video"]) -> None:
 def transform_labels(
     labels: "Labels",
     transforms: dict[int, Transform] | Transform,
-    output_path: Path,
-    video_output_dir: Path | None = None,
+    output_path: str | Path,
+    video_output_dir: str | Path | None = None,
     fps: float | None = None,
     crf: int = 25,
     preset: str = "superfast",
@@ -371,8 +373,8 @@ def transform_labels(
         labels: Source Labels object.
         transforms: Either a single Transform to apply to all videos, or a dict
             mapping video indices to their respective Transforms.
-        output_path: Path to save transformed SLP file.
-        video_output_dir: Directory for transformed videos. If None, uses
+        output_path: Path (or str) to save the transformed SLP file.
+        video_output_dir: Directory (str or Path) for transformed videos. If None, uses
             "{output_path.stem}.videos/". Ignored for embedded videos.
         fps: Output frame rate. If None, preserves source FPS. Ignored for embedded.
         crf: Constant rate factor for video quality (0-51, lower is better).
@@ -393,6 +395,10 @@ def transform_labels(
         parameters are ignored for embedded videos.
     """
     from sleap_io.model.video import Video
+
+    output_path = Path(output_path)
+    if video_output_dir is not None:
+        video_output_dir = Path(video_output_dir)
 
     # Normalize transforms to dict
     if isinstance(transforms, Transform):

--- a/tests/transform/test_transform.py
+++ b/tests/transform/test_transform.py
@@ -1020,6 +1020,66 @@ class TestVideoTransforms:
         expected_dir = output_path.with_name("output.videos")
         assert expected_dir.exists()
 
+    def test_transform_labels_str_output_path(self, tmp_path, slp_real_data):
+        """A str output_path is coerced to Path (regression for with_name)."""
+        import sleap_io as sio
+        from sleap_io.transform.video import transform_labels
+
+        labels = sio.load_slp(slp_real_data)
+        transform = Transform(scale=(0.5, 0.5))
+
+        # A bare str previously raised AttributeError at
+        # output_path.with_name(...) when video_output_dir defaulted.
+        result = transform_labels(
+            labels=labels,
+            transforms=transform,
+            output_path=str(tmp_path / "output.slp"),
+            video_output_dir=None,
+            dry_run=True,
+        )
+
+        assert result is not None
+        assert len(result.labeled_frames) > 0
+
+    def test_transform_labels_str_video_output_dir(self, tmp_path, slp_real_data):
+        """A str output_path and video_output_dir are both coerced to Path."""
+        import sleap_io as sio
+        from sleap_io.transform.video import transform_labels
+
+        labels = sio.load_slp(slp_real_data)
+        transform = Transform(scale=(0.5, 0.5))
+
+        result = transform_labels(
+            labels=labels,
+            transforms=transform,
+            output_path=str(tmp_path / "output.slp"),
+            video_output_dir=str(tmp_path / "videos"),
+            crf=35,
+        )
+
+        assert result is not None
+        assert (tmp_path / "videos").exists()
+
+    def test_transform_video_str_output_path(
+        self, tmp_path, centered_pair_low_quality_path
+    ):
+        """A str output_path is coerced to Path in transform_video."""
+        import sleap_io as sio
+        from sleap_io.transform.video import transform_video
+
+        video = sio.load_video(str(centered_pair_low_quality_path))
+        transform = Transform(scale=(0.5, 0.5))
+
+        result = transform_video(
+            video=video,
+            output_path=str(tmp_path / "output.mp4"),
+            transform=transform,
+            crf=35,
+        )
+
+        # Returned value is the coerced Path; the file should exist.
+        assert result.exists()
+
     def test_transform_labels_per_video_transforms(self, tmp_path, slp_real_data):
         """Test transform_labels with per-video transforms dict."""
         import sleap_io as sio


### PR DESCRIPTION
## Summary

Closes audit finding **N2**. `sio.transform_labels()` and `sio.transform_video()` annotated `output_path` (and `video_output_dir`) as `Path` and called `Path`-only methods like `output_path.with_name(...)`, so passing a bare `str` raised `AttributeError: 'str' object has no attribute 'with_name'`. Every Python example in `docs/transforms.md` passes a `str`, so they failed on copy-paste.

## Key Changes

- Coerce `str -> Path` at the top of both public entry points (`transform_labels`, `transform_video`), and coerce `video_output_dir` when provided.
- Widen the type hints to `str | Path` (and `str | Path | None` for `video_output_dir`) and note it in the docstrings.

## Why the library, not the docs

The audit flagged ~19 `transforms.md` snippets that pass a `str`. Coercing once in the library fixes all of them (and any user code) rather than wrapping each example in `Path(...)`.

## Testing

- `tests/transform/test_transform.py`: 3 new regression tests — str `output_path` with the defaulted video dir (the `with_name` path, via `dry_run`), str `output_path` + str `video_output_dir` (real run), and `transform_video` with a str `output_path`.
- Full module: `143 passed`. `ruff check`/`format`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)