### PR TITLE
docs: split formats into leaf pages + remote cross-links + Guides landing

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2676,7 +2676,7 @@ The `--seed` option ensures you can recreate the exact same split later, which i
     sio.save_nwb(labels, "training.nwb", nwb_format="annotations")
     ```
 
-    See [NWB Format](formats/#nwb-format-nwb) for details.
+    See [NWB Format](formats/nwb.md) for details.
 
 ### Merging Training Splits
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -151,7 +151,7 @@ labels.save("boxes.slp")
 
 !!! note "See also"
     - [Regions: Bounding boxes](model/boxes.md) — full API and metadata fields
-    - [Formats: COCO](formats/index.md#coco-format-json) and [Ultralytics](formats/index.md#ultralytics-yolo-format) for detection round-trips
+    - [Formats: COCO](formats/coco.md) and [Ultralytics](formats/ultralytics.md) for detection round-trips
 
 ### Centroid tracking and TrackMate import
 
@@ -257,7 +257,7 @@ labels = sio.load_file("regions.geojson")
 ```
 
 !!! note "See also"
-    - [Formats: GeoJSON](formats/index.md#geojson-format-geojson) — schema and movement-library interop
+    - [Formats: GeoJSON](formats/geojson.md) — schema and movement-library interop
     - [Regions: Static vs. temporal ROIs](model/rois.md#static-vs-temporal-rois)
 
 ### Adding annotations to frames (type dispatch)
@@ -544,9 +544,9 @@ nwb_labels.save("converted.slp")
     - Video metadata (when using `annotations_export`)
 
 !!! note "See also"
-    - [NWB Format Documentation](formats/#nwb-format-nwb): Complete NWB format reference
-    - [`load_nwb`](formats/#sleap_io.load_nwb): NWB loading function
-    - [`save_nwb`](formats/#sleap_io.save_nwb): NWB saving function with format options
+    - [NWB Format Documentation](formats/nwb.md): Complete NWB format reference
+    - [`load_nwb`](formats/nwb.md#sleap_io.load_nwb): NWB loading function
+    - [`save_nwb`](formats/nwb.md#sleap_io.save_nwb): NWB saving function with format options
 
 ### Convert to Ultralytics YOLO format
 
@@ -622,9 +622,9 @@ sio.save_coco(
     - Integration with COCO-compatible evaluation tools
 
 !!! note "See also"
-    - [`save_coco`](formats/#sleap_io.save_coco): Full COCO export documentation
-    - [`load_coco`](formats/#sleap_io.load_coco): COCO import documentation
-    - [COCO Format](formats/#coco-format-json): COCO format details
+    - [`save_coco`](formats/coco.md#sleap_io.save_coco): Full COCO export documentation
+    - [`load_coco`](formats/coco.md#sleap_io.load_coco): COCO import documentation
+    - [COCO Format](formats/coco.md): COCO format details
 
 ## Loading from URLs
 

--- a/docs/formats/coco.md
+++ b/docs/formats/coco.md
@@ -1,0 +1,15 @@
+# COCO Format (.json)
+
+[COCO](https://cocodataset.org/) (Common Objects in Context) format is widely used in computer vision and pose estimation. sleap-io provides full read and write support, making it compatible with tools like [mmpose](https://github.com/open-mmlab/mmpose), [CVAT](https://www.cvat.ai/), and other COCO-compatible frameworks.
+
+!!! note "Unannotated images become empty frames"
+    `load_coco` creates a `LabeledFrame` for every entry in the `images` array,
+    including images with zero annotations — these become **empty**
+    `LabeledFrame`s, so the frame count matches the input and unannotated images
+    round-trip losslessly. One caveat: an image whose file path cannot be resolved
+    is skipped, so a 0-annotation image with a missing file is dropped rather than
+    preserved.
+
+::: sleap_io.io.main.load_coco
+
+::: sleap_io.io.main.save_coco

--- a/docs/formats/dlc.md
+++ b/docs/formats/dlc.md
@@ -1,0 +1,83 @@
+# DeepLabCut Format (.h5, .csv)
+
+Load annotations from [DeepLabCut](http://www.mackenziemathislab.org/deeplabcut), a popular markerless pose estimation tool.
+
+`load_dlc` reads a single DLC annotation CSV. When a project `config.yaml` is
+available — either passed explicitly via `config=` or auto-discovered by walking
+up from the CSV — the following extra metadata is imported:
+
+- **Skeleton edges** from the config `skeleton:` list. Edges that reference
+  bodyparts not present in the labeled data are dropped with a warning.
+- **Source videos**: each `labeled-data/<video>/` image folder is linked back to
+  its original video file (from the config `video_sets`) via `Video.source_video`,
+  matched by filename stem. The link is best-effort and left unset on a stem
+  mismatch or missing file.
+
+Pass `config=False` to disable config use entirely and reproduce the legacy,
+config-free output.
+
+!!! note "Cropping is not yet applied"
+    DeepLabCut's `video_sets[...].crop` is a *virtual* read-time crop (an ROI
+    that DLC's video reader slices out of each full frame on the fly). When a
+    project uses cropping, the images under `labeled-data/<video>/` are the
+    cropped region and the labels are stored in **cropped-frame coordinates**,
+    whereas the linked `source_video` points at the original, **uncropped**
+    video. sleap-io does not yet apply this crop, so for cropped projects the
+    labels are offset from the source video by the crop origin `(x1, y1)`.
+    Reconciling the two requires virtual ROI-cropping of a `Video` on read,
+    which is planned future work. For the common case of no cropping (the DLC
+    default is the full frame), there is no offset and the link is exact.
+
+```python
+import sleap_io as sio
+
+# Single CSV; auto-discovers config.yaml for edges + source-video links.
+labels = sio.load_dlc("project/labeled-data/vid1/CollectedData_Scorer.csv")
+
+# Strict legacy output (no edges/links), even inside a project.
+labels = sio.load_dlc("project/labeled-data/vid1/CollectedData_Scorer.csv", config=False)
+```
+
+!!! note "Unannotated rows become empty frames"
+    Every CSV row (image) is loaded as a `LabeledFrame`, including rows with no
+    labeled bodyparts (all-NaN) — these become **empty** `LabeledFrame`s, so the
+    frame count matches the input. Drop them with
+    [`Labels.clean()`](../model/labels.md) if you don't want them.
+
+::: sleap_io.io.main.load_dlc
+
+## Loading a whole DLC project
+
+`load_dlc_project` loads every `labeled-data/<video>/` folder in a project at
+once and merges them into a single `Labels` that shares one `Skeleton` (with
+edges) and one set of `Track`s, recording provenance under the `dlc_project`,
+`dlc_scorer`, and `dlc_task` keys. A project directory or its `config.yaml` can
+also be passed to `load_file`, which routes it here automatically.
+
+```python
+labels = sio.load_dlc_project("path/to/dlc_project")  # dir or config.yaml
+labels = sio.load_file("path/to/dlc_project")          # auto-routed
+```
+
+::: sleap_io.io.main.load_dlc_project
+
+## Importing train/test splits
+
+`load_dlc_splits` recovers the train/test splits created by DLC's
+`create_training_dataset`, reading the positional indices stored in the project's
+`Documentation_data-*.pickle` and reconstructing DLC's globally, lexicographically
+sorted merge of all per-video annotations. It returns a
+[`LabelsSet`](../model/index.md) with `"train"` and `"test"` keys.
+
+Splits require the labeled images to be present on disk. For non-zero-padded
+image filenames a warning is emitted, since DLC's lexicographic ordering (e.g.
+`img10` < `img2`) differs from numeric ordering and could otherwise cause silent
+train/test mis-assignment. If a project has multiple training fractions or
+shuffles, pass `train_fraction=` and/or `shuffle=` to disambiguate.
+
+```python
+splits = sio.load_dlc_splits("path/to/dlc_project", shuffle=1)
+train, test = splits["train"], splits["test"]
+```
+
+::: sleap_io.io.main.load_dlc_splits

--- a/docs/formats/geojson.md
+++ b/docs/formats/geojson.md
@@ -1,0 +1,33 @@
+# GeoJSON Format (.geojson)
+
+[GeoJSON](https://geojson.org/) (RFC 7946) is a JSON-based format for encoding geographic data structures. sleap-io uses it to store ROIs (regions of interest) as a human-readable, standalone format. The output is compatible with the [movement](https://github.com/neuroinformatics-unit/movement) library (v0.15.0+) and the broader geospatial Python ecosystem (Shapely, GeoPandas, QGIS, QuPath).
+
+Each ROI is serialized as a GeoJSON Feature with geometry and metadata properties. The `ROI` class also implements the Python `__geo_interface__` protocol for direct interoperability with Shapely and other geo-aware libraries.
+
+## Examples
+
+```python
+import sleap_io as sio
+from sleap_io.model.roi import UserROI
+from shapely.geometry import box
+
+# Create some ROIs
+rois = [
+    UserROI(geometry=box(100, 200, 150, 280), name="box1", category="animal"),
+    UserROI.from_polygon([(0, 0), (50, 0), (50, 50)], name="region"),
+]
+
+# Save to GeoJSON
+sio.save_geojson(rois, "rois.geojson")
+
+# Load back
+loaded_rois = sio.load_geojson("rois.geojson")
+
+# Also works with load_file/save_file (wraps in Labels)
+labels = sio.load_file("rois.geojson")  # Returns Labels(rois=...)
+sio.save_file(labels, "rois.geojson")
+```
+
+::: sleap_io.io.main.load_geojson
+
+::: sleap_io.io.main.save_geojson

--- a/docs/formats/index.md
+++ b/docs/formats/index.md
@@ -17,7 +17,7 @@ sleap-io provides a unified interface for reading and writing pose tracking data
 Media videos can also be read from `http`/`https` URLs with
 [`load_video`][sleap_io.load_video] (requires the `pyav` extra; cloud schemes
 and Google Drive are not supported for video). See
-[Remote video](../examples.md#loading-from-urls).
+[Remote video](../remote.md#remote-video).
 
 ### Norpix .seq Format
 
@@ -48,7 +48,7 @@ sio reencode recording.seq -o recording.mp4
 
 The native SLEAP format stores complete pose tracking projects including videos, skeletons, and annotations. SLP is the primary format with full round-trip support for bounding boxes (format 1.7+), regions of interest (ROIs), and segmentation masks (format 1.5+).
 
-`.slp` and `.pkg.slp` files can also be loaded directly from `http`/`https`, cloud (`s3://`, `gs://`, `az://`), and Google Drive URLs with lazy range-based streaming via [`load_slp`][sleap_io.load_slp] — see [Loading from URLs](../examples.md#loading-from-urls).
+`.slp` and `.pkg.slp` files can also be loaded directly from `http`/`https`, cloud (`s3://`, `gs://`, `az://`), and Google Drive URLs with lazy range-based streaming via [`load_slp`][sleap_io.load_slp] — see [Loading from URLs](../remote.md).
 
 !!! tip "Detailed Format Specification"
     For comprehensive documentation of the SLP file format including HDF5 layout, data structures, and version history, see the **[SLP File Format Reference](slp.md)**.
@@ -147,158 +147,10 @@ Lazy loading excels at avoiding unnecessary work. If you need to iterate over al
 
 ### NWB Format (.nwb)
 
-[Neurodata Without Borders (NWB)](https://www.nwb.org/) is a standardized format for neurophysiology data. sleap-io provides comprehensive support for both reading and writing pose tracking data in NWB format.
-
-#### Harmonized NWB I/O
-
-The harmonized API automatically detects and routes to the appropriate NWB backend:
-
-::: sleap_io.io.main.load_nwb
-
-::: sleap_io.io.main.save_nwb
-
-#### NWB Format Types
-
-sleap-io supports multiple NWB format types through the `nwb_format` parameter:
-
-- **`"auto"`** (default): Automatically detect based on data content
-  - Uses `"annotations"` if data contains user-labeled instances
-  - Uses `"predictions"` if data contains only predicted instances
-
-- **`"annotations"`**: Save as PoseTraining format (ndx-pose extension)
-  - Stores manual annotations for training data
-  - Preserves skeleton structure and node names
-  - Includes annotator information
-
-- **`"annotations_export"`**: Export annotations with embedded video frames
-  - Creates self-contained NWB file with video data
-  - Generates MJPEG video with frame provenance tracking
-  - Useful for sharing complete datasets
-
-- **`"predictions"`**: Save as PoseEstimation format (ndx-pose extension)
-  - Stores predicted pose data from inference
-  - Includes confidence scores
-  - Supports multiple animals/tracks
-
-#### Examples
-
-##### Basic NWB Usage
-
-```python
-import sleap_io as sio
-
-# Load any NWB file (auto-detects format)
-labels = sio.load_nwb("pose_data.nwb")
-
-# Save with auto-detection
-sio.save_nwb(labels, "output.nwb")
-
-# Save with specific format
-sio.save_nwb(labels, "training.nwb", nwb_format="annotations")
-sio.save_nwb(labels, "predictions.nwb", nwb_format="predictions")
-```
-
-##### Advanced Annotations API
-
-For more control over NWB training data, use the annotations module directly:
-
-```python
-from sleap_io.io.nwb_annotations import save_labels, load_labels
-
-# Save with custom metadata
-save_labels(
-    labels,
-    "training.nwb",
-    session_description="Mouse reaching task",
-    identifier="mouse_01_session_03",
-    annotator="researcher_name",
-    nwb_kwargs={
-        "session_id": "session_003",
-        "experimenter": ["John Doe", "Jane Smith"],
-        "lab": "Motor Control Lab",
-        "institution": "University",
-        "experiment_description": "Skilled reaching behavior"
-    }
-)
-
-# Load annotations
-labels = load_labels("training.nwb")
-```
-
-##### Export with Video Frames
-
-```python
-from sleap_io.io.nwb_annotations import export_labels, export_labeled_frames
-
-# Export complete dataset with videos
-export_labels(
-    labels,
-    output_dir="export/",
-    nwb_filename="dataset_with_videos.nwb",
-    as_training=True,  # Include manual annotations
-    include_videos=True  # Embed video frames
-)
-
-# Export only labeled frames as video
-export_labeled_frames(
-    labels,
-    output_path="labeled_frames.avi",
-    labels_output_path="labels.nwb",
-    fps=30.0
-)
-```
-
-
-##### Multi-Subject Support
-
-For multi-animal experiments, sleap-io supports the [ndx-multisubjects](https://pypi.org/project/ndx-multisubjects/) NWB extension. This links each tracked animal to a proper NWB Subject entry.
-
-```python
-from sleap_io.io.nwb_annotations import save_labels
-
-# Basic multi-subject export (uses track names as subject IDs)
-save_labels(labels, "output.nwb", use_multisubjects=True)
-
-# With detailed subject metadata
-subjects_metadata = [
-    {"sex": "M", "species": "Mus musculus", "age": "P30D"},
-    {"sex": "F", "species": "Mus musculus", "age": "P45D"},
-]
-save_labels(
-    labels,
-    "output.nwb",
-    use_multisubjects=True,
-    subjects_metadata=subjects_metadata
-)
-```
-
-!!! info "Subject metadata fields"
-    The `subjects_metadata` list should have one entry per track. Each entry can include:
-
-    - `sex`: Subject sex (defaults to "U" for unknown)
-    - `species`: Species name (defaults to "unknown")
-    - `age`: Age in ISO 8601 duration format (e.g., "P30D" for 30 days)
-    - Any other fields supported by NWB Subject
-
-!!! warning "Tracked instances required"
-    Multi-subject export requires all instances to have track assignments. A warning is issued if untracked instances are present.
-
-#### NWB Metadata
-
-The NWB format requires certain metadata fields. sleap-io provides sensible defaults:
-
-- **Required fields** (auto-generated if not provided):
-  - `session_description`: Defaults to "Processed SLEAP pose data"
-  - `identifier`: Auto-generated UUID string
-  - `session_start_time`: Current timestamp
-
-- **Optional fields** (via `nwb_kwargs`):
-  - `session_id`: Unique session identifier
-  - `experimenter`: List of experimenters
-  - `lab`: Laboratory name
-  - `institution`: Institution name
-  - `experiment_description`: Detailed experiment description
-  - Any other valid NWB file fields
+[Neurodata Without Borders (NWB)](https://www.nwb.org/) is a standardized
+neurophysiology format with full read/write support for pose tracking. See
+the **[NWB Format](nwb.md)** page for harmonized I/O, the `nwb_format` types,
+the advanced annotations API, multi-subject export, and metadata handling.
 
 ### JABS Format (.h5)
 
@@ -365,87 +217,10 @@ with h5py.File("output.h5", "r") as f:
 
 ### DeepLabCut Format (.h5, .csv)
 
-Load annotations from [DeepLabCut](http://www.mackenziemathislab.org/deeplabcut), a popular markerless pose estimation tool.
-
-`load_dlc` reads a single DLC annotation CSV. When a project `config.yaml` is
-available — either passed explicitly via `config=` or auto-discovered by walking
-up from the CSV — the following extra metadata is imported:
-
-- **Skeleton edges** from the config `skeleton:` list. Edges that reference
-  bodyparts not present in the labeled data are dropped with a warning.
-- **Source videos**: each `labeled-data/<video>/` image folder is linked back to
-  its original video file (from the config `video_sets`) via `Video.source_video`,
-  matched by filename stem. The link is best-effort and left unset on a stem
-  mismatch or missing file.
-
-Pass `config=False` to disable config use entirely and reproduce the legacy,
-config-free output.
-
-!!! note "Cropping is not yet applied"
-    DeepLabCut's `video_sets[...].crop` is a *virtual* read-time crop (an ROI
-    that DLC's video reader slices out of each full frame on the fly). When a
-    project uses cropping, the images under `labeled-data/<video>/` are the
-    cropped region and the labels are stored in **cropped-frame coordinates**,
-    whereas the linked `source_video` points at the original, **uncropped**
-    video. sleap-io does not yet apply this crop, so for cropped projects the
-    labels are offset from the source video by the crop origin `(x1, y1)`.
-    Reconciling the two requires virtual ROI-cropping of a `Video` on read,
-    which is planned future work. For the common case of no cropping (the DLC
-    default is the full frame), there is no offset and the link is exact.
-
-```python
-import sleap_io as sio
-
-# Single CSV; auto-discovers config.yaml for edges + source-video links.
-labels = sio.load_dlc("project/labeled-data/vid1/CollectedData_Scorer.csv")
-
-# Strict legacy output (no edges/links), even inside a project.
-labels = sio.load_dlc("project/labeled-data/vid1/CollectedData_Scorer.csv", config=False)
-```
-
-!!! note "Unannotated rows become empty frames"
-    Every CSV row (image) is loaded as a `LabeledFrame`, including rows with no
-    labeled bodyparts (all-NaN) — these become **empty** `LabeledFrame`s, so the
-    frame count matches the input. Drop them with
-    [`Labels.clean()`](../model/labels.md) if you don't want them.
-
-::: sleap_io.io.main.load_dlc
-
-#### Loading a whole DLC project
-
-`load_dlc_project` loads every `labeled-data/<video>/` folder in a project at
-once and merges them into a single `Labels` that shares one `Skeleton` (with
-edges) and one set of `Track`s, recording provenance under the `dlc_project`,
-`dlc_scorer`, and `dlc_task` keys. A project directory or its `config.yaml` can
-also be passed to `load_file`, which routes it here automatically.
-
-```python
-labels = sio.load_dlc_project("path/to/dlc_project")  # dir or config.yaml
-labels = sio.load_file("path/to/dlc_project")          # auto-routed
-```
-
-::: sleap_io.io.main.load_dlc_project
-
-#### Importing train/test splits
-
-`load_dlc_splits` recovers the train/test splits created by DLC's
-`create_training_dataset`, reading the positional indices stored in the project's
-`Documentation_data-*.pickle` and reconstructing DLC's globally, lexicographically
-sorted merge of all per-video annotations. It returns a
-[`LabelsSet`](../model/index.md) with `"train"` and `"test"` keys.
-
-Splits require the labeled images to be present on disk. For non-zero-padded
-image filenames a warning is emitted, since DLC's lexicographic ordering (e.g.
-`img10` < `img2`) differs from numeric ordering and could otherwise cause silent
-train/test mis-assignment. If a project has multiple training fractions or
-shuffles, pass `train_fraction=` and/or `shuffle=` to disambiguate.
-
-```python
-splits = sio.load_dlc_splits("path/to/dlc_project", shuffle=1)
-train, test = splits["train"], splits["test"]
-```
-
-::: sleap_io.io.main.load_dlc_splits
+Load annotations from [DeepLabCut](http://www.mackenziemathislab.org/deeplabcut). See the
+**[DeepLabCut Format](dlc.md)** page for single-CSV loading with `config.yaml`
+discovery (skeleton edges + source-video links), whole-project imports with
+`load_dlc_project`, and train/test split recovery with `load_dlc_splits`.
 
 ### CSV Format (.csv)
 
@@ -562,19 +337,10 @@ Load predictions from [LEAP](https://github.com/talmo/leap), a SLEAP predecessor
 
 ### COCO Format (.json)
 
-[COCO](https://cocodataset.org/) (Common Objects in Context) format is widely used in computer vision and pose estimation. sleap-io provides full read and write support, making it compatible with tools like [mmpose](https://github.com/open-mmlab/mmpose), [CVAT](https://www.cvat.ai/), and other COCO-compatible frameworks.
-
-!!! note "Unannotated images become empty frames"
-    `load_coco` creates a `LabeledFrame` for every entry in the `images` array,
-    including images with zero annotations — these become **empty**
-    `LabeledFrame`s, so the frame count matches the input and unannotated images
-    round-trip losslessly. One caveat: an image whose file path cannot be resolved
-    is skipped, so a 0-annotation image with a missing file is dropped rather than
-    preserved.
-
-::: sleap_io.io.main.load_coco
-
-::: sleap_io.io.main.save_coco
+[COCO](https://cocodataset.org/) (Common Objects in Context) is widely used in
+computer vision and pose estimation. See the **[COCO Format](coco.md)** page
+for full read/write support (compatible with mmpose, CVAT, and other COCO-based
+tools) and empty-frame handling.
 
 ### TIFF Label Images (.tif, .tiff)
 
@@ -609,45 +375,16 @@ write_coco_panoptic("output.json", labels, images_dir="output_pngs/")
 
 ### Ultralytics YOLO Format
 
-Support for [Ultralytics YOLO](https://docs.ultralytics.com/) pose format.
-
-::: sleap_io.io.main.load_ultralytics
-
-::: sleap_io.io.main.save_ultralytics
+Read and write the [Ultralytics YOLO](https://docs.ultralytics.com/) pose
+format. See the **[Ultralytics YOLO Format](ultralytics.md)** page for details.
 
 ### GeoJSON Format (.geojson)
 
-[GeoJSON](https://geojson.org/) (RFC 7946) is a JSON-based format for encoding geographic data structures. sleap-io uses it to store ROIs (regions of interest) as a human-readable, standalone format. The output is compatible with the [movement](https://github.com/neuroinformatics-unit/movement) library (v0.15.0+) and the broader geospatial Python ecosystem (Shapely, GeoPandas, QGIS, QuPath).
-
-Each ROI is serialized as a GeoJSON Feature with geometry and metadata properties. The `ROI` class also implements the Python `__geo_interface__` protocol for direct interoperability with Shapely and other geo-aware libraries.
-
-#### Examples
-
-```python
-import sleap_io as sio
-from sleap_io.model.roi import UserROI
-from shapely.geometry import box
-
-# Create some ROIs
-rois = [
-    UserROI(geometry=box(100, 200, 150, 280), name="box1", category="animal"),
-    UserROI.from_polygon([(0, 0), (50, 0), (50, 50)], name="region"),
-]
-
-# Save to GeoJSON
-sio.save_geojson(rois, "rois.geojson")
-
-# Load back
-loaded_rois = sio.load_geojson("rois.geojson")
-
-# Also works with load_file/save_file (wraps in Labels)
-labels = sio.load_file("rois.geojson")  # Returns Labels(rois=...)
-sio.save_file(labels, "rois.geojson")
-```
-
-::: sleap_io.io.main.load_geojson
-
-::: sleap_io.io.main.save_geojson
+[GeoJSON](https://geojson.org/) (RFC 7946) stores ROIs as a human-readable,
+standalone format that interoperates with the
+[movement](https://github.com/neuroinformatics-unit/movement) library and the
+geospatial Python ecosystem (Shapely, GeoPandas, QGIS). See the
+**[GeoJSON Format](geojson.md)** page for the schema and examples.
 
 ## Working with Multiple Datasets
 
@@ -673,7 +410,7 @@ sleap-io automatically detects file formats based on:
 2. **File content**: For ambiguous extensions like `.h5` (JABS vs DLC) or `.json` (Label Studio vs COCO)
 3. **Explicit format**: Pass `format` parameter to override auto-detection
 
-For URLs, ambiguous extensions (`.h5`, `.json`, `.csv`) are disambiguated with a magic-byte sniff via a Range request, controllable with [`load_file`][sleap_io.load_file]'s `sniff=` argument. See [Loading from URLs](../examples.md#loading-from-urls).
+For URLs, ambiguous extensions (`.h5`, `.json`, `.csv`) are disambiguated with a magic-byte sniff via a Range request, controllable with [`load_file`][sleap_io.load_file]'s `sniff=` argument. See [Loading from URLs](../remote.md).
 
 ## Format Conversion Examples
 
@@ -754,7 +491,7 @@ Different formats have varying capabilities:
 *******TrackMate auto-detects sibling `.tif`/`.tiff` video files
 
 !!! note "Remote URL loading"
-    Loading from a URL is currently supported only for SLEAP `.slp`/`.pkg.slp` (labels) and `http`/`https` media video; all other labels formats raise `NotImplementedError` over a URL — download the file locally first. See [Loading from URLs](../examples.md#loading-from-urls).
+    Loading from a URL is currently supported only for SLEAP `.slp`/`.pkg.slp` (labels) and `http`/`https` media video; all other labels formats raise `NotImplementedError` over a URL — download the file locally first. See [Loading from URLs](../remote.md).
 
 ## See Also
 

--- a/docs/formats/nwb.md
+++ b/docs/formats/nwb.md
@@ -1,0 +1,154 @@
+# NWB Format (.nwb)
+
+[Neurodata Without Borders (NWB)](https://www.nwb.org/) is a standardized format for neurophysiology data. sleap-io provides comprehensive support for both reading and writing pose tracking data in NWB format.
+
+## Harmonized NWB I/O
+
+The harmonized API automatically detects and routes to the appropriate NWB backend:
+
+::: sleap_io.io.main.load_nwb
+
+::: sleap_io.io.main.save_nwb
+
+## NWB Format Types
+
+sleap-io supports multiple NWB format types through the `nwb_format` parameter:
+
+- **`"auto"`** (default): Automatically detect based on data content
+  - Uses `"annotations"` if data contains user-labeled instances
+  - Uses `"predictions"` if data contains only predicted instances
+
+- **`"annotations"`**: Save as PoseTraining format (ndx-pose extension)
+  - Stores manual annotations for training data
+  - Preserves skeleton structure and node names
+  - Includes annotator information
+
+- **`"annotations_export"`**: Export annotations with embedded video frames
+  - Creates self-contained NWB file with video data
+  - Generates MJPEG video with frame provenance tracking
+  - Useful for sharing complete datasets
+
+- **`"predictions"`**: Save as PoseEstimation format (ndx-pose extension)
+  - Stores predicted pose data from inference
+  - Includes confidence scores
+  - Supports multiple animals/tracks
+
+## Examples
+
+### Basic NWB Usage
+
+```python
+import sleap_io as sio
+
+# Load any NWB file (auto-detects format)
+labels = sio.load_nwb("pose_data.nwb")
+
+# Save with auto-detection
+sio.save_nwb(labels, "output.nwb")
+
+# Save with specific format
+sio.save_nwb(labels, "training.nwb", nwb_format="annotations")
+sio.save_nwb(labels, "predictions.nwb", nwb_format="predictions")
+```
+
+### Advanced Annotations API
+
+For more control over NWB training data, use the annotations module directly:
+
+```python
+from sleap_io.io.nwb_annotations import save_labels, load_labels
+
+# Save with custom metadata
+save_labels(
+    labels,
+    "training.nwb",
+    session_description="Mouse reaching task",
+    identifier="mouse_01_session_03",
+    annotator="researcher_name",
+    nwb_kwargs={
+        "session_id": "session_003",
+        "experimenter": ["John Doe", "Jane Smith"],
+        "lab": "Motor Control Lab",
+        "institution": "University",
+        "experiment_description": "Skilled reaching behavior"
+    }
+)
+
+# Load annotations
+labels = load_labels("training.nwb")
+```
+
+### Export with Video Frames
+
+```python
+from sleap_io.io.nwb_annotations import export_labels, export_labeled_frames
+
+# Export complete dataset with videos
+export_labels(
+    labels,
+    output_dir="export/",
+    nwb_filename="dataset_with_videos.nwb",
+    as_training=True,  # Include manual annotations
+    include_videos=True  # Embed video frames
+)
+
+# Export only labeled frames as video
+export_labeled_frames(
+    labels,
+    output_path="labeled_frames.avi",
+    labels_output_path="labels.nwb",
+    fps=30.0
+)
+```
+
+
+### Multi-Subject Support
+
+For multi-animal experiments, sleap-io supports the [ndx-multisubjects](https://pypi.org/project/ndx-multisubjects/) NWB extension. This links each tracked animal to a proper NWB Subject entry.
+
+```python
+from sleap_io.io.nwb_annotations import save_labels
+
+# Basic multi-subject export (uses track names as subject IDs)
+save_labels(labels, "output.nwb", use_multisubjects=True)
+
+# With detailed subject metadata
+subjects_metadata = [
+    {"sex": "M", "species": "Mus musculus", "age": "P30D"},
+    {"sex": "F", "species": "Mus musculus", "age": "P45D"},
+]
+save_labels(
+    labels,
+    "output.nwb",
+    use_multisubjects=True,
+    subjects_metadata=subjects_metadata
+)
+```
+
+!!! info "Subject metadata fields"
+    The `subjects_metadata` list should have one entry per track. Each entry can include:
+
+    - `sex`: Subject sex (defaults to "U" for unknown)
+    - `species`: Species name (defaults to "unknown")
+    - `age`: Age in ISO 8601 duration format (e.g., "P30D" for 30 days)
+    - Any other fields supported by NWB Subject
+
+!!! warning "Tracked instances required"
+    Multi-subject export requires all instances to have track assignments. A warning is issued if untracked instances are present.
+
+## NWB Metadata
+
+The NWB format requires certain metadata fields. sleap-io provides sensible defaults:
+
+- **Required fields** (auto-generated if not provided):
+  - `session_description`: Defaults to "Processed SLEAP pose data"
+  - `identifier`: Auto-generated UUID string
+  - `session_start_time`: Current timestamp
+
+- **Optional fields** (via `nwb_kwargs`):
+  - `session_id`: Unique session identifier
+  - `experimenter`: List of experimenters
+  - `lab`: Laboratory name
+  - `institution`: Institution name
+  - `experiment_description`: Detailed experiment description
+  - Any other valid NWB file fields

--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -761,7 +761,7 @@ The `/negative_frames` dataset is optional. Files without negative frames will n
 For large SLP files with hundreds of thousands of frames, sleap-io provides a lazy loading mode that defers [`Labels`][sleap_io.Labels] object creation until needed.
 
 !!! tip "Streaming from a URL"
-    `.slp`/`.pkg.slp` files can be opened straight from `http`/`https`, cloud, or Google Drive URLs via [`load_slp`][sleap_io.load_slp] with lazy range-based reads (embedded `pkg.slp` frames reopen the remote file on demand). See [Loading from URLs](../examples.md#loading-from-urls).
+    `.slp`/`.pkg.slp` files can be opened straight from `http`/`https`, cloud, or Google Drive URLs via [`load_slp`][sleap_io.load_slp] with lazy range-based reads (embedded `pkg.slp` frames reopen the remote file on demand). See [Loading from URLs](../remote.md).
 
 ### Architecture
 

--- a/docs/formats/ultralytics.md
+++ b/docs/formats/ultralytics.md
@@ -1,0 +1,7 @@
+# Ultralytics YOLO Format
+
+Support for [Ultralytics YOLO](https://docs.ultralytics.com/) pose format.
+
+::: sleap_io.io.main.load_ultralytics
+
+::: sleap_io.io.main.save_ultralytics

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,0 +1,31 @@
+# Guides
+
+Task-oriented how-to guides for working with sleap-io. Start with **Examples** for
+copy-paste recipes, then reach for the focused guides below.
+
+**[Examples](examples.md)**: Practical recipes — loading and saving, editing
+skeletons and tracks, fixing video paths, exporting to other formats, rendering,
+and more.
+
+**[Remote loading](remote.md)**: Load `.slp` files and videos straight from
+`http`/`https`, cloud storage (`s3://`, `gs://`, `az://`), and Google Drive URLs,
+with lazy range-based streaming, optional persistent caching, and authentication.
+
+**[Codecs](codecs.md)**: Convert `Labels` to and from NumPy arrays and pandas
+DataFrames using the array and table codecs.
+
+**[Merging](merging.md)**: Combine datasets from multiple sources with track,
+skeleton, instance, and video matching.
+
+**[Rendering](rendering.md)**: Render videos and images with pose overlays,
+customizable colors, markers, presets, and motion trails.
+
+**[Transforms](transforms.md)**: Crop, scale, rotate, and pad labels and their
+videos while keeping coordinates aligned.
+
+!!! tip "Reference material"
+
+    For the data structures these guides operate on, see the
+    **[Data model](model/index.md)**; for format-specific details, see
+    **[Formats](formats/index.md)**; and for the `sio` command line, see the
+    **[CLI reference](cli.md)**.

--- a/docs/install.md
+++ b/docs/install.md
@@ -130,7 +130,9 @@ sio --version
 
     Video support via imageio-ffmpeg is always included. The `[all]` extra also
     includes the cloud-storage adapters (`s3fs`, `gcsfs`, `adlfs`) needed to
-    load `.slp` files from `s3://`/`gs://`/`az://` URLs.
+    load `.slp` files from `s3://`/`gs://`/`az://` URLs. Loading remote **media
+    video** over `http`/`https` additionally needs a PyAV backend (`[all]` or
+    `[pyav]`) — see [Remote video](remote.md#remote-video).
 
 See the [CLI documentation](cli.md) for a complete command reference.
 
@@ -395,9 +397,9 @@ sleap-io uses optional dependencies for specific features:
 | `polars` | `polars`, `pyarrow` | Fast dataframe operations |
 | `all` | All of the above | Everything included |
 
-`http`/`https` URLs work with the base install; cloud-storage URLs need the
-`cloud` extra and remote media video needs the `pyav` extra. See
-[Loading from URLs](examples.md#loading-from-urls).
+`http`/`https` URLs — including Google Drive share links — work with the base
+install; cloud-storage URLs need the `cloud` extra and remote media video needs
+the `pyav` extra. See the [Remote loading](remote.md) guide.
 
 Install specific extras:
 

--- a/docs/model/boxes.md
+++ b/docs/model/boxes.md
@@ -108,7 +108,7 @@ Every bounding box can carry optional metadata:
 
     - **[Centroids](centroids.md)**, **[ROIs](rois.md)**, **[Segmentation](segmentation.md)** — the other spatial annotation types.
     - **[Labels & Frames](labels.md)**: Accessing boxes via `labels.bboxes` and filtered queries with `get_bboxes()`.
-    - **[Formats: COCO](../formats/index.md#coco-format-json)** and **[Ultralytics YOLO](../formats/index.md#ultralytics-yolo-format)**: Bounding-box detection round-trips.
+    - **[Formats: COCO](../formats/coco.md)** and **[Ultralytics YOLO](../formats/ultralytics.md)**: Bounding-box detection round-trips.
     - **[Converting between annotation types](segmentation.md#converting-between-annotation-types)**: `bbox.to_roi()`, `bbox.to_mask()`, and more.
 
 ---

--- a/docs/model/video.md
+++ b/docs/model/video.md
@@ -18,7 +18,7 @@ video = sio.Video.from_filename("test.mp4")
 
 A media video can also be loaded from an `http`/`https` URL with
 [`load_video`][sleap_io.load_video] (requires the `pyav` extra; cloud schemes
-and Google Drive are not supported for video — see [Remote video](../examples.md#loading-from-urls)):
+and Google Drive are not supported for video — see [Remote video](../remote.md#remote-video)):
 
 ```python
 video = sio.load_video("https://example.com/clip.mp4")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -154,6 +154,7 @@ nav:
   - Changelog: changelog.md
   - Releases: https://github.com/talmolab/sleap-io/releases
   - Guides:
+    - guides.md
     - Examples: examples.md
     - Remote loading: remote.md
     - Codecs: codecs.md
@@ -174,9 +175,14 @@ nav:
     - Formats:
       - formats/index.md
       - SLP Format: formats/slp.md
-      - CSV Format: formats/csv.md
+      - NWB: formats/nwb.md
       - Analysis HDF5: formats/analysis_h5.md
+      - DeepLabCut: formats/dlc.md
+      - CSV Format: formats/csv.md
+      - COCO: formats/coco.md
       - TIFF: formats/tiff.md
+      - Ultralytics: formats/ultralytics.md
+      - GeoJSON: formats/geojson.md
       - TrackMate: formats/trackmate.md
     - CLI: cli.md
     - Full API: reference/

--- a/scripts/gen_llms_txt.py
+++ b/scripts/gen_llms_txt.py
@@ -23,6 +23,7 @@ DESCRIPTION = (
 )
 
 GUIDES = [
+    ("Guides overview", "guides.md", "Index of the task-oriented how-to guides"),
     ("Examples", "examples.md", "Practical recipes for common tasks"),
     (
         "Remote loading",
@@ -60,9 +61,14 @@ FORMATS = [
         "All supported I/O formats and their limitations",
     ),
     ("SLP", "formats/slp.md", "Native SLEAP format"),
-    ("CSV", "formats/csv.md", "Flat tabular export/import"),
+    ("NWB", "formats/nwb.md", "Neurodata Without Borders pose data"),
     ("Analysis HDF5", "formats/analysis_h5.md", "SLEAP analysis arrays"),
+    ("DeepLabCut", "formats/dlc.md", "DeepLabCut CSV and project import"),
+    ("CSV", "formats/csv.md", "Flat tabular export/import"),
+    ("COCO", "formats/coco.md", "COCO keypoint detection JSON"),
     ("TIFF", "formats/tiff.md", "Label images"),
+    ("Ultralytics", "formats/ultralytics.md", "Ultralytics YOLO pose format"),
+    ("GeoJSON", "formats/geojson.md", "ROIs as GeoJSON (RFC 7946)"),
     ("TrackMate", "formats/trackmate.md", "ImageJ/Fiji point tracking"),
 ]
 REFERENCE = [


### PR DESCRIPTION
## Summary

Completes the remaining 0.8.0 docs-audit items: **M4** (Formats nav discoverability), **L4–L7** (remote cross-link canonicalization), and **L11** (Guides landing page).

> ⚠️ Stacked on #457. GitHub auto-retargets this to `main` once #457 merges.

## Key Changes

### M4 — Formats leaf-page split
- Promoted the high-traffic in-page sections **NWB, DeepLabCut, COCO, Ultralytics, GeoJSON** from the 745-line `formats/index.md` into dedicated leaf pages (`formats/{nwb,dlc,coco,ultralytics,geojson}.md`) and added them to the **Formats nav**. This resolves the audit headline that *NWB and COCO were invisible in the left nav*.
- Each moved section becomes an **anchor-preserving stub** in `index.md` (heading kept → `#nwb-format-nwb` etc. still resolve) with a one-liner linking to its leaf page.
- Repointed the "see also / reference" cross-links that targeted those sections to the new leaf pages (`examples.md`, `model/boxes.md`, `cli.md`), including the 4 hardcoded `formats/#sleap_io.{load,save}_{nwb,coco}` API-symbol links.
- Added the 5 new pages to the **`llms.txt`** generator (`scripts/gen_llms_txt.py`).

### L4–L7 — Remote cross-links
- Repointed the two-hop `examples.md#loading-from-urls` cross-links to the canonical **`remote.md`** guide (and `remote.md#remote-video` for video) across `install.md`, `formats/index.md`, `formats/slp.md`, `model/video.md`.
- L6: the install URL-scheme summary now mentions **Google Drive** and points at `remote.md`.
- L7: the `[all]` extra callout now notes that remote **media video** needs the `[all]`/`[pyav]` backend, cross-linking `remote.md#remote-video`.

### L11 — Guides landing page
- Added `docs/guides.md` as the **Guides** nav section index (mirrors `model/index.md`/`formats/index.md`), linking Examples / Remote loading / Codecs / Merging / Rendering / Transforms.

## Design note

mkdocs **nav cannot deep-link to section anchors** (`formats/index.md#jabs-format-h5` raises "not found in the documentation files"). So the smaller in-page formats (JABS, Label Studio, AlphaTracker, LEAP, COCO Panoptic) stay documented in the Formats **overview** (itself a nav node) rather than shipping broken anchored nav entries. They can be promoted to leaf pages later if desired.

## Testing
- `mkdocs build` (EAGER_IMPORT=1): **exit 0**, no nav warnings, all repointed leaf-page links resolve, `llms.txt` regenerated with the new pages. Remaining warnings are the pre-existing `griffe **kwargs` ones (the deferred M6).
- `pytest tests/test_docs.py` (pycon guard): **73 passed**.
- An 8-agent adversarial verification pass confirmed each leaf page is a **byte-for-byte faithful move** (only heading levels shifted), anchors preserved, and no stale/broken inbound links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)