### PR TITLE
feat: virtual on-read video cropping (CropVideoBackend)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,6 +72,7 @@ sio render --help
 sio trim --help
 sio reencode --help
 sio transform --help
+sio apply-crops --help
 
 # Check version and installed plugins
 sio --version
@@ -2520,6 +2521,26 @@ sio transform labels.slp --config transforms.yaml -o output.slp
 ```
 
 See the [Transforms Guide](transforms.md#config-file-format) for config file format and examples.
+
+---
+
+## Apply Crops
+
+`sio apply-crops` materializes [virtual crops](cropping.md) (created via `Video.crop` and
+stored in a `.slp`'s `/video_crops`) into real video files, updating the labels to point at
+the baked files. Unlike `sio transform --crop` (which applies a *new* crop and adjusts
+coordinates), this bakes an *existing* virtual crop and is coordinate-neutral.
+
+```bash
+# Bake every virtually-cropped video; baked files go next to the output SLP.
+sio apply-crops mosaic.slp -o baked.slp
+
+# Choose the output video directory and filename suffix.
+sio apply-crops mosaic.slp -o baked.slp --video-dir baked_videos/ --suffix _crop
+```
+
+Each baked video keeps `source_video` provenance to the uncropped original; uncropped videos
+are left untouched. See the [Virtual cropping guide](cropping.md#applying-baking-a-crop-to-disk).
 
 ---
 

--- a/docs/cropping.md
+++ b/docs/cropping.md
@@ -1,0 +1,182 @@
+# Virtual cropping
+
+sleap-io can expose a **virtual, on-read crop** of a video — a cropped view whose
+frames are produced by decoding the source and slicing in memory, without copying or
+re-encoding any pixels on disk. It is the lazy, non-destructive counterpart of the
+materializing [Transforms](transforms.md) pipeline: a virtually-cropped frame is
+byte-identical to what baking a `Transform(crop=...)` would write.
+
+---
+
+## Quick start
+
+```python
+import sleap_io as sio
+
+full = sio.load_video("session.mp4")              # (1000, 1080, 1920, 3)
+
+# A cropped view. crop = (x1, y1, x2, y2), with x2/y2 EXCLUSIVE.
+view = full.crop((320, 200, 576, 456))
+view.shape            # (1000, 256, 256, 3)  -- cropped
+view[0].shape         # (256, 256, 3)        -- a cropped frame
+view.crop             # not a thing; use view._crop_tuple() -> (320, 200, 576, 456)
+view.source_video is full   # True  -- provenance to the uncropped original
+```
+
+`Video.from_crop` opens a file and crops it in one call:
+
+```python
+view = sio.Video.from_crop("session.mp4", crop=(320, 200, 576, 456))
+```
+
+The returned object is a normal [`Video`](model/video.md): `shape`, `len()`, `grayscale`,
+NumPy-style indexing, and matching all report the **cropped** view.
+
+---
+
+## The crop convention
+
+A crop is `(x1, y1, x2, y2)` in **source pixel coordinates**, with `x2`/`y2`
+**exclusive** — exactly the convention used by [`Transform`](transforms.md) and
+`crop_frame`. The cropped size is `(y2 - y1, x2 - x1)`.
+
+Coordinates may be **negative or extend past the source** — out-of-bounds regions are
+**padded** with `fill` (default `0`), never clamped, so the output shape is always
+exactly `(y2 - y1, x2 - x1)`. This makes fixed-size, centroid-following windows easy:
+
+```python
+# Fixed 128x128 window centered on a point (may run off the frame edge -> padded).
+view = full.crop(center=(cx, cy), size=(128, 128), fill=0)
+view.shape            # (n_frames, 128, 128, 3)
+```
+
+`Video.crop` accepts one region spec — an explicit `crop` rect, a `bbox=(x1,y1,x2,y2)`,
+an `roi` (anything exposing shapely-style `.bounds`, expanded by `margin`), or a
+`center`/`size` pair:
+
+```python
+full.crop((x1, y1, x2, y2))                  # explicit rect
+full.crop(bbox=(x1, y1, x2, y2))             # same, named
+full.crop(roi=my_roi, margin=8)              # axis-aligned bounds of an ROI + margin
+full.crop(center=(cx, cy), size=(w, h))      # fixed-size window
+```
+
+---
+
+## Coordinates
+
+A crop is a pure integer translation by `(x1, y1)`, so mapping landmark coordinates
+between source and cropped frames is exact and NaN-preserving:
+
+```python
+pts_crop   = view.to_crop_coords(pts_source)     # subtract (x1, y1)
+pts_source = view.to_source_coords(pts_crop)      # add (x1, y1)
+```
+
+On an uncropped video these are identity passthroughs, so the same call works
+regardless of whether a video happens to be cropped. The underlying functions live in
+`sleap_io.transform.points` as `crop_points` / `uncrop_points`.
+
+!!! note "Coordinates are never rewritten on disk"
+    Virtual cropping never mutates stored `instance.points`. These helpers are
+    read-time conveniences for presenting/ingesting coordinates in cropped-frame space.
+
+---
+
+## Mosaics: many crops, one decode
+
+Multiple differently-cropped views of one physical file can share a single decoder, so
+the source frame is decoded once per read rather than once per tile:
+
+```python
+full = sio.load_video("session.mp4")
+tiles = [
+    full.crop((x, y, x + 128, y + 128))       # share_decode=True (default)
+    for y in range(0, 1080 - 128, 128)
+    for x in range(0, 1920 - 128, 128)
+]
+labels = sio.Labels(videos=tiles)
+```
+
+Each tile reuses `full`'s backend as its inner reader. The tiles do **not** own that
+shared decoder, so closing one tile does not tear down its siblings; the owning source
+`Video` manages the decoder's lifetime. (Decoder sharing is intentionally not preserved
+across `pickle`/`deepcopy`/`open()` — each reconstruction rebuilds its own reader.)
+
+Two crops of the same file with **different** crops are kept distinct through merge,
+append, and matching; two crops with the **same** rect dedup to one view.
+
+---
+
+## Saving & loading (SLP round-trip)
+
+Crops round-trip through `.slp` without breaking older readers:
+
+```python
+sio.save_file(labels, "mosaic.slp")
+labels2 = sio.load_file("mosaic.slp")
+labels2.videos[0]._crop_tuple()         # (0, 0, 128, 128)        -- preserved
+labels2.videos[0].shape                 # (1000, 128, 128, 3)
+labels2.videos[0].source_video.shape    # (1000, 1080, 1920, 3)
+len(labels2.videos)                     # all tiles preserved (not collapsed)
+```
+
+- The crop rects are stored in a dedicated top-level `/video_crops` dataset, written
+  **only when a crop is present**; the `videos_json` entry describes the **uncropped
+  source**.
+- An older reader that does not understand `/video_crops` simply loads the uncropped
+  source video — a graceful, lossy degrade, never an error.
+- Files with no crops are byte-identical to before this feature existed (no
+  `/video_crops`, no format-version bump).
+
+---
+
+## Baking a crop to disk
+
+A virtual crop is the lazy dual of the materializing pipeline. To write a real cropped
+file later, feed the same rect to [`transform_video`](transforms.md) /
+`transform_labels`; the baked pixels are identical to the virtual view:
+
+```python
+sio.transform_video(full, "baked.mp4", sio.Transform(crop=(320, 200, 576, 456)))
+```
+
+---
+
+## Performance expectations
+
+The crop is applied **after** a full-frame decode for every backend except raw,
+sub-frame-chunked HDF5, where it can push the region read down to the storage layer:
+
+| Backend | Strategy | I/O effect |
+|---|---|---|
+| `MediaVideo` (mp4/H.264/…) | decode full frame, slice | **No decode/I/O savings** — inter-frame codecs must decode the whole frame; the slice is a free in-memory view. Saves resident array size only. |
+| `HDF5Video` raw rank-4, **sub-frame chunked** | hyperslab region read (`ds[i, y1:y2, x1:x2, :]`) | **Real I/O reduction** — only the overlapping chunks are read/decompressed. The one case where a crop saves disk work. |
+| `HDF5Video` raw rank-4, per-frame chunked | region read (whole chunk still fetched) | Modest — skips chunk reassembly, not I/O. |
+| `HDF5Video` embedded PNG/JPEG (`.pkg.slp`) | decode full image, slice | **No savings** — the whole image must be decoded before any spatial selection. |
+| `ImageVideo`, `TiffVideo`, `SeqVideo` | decode full frame, slice | **No savings** with the current decoders. |
+
+Pushdown for raw HDF5 is automatic and gated on the dataset's actual chunking; it falls
+back to a full decode plus slice (byte-identical) whenever it would not help.
+
+---
+
+## Non-goals
+
+Virtual cropping is a pure translate-and-clip view. It deliberately does **not** do:
+
+- **Rotation, scale, pad, or flip on read** — those remain the domain of the
+  materializing [`Transform`](transforms.md) pipeline.
+- **Decode-cost savings for compressed video** — only sub-frame-chunked raw HDF5 sees
+  real I/O savings; everywhere else the crop is a free post-decode view.
+- **Lossless export through non-SLP writers** (NWB, COCO, JABS, Ultralytics) — those
+  formats have no crop concept; exporting a cropped `Labels` through them is acceptably
+  lossy (the cropped frame and its coordinates are emitted as-is).
+- **Rewriting on-disk point coordinates** — the source labels are never mutated.
+
+---
+
+## See also
+
+- [Transforms](transforms.md): the materializing crop/scale/rotate/pad/flip pipeline.
+- [Video](model/video.md): the `Video` facade and its backends.

--- a/docs/cropping.md
+++ b/docs/cropping.md
@@ -131,15 +131,52 @@ len(labels2.videos)                     # all tiles preserved (not collapsed)
 
 ---
 
-## Baking a crop to disk
+## Applying (baking) a crop to disk
 
-A virtual crop is the lazy dual of the materializing pipeline. To write a real cropped
-file later, feed the same rect to [`transform_video`](transforms.md) /
-`transform_labels`; the baked pixels are identical to the virtual view:
+A virtual crop can be **materialized** to a real video file — the cropped pixels become
+physical and the crop is no longer a read-time view. This is coordinate-neutral: a virtual
+crop already presents cropped-frame coordinates, so baking the pixels leaves all point
+coordinates unchanged.
+
+`Video.apply_crop` bakes one cropped video and returns a new `Video` for the baked file,
+preserving provenance (`source_video` is the uncropped original):
 
 ```python
-sio.transform_video(full, "baked.mp4", sio.Transform(crop=(320, 200, 576, 456)))
+view = full.crop((320, 200, 576, 456))
+baked = view.apply_crop("crop.mp4")
+baked.shape                    # (1000, 256, 256, 3)  — cropped, now physical
+baked.source_video.shape       # (1000, 1080, 1920, 3) — uncropped original
+baked._crop_tuple()            # None — the crop is materialized, not virtual
 ```
+
+`Labels.apply_crops` bakes every virtually-cropped video in a `Labels` and rewires all
+references (labeled frames, ROIs, suggestions) to the baked files; uncropped videos are
+untouched and coordinates are unchanged:
+
+```python
+labels.apply_crops(video_dir="baked_videos/")   # one file per tile, unique names
+```
+
+From the command line, `sio apply-crops` materializes every virtual crop in an SLP,
+writing baked videos to a directory next to the output and updating the references:
+
+```bash
+sio apply-crops mosaic.slp -o baked.slp --video-dir baked_videos/
+```
+
+!!! note "`apply_crop` vs `sio transform --crop`"
+    `apply_crop` materializes an **existing** virtual crop (no coordinate change).
+    `sio transform --crop` applies a **new** crop and adjusts coordinates — that is the
+    materializing [`transform_video`](transforms.md) / `transform_labels` path:
+
+    ```python
+    sio.transform_video(full, "baked.mp4", sio.Transform(crop=(320, 200, 576, 456)))
+    ```
+
+!!! info "Encoder padding"
+    The H.264 encoder pads frame dimensions up to a multiple of 16 (bottom/right only,
+    preserving the top-left content and coordinate alignment). A baked video whose cropped
+    width/height are not multiples of 16 is padded on those edges.
 
 ---
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1007,6 +1007,73 @@ sio.save_video(sio.load_video("input.mp4"), "output.mp4")
 !!! note "See also"
     [`save_video`](formats/#sleap_io.save_video): Video saving options and codec settings
 
+### Virtual cropping and batch autocrop
+
+Expose a virtual, on-read crop of a video — frames are decoded and sliced in memory, with no pixels copied or re-encoded ([`Video.crop`](model/video.md#sleap_io.Video.crop) / [`Video.from_crop`](model/video.md#sleap_io.Video.from_crop)). The crop is `(x1, y1, x2, y2)` in source pixels (`x2`/`y2` exclusive); out-of-bounds regions are padded.
+
+```python title="virtual_crop.py" linenums="1"
+import sleap_io as sio
+
+full = sio.load_video("session.mp4")              # (1000, 1080, 1920, 3)
+view = full.crop((320, 200, 576, 456))            # virtual view, no decode yet
+view.shape                                         # (1000, 256, 256, 3)
+view.is_cropped, view.crop_rect                    # True, (320, 200, 576, 456)
+view.source_video is full                          # True - provenance preserved
+frame = view[0]                                    # decode-then-slice (256, 256, 3)
+
+# Other region specs: a bbox, an ROI (+ margin), or a fixed-size centered window.
+view = full.crop(bbox=(320.0, 200.0, 576.0, 456.0))
+view = full.crop(roi=my_shapely_poly, margin=8)
+view = full.crop(center=(cx, cy), size=(128, 128))   # fixed shape; off-frame is padded
+```
+
+**Batch autocrop (e.g. a multi-chamber rig).** Apply a fixed set of per-chamber rects across many recordings and write one cropped file per `(video x chamber)`. `apply_crop` bakes the virtual crop to disk and keeps `source_video` pointing at the uncropped original.
+
+```python title="batch_autocrop.py" linenums="1"
+import sleap_io as sio
+from pathlib import Path
+
+# Chamber layout, defined once (x1, y1, x2, y2). 16-aligned dims avoid encoder padding.
+chambers = {
+    "A": (0, 0, 640, 480),
+    "B": (640, 0, 1280, 480),
+    "C": (0, 480, 640, 960),
+    "D": (640, 480, 1280, 960),
+}
+
+out_dir = Path("crops")
+out_dir.mkdir(exist_ok=True)
+for path in Path("recordings").glob("*.mp4"):
+    full = sio.load_video(path.as_posix())
+    for name, rect in chambers.items():
+        crop = sio.Video.from_crop(full, rect)
+        crop.apply_crop((out_dir / f"{path.stem}_{name}.mp4").as_posix())
+```
+
+Prefer to stay lazy (no re-encode) and carry the crops in a labels file? Build the views into a `Labels`, save (crops ride a `/video_crops` dataset; pixels are untouched), and bake them all later in one call with [`Labels.apply_crops`](model/labels.md#sleap_io.Labels.apply_crops):
+
+```python title="virtual_crop_slp.py" linenums="1"
+import sleap_io as sio
+
+full = sio.load_video("session.mp4")
+tiles = [sio.Video.from_crop(full, rect) for rect in chambers.values()]
+sio.save_file(sio.Labels(videos=tiles), "session.slp")   # virtual; no re-encode
+
+# Later - materialize every virtual crop to real files and update references:
+sio.load_file("session.slp").apply_crops(video_dir="crops/")
+```
+
+The same step is available from the command line for an SLP that already carries virtual crops:
+
+```bash
+sio apply-crops session.slp -o baked.slp --video-dir crops/
+```
+
+!!! note "See also"
+    - [Virtual cropping guide](cropping.md): conventions, mosaics, coordinates, performance, and non-goals.
+    - [`Video.apply_crop`](model/video.md#sleap_io.Video.apply_crop) / [`Labels.apply_crops`](model/labels.md#sleap_io.Labels.apply_crops): materialize virtual crops to disk.
+    - [Transforms](transforms.md): the materializing crop/scale/rotate/pad/flip pipeline (`sio transform --crop` applies a *new* crop and adjusts coordinates).
+
 ### Switch video and image backends
 
 Control which backend is used for video reading and embedded frame encoding.

--- a/docs/formats/dlc.md
+++ b/docs/formats/dlc.md
@@ -16,17 +16,32 @@ up from the CSV — the following extra metadata is imported:
 Pass `config=False` to disable config use entirely and reproduce the legacy,
 config-free output.
 
-!!! note "Cropping is not yet applied"
+!!! note "Cropping (`video_sets[...].crop`)"
     DeepLabCut's `video_sets[...].crop` is a *virtual* read-time crop (an ROI
-    that DLC's video reader slices out of each full frame on the fly). When a
-    project uses cropping, the images under `labeled-data/<video>/` are the
-    cropped region and the labels are stored in **cropped-frame coordinates**,
-    whereas the linked `source_video` points at the original, **uncropped**
-    video. sleap-io does not yet apply this crop, so for cropped projects the
-    labels are offset from the source video by the crop origin `(x1, y1)`.
-    Reconciling the two requires virtual ROI-cropping of a `Video` on read,
-    which is planned future work. For the common case of no cropping (the DLC
-    default is the full frame), there is no offset and the link is exact.
+    that DLC's video reader slices out of each full frame). The images under
+    `labeled-data/<video>/` are the cropped region and the labels are stored in
+    **cropped-frame coordinates**, while the linked `source_video` is the
+    original, **uncropped** video. sleap-io now imports this crop:
+
+    - The crop rect is parsed from `video_sets` (DLC stores it width-range-first
+      as `x1, x2, y1, y2`; sleap-io reorders it to its `(x1, y1, x2, y2)`
+      convention, `x2`/`y2` exclusive) and recorded under
+      `labels.provenance["dlc_crops"]`, keyed by source-video path. This record
+      **persists through an SLP round-trip**.
+    - Labels are left **verbatim in cropped-frame coordinates** on the uncropped
+      `labeled-data` `ImageVideo` — no offset is applied (and the already-cropped
+      images are never cropped again). To map a label into the full source frame,
+      use [`Video.to_source_coords`](../model/video.md#sleap_io.Video.to_source_coords)
+      with the recorded rect (it adds the crop origin `(x1, y1)`).
+    - When the source video file is available, `source_video` is set to a
+      [`Video.from_crop`](../model/video.md#sleap_io.Video.from_crop) view of it,
+      so `source_video.crop_rect` / `to_source_coords` work in memory (this view's
+      crop is in-memory only; the persistent record is `provenance["dlc_crops"]`).
+      When the source is absent, `source_video` is a closed `Video` as before.
+    - Identity crops at the origin (`0, W, 0, H` — the DLC no-cropping default)
+      record no crop and leave the link exact.
+
+    See the [virtual cropping guide](../cropping.md) for the crop conventions.
 
 ```python
 import sleap_io as sio

--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -103,6 +103,8 @@ file.slp
 ├── /label_image_obj_categories  # Dataset: vlen string, one per object (Format 1.9+)
 ├── /label_image_obj_names       # Dataset: vlen string, one per object (Format 1.9+)
 │
+├── /video_crops                 # Dataset: JSON, virtual on-read crops (Format 2.3+, optional)
+│
 └── /video{N}/                   # Group: Per-video embedded data (one per video)
     ├── /video                   # Dataset: Embedded image data
     │   ├── @format              # Attribute: "png", "jpg", or "hdf5"
@@ -183,6 +185,28 @@ Videos can have a `source_video` field that tracks the original video when frame
 ```
 
 This creates a chain of provenance, allowing the original video to be restored when extracting embedded data.
+
+### Virtual Crops (Format 2.3+)
+
+A [virtually-cropped video](../cropping.md) stores its crop rect in a dedicated top-level
+`/video_crops` dataset (a single JSON string), written **only when at least one video is
+cropped**. Its `/videos_json` entry describes the **uncropped source** backend, and its
+`source_video` is the uncropped original — so a reader that does not understand
+`/video_crops` simply loads the full-frame source (a graceful, lossy degrade).
+
+```json
+[
+  {"video": 2, "crop": [128, 96, 384, 352], "fill": 0},
+  {"video": 5, "crop": [0, 0, 256, 256], "fill": 0}
+]
+```
+
+- `video` — integer index into the `/videos_json` video list.
+- `crop` — `[x1, y1, x2, y2]` in **source** pixel coordinates, `x2`/`y2` exclusive.
+- `fill` — out-of-bounds fill value (regions outside the source are padded, not clamped).
+
+The presence of any crop bumps `format_id` to `2.3`. Files with no crops are byte-identical
+to earlier versions (no `/video_crops` dataset, no version bump).
 
 ## Embedded Images
 

--- a/docs/model/video.md
+++ b/docs/model/video.md
@@ -161,6 +161,22 @@ video.original_video  # Root video in the chain
 
 This provenance chain enables restoring original video paths when extracting labels from packaged files.
 
+## Virtual cropping
+
+A `Video` can expose a virtual, on-read crop of another video — a cropped view whose frames are decoded from the source and sliced in memory, with no pixels copied or re-encoded:
+
+```python
+full = sio.load_video("session.mp4")          # (1000, 1080, 1920, 3)
+view = full.crop((320, 200, 576, 456))        # (x1, y1, x2, y2), x2/y2 exclusive
+view.shape                                     # (1000, 256, 256, 3)
+view.source_video is full                      # True
+
+# Map landmark coordinates between source and cropped frames (NaN-preserving):
+pts_crop = view.to_crop_coords(pts_source)
+```
+
+The view reports the cropped `shape`, `len()`, and `grayscale`, and indexes like any other video. Crops round-trip through `.slp` (stored in a dedicated `/video_crops` dataset; older readers see the uncropped source), and many crops of one file can share a single decoder. See the [Virtual cropping guide](../cropping.md) for conventions, mosaics, performance, and non-goals.
+
 ## File management
 
 ### Checking existence

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
     - Merging: merging.md
     - Rendering: rendering.md
     - Transforms: transforms.md
+    - Virtual cropping: cropping.md
   - Reference:
     - Model:
       - model/index.md

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -54,6 +54,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
         "io.seq": ["SeqVideo"],
         "io.video_reading": [
             "VideoBackend",
+            "CropVideoBackend",
             "get_default_image_plugin",
             "get_default_video_plugin",
             "set_default_image_plugin",

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -84,6 +84,7 @@ click.rich_click.COMMAND_GROUPS = {
                 "trim",
                 "reencode",
                 "transform",
+                "apply-crops",
             ],
         },
         {"name": "Embedding", "commands": ["embed", "unembed"]},
@@ -6389,6 +6390,240 @@ def reencode(
         f"{_format_file_size(output_size)} "
         f"({size_change:+.1f}%)[/]"
     )
+
+
+@cli.command(name="apply-crops")
+@click.argument(
+    "input_arg",
+    required=False,
+    default=None,
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.option(
+    "-i",
+    "--input",
+    "input_opt",
+    default=None,
+    type=click.Path(exists=True, path_type=Path),
+    help="Input SLP file. Can also be passed as positional argument.",
+)
+@click.option(
+    "-o",
+    "--output",
+    "output_path",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Output SLP path. Default: {input}.cropped.slp.",
+)
+@click.option(
+    "--video-dir",
+    "video_dir",
+    default=None,
+    type=click.Path(path_type=Path),
+    help="Directory for baked videos. Default: {output stem}.videos next to OUTPUT.",
+)
+@click.option(
+    "--suffix",
+    default="_crop",
+    show_default=True,
+    help="Suffix appended to each source stem for baked video filenames.",
+)
+# Quality options (mutually exclusive group)
+@click.option(
+    "--quality",
+    type=click.Choice(["lossless", "high", "medium", "low"]),
+    default=None,
+    help="Quality level. Maps to CRF: lossless=0, high=18, medium=25, low=32.",
+)
+@click.option(
+    "--crf",
+    type=int,
+    default=None,
+    help="Constant rate factor (0-51, lower=better). Overrides --quality.",
+)
+@click.option(
+    "--encoding",
+    "preset",
+    type=click.Choice(
+        [
+            "ultrafast",
+            "superfast",
+            "veryfast",
+            "faster",
+            "fast",
+            "medium",
+            "slow",
+            "slower",
+            "veryslow",
+        ]
+    ),
+    default="superfast",
+    show_default=True,
+    help="Encoding speed preset. Slower = better compression.",
+)
+@click.option(
+    "--output-fps",
+    "output_fps",
+    type=float,
+    default=None,
+    help="Output frame rate. Default: preserve each source FPS.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show what would be baked without writing any files.",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Overwrite existing output SLP file.",
+)
+def apply_crops(
+    input_arg: Path | None,
+    input_opt: Path | None,
+    output_path: Path | None,
+    video_dir: Path | None,
+    suffix: str,
+    quality: str | None,
+    crf: int | None,
+    preset: str,
+    output_fps: float | None,
+    dry_run: bool,
+    overwrite: bool,
+) -> None:
+    """Materialize virtual crops in an SLP to physical video files.
+
+    Bakes every virtually-cropped video (created via [bold]Video.crop[/] /
+    [bold]Video.from_crop[/], or round-tripped through the SLP ``/video_crops``
+    table) into a new video file holding the cropped pixels, then rewires all
+    label references to the baked files and writes an updated SLP.
+
+    This is distinct from [bold]sio transform --crop[/]: that applies a NEW crop
+    and adjusts coordinates, whereas a virtual crop already presents cropped-frame
+    coordinates, so baking is coordinate-neutral (no point coordinates change).
+    Provenance is preserved: each baked video's [bold]source_video[/] is the
+    uncropped original. Uncropped videos are left untouched.
+
+    [bold]Quality levels:[/]
+    lossless: CRF 0 (mathematically identical, huge files)
+    high: CRF 18 (visually lossless)
+    medium: CRF 25 (good quality, reasonable size) [default]
+    low: CRF 32 (smaller files, some quality loss)
+
+    [dim]Examples:[/]
+
+        $ sio apply-crops cropped.slp -o baked.slp
+
+        $ sio apply-crops cropped.slp -o baked.slp --quality high
+
+        $ sio apply-crops cropped.slp -o baked.slp --video-dir baked_videos
+
+        $ sio apply-crops cropped.slp -o baked.slp --dry-run
+    """
+    # Resolve input path.
+    input_path = _resolve_input(input_arg, input_opt, "input SLP file")
+
+    # Resolve output path for SLP.
+    if output_path is None:
+        output_path = input_path.with_name(input_path.stem + ".cropped.slp")
+
+    # Ensure output has .slp extension.
+    if output_path.suffix.lower() != ".slp":
+        output_path = output_path.with_suffix(".slp")
+
+    # Check for same file.
+    if output_path.resolve() == input_path.resolve():
+        raise click.ClickException(
+            f"Output path cannot be the same as input: {input_path}\n"
+            "Use a different output path or rename the output file."
+        )
+
+    # Check output exists.
+    if output_path.exists() and not overwrite:
+        raise click.ClickException(
+            f"Output SLP already exists: {output_path}\nUse --overwrite to replace it."
+        )
+
+    # Resolve quality/CRF into a single value.
+    if crf is not None and quality is not None:
+        raise click.ClickException("Cannot use both --quality and --crf. Choose one.")
+
+    if crf is not None:
+        resolved_crf = crf
+    elif quality is not None:
+        resolved_crf = _QUALITY_TO_CRF[quality]
+    else:
+        resolved_crf = _QUALITY_TO_CRF["medium"]
+
+    # Validate CRF.
+    if not 0 <= resolved_crf <= 51:
+        raise click.ClickException(f"CRF must be between 0 and 51, got {resolved_crf}")
+
+    # Load the input labels.
+    console.print(f"[bold]Loading SLP:[/] {input_path}")
+    labels = io_main.load_slp(str(input_path))
+
+    if not labels.videos:
+        console.print("[yellow]No videos found in SLP file.[/]")
+        n_cropped = 0
+    else:
+        console.print(f"[dim]  Found {len(labels.videos)} video(s)[/]")
+        # Count cropped videos up front for reporting (apply_crops returns self).
+        n_cropped = sum(1 for video in labels.videos if video._crop_tuple() is not None)
+
+    # Resolve the video output directory: --video-dir if given, else a directory
+    # next to the output SLP (mirrors reencode's batch naming).
+    if video_dir is None:
+        video_dir = output_path.with_name(output_path.stem + ".videos")
+    console.print(f"[dim]  Video output directory: {video_dir}[/]")
+
+    # If nothing is cropped, there is no work to bake; still write the output so
+    # the command is a safe no-op pass-through.
+    if n_cropped == 0:
+        console.print("[yellow]No virtually-cropped videos found; nothing to bake.[/]")
+        if dry_run:
+            console.print(
+                f"[bold]Dry run - would save SLP (unchanged) to:[/] {output_path}"
+            )
+            return
+        console.print(f"[bold]Saving SLP:[/] {output_path}")
+        labels.save(str(output_path))
+        console.print(f"[bold green]Saved:[/] {output_path}")
+        return
+
+    # Build video_kwargs from encoding options (threaded into save_video).
+    video_kwargs: dict[str, Any] = {
+        "crf": resolved_crf,
+        "preset": preset,
+    }
+
+    console.print(
+        f"[dim]  Baking {n_cropped} cropped video(s): "
+        f"CRF {resolved_crf}, Preset: {preset}[/]"
+    )
+
+    if dry_run:
+        console.print(
+            f"[bold]Dry run - would bake {n_cropped} video(s) into:[/] {video_dir}"
+        )
+        console.print(f"[bold]Dry run - would save SLP to:[/] {output_path}")
+        return
+
+    # Materialize every virtual crop and update references in place.
+    labels.apply_crops(
+        video_dir=video_dir,
+        suffix=suffix,
+        fps=output_fps,
+        video_kwargs=video_kwargs,
+    )
+
+    # Save the updated labels.
+    console.print(f"[bold]Saving SLP:[/] {output_path}")
+    labels.save(str(output_path))
+    console.print(f"[bold green]Saved:[/] {output_path}")
+    console.print(f"[dim]  Baked {n_cropped} cropped video(s) to {video_dir}[/]")
 
 
 def _parse_transform_param(

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -6462,7 +6462,7 @@ def reencode(
     help="Encoding speed preset. Slower = better compression.",
 )
 @click.option(
-    "--output-fps",
+    "--fps",
     "output_fps",
     type=float,
     default=None,

--- a/sleap_io/io/dlc.py
+++ b/sleap_io/io/dlc.py
@@ -17,11 +17,27 @@ imported:
 DLC's ``video_sets[...].crop`` is a *virtual* read-time crop (an ROI sliced out
 of each full frame by DLC's video reader). When a project uses cropping, the
 ``labeled-data`` images are the cropped region and labels are in cropped-frame
-coordinates, while the linked ``source_video`` is the original, *uncropped*
-video -- so labels are offset from the source video by the crop origin. This
-crop is not yet applied on import; reconciling the two coordinate systems
-requires virtual ROI-cropping of a `Video` on read, which is planned future
-work. With no cropping (the DLC default), there is no offset.
+coordinates, while the original ``source_video`` is the full, *uncropped* video
+-- so labels are offset from the source video by the crop origin.
+
+On import, the crop rect is parsed from ``video_sets`` (DLC's width-range-first
+``x1, x2, y1, y2`` is reordered to the sleap rect ``(x1, y1, x2, y2)``) and
+recorded as provenance on the returned `Labels` under
+``provenance["dlc_crops"]``, keyed by source-video path. This dict is the
+*persistent* record of the crop: it round-trips through SLP unchanged. When the
+original source video is available on disk, ``source_video`` is set to a
+`Video.from_crop` view so ``source_video.crop_rect`` and
+``source_video.to_source_coords`` work in-memory (the crop on this view is
+in-memory only and is not persisted on the source on SLP save -- the provenance
+dict is the persistent record); otherwise ``source_video`` is a closed `Video`
+(``open_backend=False``) with no crop.
+
+The labeled-data `Video` itself is left *uncropped* (the ``labeled-data`` PNGs
+are already the cropped region) and labels remain verbatim in cropped-frame
+coordinates -- no offset is applied to points. Identity crops at origin
+``(0, 0)`` (the DLC default / no-op) are not recorded. To map labels into the
+source frame, use ``source_video.to_source_coords(...)`` (or apply a rect from
+``provenance["dlc_crops"]``), which adds the crop origin.
 """
 
 from __future__ import annotations
@@ -236,56 +252,125 @@ def _attach_config_skeleton(skeleton: Skeleton, cfg: dict) -> None:
         )
 
 
-def _video_sets_stem_map(cfg: dict) -> dict[str, str]:
-    """Map video filename stems to original video paths from config ``video_sets``.
+def _parse_dlc_crop(crop: object) -> tuple[int, int, int, int] | None:
+    """Parse a DLC ``video_sets[...].crop`` value into a sleap crop rect.
+
+    DLC stores the crop width-range-first as ``x1, x2, y1, y2`` (either a
+    comma-separated string ``"x1, x2, y1, y2"`` or a list/tuple
+    ``[x1, x2, y1, y2]``). This is reordered to the sleap rect convention
+    ``(x1, y1, x2, y2)`` with ``x2``/``y2`` exclusive and 0-indexed.
+
+    Args:
+        crop: The raw ``crop`` value from a DLC config (string, list/tuple, or
+            ``None``).
+
+    Returns:
+        The crop rect ``(x1, y1, x2, y2)`` as ints, or ``None`` when the crop is
+        missing/empty/unparseable, has the wrong arity, is inverted
+        (``x2 <= x1`` or ``y2 <= y1``; a warning is emitted), or is an identity
+        crop at origin ``(0, 0)`` (a no-op that needs no provenance, matching
+        DLC's default full-frame ``0, W, 0, H``).
+    """
+    if crop is None:
+        return None
+
+    if isinstance(crop, str):
+        parts = [p.strip() for p in crop.split(",") if p.strip() != ""]
+    elif isinstance(crop, (list, tuple)):
+        parts = list(crop)
+    else:
+        return None
+
+    if len(parts) != 4:
+        return None
+
+    try:
+        x1, x2, y1, y2 = (int(float(p)) for p in parts)
+    except (TypeError, ValueError):
+        return None
+
+    if x2 <= x1 or y2 <= y1:
+        warnings.warn(
+            f"Ignoring inverted DLC crop {crop!r}: expected x1 < x2 and y1 < y2 "
+            "(width-range-first 'x1, x2, y1, y2')."
+        )
+        return None
+
+    # Identity crop at origin (0, 0) is a no-op (DLC's default full-frame crop);
+    # recording it buys nothing and would needlessly create provenance.
+    if x1 == 0 and y1 == 0:
+        return None
+
+    return (x1, y1, x2, y2)
+
+
+def _video_sets_stem_map(
+    cfg: dict,
+) -> dict[str, tuple[str, tuple[int, int, int, int] | None]]:
+    """Map video filename stems to original paths and crop rects from config.
 
     Paths are normalized so Windows-style backslash separators are handled on any
-    OS. Placeholder entries (e.g. DLC demo templates) are skipped.
+    OS. Placeholder entries (e.g. DLC demo templates) are skipped. The crop rect
+    is parsed from each video's ``crop`` value via `_parse_dlc_crop` (reordered to
+    the sleap ``(x1, y1, x2, y2)`` convention), or ``None`` when absent/identity.
 
     Args:
         cfg: A parsed DLC config dictionary.
 
     Returns:
-        A dictionary mapping each video's filename stem to its original path
-        string (preserving config order).
+        A dictionary mapping each video's filename stem to a tuple of
+        ``(original_path_string, crop_rect_or_None)`` (preserving config order).
     """
-    out: dict[str, str] = {}
+    out: dict[str, tuple[str, tuple[int, int, int, int] | None]] = {}
     video_sets = cfg.get("video_sets") or {}
-    for key in video_sets.keys():
+    for key, value in video_sets.items():
         key_str = str(key)
         if "WILL BE AUTOMATICALLY UPDATED" in key_str:
             continue
         name = key_str.replace("\\", "/").rsplit("/", 1)[-1]
         stem = name.rsplit(".", 1)[0] if "." in name else name
         if stem:
-            out[stem] = key_str
+            crop = value.get("crop") if isinstance(value, dict) else None
+            out[stem] = (key_str, _parse_dlc_crop(crop))
     return out
 
 
 def _set_source_video(
     video: Video,
     folder_name: str,
-    stem_map: dict[str, str],
+    stem_map: dict[str, tuple[str, tuple[int, int, int, int] | None]],
     video_search_paths: list[str | Path] | None = None,
-) -> None:
+) -> tuple[str, tuple[int, int, int, int] | None] | None:
     """Link an image-folder `Video` back to its original source video.
 
     Args:
         video: The image-sequence `Video` to annotate (mutated in place).
         folder_name: The ``labeled-data/<folder>`` name for this video.
-        stem_map: Mapping of video stems to original paths (see
-            `_video_sets_stem_map`).
+        stem_map: Mapping of video stems to ``(original_path, crop_rect)`` tuples
+            (see `_video_sets_stem_map`).
         video_search_paths: Optional paths to search for the original video file
             by basename (best-effort path repair).
 
+    Returns:
+        A tuple ``(resolved_path, crop_rect)`` for the linked source video, or
+        ``None`` on a stem mismatch (when `video.source_video` is left as
+        ``None``). The caller uses this to record crop provenance.
+
     Notes:
-        The source `Video` is created with ``open_backend=False`` so a missing
-        original file (the common case on import) never raises. On a stem
-        mismatch, `video.source_video` is left as `None`.
+        When a non-identity crop is configured AND the resolved source file
+        exists on disk, `video.source_video` is set to a `Video.from_crop` view
+        so ``source_video.crop_rect`` / ``to_source_coords`` work in-memory; this
+        crop view is import-time only (it is not persisted on the source on SLP
+        save -- the persistent record is the returned rect, written to
+        ``labels.provenance["dlc_crops"]``). Otherwise the source `Video` is
+        created with ``open_backend=False`` (no crop attached) so a missing
+        original file (the common case on import) never raises and serialization
+        is never put at risk. The labeled-data `video` itself is never cropped.
     """
-    original = stem_map.get(folder_name)
-    if original is None:
-        return
+    entry = stem_map.get(folder_name)
+    if entry is None:
+        return None
+    original, rect = entry
 
     path = original
     if video_search_paths:
@@ -296,7 +381,18 @@ def _set_source_video(
                 path = str(candidate)
                 break
 
+    if rect is not None and Path(path).exists():
+        try:
+            video.source_video = Video.from_crop(path, crop=rect)
+            return path, rect
+        except Exception:
+            # Source could not be opened/cropped; fall back to a closed source
+            # with no crop on its backend_metadata (avoids the closed-crop
+            # serialization guard) while still recording the rect as provenance.
+            pass
+
     video.source_video = Video(filename=path, open_backend=False)
+    return path, rect
 
 
 # -----------------------------------------------------------------------------
@@ -471,11 +567,17 @@ def _load_dlc_csv(
         if actual_image_files:
             videos[video_name] = Video.from_filename(actual_image_files)
 
-    # Link image folders back to their original videos from config video_sets.
+    # Link image folders back to their original videos from config video_sets,
+    # collecting crop provenance keyed by source-video path.
+    dlc_crops: dict[str, list[int]] = {}
     if config is not None and videos:
         stem_map = _video_sets_stem_map(config)
         for video_name, video in videos.items():
-            _set_source_video(video, video_name, stem_map, video_search_paths)
+            result = _set_source_video(video, video_name, stem_map, video_search_paths)
+            if result is not None:
+                source_path, rect = result
+                if rect is not None:
+                    dlc_crops[source_path] = list(rect)
 
     # Parse the actual data rows and create labeled frames.
     labeled_frames = []
@@ -515,12 +617,15 @@ def _load_dlc_csv(
 
     unique_videos = list(videos.values())
 
-    return Labels(
+    labels = Labels(
         labeled_frames=labeled_frames,
         videos=unique_videos,
         tracks=tracks,
         skeletons=[skeleton] if skeleton.nodes else [],
     )
+    if dlc_crops:
+        labels.provenance["dlc_crops"] = dlc_crops
+    return labels
 
 
 # -----------------------------------------------------------------------------
@@ -644,6 +749,7 @@ def load_dlc_project(
     # Load each folder using the shared skeleton/tracks and collect the frames.
     all_frames: list[LabeledFrame] = []
     videos: list[Video] = []
+    dlc_crops: dict[str, list[int]] = {}
     for _, csv in folders:
         folder_labels = _load_dlc_csv(
             csv,
@@ -654,6 +760,7 @@ def load_dlc_project(
         )
         all_frames.extend(folder_labels.labeled_frames)
         videos.extend(folder_labels.videos)
+        dlc_crops.update(folder_labels.provenance.get("dlc_crops", {}))
 
     labels = Labels(
         labeled_frames=all_frames,
@@ -668,6 +775,8 @@ def load_dlc_project(
             "dlc_task": cfg.get("Task"),
         }
     )
+    if dlc_crops:
+        labels.provenance["dlc_crops"] = dlc_crops
     return labels
 
 

--- a/sleap_io/io/dlc.py
+++ b/sleap_io/io/dlc.py
@@ -266,7 +266,7 @@ def _parse_dlc_crop(crop: object) -> tuple[int, int, int, int] | None:
 
     Returns:
         The crop rect ``(x1, y1, x2, y2)`` as ints, or ``None`` when the crop is
-        missing/empty/unparseable, has the wrong arity, is inverted
+        missing/empty/unparsable, has the wrong arity, is inverted
         (``x2 <= x1`` or ``y2 <= y1``; a warning is emitted), or is an identity
         crop at origin ``(0, 0)`` (a no-op that needs no provenance, matching
         DLC's default full-frame ``0, W, 0, H``).

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -389,38 +389,14 @@ def make_video(
         x1, y1, x2, y2 = crop
 
         if open_backend and backend is not None:
-            # Optionally reuse the reconstructed source backend as the shared
-            # inner (D-126) so a reloaded mosaic of tiles over one physical file
-            # decodes each frame once (the source Video owns that decoder, so the
-            # tile does not). Only safe when the source reports the SAME shape as
-            # the just-rebuilt inner: an embedded/frame-remapped source has a
-            # different frame index space and must NOT be substituted (it would
-            # read the wrong frame). On any mismatch, wrap the reconstructed inner
-            # directly.
-            reuse_inner = None
-            if (
-                source_video is not None
-                and source_video.backend is not None
-                and not isinstance(source_video.backend, CropVideoBackend)
-            ):
-                try:
-                    # Reuse only when the source is the SAME physical file/dataset
-                    # (not merely the same shape), so two equal-shaped distinct
-                    # sources are never conflated (DI-5).
-                    same_file = source_video.backend.filename == backend.filename and (
-                        getattr(source_video.backend, "dataset", None)
-                        == getattr(backend, "dataset", None)
-                    )
-                    if same_file and source_video.backend.shape == backend.shape:
-                        reuse_inner = source_video.backend
-                except Exception:
-                    reuse_inner = None
-            if reuse_inner is not None:
-                backend = CropVideoBackend.wrap(
-                    inner=reuse_inner, crop=crop, fill=fill, owns_inner=False
-                )
-            else:
-                backend = CropVideoBackend.wrap(inner=backend, crop=crop, fill=fill)
+            # Wrap the freshly reconstructed (uncropped) backend. Each reloaded tile
+            # gets its OWN inner decoder that its close() releases (owns_inner=True).
+            # We do not reuse source_video.backend here: on reload each tile rebuilds
+            # a private source_video.backend, so reusing it would share nothing across
+            # tiles yet leak the unowned decoder (it would never be closed). Live
+            # decoder sharing for a mosaic is created in-memory via Video.crop and is
+            # intentionally not reconstructed on load.
+            backend = CropVideoBackend.wrap(inner=backend, crop=crop, fill=fill)
 
         # Copy before overwriting so a shared dict is never mutated (D-126), then
         # record the cropped shape derived from the uncropped inner/source shape.
@@ -553,7 +529,17 @@ def video_to_dict(video: Video, labels_path: str | None = None) -> dict:
                 "transform_labels before saving."
             )
         backend = inner
-        shape = inner.shape
+        # Mirror Video._get_shape(): never let a missing/unreadable inner file crash
+        # the save. Fall back to the recorded uncropped source shape (videos_json must
+        # describe the full frame); the per-type writers below tolerate shape=None,
+        # exactly as the uncropped Video.shape==None path does.
+        try:
+            shape = inner.shape
+        except Exception:
+            src_shape = video.backend_metadata.get("source_shape")
+            if src_shape is None and video.source_video is not None:
+                src_shape = video.source_video.shape
+            shape = tuple(src_shape) if src_shape is not None else None
         grayscale = inner.grayscale
         fps = inner.fps
     else:
@@ -1336,16 +1322,13 @@ def write_videos(
                 else:
                     # Collect information for embedding (source_inds live on the
                     # inner backend for a crop-over-embedded video, D-125). Embed
-                    # the UNCROPPED inner-backed view (``video.source_video`` for a
-                    # crop, else ``video``) so the embedded frames and their
-                    # videos_json entry describe the full frame; the crop rides
+                    # ``video`` itself (the crop facade): process_and_embed_frames
+                    # special-cases a CropVideoBackend and reads the UNCROPPED frame
+                    # straight from the embedded inner, so the embedded data + its
+                    # videos_json entry describe the full frame WITHOUT touching the
+                    # (possibly missing external) source_video. The crop rides
                     # /video_crops and is re-applied on read.
-                    embed_target = (
-                        video.source_video
-                        if isinstance(video.backend, CropVideoBackend)
-                        and video.source_video is not None
-                        else video
-                    )
+                    embed_target = video
                     frames_to_embed = [
                         (embed_target, frame_idx)
                         for frame_idx in inner_backend.source_inds
@@ -4742,6 +4725,7 @@ def _write_metadata_standalone(
     format_id: float = 2.2,
     skeletons: list[Skeleton] | None = None,
     provenance: dict | None = None,
+    videos: list[Video] | None = None,
 ) -> None:
     """Write minimal metadata group to an SLP file.
 
@@ -4753,6 +4737,8 @@ def _write_metadata_standalone(
         format_id: Format version identifier.
         skeletons: Optional list of skeletons to serialize.
         provenance: Optional provenance dict.
+        videos: Optional list of videos; if any carries a virtual crop the
+            ``format_id`` is bumped to 2.3 (matching ``write_metadata``).
     """
     skeletons = skeletons or []
     provenance = dict(provenance or {})
@@ -4805,6 +4791,9 @@ def _write_metadata_standalone(
             ("instance_id_end", "u8"),
         ]
     )
+
+    if videos and any(v._crop_tuple() is not None for v in videos):
+        format_id = max(format_id, 2.3)
 
     with h5py.File(labels_path, "a") as f:
         # Bump for chunked label image format
@@ -5095,7 +5084,7 @@ class LabelImageWriter:
             write_videos(self.path, videos)
             write_video_crops(self.path, Labels(videos=videos))
             write_tracks(self.path, self.tracks)
-            _write_metadata_standalone(self.path, skeletons=skeletons)
+            _write_metadata_standalone(self.path, skeletons=skeletons, videos=videos)
             return Labels(
                 videos=videos,
                 skeletons=skeletons,
@@ -5145,7 +5134,7 @@ class LabelImageWriter:
         write_videos(self.path, videos)
         write_video_crops(self.path, Labels(videos=videos))
         write_tracks(self.path, self.tracks)
-        _write_metadata_standalone(self.path, skeletons=skeletons)
+        _write_metadata_standalone(self.path, skeletons=skeletons, videos=videos)
 
         li_tuples, li_file = read_label_images(self.path, videos, self.tracks, [])
         # Distribute label images to frames
@@ -5599,7 +5588,7 @@ def merge_label_images(
         write_videos(dest_path, merged_videos)
         write_video_crops(dest_path, Labels(videos=merged_videos))
         write_tracks(dest_path, merged_tracks)
-        _write_metadata_standalone(dest_path)
+        _write_metadata_standalone(dest_path, videos=merged_videos)
 
         # Return Labels pointing at the merged file
         li_tuples, li_file = read_label_images(

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -14,6 +14,9 @@ Format version history:
             predicted variants (is_predicted, score) for masks/ROIs/label images;
             instance association for masks; string datasets for metadata
     - 2.0: Columnar bounding box storage (/bboxes group with x1/y1/x2/y2 datasets)
+    - 2.1: Spatial transform metadata on dense annotations (masks/label images)
+    - 2.2: Chunked label image data format (/label_image_data as rank-3 dataset)
+    - 2.3: Virtual on-read video crops (/video_crops dataset)
 """
 
 from __future__ import annotations
@@ -38,6 +41,7 @@ from sleap_io.io.utils import (
     read_hdf5_attrs,
     read_hdf5_dataset,
     sanitize_filename,
+    write_hdf5_dataset,
 )
 from sleap_io.io.video_reading import (
     HDF5Video,
@@ -189,6 +193,7 @@ def make_video(
     _hdf5_file: h5py.File | None = None,
     _url_headers: dict[str, str] | None = None,
     _url_stream_mode: str = "blockcache",
+    _crop_entry: dict | None = None,
 ) -> Video:
     """Create a `Video` object from a JSON dictionary.
 
@@ -206,6 +211,12 @@ def make_video(
             authenticated. Private; ignored for local files.
         _url_stream_mode: Remote streaming strategy for a URL-backed video. Private;
             ignored for local files.
+        _crop_entry: Optional ``{"crop": [x1, y1, x2, y2], "fill": n}`` record from
+            the ``/video_crops`` dataset (see ``read_video_crops``). When present,
+            the reconstructed (uncropped) backend is re-wrapped in a
+            ``CropVideoBackend`` and the crop is seeded into ``backend_metadata`` so
+            both the open and closed paths report the cropped view. Private; mirrors
+            the ``_url_headers`` threading pattern.
     """
     backend_metadata = video_json["backend"]
 
@@ -366,6 +377,68 @@ def make_video(
             sanitize_filename(p) if isinstance(p, Path) else p for p in video_path
         ]
 
+    # Crop reconstruction (D-126, §6.4): the inner/source backend was just rebuilt
+    # from the UNCROPPED ``videos_json`` entry; re-wrap it in a ``CropVideoBackend``
+    # (open path) and ALWAYS seed the crop record on ``backend_metadata`` so the
+    # closed path reports the cropped shape and ``Video.open()`` can re-wrap.
+    if _crop_entry is not None:
+        from sleap_io.io.video_reading import CropVideoBackend
+
+        crop = tuple(_crop_entry["crop"])
+        fill = _crop_entry.get("fill", 0)
+        x1, y1, x2, y2 = crop
+
+        if open_backend and backend is not None:
+            # Optionally reuse the reconstructed source backend as the shared
+            # inner (D-126) so a reloaded mosaic of tiles over one physical file
+            # decodes each frame once (the source Video owns that decoder, so the
+            # tile does not). Only safe when the source reports the SAME shape as
+            # the just-rebuilt inner: an embedded/frame-remapped source has a
+            # different frame index space and must NOT be substituted (it would
+            # read the wrong frame). On any mismatch, wrap the reconstructed inner
+            # directly.
+            reuse_inner = None
+            if (
+                source_video is not None
+                and source_video.backend is not None
+                and not isinstance(source_video.backend, CropVideoBackend)
+            ):
+                try:
+                    # Reuse only when the source is the SAME physical file/dataset
+                    # (not merely the same shape), so two equal-shaped distinct
+                    # sources are never conflated (DI-5).
+                    same_file = source_video.backend.filename == backend.filename and (
+                        getattr(source_video.backend, "dataset", None)
+                        == getattr(backend, "dataset", None)
+                    )
+                    if same_file and source_video.backend.shape == backend.shape:
+                        reuse_inner = source_video.backend
+                except Exception:
+                    reuse_inner = None
+            if reuse_inner is not None:
+                backend = CropVideoBackend.wrap(
+                    inner=reuse_inner, crop=crop, fill=fill, owns_inner=False
+                )
+            else:
+                backend = CropVideoBackend.wrap(inner=backend, crop=crop, fill=fill)
+
+        # Copy before overwriting so a shared dict is never mutated (D-126), then
+        # record the cropped shape derived from the uncropped inner/source shape.
+        backend_metadata = dict(backend_metadata)
+        inner_shape = backend_metadata.get("shape")
+        if inner_shape is not None:
+            # Preserve the uncropped source shape so a closed re-serialize keeps
+            # videos_json describing the full frame (DI-2).
+            backend_metadata["source_shape"] = list(inner_shape)
+            backend_metadata["shape"] = (
+                inner_shape[0],
+                y2 - y1,
+                x2 - x1,
+                inner_shape[3],
+            )
+        backend_metadata["crop"] = list(crop)
+        backend_metadata["crop_fill"] = fill
+
     video = Video(
         filename=video_path,
         backend=backend,
@@ -414,8 +487,10 @@ def read_videos(
     videos = []
 
     def _read_videos(f: h5py.File) -> None:
+        # Read the per-video crop records once (absent on old/uncropped files).
+        video_crops = read_video_crops(labels_path, _hdf5_file=f)
         videos_metadata = f["videos_json"][:]
-        for video_data in videos_metadata:
+        for video_index, video_data in enumerate(videos_metadata):
             video_json = json.loads(video_data)
             video = make_video(
                 labels_path,
@@ -424,6 +499,7 @@ def read_videos(
                 _hdf5_file=f,
                 _url_headers=_url_headers,
                 _url_stream_mode=_url_stream_mode,
+                _crop_entry=video_crops.get(video_index),
             )
             videos.append(video)
 
@@ -448,8 +524,44 @@ def video_to_dict(video: Video, labels_path: str | None = None) -> dict:
     Returns:
         A dictionary containing the video metadata.
     """
+    from sleap_io.io.video_reading import CropVideoBackend
+
     video_filename = sanitize_filename(video.filename)
     result = {"filename": video_filename}
+
+    # Crop unwrap (D-123): a cropped Video serializes as its UNCROPPED source
+    # backend so ``videos_json`` describes the full frame and old readers never
+    # hit a KeyError on an unknown wrapper type. The crop tuple is emitted
+    # separately into ``/video_crops`` by ``write_video_crops``; it must NOT
+    # enter ``videos_json``. Dispatch on ``type(inner)`` through the existing
+    # per-type whitelist below WITHOUT building a throwaway Video (which would
+    # trigger ``exists()``/``open()`` side effects, F-ser-5). The uncropped
+    # source's shape/grayscale/fps come from the inner backend, not the cropped
+    # facade, so ``videos_json`` stays byte-identical to the uncropped save.
+    backend = video.backend
+    if isinstance(backend, CropVideoBackend):
+        inner = backend.inner
+        if isinstance(inner, CropVideoBackend):
+            # A nested (un-flattened) crop-of-crop cannot be represented by the
+            # single-crop-per-video /video_crops schema. wrap() only nests when
+            # fills differ or the outer rect exceeds the inner frame; flatten it
+            # (matching fills, in-bounds rect) or materialize before saving.
+            raise ValueError(
+                "Cannot serialize a nested crop-of-crop video: the /video_crops "
+                "format stores a single crop per video. Flatten the crop (use "
+                "matching fills and an in-bounds region) or materialize it with "
+                "transform_labels before saving."
+            )
+        backend = inner
+        shape = inner.shape
+        grayscale = inner.grayscale
+        fps = inner.fps
+    else:
+        # Uncropped path: read through the Video facade exactly as before so
+        # that uncropped serialization is unchanged (golden byte-identical).
+        shape = video.shape
+        grayscale = video.grayscale
+        fps = video.fps
 
     # Add backend metadata
     if video.backend is None:
@@ -459,21 +571,42 @@ def video_to_dict(video: Video, labels_path: str | None = None) -> dict:
         # with make_video() which expects backend["filename"] to exist
         if "filename" not in result["backend"]:
             result["backend"]["filename"] = video_filename
-    elif type(video.backend) is MediaVideo:
+        # Closed cropped path: the copied metadata carries the CROPPED shape plus
+        # a crop record. Restore the UNCROPPED source shape so videos_json describes
+        # the full frame (old-reader guarantee), then drop the crop keys (the crop
+        # rides /video_crops). Recover the source shape from a live source_video or
+        # the recorded "source_shape"; refuse to emit a self-inconsistent entry
+        # (uncropped frame with cropped dims) when neither is available.
+        if "crop" in result["backend"]:
+            src_shape = None
+            if video.source_video is not None and video.source_video.shape is not None:
+                src_shape = list(video.source_video.shape)
+            elif result["backend"].get("source_shape") is not None:
+                src_shape = list(result["backend"]["source_shape"])
+            if src_shape is None:
+                raise ValueError(
+                    "Cannot serialize closed cropped video: the uncropped source "
+                    "shape is unavailable (no source_video and no recorded "
+                    "source_shape), so videos_json cannot describe the full frame."
+                )
+            result["backend"]["shape"] = src_shape
+        for key in ("crop", "crop_fill", "source_shape"):
+            result["backend"].pop(key, None)
+    elif type(backend) is MediaVideo:
         result["backend"] = {
             "type": "MediaVideo",
-            "shape": video.shape,
+            "shape": shape,
             "filename": video_filename,
-            "grayscale": video.grayscale,
+            "grayscale": grayscale,
             "bgr": True,
             "dataset": "",
             "input_format": "",
-            "fps": video.fps,
+            "fps": fps,
         }
-    elif type(video.backend) is HDF5Video:
+    elif type(backend) is HDF5Video:
         # Determine if we should use self-reference or external reference
         use_self_reference = (
-            video.backend.has_embedded_images
+            backend.has_embedded_images
             and labels_path is not None
             and Path(sanitize_filename(video.filename)).resolve()
             == Path(sanitize_filename(labels_path)).resolve()
@@ -481,40 +614,40 @@ def video_to_dict(video: Video, labels_path: str | None = None) -> dict:
 
         result["backend"] = {
             "type": "HDF5Video",
-            "shape": video.shape,
+            "shape": shape,
             "filename": ("." if use_self_reference else video_filename),
-            "dataset": video.backend.dataset,
-            "input_format": video.backend.input_format,
+            "dataset": backend.dataset,
+            "input_format": backend.input_format,
             "convert_range": False,
-            "has_embedded_images": video.backend.has_embedded_images,
-            "grayscale": video.grayscale,
-            "fps": video.fps,
+            "has_embedded_images": backend.has_embedded_images,
+            "grayscale": grayscale,
+            "fps": fps,
         }
-    elif type(video.backend) is ImageVideo:
-        if video.shape is not None:
-            height, width, channels = video.shape[1:4]
+    elif type(backend) is ImageVideo:
+        if shape is not None:
+            height, width, channels = shape[1:4]
         else:
             height, width, channels = None, None, 3
         result["backend"] = {
             "type": "ImageVideo",
-            "shape": video.shape,
-            "filename": sanitize_filename(video.backend.filename[0]),
-            "filenames": sanitize_filename(video.backend.filename),
+            "shape": shape,
+            "filename": sanitize_filename(backend.filename[0]),
+            "filenames": sanitize_filename(backend.filename),
             "height_": height,
             "width_": width,
             "channels_": channels,
-            "grayscale": video.grayscale,
-            "fps": video.fps,
+            "grayscale": grayscale,
+            "fps": fps,
         }
-    elif type(video.backend) is TiffVideo:
+    elif type(backend) is TiffVideo:
         result["backend"] = {
             "type": "TiffVideo",
-            "shape": video.shape,
+            "shape": shape,
             "filename": video_filename,
-            "grayscale": video.grayscale,
-            "keep_open": video.backend.keep_open,
-            "format": video.backend.format,
-            "fps": video.fps,
+            "grayscale": grayscale,
+            "keep_open": backend.keep_open,
+            "format": backend.format,
+            "fps": fps,
         }
 
     # Add source_video metadata if present
@@ -525,6 +658,71 @@ def video_to_dict(video: Video, labels_path: str | None = None) -> dict:
     # so we don't store it. Legacy files with original_video are handled on load.
 
     return result
+
+
+def read_video_crops(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> dict[int, dict]:
+    """Read the top-level ``/video_crops`` dataset keyed by video index.
+
+    The dataset is a single JSON string holding a list of
+    ``{"video": i, "crop": [x1, y1, x2, y2], "fill": n}`` entries (one per
+    cropped video). It is absent on old/uncropped files, in which case an empty
+    mapping is returned so the loader falls back to the uncropped source.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open ``h5py.File`` handle to read from. If
+            provided, the data is read from this handle (left open for the
+            caller to close); otherwise ``labels_path`` is opened and closed
+            internally. Private, mirrors the other ``read_*`` helpers.
+
+    Returns:
+        A mapping ``{video_index: {"crop": [...], "fill": n}}`` keyed by int.
+        Empty if the ``/video_crops`` dataset is absent.
+    """
+    try:
+        raw = read_hdf5_dataset(labels_path, "video_crops", _hdf5_file=_hdf5_file)
+    except KeyError:
+        return {}
+    if isinstance(raw, (bytes, np.bytes_)):
+        raw = raw.decode()
+    elif isinstance(raw, np.ndarray):
+        raw = raw.item()
+        if isinstance(raw, (bytes, np.bytes_)):
+            raw = raw.decode()
+    return {int(entry["video"]): entry for entry in json.loads(raw)}
+
+
+def write_video_crops(labels_path: str, labels: Labels) -> None:
+    """Write the top-level ``/video_crops`` JSON dataset for cropped videos.
+
+    Emits one ``{"video": i, "crop": [x1, y1, x2, y2], "fill": n}`` entry for
+    each cropped video in ``labels.videos`` (open or closed). The dataset is
+    omitted entirely when no video is cropped, so uncropped files stay
+    byte-identical to today and old readers never see an unknown dataset.
+
+    When a cropped video's frames are embedded, the UNCROPPED source frames are
+    stored (see ``embed_videos``) and the crop is recorded here, so the reader
+    applies it exactly once over the full-frame embedded data.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        labels: A ``Labels`` whose videos may carry virtual crops.
+    """
+    crops = []
+    for i, video in enumerate(labels.videos):
+        rect = video._crop_tuple()
+        if rect is None:
+            continue
+        crops.append({"video": i, "crop": list(rect), "fill": video._crop_fill()})
+
+    if crops:
+        write_hdf5_dataset(
+            labels_path,
+            "video_crops",
+            np.bytes_(json.dumps(crops, separators=(",", ":"))),
+        )
 
 
 def prepare_frames_to_embed(
@@ -653,7 +851,7 @@ def process_and_embed_frames(
         ExportCancelled: If the progress_callback returns `False`.
     """
     # Determine which plugin to use for encoding
-    from sleap_io.io.video_reading import get_default_image_plugin
+    from sleap_io.io.video_reading import CropVideoBackend, get_default_image_plugin
 
     if plugin is None:
         plugin = get_default_image_plugin()
@@ -704,8 +902,15 @@ def process_and_embed_frames(
                         raise ExportCancelled("Export cancelled by user")
                 continue
 
-        # Slow path: Load and encode the frame
-        frame = video[frame_idx]
+        # Slow path: Load and encode the frame. For a virtually-cropped video,
+        # embed the UNCROPPED source frame; the crop is preserved separately in
+        # /video_crops and re-applied on load, so it is baked exactly once. This
+        # matches the crop-over-embedded path (which already embeds the uncropped
+        # source) and keeps the reloaded video a CropVideoBackend over full frames.
+        if isinstance(video.backend, CropVideoBackend):
+            frame = video.backend.inner.get_frame(frame_idx)
+        else:
+            frame = video[frame_idx]
 
         # Encode the frame
         if image_format == "hdf5":
@@ -777,7 +982,12 @@ def process_and_embed_frames(
             # Store metadata
             ds.attrs["format"] = image_format
             ds.attrs["channel_order"] = data["channel_order"]
-            video_shape = video.shape
+            # Embedded attrs describe the UNCROPPED frame for a cropped video
+            # (the embedded pixels are the full source frame).
+            if isinstance(video.backend, CropVideoBackend):
+                video_shape = video.backend.inner.shape
+            else:
+                video_shape = video.shape
             (
                 ds.attrs["frames"],
                 ds.attrs["height"],
@@ -799,16 +1009,41 @@ def process_and_embed_frames(
                 source_video = video
 
             # Create embedded video object
-            embedded_video = Video(
-                filename=labels_path,
-                backend=VideoBackend.from_filename(
-                    labels_path,
-                    dataset=f"{group}/video",
-                    grayscale=video.grayscale,
-                    keep_open=False,
-                ),
-                source_video=source_video,
+            embedded_backend = VideoBackend.from_filename(
+                labels_path,
+                dataset=f"{group}/video",
+                grayscale=video.grayscale,
+                keep_open=False,
             )
+            if isinstance(video.backend, CropVideoBackend):
+                # The embedded frames are UNCROPPED; re-wrap so the crop survives
+                # (write_video_crops emits it from labels.videos and reload
+                # re-applies it over the full-frame embedded data).
+                crop = video.backend.crop
+                fill = video.backend.fill
+                x1, y1, x2, y2 = crop
+                src_shape = embedded_backend.shape
+                embedded_video = Video(
+                    filename=labels_path,
+                    backend=CropVideoBackend.wrap(
+                        inner=embedded_backend, crop=crop, fill=fill
+                    ),
+                    source_video=source_video,
+                )
+                embedded_video.backend_metadata = {
+                    "crop": list(crop),
+                    "crop_fill": fill,
+                    "source_shape": list(src_shape) if src_shape is not None else None,
+                    "shape": (src_shape[0], y2 - y1, x2 - x1, src_shape[3])
+                    if src_shape is not None
+                    else None,
+                }
+            else:
+                embedded_video = Video(
+                    filename=labels_path,
+                    backend=embedded_backend,
+                    source_video=source_video,
+                )
 
             # Store source video metadata
             grp = f.require_group(f"{group}/source_video")
@@ -1055,11 +1290,22 @@ def write_videos(
     videos_to_write = []
     videos_to_copy = []  # For embedded videos without backend (raw HDF5 copy)
 
+    from sleap_io.io.video_reading import CropVideoBackend
+
     # First determine which videos need embedding
     for video_ind, video in enumerate(videos):
+        # Crop-over-embedded (D-125): a virtual crop over an embedded HDF5Video
+        # must route through the embed machinery, not the plain-external else
+        # branch. Test embedded-ness / collect source_inds from the INNER backend;
+        # the crop itself still rides /video_crops.
+        inner_backend = (
+            video.backend.inner
+            if isinstance(video.backend, CropVideoBackend)
+            else video.backend
+        )
         # Check if video has an open backend with embedded images
         has_backend_with_embedded = (
-            type(video.backend) is HDF5Video and video.backend.has_embedded_images
+            type(inner_backend) is HDF5Video and inner_backend.has_embedded_images
         )
         # Also detect embedded videos via metadata (when backend is None)
         has_embedded_via_metadata = (
@@ -1088,11 +1334,23 @@ def write_videos(
                 if already_embedded:
                     videos_to_write.append((video_ind, video))
                 else:
-                    # Collect information for embedding
+                    # Collect information for embedding (source_inds live on the
+                    # inner backend for a crop-over-embedded video, D-125). Embed
+                    # the UNCROPPED inner-backed view (``video.source_video`` for a
+                    # crop, else ``video``) so the embedded frames and their
+                    # videos_json entry describe the full frame; the crop rides
+                    # /video_crops and is re-applied on read.
+                    embed_target = (
+                        video.source_video
+                        if isinstance(video.backend, CropVideoBackend)
+                        and video.source_video is not None
+                        else video
+                    )
                     frames_to_embed = [
-                        (video, frame_idx) for frame_idx in video.backend.source_inds
+                        (embed_target, frame_idx)
+                        for frame_idx in inner_backend.source_inds
                     ]
-                    videos_to_embed.append((video_ind, video, frames_to_embed))
+                    videos_to_embed.append((video_ind, embed_target, frames_to_embed))
         elif has_embedded_via_metadata:
             # Video has embedded frames but backend is not open (open_videos=False)
             if reference_mode == VideoReferenceMode.RESTORE_ORIGINAL:
@@ -1646,6 +1904,12 @@ def write_metadata(labels_path: str, labels: Labels):
     )
     if has_spatial_metadata:
         format_id = max(format_id, 2.1)
+
+    # Bump for virtual video crops (new in 2.3). 2.3 does not cross the only
+    # legacy threshold (< 1.4, BGR embedded parsing), so this is purely additive
+    # and only set when a crop is actually present (uncropped files stay <= 2.2).
+    if any(v._crop_tuple() is not None for v in labels.videos):
+        format_id = max(format_id, 2.3)
 
     with h5py.File(labels_path, "a") as f:
         # Bump for chunked label image format (new in 2.2)
@@ -4829,6 +5093,7 @@ class LabelImageWriter:
             videos = [self.video] if self.video is not None else []
             skeletons = [self.skeleton] if self.skeleton is not None else []
             write_videos(self.path, videos)
+            write_video_crops(self.path, Labels(videos=videos))
             write_tracks(self.path, self.tracks)
             _write_metadata_standalone(self.path, skeletons=skeletons)
             return Labels(
@@ -4878,6 +5143,7 @@ class LabelImageWriter:
         videos = [self.video] if self.video is not None else []
         skeletons = [self.skeleton] if self.skeleton is not None else []
         write_videos(self.path, videos)
+        write_video_crops(self.path, Labels(videos=videos))
         write_tracks(self.path, self.tracks)
         _write_metadata_standalone(self.path, skeletons=skeletons)
 
@@ -5331,6 +5597,7 @@ def merge_label_images(
 
         # Write video, track, and metadata info
         write_videos(dest_path, merged_videos)
+        write_video_crops(dest_path, Labels(videos=merged_videos))
         write_tracks(dest_path, merged_tracks)
         _write_metadata_standalone(dest_path)
 
@@ -5722,6 +5989,8 @@ def _write_labels_lazy(
         original_videos=None,
         verbose=verbose,
     )
+    # Emit virtual crop records (after videos_json so indices line up).
+    write_video_crops(labels_path, labels)
 
     # Write other metadata
     write_tracks(labels_path, labels.tracks)
@@ -5953,6 +6222,9 @@ def write_labels(
         original_videos=original_videos,
         verbose=verbose,
     )
+    # Emit virtual crop records (after videos_json so indices line up). Omitted
+    # entirely when no video is cropped (uncropped files stay byte-identical).
+    write_video_crops(labels_path, labels)
     write_tracks(labels_path, labels.tracks)
     write_identities(labels_path, labels.identities)
     write_suggestions(labels_path, labels.suggestions, labels.videos)

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -14,6 +14,8 @@ import numpy as np
 import simplejson as json
 
 from sleap_io.io import _remote
+from sleap_io.transform.frame import crop_frame
+from sleap_io.transform.points import crop_points, uncrop_points
 
 try:
     import cv2
@@ -1165,6 +1167,9 @@ class HDF5Video(VideoBackend):
         validator=attrs.validators.in_(["channels_last", "channels_first"]),
     )
     frame_map: dict[int, int] = attrs.field(init=False, default=attrs.Factory(dict))
+    _can_push_crop_cached: bool | None = attrs.field(
+        init=False, default=None, repr=False, eq=False
+    )
     source_filename: str | None = None
     source_inds: np.ndarray | None = None
     image_format: str = "hdf5"
@@ -1596,6 +1601,232 @@ class HDF5Video(VideoBackend):
 
         return imgs
 
+    @property
+    def _can_push_crop(self) -> bool:
+        """Whether this dataset supports HDF5 crop pushdown (dataset-level gate).
+
+        Pushdown reads only a spatial hyperslab of a frame instead of decoding the
+        whole frame, but it is only valid (and beneficial) for raw rank-4 chunked
+        datasets with sub-frame spatial chunking and no embedded/frame-mapped
+        subset. This is the dataset-level gate only (the per-call "crop smaller than
+        the chunk span" predicate is evaluated in :meth:`read_crop`/:meth:`read_crops`).
+        The probe reflects the immutable on-disk layout, so the result is cached
+        after the first call (no file open per read).
+
+        Returns:
+            ``True`` if the dataset is a raw (``image_format == "hdf5"``) rank-4
+            chunked array with sub-frame spatial chunking and an empty
+            ``frame_map``; ``False`` otherwise (including any error while probing,
+            so a non-applicable dataset never raises).
+        """
+        # Cheap short-circuit (no file open) for embedded/frame-mapped datasets.
+        if self.image_format != "hdf5" or self.frame_map:
+            return False
+        if self._can_push_crop_cached is None:
+            self._can_push_crop_cached = self._probe_can_push_crop()
+        return self._can_push_crop_cached
+
+    def _probe_can_push_crop(self) -> bool:
+        """Probe the on-disk layout for pushdown eligibility (opens the file once)."""
+        try:
+            with self._open_h5() as f:
+                ds = f[self.dataset]
+                if ds.ndim != 4 or ds.chunks is None:
+                    return False
+                chunks = ds.chunks
+                if self.input_format == "channels_first":
+                    # On-disk layout is (F, C, W, H).
+                    disk_w, disk_h = ds.shape[2], ds.shape[3]
+                    return chunks[2] < disk_w or chunks[3] < disk_h
+                # channels_last on-disk layout is (F, H, W, C).
+                height, width = ds.shape[1], ds.shape[2]
+                return chunks[1] < height or chunks[2] < width
+        except (OSError, KeyError, TypeError):  # pragma: no cover - defensive
+            return False
+
+    def read_crop(
+        self,
+        frame_idx: int,
+        crop: tuple[int, int, int, int],
+        fill: int | tuple[int, ...] = 0,
+    ) -> np.ndarray | None:
+        """Read a spatial hyperslab of a frame, padded to the crop shape.
+
+        This is the single-frame HDF5 crop pushdown hook consumed by
+        :class:`CropVideoBackend`. When applicable, it reads only the spatial
+        region of the frame that overlaps ``crop`` directly from the chunked
+        dataset (avoiding a full-frame decode) and pads out-of-bounds regions
+        exactly as :func:`sleap_io.transform.frame.crop_frame` would.
+
+        Args:
+            frame_idx: Index of the frame to read (source-video index; mapped
+                through ``frame_map`` if present, though pushdown is gated off when
+                a ``frame_map`` exists).
+            crop: Crop region ``(x1, y1, x2, y2)`` with ``x2``/``y2`` exclusive.
+                May be negative or exceed the frame bounds (padded with ``fill``).
+            fill: Fill value for out-of-bounds regions.
+
+        Returns:
+            A ``(y2 - y1, x2 - x1, C)`` array (pre-grayscale, ``dtype == ds.dtype``)
+            byte-identical to ``crop_frame(self._read_frame(frame_idx), crop,
+            fill)`` when pushdown is applicable; otherwise ``None`` to signal the
+            caller should fall back to a full-frame decode plus ``crop_frame``.
+            Never raises for out-of-bounds crops.
+        """
+        if not self._can_push_crop:
+            return None
+        try:
+            if self.keep_open:
+                if self._open_reader is None:
+                    self._open_reader = self._open_h5()
+                f = self._open_reader
+                ds = f[self.dataset]
+                return self._read_crop_from_ds(ds, frame_idx, crop, fill)
+            else:
+                with self._open_h5() as f:
+                    ds = f[self.dataset]
+                    return self._read_crop_from_ds(ds, frame_idx, crop, fill)
+        except (OSError, KeyError, IndexError):  # pragma: no cover - defensive
+            return None
+
+    def read_crops(
+        self,
+        frame_inds: list,
+        crop: tuple[int, int, int, int],
+        fill: int | tuple[int, ...] = 0,
+    ) -> np.ndarray | None:
+        """Batched :meth:`read_crop`.
+
+        Args:
+            frame_inds: List of source-video frame indices to read.
+            crop: Crop region ``(x1, y1, x2, y2)`` with ``x2``/``y2`` exclusive.
+            fill: Fill value for out-of-bounds regions.
+
+        Returns:
+            A ``(N, y2 - y1, x2 - x1, C)`` array byte-identical to stacking
+            per-frame ``crop_frame`` results, or ``None`` to fall back to a
+            full-frame decode plus ``crop_frame``.
+        """
+        if not self._can_push_crop:
+            return None
+        try:
+            if self.keep_open:
+                if self._open_reader is None:
+                    self._open_reader = self._open_h5()
+                f = self._open_reader
+                ds = f[self.dataset]
+                return self._stack_crops(ds, frame_inds, crop, fill)
+            else:
+                with self._open_h5() as f:
+                    ds = f[self.dataset]
+                    return self._stack_crops(ds, frame_inds, crop, fill)
+        except (OSError, KeyError, IndexError):  # pragma: no cover - defensive
+            return None
+
+    def _stack_crops(
+        self,
+        ds: h5py.Dataset,
+        frame_inds: list,
+        crop: tuple[int, int, int, int],
+        fill: int | tuple[int, ...],
+    ) -> np.ndarray | None:
+        """Stack per-frame crop reads, falling back to ``None`` if the gate declines.
+
+        The per-call gate in :meth:`_read_crop_from_ds` is frame-index independent, so
+        a batch is uniformly all-arrays or all-``None``; returning ``None`` on any
+        ``None`` keeps batched reads byte-for-byte consistent with the scalar path
+        (the caller then decodes the full frames and crops them).
+
+        Args:
+            ds: The open ``h5py.Dataset`` (raw rank-4).
+            frame_inds: Frame indices to read.
+            crop: Crop region ``(x1, y1, x2, y2)``.
+            fill: Fill value for out-of-bounds regions.
+
+        Returns:
+            A ``(N, y2 - y1, x2 - x1, C)`` array, or ``None`` to signal fallback.
+        """
+        parts = [self._read_crop_from_ds(ds, i, crop, fill) for i in frame_inds]
+        if any(p is None for p in parts):
+            return None
+        return np.stack(parts, axis=0)
+
+    def _read_crop_from_ds(
+        self,
+        ds: h5py.Dataset,
+        frame_idx: int,
+        crop: tuple[int, int, int, int],
+        fill: int | tuple[int, ...],
+    ) -> np.ndarray | None:
+        """Read and pad one frame's crop region from an open dataset.
+
+        Performs the per-call gate (crop must be smaller than the chunk span on at
+        least one spatial axis) and the clamp+pad hyperslab read. Axis ordering is
+        derived from ``ds.shape`` rather than assumed. Pushdown is structurally gated
+        off for frame-mapped/embedded datasets (see :attr:`_can_push_crop`), so
+        ``frame_idx`` is always a raw source index here.
+
+        Args:
+            ds: The open ``h5py.Dataset`` (raw rank-4).
+            frame_idx: Frame index (raw source index; no ``frame_map`` remap needed).
+            crop: Crop region ``(x1, y1, x2, y2)``.
+            fill: Fill value for out-of-bounds regions.
+
+        Returns:
+            The ``(y2 - y1, x2 - x1, C)`` cropped/padded frame, or ``None`` if the
+            per-call gate decides a full read is at least as good.
+        """
+        x1, y1, x2, y2 = crop
+        chunks = ds.chunks
+
+        if self.input_format == "channels_first":
+            # On-disk layout (F, C, W, H): x maps to axis 2 (W), y to axis 3 (H).
+            channels = ds.shape[1]
+            disk_w, disk_h = ds.shape[2], ds.shape[3]
+            width, height = disk_w, disk_h
+            chunk_w, chunk_h = chunks[2], chunks[3]
+        else:
+            # channels_last (F, H, W, C).
+            height, width, channels = ds.shape[1], ds.shape[2], ds.shape[3]
+            chunk_h, chunk_w = chunks[1], chunks[2]
+
+        # Per-call gate: only push down when the crop touches fewer spatial chunks
+        # than the full frame does on at least one axis. If the (in-bounds) crop
+        # already touches every chunk on both spatial axes, a hyperslab read buys
+        # nothing over a full read, so fall back.
+        crop_w, crop_h = x2 - x1, y2 - y1
+        in_sx1, in_sy1 = max(0, x1), max(0, y1)
+        in_sx2, in_sy2 = min(width, x2), min(height, y2)
+        if in_sx2 <= in_sx1 or in_sy2 <= in_sy1:
+            # Fully outside on at least one axis: no valid source pixels to read,
+            # so the hyperslab touches no chunks; pushdown is trivially beneficial.
+            n_chunks_w = n_chunks_h = 0
+        else:
+            n_chunks_w = (in_sx2 - 1) // chunk_w - in_sx1 // chunk_w + 1
+            n_chunks_h = (in_sy2 - 1) // chunk_h - in_sy1 // chunk_h + 1
+        frame_chunks_w = -(-width // chunk_w)
+        frame_chunks_h = -(-height // chunk_h)
+        if n_chunks_w >= frame_chunks_w and n_chunks_h >= frame_chunks_h:
+            return None
+
+        # frame_map is always empty here: _can_push_crop gates pushdown off for
+        # frame-mapped/embedded datasets, so frame_idx is a raw source index.
+        out = np.full((crop_h, crop_w, channels), fill, dtype=ds.dtype)
+
+        # Clamp the requested rect to the valid frame bounds.
+        sx1, sy1 = max(0, x1), max(0, y1)
+        sx2, sy2 = min(width, x2), min(height, y2)
+        if sx2 > sx1 and sy2 > sy1:
+            if self.input_format == "channels_first":
+                region = np.transpose(ds[frame_idx, :, sx1:sx2, sy1:sy2], (2, 1, 0))
+            else:
+                region = ds[frame_idx, sy1:sy2, sx1:sx2, :]
+            out[
+                sy1 - y1 : sy1 - y1 + (sy2 - sy1),
+                sx1 - x1 : sx1 - x1 + (sx2 - sx1),
+            ] = region
+        return out
+
 
 @attrs.define
 class ImageVideo(VideoBackend):
@@ -1970,3 +2201,273 @@ class TiffVideo(VideoBackend):
                 return frames
             else:
                 raise ValueError(f"Unknown format: {self.format}")
+
+
+@attrs.define(eq=False)
+class CropVideoBackend(VideoBackend):
+    """Virtual, axis-aligned, on-read crop of an inner :class:`VideoBackend`.
+
+    Wraps an inner backend and reports a cropped ``(F, h, w, c)`` view. Frames are
+    decoded by the inner backend, then cropped/padded by
+    :func:`sleap_io.transform.frame.crop_frame` (byte-identical), so no pixels are
+    copied or re-encoded on disk. Frame count is unchanged (a crop is spatial, not
+    temporal). Reports the cropped shape/grayscale and is a drop-in substitute
+    anywhere a ``VideoBackend`` is accepted.
+
+    Equality is by object identity (``eq=False``): inherited cache fields
+    (``_cached_shape``, ``_open_reader``, ...) would otherwise pollute value
+    equality, and dedup never relies on backend ``==`` (it uses an explicit crop
+    key). Always construct via :meth:`wrap` (never the raw constructor) so the
+    "inner is never a crop" invariant and fill-aware flatten hold by construction.
+
+    Attributes:
+        inner: The wrapped source backend. Decodes full frames; this wrapper crops
+            its output. Invariant: ``inner`` is never itself a ``CropVideoBackend``
+            (enforced by :meth:`wrap`).
+        crop: Crop region ``(x1, y1, x2, y2)``, ``x2``/``y2`` exclusive. May be
+            negative or exceed source bounds; out-of-bounds regions are pad-filled.
+            Stored as a tuple of ints.
+        fill: Fill value for out-of-bounds regions, forwarded to ``crop_frame``.
+        owns_inner: Whether this wrapper owns the inner backend's decode handle. If
+            ``True`` (the default), :meth:`close` cascades to ``inner.close()``; if
+            ``False`` (a shared-decode mosaic tile), it does not, so closing one
+            tile does not tear down siblings sharing the inner.
+        filename: Derived from ``inner.filename`` in post-init; NOT a constructor
+            argument.
+    """
+
+    filename: str | Path | list[str] | list[Path] = attrs.field(
+        init=False, default=None
+    )
+    inner: VideoBackend = attrs.field(kw_only=True)
+    crop: tuple[int, int, int, int] = attrs.field(
+        kw_only=True, converter=lambda c: tuple(int(v) for v in c)
+    )
+    fill: int | tuple[int, ...] = attrs.field(default=0, kw_only=True)
+    owns_inner: bool = attrs.field(default=True, kw_only=True)
+
+    def __attrs_post_init__(self) -> None:
+        """Derive ``filename`` from the inner; inherit resolved grayscale/fps lazily."""
+        object.__setattr__(self, "filename", getattr(self.inner, "filename", None))
+        # Inherit only an ALREADY-resolved inner grayscale; never force a decode at
+        # construction (keeps crop construction lazy). When unresolved, grayscale is
+        # resolved on first real access via the overridden ``detect_grayscale`` /
+        # ``img_shape``, always on the inner's FULL frame (so a degenerate crop never
+        # skews detection).
+        if self.grayscale is None and self.inner.grayscale is not None:
+            object.__setattr__(self, "grayscale", self.inner.grayscale)
+        # Carry fps so a closed/non-MediaVideo inner still reports fps.
+        if self._fps is None:
+            object.__setattr__(self, "_fps", getattr(self.inner, "_fps", None))
+
+    @classmethod
+    def wrap(
+        cls,
+        inner: VideoBackend,
+        crop: tuple[int, int, int, int],
+        fill: int | tuple[int, ...] = 0,
+        owns_inner: bool = True,
+    ) -> "CropVideoBackend":
+        """Wrap ``inner`` in a crop view, flattening crop-of-crop when safe.
+
+        Flattens (composes into a single wrapper) only when ``inner`` is itself a
+        ``CropVideoBackend``, the fills agree, AND the outer crop lies fully within
+        the inner cropped frame ``[0, iw] x [0, ih]`` (``iw = ix2 - ix1``,
+        ``ih = iy2 - iy1``). Otherwise it nests, preserving byte-parity:
+
+        - Different fills: the inner crop's materialized pad of value ``inner.fill``
+          would be silently replaced after a flatten.
+        - Outer crop exceeds the inner frame: a flatten would read real source
+          pixels where the nested view pads with ``fill``.
+
+        The flatten composition law expresses the outer rect in source coordinates:
+        ``(ix1 + ox1, iy1 + oy1, ix1 + ox2, iy1 + oy2)``. A flattened ``inner`` is
+        always unwrapped to ``inner.inner`` so the "inner is never a crop"
+        invariant holds.
+
+        Args:
+            inner: The backend to wrap (may itself be a ``CropVideoBackend``).
+            crop: Outer crop region ``(x1, y1, x2, y2)``, expressed in the inner
+                (possibly already-cropped) frame.
+            fill: Fill value for out-of-bounds regions.
+            owns_inner: Whether the returned wrapper owns the inner's decode handle
+                (see the class ``owns_inner`` attribute).
+
+        Returns:
+            A ``CropVideoBackend`` whose ``inner`` is never a crop.
+        """
+        if isinstance(inner, CropVideoBackend) and inner.fill == fill:
+            ix1, iy1, ix2, iy2 = inner.crop
+            ox1, oy1, ox2, oy2 = (int(v) for v in crop)
+            iw, ih = ix2 - ix1, iy2 - iy1
+            if 0 <= ox1 and 0 <= oy1 and ox2 <= iw and oy2 <= ih:
+                crop = (ix1 + ox1, iy1 + oy1, ix1 + ox2, iy1 + oy2)
+                inner = inner.inner  # invariant: inner.inner is never a crop
+        return cls(inner=inner, crop=crop, fill=fill, owns_inner=owns_inner)
+
+    @property
+    def num_frames(self) -> int:
+        """Number of frames in the video (identity: a crop is spatial)."""
+        return self.inner.num_frames
+
+    @property
+    def img_shape(self) -> tuple[int, int, int]:
+        """Shape of a single cropped frame as ``(height, width, channels)``."""
+        x1, y1, x2, y2 = self.crop
+        if self.grayscale is None:
+            self.detect_grayscale()
+        c = 1 if self.grayscale else self.inner.img_shape[2]
+        return int(y2 - y1), int(x2 - x1), int(c)
+
+    @property
+    def dataset(self) -> object | None:
+        """Inner backend's dataset name (delegated; ``None`` if absent)."""
+        return getattr(self.inner, "dataset", None)
+
+    @property
+    def input_format(self) -> object | None:
+        """Inner backend's input format (delegated; ``None`` if absent)."""
+        return getattr(self.inner, "input_format", None)
+
+    def has_frame(self, frame_idx: int) -> bool:
+        """Check if a frame index is contained in the video (delegates to inner).
+
+        Args:
+            frame_idx: Index of frame to check.
+
+        Returns:
+            ``True`` if the inner backend contains the index, else ``False``.
+        """
+        return self.inner.has_frame(frame_idx)
+
+    def read_test_frame(self) -> np.ndarray:
+        """Read the inner backend's UNCROPPED test frame (frame_map-safe)."""
+        return self.inner.read_test_frame()
+
+    def detect_grayscale(self, test_img: np.ndarray | None = None) -> bool:
+        """Resolve grayscale from the inner, ignoring any passed cropped image.
+
+        Args:
+            test_img: Ignored; grayscale is always resolved on the inner's full
+                frame so a degenerate (e.g. 1px-wide) crop never breaks detection.
+
+        Returns:
+            Whether the video is grayscale (also cached on ``self.grayscale``).
+        """
+        gs = self.inner.grayscale
+        if gs is None:
+            gs = self.inner.detect_grayscale()
+        self.grayscale = gs
+        self._cached_shape = None
+        return gs
+
+    def close(self) -> None:
+        """Release this wrapper's handle and the inner's, if owned.
+
+        Always releases the wrapper's own (unused) cached reader via
+        :meth:`VideoBackend.close`, then cascades to ``inner.close()`` only when
+        ``owns_inner`` (a shared-decode mosaic tile leaves the shared inner open).
+        """
+        super().close()
+        if self.owns_inner:
+            self.inner.close()
+
+    def _source_frame(self, frame_idx: int) -> tuple[np.ndarray, bool]:
+        """Return ``(frame, already_cropped)`` for a single frame.
+
+        Tries the inner's HDF5 crop pushdown first (returns the final cropped
+        frame); otherwise delegates to ``inner._read_frame`` (NOT ``get_frame``, so
+        the base ``get_frame`` applies the grayscale slice exactly once to our
+        cropped result).
+
+        Args:
+            frame_idx: Index of frame to read.
+
+        Returns:
+            A tuple of the frame and a flag indicating whether it is already
+            cropped (pushdown) or still a full source frame.
+        """
+        read_crop = getattr(self.inner, "read_crop", None)
+        if read_crop is not None:
+            out = read_crop(frame_idx, self.crop, self.fill)
+            if out is not None:
+                return out, True
+        return self.inner._read_frame(frame_idx), False
+
+    def _apply_view(self, frame: np.ndarray, frame_idx: int) -> np.ndarray:
+        """Crop/pad a full source frame into the cropped view.
+
+        Args:
+            frame: A full source frame ``(H, W, C)``.
+            frame_idx: Reserved for a future per-frame-varying window; unused.
+
+        Returns:
+            The cropped frame, materialized as a contiguous owned array.
+        """
+        return np.ascontiguousarray(crop_frame(frame, self.crop, fill=self.fill))
+
+    def _read_frame(self, frame_idx: int) -> np.ndarray:
+        """Read a single cropped frame.
+
+        Args:
+            frame_idx: Index of frame to read.
+
+        Returns:
+            The cropped frame ``(crop_h, crop_w, C)``.
+        """
+        src, already_cropped = self._source_frame(frame_idx)
+        return src if already_cropped else self._apply_view(src, frame_idx)
+
+    def _read_frames(self, frame_inds: list) -> np.ndarray:
+        """Read a list of cropped frames.
+
+        Tries the inner's batched HDF5 crop pushdown first; otherwise reads full
+        frames from the inner and crops them. The fully-in-bounds case uses a basic
+        slice then ``.copy()`` to defuse aliasing into the inner's reused decode
+        buffer; otherwise it pads per-frame via ``crop_frame``.
+
+        Args:
+            frame_inds: List of frame indices to read.
+
+        Returns:
+            Cropped frames ``(N, crop_h, crop_w, C)``.
+        """
+        read_crops = getattr(self.inner, "read_crops", None)
+        if read_crops is not None:
+            out = read_crops(frame_inds, self.crop, self.fill)
+            if out is not None:
+                return out
+        imgs = self.inner._read_frames(frame_inds)
+        x1, y1, x2, y2 = self.crop
+        h, w = imgs.shape[1], imgs.shape[2]
+        if 0 <= x1 and 0 <= y1 and x2 <= w and y2 <= h:
+            return imgs[:, y1:y2, x1:x2].copy()
+        return np.stack(
+            [crop_frame(im, self.crop, fill=self.fill) for im in imgs], axis=0
+        )
+
+    def to_crop_coords(self, points: np.ndarray) -> np.ndarray:
+        """Map source-frame ``(x, y)`` coordinates into the cropped frame.
+
+        Args:
+            points: Coordinate array of shape ``(..., 2)``. NaN values are
+                preserved.
+
+        Returns:
+            Coordinates translated by ``-(x1, y1)`` (copy-based, NaN-preserving).
+        """
+        return crop_points(points, self.crop)
+
+    def to_source_coords(self, points: np.ndarray) -> np.ndarray:
+        """Map cropped-frame ``(x, y)`` coordinates back to source coordinates.
+
+        Inverse of :meth:`to_crop_coords`.
+
+        Args:
+            points: Coordinate array of shape ``(..., 2)``. NaN values are
+                preserved.
+
+        Returns:
+            Coordinates translated by ``+(x1, y1)`` (copy-based, NaN-preserving).
+        """
+        return uncrop_points(points, self.crop)

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -2243,7 +2243,13 @@ class CropVideoBackend(VideoBackend):
     crop: tuple[int, int, int, int] = attrs.field(
         kw_only=True, converter=lambda c: tuple(int(v) for v in c)
     )
-    fill: int | tuple[int, ...] = attrs.field(default=0, kw_only=True)
+    fill: int | tuple[int, ...] = attrs.field(
+        default=0,
+        kw_only=True,
+        converter=lambda f: (
+            tuple(int(v) for v in f) if isinstance(f, (list, tuple)) else f
+        ),
+    )
     owns_inner: bool = attrs.field(default=True, kw_only=True)
 
     def __attrs_post_init__(self) -> None:
@@ -2296,7 +2302,13 @@ class CropVideoBackend(VideoBackend):
         Returns:
             A ``CropVideoBackend`` whose ``inner`` is never a crop.
         """
-        if isinstance(inner, CropVideoBackend) and inner.fill == fill:
+
+        # Normalize fills (a list and the equivalent tuple must compare equal so a
+        # crop reloaded from /video_crops still flattens against its tuple fill).
+        def _norm(f):
+            return tuple(int(v) for v in f) if isinstance(f, (list, tuple)) else f
+
+        if isinstance(inner, CropVideoBackend) and _norm(inner.fill) == _norm(fill):
             ix1, iy1, ix2, iy2 = inner.crop
             ox1, oy1, ox2, oy2 = (int(v) for v in crop)
             iw, ih = ix2 - ix1, iy2 - iy1
@@ -2312,10 +2324,15 @@ class CropVideoBackend(VideoBackend):
 
     @property
     def img_shape(self) -> tuple[int, int, int]:
-        """Shape of a single cropped frame as ``(height, width, channels)``."""
+        """Shape of a single cropped frame as ``(height, width, channels)``.
+
+        Mirrors the inner's channel policy without forcing a decode here: when the
+        wrapper's grayscale is unresolved (``None``), inherit the inner's channel
+        count (``inner.img_shape`` resolves it from HDF5 attrs or a single detect),
+        so the cropped channels equal the source and stay stable across an SLP
+        round-trip. An explicit ``grayscale=True`` still collapses to 1 channel.
+        """
         x1, y1, x2, y2 = self.crop
-        if self.grayscale is None:
-            self.detect_grayscale()
         c = 1 if self.grayscale else self.inner.img_shape[2]
         return int(y2 - y1), int(x2 - x1), int(c)
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -2402,6 +2402,111 @@ class Labels:
         # Frame index is keyed by id(video), so must be rebuilt
         self._invalidate_indices()
 
+    def apply_crops(
+        self,
+        video_dir: str | Path | None = None,
+        *,
+        suffix: str = "_crop",
+        fps: float | None = None,
+        video_kwargs: dict[str, Any] | None = None,
+    ) -> "Labels":
+        """Bake every virtually-cropped video to disk and update references.
+
+        For each video in :attr:`videos` that carries a virtual crop (i.e.
+        ``video._crop_tuple()`` is not ``None``), materialize the cropped frames
+        to a new physical video file via :meth:`Video.apply_crop` and rewire all
+        references (labeled frames, ROIs, suggestions, and :attr:`videos`) to the
+        baked file via :meth:`replace_videos`. Uncropped videos are left
+        untouched.
+
+        Baked files are written to deterministic, unique paths derived from each
+        source video's filename stem. The output directory is ``video_dir`` if
+        given, otherwise the source video's own directory. The filename is
+        ``{stem}{suffix}.mp4``; when multiple cropped videos share a stem (e.g. a
+        mosaic of tiles over a single source file), the colliding files are
+        disambiguated as ``{stem}{suffix}_{i}.mp4`` so no two baked files collide.
+
+        This operation is coordinate-neutral. A virtual crop already presents
+        cropped-frame coordinates, so baking the cropped pixels does not change
+        any instance point coordinates; ``instance.points`` is not touched.
+        Provenance is preserved per :meth:`Video.apply_crop`: each baked video's
+        ``source_video`` is the uncropped original.
+
+        Args:
+            video_dir: Directory to write baked videos to. If ``None`` (the
+                default), each baked video is written next to its source video.
+                The directory is created if it does not exist.
+            suffix: Suffix appended to the source stem for baked filenames.
+                Defaults to ``"_crop"``.
+            fps: Frames per second for the baked videos. If ``None`` (the
+                default), each video's own FPS is used (falling back to 30).
+            video_kwargs: Keyword arguments forwarded to ``sio.save_video`` for
+                video compression of each baked video.
+
+        Returns:
+            This ``Labels`` (mutated in place) with all cropped videos baked to
+            disk and references updated.
+        """
+        out_dir = None if video_dir is None else Path(video_dir)
+        if out_dir is not None:
+            out_dir.mkdir(parents=True, exist_ok=True)
+
+        # Resolve the output directory and stem for each cropped video. Index is
+        # carried so colliding stems can be disambiguated deterministically.
+        cropped: list[tuple[int, Video, Path, str]] = []
+        # Count cropped videos per (resolved output dir, stem) to detect stem
+        # collisions (e.g. a mosaic of tiles over one source file).
+        stem_counts: dict[tuple[str, str], int] = {}
+        # Resolved paths of every source video file, so a baked file can never
+        # overwrite a source (e.g. an empty suffix written next to the source).
+        source_paths: set[str] = set()
+        for video in self.videos:
+            fns = (
+                video.filename if isinstance(video.filename, list) else [video.filename]
+            )
+            for fn in fns:
+                try:
+                    source_paths.add(Path(fn).resolve().as_posix())
+                except (OSError, ValueError):  # pragma: no cover - defensive
+                    pass
+        for i, video in enumerate(self.videos):
+            if video._crop_tuple() is None:
+                continue
+            src_path = Path(
+                video.filename[0]
+                if isinstance(video.filename, list)
+                else video.filename
+            )
+            stem = src_path.stem
+            dest_dir = out_dir if out_dir is not None else src_path.parent
+            cropped.append((i, video, dest_dir, stem))
+            key = (dest_dir.as_posix(), stem)
+            stem_counts[key] = stem_counts.get(key, 0) + 1
+
+        video_map: dict[Video, Video] = {}
+        for i, video, dest_dir, stem in cropped:
+            if stem_counts[(dest_dir.as_posix(), stem)] > 1:
+                # Multiple crops share this stem; disambiguate with the video
+                # index so the name is deterministic and collision-free.
+                out_path = dest_dir / f"{stem}{suffix}_{i}.mp4"
+            else:
+                out_path = dest_dir / f"{stem}{suffix}.mp4"
+
+            if out_path.resolve().as_posix() in source_paths:
+                raise ValueError(
+                    f"Baked crop path {out_path} would overwrite a source video "
+                    "file. Pass a distinct video_dir or a non-empty suffix so "
+                    "baked videos are written to separate files."
+                )
+
+            baked = video.apply_crop(out_path, fps=fps, video_kwargs=video_kwargs)
+            video_map[video] = baked
+
+        if video_map:
+            self.replace_videos(video_map=video_map)
+
+        return self
+
     def replace_filenames(
         self,
         new_filenames: list[str | Path] | None = None,

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1317,6 +1317,7 @@ class Labels:
         from sleap_io.model.matching import (
             VideoMatcher,
             VideoMatchMethod,
+            _crop_key,
             is_same_file,
         )
 
@@ -1367,17 +1368,31 @@ class Labels:
         if matcher is None:
             # Tiered cascade: prefer a definitive (file identity / exact path)
             # match so a shared basename never shadows a true match.
+            # The strict-path and basename rungs must also be crop-aware: two
+            # distinct crops (mosaic tiles) of one source share a path, so an
+            # unguarded path match would mis-resolve one tile to the other.
+            # `is_same_file` is already crop-aware; for uncropped videos both
+            # crop keys are None, so these guards leave behavior unchanged.
             definitive = [
                 v
                 for v in self.videos
-                if is_same_file(v, query) or v.matches_path(query, strict=True)
+                if is_same_file(v, query)
+                or (
+                    v.matches_path(query, strict=True)
+                    and _crop_key(v) == _crop_key(query)
+                )
             ]
             if len(definitive) > 1:
                 raise _ambiguous(definitive, "by file identity")
             if definitive:
                 return definitive[0]
 
-            basename = [v for v in self.videos if v.matches_path(query, strict=False)]
+            basename = [
+                v
+                for v in self.videos
+                if v.matches_path(query, strict=False)
+                and _crop_key(v) == _crop_key(query)
+            ]
             if len(basename) > 1:
                 raise _ambiguous(basename, "by basename")
             return basename[0] if basename else None

--- a/sleap_io/model/matching.py
+++ b/sleap_io/model/matching.py
@@ -504,6 +504,26 @@ def _is_same_file_direct(video1: Video, video2: Video) -> bool:
     return True
 
 
+def _crop_key(video: Video) -> tuple[int, int, int, int] | None:
+    """Return a video's crop rect as a hashable identity key, or ``None``.
+
+    This is the per-video crop identity used to disambiguate distinct crops
+    (e.g. mosaic tiles) of one underlying source file. It reads the composed
+    source-coordinate crop rect via :meth:`Video._crop_tuple` (which prefers
+    ``backend.crop`` on an open ``CropVideoBackend`` and falls back to
+    ``backend_metadata["crop"]`` when closed), normalized to a plain tuple.
+
+    Args:
+        video: The video to read the crop key from.
+
+    Returns:
+        The crop rect ``(x1, y1, x2, y2)`` as a tuple, or ``None`` when the
+        video is not cropped (or does not expose ``_crop_tuple``).
+    """
+    crop = getattr(video, "_crop_tuple", lambda: None)()
+    return tuple(crop) if crop is not None else None
+
+
 def is_same_file(video1: Video, video2: Video) -> bool:
     """Check if two videos refer to the same underlying file.
 
@@ -511,21 +531,32 @@ def is_same_file(video1: Video, video2: Video) -> bool:
     - Traversing source_video/original_video chains to find root videos
     - Using os.path.samefile() when files exist (handles symlinks)
     - Falling back to path resolution and string comparison
+    - Requiring matching crop rects (so two distinct crops of one source file
+      -- e.g. mosaic tiles -- are NOT collapsed into one video)
 
     Args:
         video1: First video to compare.
         video2: Second video to compare.
 
     Returns:
-        True if both videos refer to the same underlying file.
+        True if both videos refer to the same underlying file AND have the same
+        crop identity.
 
     Notes:
         This is stricter than matches_path(strict=False) - it only returns True
         when files are verifiably the same, not just same basename.
+
+        The crop keys are read from the ORIGINAL videos (not the resolved
+        roots): two tiles share one uncropped source whose own crop key is
+        ``None``, so the disambiguation must use each video's own crop rect.
+        For non-cropped videos both keys are ``None``, so behavior is unchanged.
     """
     root1 = _get_root_video(video1)
     root2 = _get_root_video(video2)
-    return _is_same_file_direct(root1, root2)
+    if not _is_same_file_direct(root1, root2):
+        return False
+    # Same underlying file: distinct crops of it are distinct videos.
+    return _crop_key(video1) == _crop_key(video2)
 
 
 def _get_effective_shape(video: Video) -> tuple | None:
@@ -642,6 +673,43 @@ def original_videos_conflict(video1: Video, video2: Video) -> bool:
 
     # At least one file exists and they don't match - conflict
     return True
+
+
+def _same_file_different_crop(video1: Video, video2: Video) -> bool:
+    """Check if two videos are the same source file but DIFFERENT crops.
+
+    This is the definitive disambiguation for mosaic tiles: two distinct crops
+    of one physical file share a root file (so file-identity and path rungs
+    would otherwise collapse them) but have different crop rects, making them
+    genuinely different videos.
+
+    Args:
+        video1: First video to compare.
+        video2: Second video to compare.
+
+    Returns:
+        True only when the two videos resolve to the same underlying root file
+        (verifiable identity or matching root basename) AND their crop keys
+        differ. For non-cropped videos (both keys ``None``) this is always
+        False, so behavior for non-crop videos is unchanged.
+    """
+    if _crop_key(video1) == _crop_key(video2):
+        return False
+
+    root1 = _get_root_video(video1)
+    root2 = _get_root_video(video2)
+    if _is_same_file_direct(root1, root2):
+        return True
+
+    # Even without verifiable file identity, a shared root basename means the
+    # path/leaf rungs could re-match the pair; differing crops still disambiguate.
+    from pathlib import Path
+
+    fn1 = root1.filename
+    fn2 = root2.filename
+    if isinstance(fn1, list) or isinstance(fn2, list):
+        return False
+    return Path(fn1).name == Path(fn2).name
 
 
 @attrs.define
@@ -869,7 +937,13 @@ class VideoMatcher:
             if original_videos_conflict(video1, video2):
                 return False
 
-            # Definitive: same file identity
+            # Definitive: same source file but different crop (mosaic tiles).
+            # Must run before any path rung, which would otherwise re-match the
+            # shared root file. For non-crop videos this is always False.
+            if _same_file_different_crop(video1, video2):
+                return False
+
+            # Definitive: same file identity (crop-aware)
             if is_same_file(video1, video2):
                 return True
 
@@ -950,6 +1024,14 @@ class VideoMatcher:
                 # REJECTION CHECK 2: original_video conflict
                 if original_videos_conflict(candidate, incoming):
                     # Both have provenance pointing to different files - skip
+                    continue
+
+                # REJECTION CHECK 3: same source file, different crop.
+                # Distinct crops (mosaic tiles) of one physical file share a
+                # root file, so dropping them here prevents the file-identity,
+                # strict-path, and leaf-uniqueness rungs from collapsing them.
+                # For non-crop candidates this is always False.
+                if _same_file_different_crop(candidate, incoming):
                     continue
 
                 viable.append(candidate)

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -394,25 +394,50 @@ class Video:
         video: "str | Path | Video",
         crop: tuple[int, int, int, int] | None = None,
         *,
+        bbox: tuple[float, float, float, float] | None = None,
+        roi: object | None = None,
+        center: tuple[float, float] | None = None,
+        size: tuple[int, int] | None = None,
+        margin: int = 0,
         fill: int | tuple[int, ...] = 0,
+        share_decode: bool = True,
         **kwargs,
     ) -> "Video":
         """Open ``video`` (path or ``Video``) and return a virtual crop.
 
+        Accepts the same region specs as :meth:`crop` (``crop``/``bbox``/``roi``/
+        ``center``+``size``); extra keyword arguments are forwarded to
+        :meth:`from_filename` when ``video`` is a path (ignored when it is already
+        a ``Video``).
+
         Args:
             video: A path/filename to open, or an existing ``Video`` to crop.
-            crop: Explicit crop region ``(x1, y1, x2, y2)``, ``x2``/``y2``
-                exclusive.
+            crop: Explicit crop region ``(x1, y1, x2, y2)``, ``x2``/``y2`` exclusive.
+            bbox: A bounding box ``(x1, y1, x2, y2)``; bounds may be float.
+            roi: An object exposing axis-aligned ``.bounds`` (e.g. a shapely
+                geometry); ``margin`` is applied around it.
+            center: Window center ``(cx, cy)`` (with ``size``).
+            size: Fixed output ``(width, height)`` (with ``center``).
+            margin: Pixels added around the ``roi`` bounds on every side.
             fill: Fill value for out-of-bounds regions.
-            **kwargs: Forwarded to :meth:`from_filename` when ``video`` is a path
-                (ignored when ``video`` is already a ``Video``).
+            share_decode: If ``True`` (default), reuse the source decoder.
+            **kwargs: Forwarded to :meth:`from_filename` for a path input.
 
         Returns:
             A new ``Video`` exposing the cropped view.
         """
         if isinstance(video, (str, Path)):
             video = cls.from_filename(video, **kwargs)
-        return video.crop(crop, fill=fill)
+        return video.crop(
+            crop,
+            bbox=bbox,
+            roi=roi,
+            center=center,
+            size=size,
+            margin=margin,
+            fill=fill,
+            share_decode=share_decode,
+        )
 
     def _crop_tuple(self) -> tuple[int, int, int, int] | None:
         """Return this video's crop rect ``(x1, y1, x2, y2)`` or ``None``.
@@ -438,6 +463,21 @@ class Video:
         if isinstance(self.backend, CropVideoBackend):
             return self.backend.fill
         return self.backend_metadata.get("crop_fill", 0)
+
+    @property
+    def is_cropped(self) -> bool:
+        """Whether this video is a virtual crop of another video."""
+        return self._crop_tuple() is not None
+
+    @property
+    def crop_rect(self) -> tuple[int, int, int, int] | None:
+        """Crop rect ``(x1, y1, x2, y2)`` in source coords, or ``None`` if uncropped."""
+        return self._crop_tuple()
+
+    @property
+    def crop_fill(self) -> int | tuple[int, ...]:
+        """The out-of-bounds fill value for this video's crop (``0`` if uncropped)."""
+        return self._crop_fill()
 
     def to_crop_coords(self, points: np.ndarray) -> np.ndarray:
         """Map source-frame ``(x, y)`` into this video's cropped frame.
@@ -1282,7 +1322,25 @@ class Video:
             )
 
         video_kwargs = {} if video_kwargs is None else video_kwargs.copy()
-        frame_inds = np.arange(len(self)) if frame_inds is None else frame_inds
+        if frame_inds is None:
+            # A crop over a SPARSELY embedded video (frame_map keys are not the dense
+            # range 0..N-1, e.g. {5, 9}) cannot be baked by default: writing the frames
+            # compacts them to 0..k-1, so any labeled frame referencing a source index
+            # (5, 9) would dangle. Refuse with a clear error rather than crash or
+            # silently misalign. An explicit frame_inds bypasses this for advanced use.
+            inner = getattr(self.backend, "inner", None)
+            frame_map = getattr(inner, "frame_map", None)
+            if frame_map:
+                keys = sorted(frame_map.keys())
+                if keys != list(range(len(keys))):
+                    raise ValueError(
+                        "Cannot bake a virtual crop over a video with sparsely "
+                        f"embedded frames (frame_map keys {keys}): baking would "
+                        "compact frames to a contiguous range and break frame_idx "
+                        "references. Pass explicit frame_inds to override, or "
+                        "materialize from the original source video."
+                    )
+            frame_inds = np.arange(len(self))
 
         # Use this video's FPS if not explicitly specified.
         if fps is None:
@@ -1295,11 +1353,14 @@ class Video:
                 vw(self[frame_ind])
 
         baked = Video.from_filename(path, grayscale=self.grayscale)
-        # Provenance: the uncropped original. Normally that is self.source_video
-        # (the parent a virtual crop was created against). For a manually-built
-        # crop with no parent, reconstruct an uncropped view from the crop
-        # backend's inner so source_video is never the cropped video itself.
+        # Provenance: the uncropped original. Walk past any still-virtual crop
+        # ancestors (a flattened crop-of-crop's source_video may itself be a crop)
+        # to the first uncropped ancestor. For a manually-built crop with no parent,
+        # reconstruct an uncropped view from the crop backend's inner, so
+        # source_video is never a cropped video.
         source = self.source_video
+        while source is not None and source._crop_tuple() is not None:
+            source = source.source_video
         if source is None:
             inner = getattr(self.backend, "inner", None)
             source = (

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -1223,6 +1223,93 @@ class Video:
         new_video = Video.from_filename(save_path, grayscale=self.grayscale)
         return new_video
 
+    def apply_crop(
+        self,
+        path: str | Path,
+        *,
+        frame_inds: list[int] | np.ndarray | None = None,
+        fps: float | None = None,
+        video_kwargs: dict[str, Any] | None = None,
+    ) -> "Video":
+        """Bake this video's virtual crop into a new physical video file.
+
+        Materializes the cropped frames (``self[i]``, already cropped by the
+        virtual :class:`~sleap_io.io.video_reading.CropVideoBackend`) to ``path``
+        via :class:`~sleap_io.io.video_writing.VideoWriter`. The crop becomes
+        physical: the returned video has no ``CropVideoBackend`` / ``/video_crops``
+        entry. ``baked.shape`` equals this video's cropped shape when the cropped
+        width and height are multiples of 16; otherwise the H.264 encoder pads the
+        bottom/right edges up to the next multiple of 16 (the macro-block size),
+        so ``baked.shape`` may exceed the cropped shape on those edges. The
+        top-left content is preserved, so coordinates stay aligned regardless.
+
+        This operation is coordinate-neutral. A virtual crop already presents
+        cropped-frame coordinates, so baking the cropped pixels does not change
+        any point coordinates (unlike ``sio transform --crop``, which applies a
+        new crop and adjusts coordinates).
+
+        Provenance is preserved: the returned video's ``source_video`` is the
+        uncropped original — ``self.source_video`` (the parent a virtual crop is
+        created against), or, for a manually-built crop with no parent, an
+        uncropped view reconstructed from the crop backend's inner. So
+        ``baked.source_video.shape`` is the uncropped shape while ``baked.shape``
+        is the cropped shape, and ``baked.grayscale`` is carried from this video.
+
+        Args:
+            path: Path to the new video file. Should end in MP4.
+            frame_inds: Frame indices to bake. Can be specified as a list or array
+                of frame integers. If not specified, bakes all video frames.
+            fps: Frames per second for the output video. If not specified, uses
+                this video's FPS if available, otherwise defaults to 30.
+            video_kwargs: A dictionary of keyword arguments to provide to
+                ``sio.save_video`` for video compression.
+
+        Returns:
+            A new ``Video`` pointing to the baked file, with ``source_video`` set
+            to the uncropped original (or this video) and ``grayscale`` carried
+            from this video.
+
+        Raises:
+            ValueError: If this video has no virtual crop to apply (i.e.,
+                :meth:`_crop_tuple` returns ``None``). Use :meth:`save` to
+                re-encode an uncropped video.
+        """
+        if self._crop_tuple() is None:
+            raise ValueError(
+                "apply_crop requires a cropped video (a virtual crop created via "
+                "Video.crop / Video.from_crop), but this video has no crop to "
+                "apply. Use Video.save to re-encode an uncropped video."
+            )
+
+        video_kwargs = {} if video_kwargs is None else video_kwargs.copy()
+        frame_inds = np.arange(len(self)) if frame_inds is None else frame_inds
+
+        # Use this video's FPS if not explicitly specified.
+        if fps is None:
+            fps = self.fps
+        if fps is not None and "fps" not in video_kwargs:
+            video_kwargs["fps"] = fps
+
+        with VideoWriter(path, **video_kwargs) as vw:
+            for frame_ind in frame_inds:
+                vw(self[frame_ind])
+
+        baked = Video.from_filename(path, grayscale=self.grayscale)
+        # Provenance: the uncropped original. Normally that is self.source_video
+        # (the parent a virtual crop was created against). For a manually-built
+        # crop with no parent, reconstruct an uncropped view from the crop
+        # backend's inner so source_video is never the cropped video itself.
+        source = self.source_video
+        if source is None:
+            inner = getattr(self.backend, "inner", None)
+            source = (
+                Video(filename=inner.filename, backend=inner)
+                if inner is not None
+                else self
+            )
+        baked.source_video = source
+        return baked
+
     def set_video_plugin(self, plugin: str) -> None:
         """Set the video plugin and reopen the video.
 

--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -18,6 +18,85 @@ import numpy as np
 from sleap_io.io.utils import is_file_accessible
 from sleap_io.io.video_reading import HDF5Video, ImageVideo, MediaVideo, VideoBackend
 from sleap_io.io.video_writing import VideoWriter
+from sleap_io.transform.points import crop_points, uncrop_points
+
+
+def _resolve_crop_rect(
+    crop: tuple[int, int, int, int] | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+    roi: object | None = None,
+    center: tuple[float, float] | None = None,
+    size: tuple[int, int] | None = None,
+    margin: int = 0,
+) -> tuple[int, int, int, int]:
+    """Resolve a crop region spec into an integer ``(x1, y1, x2, y2)`` rect.
+
+    Exactly one region spec must be provided: an explicit ``crop`` rect, a
+    ``bbox``, a ``roi`` (its axis-aligned bounds), or a (``center``, ``size``)
+    pair for a fixed-shape centered window. Float bounds are rounded outward
+    (floor of the mins, ceil of the maxs) so the integer rect always *contains*
+    the requested region; the centered window uses ``round`` so the output shape
+    is exactly ``size`` (the position may be out of bounds and is pad-filled on
+    read). ``int()`` truncation is never used.
+
+    Args:
+        crop: Explicit crop region ``(x1, y1, x2, y2)``, ``x2``/``y2`` exclusive.
+        bbox: A bounding box ``(x1, y1, x2, y2)``; bounds may be float.
+        roi: Any object exposing axis-aligned ``.bounds`` as
+            ``(minx, miny, maxx, maxy)`` (e.g. a shapely geometry). ``margin`` is
+            applied symmetrically around the bounds.
+        center: Window center ``(cx, cy)`` (used with ``size``).
+        size: Fixed output ``(width, height)`` (used with ``center``).
+        margin: Pixels added around the ``roi`` bounds on every side.
+
+    Returns:
+        An integer crop region ``(x1, y1, x2, y2)``, possibly out of bounds.
+
+    Raises:
+        ValueError: If not exactly one of {``crop``, ``bbox``, ``roi``,
+            (``center``, ``size``)} is provided.
+    """
+    # ``center`` and ``size`` must be given together (both or neither).
+    if (center is None) != (size is None):
+        raise ValueError(
+            "center and size must be provided together for a centered window; "
+            f"got center={center!r}, size={size!r}."
+        )
+    has_center_size = center is not None and size is not None
+    n_specs = sum(
+        [crop is not None, bbox is not None, roi is not None, has_center_size]
+    )
+    if n_specs != 1:
+        raise ValueError(
+            "Exactly one of {crop, bbox, roi, (center, size)} must be provided "
+            f"to specify a crop region, got {n_specs}. For a centered window, "
+            "pass both center and size."
+        )
+
+    if crop is not None:
+        x1, y1, x2, y2 = (int(v) for v in crop)
+    elif bbox is not None:
+        bx1, by1, bx2, by2 = bbox
+        x1, y1 = int(np.floor(bx1)), int(np.floor(by1))
+        x2, y2 = int(np.ceil(bx2)), int(np.ceil(by2))
+    elif roi is not None:
+        minx, miny, maxx, maxy = roi.bounds
+        x1, y1 = int(np.floor(minx)) - margin, int(np.floor(miny)) - margin
+        x2, y2 = int(np.ceil(maxx)) + margin, int(np.ceil(maxy)) + margin
+    else:
+        # Centered window with fixed output shape.
+        cx, cy = center
+        w, h = size
+        x1 = int(round(cx - w / 2))
+        y1 = int(round(cy - h / 2))
+        x2, y2 = x1 + int(round(w)), y1 + int(round(h))
+
+    if x2 < x1 or y2 < y1:
+        raise ValueError(
+            f"Inverted crop rect: x2 ({x2}) < x1 ({x1}) or y2 ({y2}) < y1 ({y1}). "
+            "Crop bounds must satisfy x2 >= x1 and y2 >= y1."
+        )
+    return x1, y1, x2, y2
 
 
 @attrs.define(eq=False)
@@ -221,6 +300,174 @@ class Video:
             backend=backend,
             source_video=source_video,
         )
+
+    def crop(
+        self,
+        crop: tuple[int, int, int, int] | None = None,
+        *,
+        bbox: tuple[float, float, float, float] | None = None,
+        roi: object | None = None,
+        center: tuple[float, float] | None = None,
+        size: tuple[int, int] | None = None,
+        margin: int = 0,
+        fill: int | tuple[int, ...] = 0,
+        share_decode: bool = True,
+    ) -> "Video":
+        """Return a virtual, on-read cropped view of this video.
+
+        Exactly one region spec must be given: ``crop`` (explicit
+        ``(x1, y1, x2, y2)`` rect), ``bbox``, ``roi`` (its axis-aligned bounds +
+        ``margin``), or (``center``, ``size``) for a fixed-size centered/
+        centroid-following window. The returned ``Video`` shares no pixels with
+        this one; frames are decoded on read and cropped (byte-identical to
+        :func:`sleap_io.transform.frame.crop_frame`). Out-of-bounds regions are
+        pad-filled with ``fill`` (never clamped), so the output shape is always
+        exactly ``(y2 - y1, x2 - x1)``.
+
+        The crop composes (FLATTENS when fills agree and the region is in-bounds)
+        with any existing crop on this video via
+        :meth:`CropVideoBackend.wrap`. ``source_video`` is set to this video for
+        provenance. When ``share_decode`` (the default), the new crop reuses this
+        video's backend instance as the shared inner so a mosaic of tiles over
+        one file decodes each source frame once; in that case the new tile does
+        NOT own the shared decoder (this video does).
+
+        Args:
+            crop: Explicit crop region ``(x1, y1, x2, y2)``, ``x2``/``y2``
+                exclusive.
+            bbox: A bounding box ``(x1, y1, x2, y2)``; bounds may be float.
+            roi: Any object exposing axis-aligned ``.bounds`` as
+                ``(minx, miny, maxx, maxy)`` (e.g. a shapely geometry).
+            center: Window center ``(cx, cy)`` (used with ``size``).
+            size: Fixed output ``(width, height)`` (used with ``center``).
+            margin: Pixels added around the ``roi`` bounds on every side.
+            fill: Fill value for out-of-bounds regions.
+            share_decode: If ``True`` (the default), reuse this video's backend
+                as the shared inner so tiles decode each frame once; the new tile
+                does not own the shared decoder.
+
+        Returns:
+            A new ``Video`` exposing the cropped view.
+        """
+        from sleap_io.io.video_reading import CropVideoBackend
+
+        rect = _resolve_crop_rect(crop, bbox, roi, center, size, margin)
+        if self.backend is None and self.open_backend:
+            self.open()
+        if self.backend is None:
+            raise ValueError(
+                "Cannot crop a video with no open backend. Open it first (set "
+                "open_backend=True or call .open()) before cropping."
+            )
+        inner = self.backend
+        cropped_backend = CropVideoBackend.wrap(
+            inner=inner, crop=rect, fill=fill, owns_inner=not share_decode
+        )
+
+        cropped = Video(
+            filename=self.filename,
+            backend=cropped_backend,
+            source_video=self,
+            open_backend=self.open_backend,
+        )
+
+        x1, y1, x2, y2 = cropped_backend.crop
+        src_shape = self.shape
+        cropped.backend_metadata = {
+            **self.backend_metadata,
+            "shape": (src_shape[0], y2 - y1, x2 - x1, src_shape[3])
+            if src_shape is not None
+            else None,
+            # The uncropped source shape, so a closed re-serialize keeps videos_json
+            # describing the full frame even without a live source_video (D-120/DI-2).
+            "source_shape": list(src_shape) if src_shape is not None else None,
+            # COMPOSED source rect from wrap (D-120): keeps open/closed crop keys
+            # identical and root-canonical, and survives close()->open().
+            "crop": list(cropped_backend.crop),
+            "crop_fill": cropped_backend.fill,
+        }
+        return cropped
+
+    @classmethod
+    def from_crop(
+        cls,
+        video: "str | Path | Video",
+        crop: tuple[int, int, int, int] | None = None,
+        *,
+        fill: int | tuple[int, ...] = 0,
+        **kwargs,
+    ) -> "Video":
+        """Open ``video`` (path or ``Video``) and return a virtual crop.
+
+        Args:
+            video: A path/filename to open, or an existing ``Video`` to crop.
+            crop: Explicit crop region ``(x1, y1, x2, y2)``, ``x2``/``y2``
+                exclusive.
+            fill: Fill value for out-of-bounds regions.
+            **kwargs: Forwarded to :meth:`from_filename` when ``video`` is a path
+                (ignored when ``video`` is already a ``Video``).
+
+        Returns:
+            A new ``Video`` exposing the cropped view.
+        """
+        if isinstance(video, (str, Path)):
+            video = cls.from_filename(video, **kwargs)
+        return video.crop(crop, fill=fill)
+
+    def _crop_tuple(self) -> tuple[int, int, int, int] | None:
+        """Return this video's crop rect ``(x1, y1, x2, y2)`` or ``None``.
+
+        Reads ``backend.crop`` when the backend is a ``CropVideoBackend`` (open
+        path), else ``backend_metadata["crop"]`` (closed path), else ``None``
+        (uncropped).
+        """
+        from sleap_io.io.video_reading import CropVideoBackend
+
+        if isinstance(self.backend, CropVideoBackend):
+            return tuple(self.backend.crop)
+        crop = self.backend_metadata.get("crop")
+        return tuple(crop) if crop is not None else None
+
+    def _crop_fill(self) -> int | tuple[int, ...]:
+        """Return this video's crop fill value (open: backend; closed: metadata).
+
+        Returns ``0`` for an uncropped video. Mirrors :meth:`_crop_tuple`.
+        """
+        from sleap_io.io.video_reading import CropVideoBackend
+
+        if isinstance(self.backend, CropVideoBackend):
+            return self.backend.fill
+        return self.backend_metadata.get("crop_fill", 0)
+
+    def to_crop_coords(self, points: np.ndarray) -> np.ndarray:
+        """Map source-frame ``(x, y)`` into this video's cropped frame.
+
+        Args:
+            points: Coordinate array of shape ``(..., 2)``. NaN values are
+                preserved.
+
+        Returns:
+            Coordinates translated into the cropped frame. If this video is not
+            cropped, a copy of ``points`` is returned unchanged.
+        """
+        crop = self._crop_tuple()
+        return points.copy() if crop is None else crop_points(points, crop)
+
+    def to_source_coords(self, points: np.ndarray) -> np.ndarray:
+        """Map cropped-frame ``(x, y)`` back to source-frame coordinates.
+
+        Inverse of :meth:`to_crop_coords`.
+
+        Args:
+            points: Coordinate array of shape ``(..., 2)``. NaN values are
+                preserved.
+
+        Returns:
+            Coordinates translated back to source coordinates. If this video is
+            not cropped, a copy of ``points`` is returned unchanged.
+        """
+        crop = self._crop_tuple()
+        return points.copy() if crop is None else uncrop_points(points, crop)
 
     @property
     def shape(self) -> tuple[int, int, int, int] | None:
@@ -613,6 +860,18 @@ class Video:
             **backend_kwargs,
         )
 
+        # Re-wrap as a crop view if this video records a crop in its metadata.
+        # The rebuilt backend above is always a plain backend, so this wraps
+        # exactly once (idempotent across close()->open() and deepcopy).
+        if "crop" in self.backend_metadata:
+            from sleap_io.io.video_reading import CropVideoBackend
+
+            self.backend = CropVideoBackend.wrap(
+                inner=self.backend,
+                crop=tuple(self.backend_metadata["crop"]),
+                fill=self.backend_metadata.get("crop_fill", 0),
+            )
+
     def close(self):
         """Close the video backend."""
         if self.backend is not None:
@@ -627,6 +886,15 @@ class Video:
                 )
                 self.backend_metadata["shape"] = getattr(self.backend, "shape", None)
                 self.backend_metadata["fps"] = getattr(self.backend, "fps", None)
+                # Persist the crop so a Video cropped in-memory (never loaded
+                # from disk) survives a close()->open() and deepcopy: open()
+                # re-wraps from these keys (the closed-path shape above is
+                # already the cropped shape).
+                from sleap_io.io.video_reading import CropVideoBackend
+
+                if isinstance(self.backend, CropVideoBackend):
+                    self.backend_metadata["crop"] = list(self.backend.crop)
+                    self.backend_metadata["crop_fill"] = self.backend.fill
             except Exception:
                 pass
 

--- a/sleap_io/transform/frame.py
+++ b/sleap_io/transform/frame.py
@@ -70,11 +70,14 @@ def crop_frame(
     h, w = frame.shape[:2]
     crop_w, crop_h = x2 - x1, y2 - y1
 
-    # Compute valid source region
+    # Compute valid source region. Clamp the upper bounds to the lower bounds so a
+    # crop that lies wholly beyond the frame on an axis yields an empty (not
+    # negative-extent) source slice, which pastes cleanly into an all-fill output
+    # instead of raising a broadcast error.
     src_x1 = max(0, x1)
     src_y1 = max(0, y1)
-    src_x2 = min(w, x2)
-    src_y2 = min(h, y2)
+    src_x2 = max(src_x1, min(w, x2))
+    src_y2 = max(src_y1, min(h, y2))
 
     # Extract source region
     cropped = frame[src_y1:src_y2, src_x1:src_x2]

--- a/sleap_io/transform/points.py
+++ b/sleap_io/transform/points.py
@@ -31,6 +31,30 @@ def crop_points(
     return result
 
 
+def uncrop_points(
+    points: np.ndarray,
+    crop: tuple[int, int, int, int],
+) -> np.ndarray:
+    """Map crop-local point coordinates back to source coordinates.
+
+    Inverse of :func:`crop_points`: maps crop-local (x, y) coordinates back to
+    source coordinates by adding the crop origin (x1, y1).
+
+    Args:
+        points: Coordinate array of shape (..., 2) where the last dimension
+            contains (x, y) coordinates. NaN values are preserved.
+        crop: Crop region as (x1, y1, x2, y2) pixel coordinates.
+
+    Returns:
+        Adjusted coordinates with same shape as input.
+    """
+    x1, y1, x2, y2 = crop
+    result = points.copy()
+    result[..., 0] = points[..., 0] + x1
+    result[..., 1] = points[..., 1] + y1
+    return result
+
+
 def scale_points(
     points: np.ndarray,
     scale: tuple[float, float],

--- a/sleap_io/transform/video.py
+++ b/sleap_io/transform/video.py
@@ -27,12 +27,16 @@ def _is_embedded_video(video: "Video") -> bool:
     Returns:
         True if the video contains embedded images in HDF5 format.
     """
-    from sleap_io.io.video_reading import HDF5Video
+    from sleap_io.io.video_reading import CropVideoBackend, HDF5Video
 
     if not hasattr(video, "backend") or video.backend is None:
         return False
 
     backend = video.backend
+    # Unwrap a virtual crop to its inner decoder so a crop-over-embedded video is
+    # recognized as embedded (not misread as a regular, sequential video).
+    if isinstance(backend, CropVideoBackend):
+        backend = backend.inner
     if not isinstance(backend, HDF5Video):
         return False
 
@@ -51,12 +55,16 @@ def _get_frame_indices(video: "Video") -> list[int]:
     Returns:
         List of frame indices to iterate over.
     """
-    from sleap_io.io.video_reading import HDF5Video
+    from sleap_io.io.video_reading import CropVideoBackend, HDF5Video
 
-    if hasattr(video, "backend") and isinstance(video.backend, HDF5Video):
-        if video.backend.frame_map:
-            # Embedded video - return the source frame indices
-            return video.backend.embedded_frame_inds
+    backend = getattr(video, "backend", None)
+    # Unwrap a virtual crop to its inner decoder so a crop-over-embedded video
+    # iterates over its embedded source indices, not a dense 0..N-1 range.
+    if isinstance(backend, CropVideoBackend):
+        backend = backend.inner
+    if isinstance(backend, HDF5Video) and backend.frame_map:
+        # Embedded video - return the source frame indices
+        return backend.embedded_frame_inds
 
     # Regular video - sequential indices
     n_frames = video.shape[0] if video.shape else 0

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -11382,4 +11382,5 @@ def test_apply_crops_quality_crf_mutually_exclusive(tmp_path):
         ],
     )
     assert result.exit_code != 0
-    assert "Cannot use both --quality and --crf" in result.output
+    output = _strip_ansi(result.output)
+    assert "Cannot use both --quality and --crf" in output

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -9,10 +9,12 @@ import re
 import sys
 from pathlib import Path
 
+import h5py
+import numpy as np
 import pytest
 from click.testing import CliRunner
 
-from sleap_io import load_slp
+from sleap_io import load_slp, save_video
 from sleap_io.io.cli import (
     _get_ffmpeg_version,
     _is_ffmpeg_available,
@@ -21,9 +23,11 @@ from sleap_io.io.cli import (
     _parse_overlay_outline_color,
     cli,
 )
-from sleap_io.model.instance import PredictedInstance
+from sleap_io.model.instance import Instance, PredictedInstance
+from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
 from sleap_io.model.skeleton import Skeleton
+from sleap_io.model.video import Video
 from sleap_io.version import __version__
 
 # Skip marker for tests that are extremely slow on Windows CI due to video encoding
@@ -11134,3 +11138,248 @@ def test_transform_embed_provenance_embedded_video(tmp_path, slp_minimal_pkg):
         transform_json = f["provenance/transform_json"][()].decode()
         metadata = json.loads(transform_json)
         assert "videos" in metadata
+
+
+def _make_cropped_slp(
+    tmp_path: Path,
+    crop: tuple[int, int, int, int] = (10, 5, 40, 25),
+    name: str = "syn",
+) -> tuple[Path, tuple[int, int, int, int]]:
+    """Create a small .slp with one virtually-cropped synthetic video.
+
+    Args:
+        tmp_path: Directory to write the synthetic video and SLP into.
+        crop: Crop region ``(x1, y1, x2, y2)`` to apply virtually.
+        name: Stem used for the synthetic video and SLP files.
+
+    Returns:
+        Tuple of (path to the saved .slp, the crop region).
+    """
+    video_path = tmp_path / f"{name}.mp4"
+    frames = (np.random.default_rng(0).random((5, 40, 60, 3)) * 255).astype("uint8")
+    save_video(frames, str(video_path), fps=30)
+
+    video = Video.from_crop(str(video_path), crop=crop)
+    skeleton = Skeleton(["a"])
+    instance = Instance.from_numpy(np.array([[5.0, 5.0]]), skeleton=skeleton)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[instance])
+    labels = Labels(skeletons=[skeleton], videos=[video], labeled_frames=[lf])
+
+    slp_path = tmp_path / f"{name}.slp"
+    labels.save(str(slp_path))
+    return slp_path, crop
+
+
+@skip_slow_video_on_windows
+@pytest.mark.skipif(
+    not _is_ffmpeg_available(), reason="ffmpeg not available in test environment"
+)
+def test_apply_crops_roundtrip(tmp_path):
+    """Bake a virtually-cropped SLP and verify provenance + materialization."""
+    slp_path, crop = _make_cropped_slp(tmp_path)
+    x1, y1, x2, y2 = crop
+    crop_h, crop_w = y2 - y1, x2 - x1
+
+    # Record the uncropped source shape for the provenance assertion.
+    src_labels = load_slp(str(slp_path))
+    src_video = src_labels.videos[0]
+    assert src_video._crop_tuple() == crop
+    src_shape = src_video.source_video.shape
+
+    output_slp = tmp_path / "baked.slp"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["apply-crops", str(slp_path), "-o", str(output_slp)])
+
+    assert result.exit_code == 0, result.output
+    assert output_slp.exists()
+
+    # The video directory next to the output SLP should hold the baked file.
+    video_dir = tmp_path / "baked.videos"
+    assert video_dir.exists()
+    baked_file = video_dir / "syn_crop.mp4"
+    assert baked_file.exists()
+
+    # Reload the output and inspect the (now physical) video.
+    out_labels = load_slp(str(output_slp))
+    assert len(out_labels.videos) == 1
+    baked = out_labels.videos[0]
+
+    # Reference points at the baked file.
+    assert Path(baked.filename).name == "syn_crop.mp4"
+
+    # The virtual crop has been materialized: no crop tuple remains.
+    assert baked._crop_tuple() is None
+
+    # Provenance: source_video is the uncropped original.
+    assert baked.source_video is not None
+    assert baked.source_video.shape == src_shape
+
+    # The baked shape carries the cropped dimensions (encoders may pad up to a
+    # block-aligned size, never below the logical crop).
+    assert baked.shape[1] >= crop_h
+    assert baked.shape[2] >= crop_w
+    # And it is strictly smaller than the uncropped source frame.
+    assert baked.shape[1] <= src_shape[1]
+    assert baked.shape[2] <= src_shape[2]
+
+
+@skip_slow_video_on_windows
+@pytest.mark.skipif(
+    not _is_ffmpeg_available(), reason="ffmpeg not available in test environment"
+)
+def test_apply_crops_no_virtual_crop_remains(tmp_path):
+    """The baked SLP must not contain a /video_crops virtual crop entry."""
+    slp_path, _ = _make_cropped_slp(tmp_path)
+    output_slp = tmp_path / "baked.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["apply-crops", str(slp_path), "-o", str(output_slp)])
+    assert result.exit_code == 0, result.output
+
+    with h5py.File(output_slp, "r") as f:
+        assert "video_crops" not in f
+
+
+@skip_slow_video_on_windows
+@pytest.mark.skipif(
+    not _is_ffmpeg_available(), reason="ffmpeg not available in test environment"
+)
+def test_apply_crops_custom_video_dir_and_suffix(tmp_path):
+    """--video-dir and --suffix control the baked file location and name."""
+    slp_path, _ = _make_cropped_slp(tmp_path)
+    output_slp = tmp_path / "baked.slp"
+    baked_dir = tmp_path / "baked_videos"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "apply-crops",
+            str(slp_path),
+            "-o",
+            str(output_slp),
+            "--video-dir",
+            str(baked_dir),
+            "--suffix",
+            "_baked",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    baked_file = baked_dir / "syn_baked.mp4"
+    assert baked_file.exists()
+
+    out_labels = load_slp(str(output_slp))
+    assert Path(out_labels.videos[0].filename).name == "syn_baked.mp4"
+    assert out_labels.videos[0]._crop_tuple() is None
+
+
+@skip_slow_video_on_windows
+@pytest.mark.skipif(
+    not _is_ffmpeg_available(), reason="ffmpeg not available in test environment"
+)
+def test_apply_crops_dry_run_writes_nothing(tmp_path):
+    """--dry-run reports the plan without writing the SLP or baked videos."""
+    slp_path, _ = _make_cropped_slp(tmp_path)
+    output_slp = tmp_path / "baked.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["apply-crops", str(slp_path), "-o", str(output_slp), "--dry-run"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Dry run" in result.output
+    assert not output_slp.exists()
+    assert not (tmp_path / "baked.videos").exists()
+
+
+def test_apply_crops_no_crops_message(tmp_path):
+    """A project with no virtual crops prints a clear message and still writes."""
+    video_path = tmp_path / "plain.mp4"
+    frames = (np.random.default_rng(1).random((3, 40, 60, 3)) * 255).astype("uint8")
+    save_video(frames, str(video_path), fps=30)
+
+    video = Video.from_filename(str(video_path))
+    skeleton = Skeleton(["a"])
+    instance = Instance.from_numpy(np.array([[5.0, 5.0]]), skeleton=skeleton)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[instance])
+    labels = Labels(skeletons=[skeleton], videos=[video], labeled_frames=[lf])
+
+    slp_path = tmp_path / "plain.slp"
+    labels.save(str(slp_path))
+
+    output_slp = tmp_path / "out.slp"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["apply-crops", str(slp_path), "-o", str(output_slp)])
+
+    assert result.exit_code == 0, result.output
+    assert "nothing to bake" in result.output
+    # The output is still written as a safe pass-through.
+    assert output_slp.exists()
+    out_labels = load_slp(str(output_slp))
+    assert len(out_labels.videos) == 1
+    assert out_labels.videos[0]._crop_tuple() is None
+
+
+def test_apply_crops_no_videos_message(tmp_path):
+    """A project with no videos reports it and still writes the output SLP."""
+    skeleton = Skeleton(["node"])
+    labels = Labels(skeletons=[skeleton], videos=[], labeled_frames=[])
+    input_slp = tmp_path / "empty.slp"
+    output_slp = tmp_path / "out.slp"
+    labels.save(str(input_slp))
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["apply-crops", str(input_slp), "-o", str(output_slp)])
+
+    assert result.exit_code == 0, result.output
+    assert "No videos found" in result.output
+    assert output_slp.exists()
+
+
+@skip_slow_video_on_windows
+@pytest.mark.skipif(
+    not _is_ffmpeg_available(), reason="ffmpeg not available in test environment"
+)
+def test_apply_crops_overwrite(tmp_path):
+    """--overwrite is required to replace an existing output SLP."""
+    slp_path, _ = _make_cropped_slp(tmp_path)
+    output_slp = tmp_path / "baked.slp"
+    output_slp.touch()
+
+    runner = CliRunner()
+
+    # Without --overwrite the existing output blocks the command.
+    result = runner.invoke(cli, ["apply-crops", str(slp_path), "-o", str(output_slp)])
+    assert result.exit_code != 0
+    assert "already exists" in result.output
+
+    # With --overwrite it succeeds.
+    result = runner.invoke(
+        cli, ["apply-crops", str(slp_path), "-o", str(output_slp), "--overwrite"]
+    )
+    assert result.exit_code == 0, result.output
+    assert output_slp.exists()
+
+
+def test_apply_crops_quality_crf_mutually_exclusive(tmp_path):
+    """--quality and --crf cannot be combined."""
+    slp_path, _ = _make_cropped_slp(tmp_path)
+    output_slp = tmp_path / "baked.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "apply-crops",
+            str(slp_path),
+            "-o",
+            str(output_slp),
+            "--quality",
+            "high",
+            "--crf",
+            "20",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Cannot use both --quality and --crf" in result.output

--- a/tests/io/test_dlc.py
+++ b/tests/io/test_dlc.py
@@ -1146,7 +1146,7 @@ def test_parse_dlc_crop_float_strings_coerced_to_int():
 
 @pytest.mark.parametrize("crop", [None, "", "  ", "10, 60", "10, 60, 20", "a, b, c, d"])
 def test_parse_dlc_crop_missing_or_bad_returns_none(crop):
-    """Missing / empty / wrong-arity / unparseable crops return None."""
+    """Missing / empty / wrong-arity / unparsable crops return None."""
     assert dlc._parse_dlc_crop(crop) is None
 
 

--- a/tests/io/test_dlc.py
+++ b/tests/io/test_dlc.py
@@ -1118,3 +1118,241 @@ def test_load_dlc_image_resolved_from_parent_dir(tmp_path):
     labels = sio.load_dlc(csv, config=False)
     assert len(labels.labeled_frames) == 2
     assert len(labels.videos) == 1
+
+
+# -----------------------------------------------------------------------------
+# Item 2: video_sets crop wiring (provenance + source_video views)
+# -----------------------------------------------------------------------------
+
+#: A real, openable video reused for the source-present from_crop path.
+REAL_VIDEO = "tests/data/videos/small_robot_3_frame.mp4"
+
+
+def test_parse_dlc_crop_string_reorders_to_sleap_rect():
+    """A comma string 'x1, x2, y1, y2' reorders to sleap '(x1, y1, x2, y2)'."""
+    # Non-square, non-zero-origin so a transpose bug is caught.
+    assert dlc._parse_dlc_crop("10, 60, 20, 90") == (10, 20, 60, 90)
+
+
+def test_parse_dlc_crop_list_form_reorders():
+    """A list [x1, x2, y1, y2] reorders identically to the string form."""
+    assert dlc._parse_dlc_crop([10, 60, 20, 90]) == (10, 20, 60, 90)
+
+
+def test_parse_dlc_crop_float_strings_coerced_to_int():
+    """Float-valued crop strings are coerced to int rect components."""
+    assert dlc._parse_dlc_crop("10.0, 60.0, 20.0, 90.0") == (10, 20, 60, 90)
+
+
+@pytest.mark.parametrize("crop", [None, "", "  ", "10, 60", "10, 60, 20", "a, b, c, d"])
+def test_parse_dlc_crop_missing_or_bad_returns_none(crop):
+    """Missing / empty / wrong-arity / unparseable crops return None."""
+    assert dlc._parse_dlc_crop(crop) is None
+
+
+def test_parse_dlc_crop_non_string_non_sequence_returns_none():
+    """A crop value that is neither string nor sequence returns None."""
+    assert dlc._parse_dlc_crop(42) is None
+
+
+def test_parse_dlc_crop_inverted_warns_and_returns_none():
+    """An inverted crop (x2 <= x1) warns and returns None."""
+    with pytest.warns(UserWarning, match="inverted"):
+        assert dlc._parse_dlc_crop("60, 10, 20, 90") is None
+
+
+def test_parse_dlc_crop_identity_origin_returns_none():
+    """An identity crop at origin (0, 0) is a no-op and returns None."""
+    assert dlc._parse_dlc_crop("0, 384, 0, 384") is None
+
+
+def test_video_sets_stem_map_carries_crop_rect():
+    """The stem map returns (path, reordered_rect) for a non-square crop."""
+    path = "/data/videos/vid1.mp4"
+    cfg = {"video_sets": {path: {"crop": "10, 60, 20, 90"}}}
+    stem_map = dlc._video_sets_stem_map(cfg)
+    assert stem_map["vid1"] == (path, (10, 20, 60, 90))
+
+
+def test_video_sets_stem_map_none_crop_when_absent():
+    """The stem map returns (path, None) when no crop is configured."""
+    path = "/data/videos/vid1.mp4"
+    cfg = {"video_sets": {path: {}}}
+    stem_map = dlc._video_sets_stem_map(cfg)
+    assert stem_map["vid1"] == (path, None)
+
+
+def test_dlc_crop_provenance_recorded_source_absent(tmp_path):
+    """A non-square crop is recorded in provenance keyed by source path."""
+    source = tmp_path / "videos" / "vid1.mp4"  # absent on disk
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+        video_sets={str(source): {"crop": "10, 60, 20, 90"}},
+    )
+    labels = sio.load_dlc_project(config_path)
+    assert labels.provenance["dlc_crops"] == {str(source): [10, 20, 60, 90]}
+
+
+def test_dlc_crop_not_applied_to_labeled_video_or_points(tmp_path):
+    """The labeled-data video stays uncropped and point coords are unchanged."""
+    source = tmp_path / "videos" / "vid1.mp4"  # absent on disk
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+        video_sets={str(source): {"crop": "10, 60, 20, 90"}},
+    )
+    labels = sio.load_dlc_project(config_path)
+    video = labels.videos[0]
+    # Crop is NOT on the labeled-data ImageVideo (would double-crop on reload).
+    assert video.is_cropped is False
+    # Points are verbatim cropped-space coords (no offset applied).
+    # Row 0 writes range(0, 6) in declared bodypart order
+    # (snout, leftear, rightear) -> snout=(0, 1), leftear=(2, 3), rightear=(4, 5).
+    # Nodes are stored sorted (leftear, rightear, snout), so reorder accordingly.
+    lf = next(lf for lf in labels.labeled_frames if lf.frame_idx == 0)
+    pts = lf.instances[0].numpy()
+    node_names = [n.name for n in labels.skeleton.nodes]
+    declared = {"snout": [0, 1], "leftear": [2, 3], "rightear": [4, 5]}
+    expected = np.array([declared[name] for name in node_names])
+    np.testing.assert_array_equal(pts, expected)
+
+
+def test_dlc_crop_source_absent_is_closed_video(tmp_path):
+    """When the source mp4 is absent, source_video is a closed (uncropped) Video."""
+    source = tmp_path / "videos" / "vid1.mp4"  # absent on disk
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000"]},
+        video_sets={str(source): {"crop": "10, 60, 20, 90"}},
+    )
+    labels = sio.load_dlc_project(config_path)
+    sv = labels.videos[0].source_video
+    assert sv is not None
+    # Closed source: no crop attached to backend_metadata (avoids save crash).
+    assert sv.backend is None
+    assert sv.is_cropped is False
+
+
+def test_dlc_crop_source_present_but_unopenable_falls_back(tmp_path):
+    """A source path that exists but cannot be opened falls back to a closed Video.
+
+    Exercises the from_crop open-failure guard in _set_source_video: the rect is
+    still recorded in provenance, but source_video is the plain closed Video.
+    Uses an existing file with an unsupported extension so from_filename raises
+    deterministically (avoids relying on a decoder rejecting a malformed video).
+    """
+    bad = tmp_path / "videos" / "vid1.bin"  # exists, but not a recognized video
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_bytes(b"not a real video at all")
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000"]},
+        video_sets={str(bad): {"crop": "10, 60, 20, 90"}},
+    )
+    labels = sio.load_dlc_project(config_path)
+    sv = labels.videos[0].source_video
+    assert sv is not None
+    assert sv.backend is None  # from_crop failed -> closed fallback
+    assert sv.is_cropped is False
+    # The persistent rect is still recorded despite the open failure.
+    assert labels.provenance["dlc_crops"] == {str(bad): [10, 20, 60, 90]}
+
+
+def test_dlc_crop_provenance_roundtrips_through_slp(tmp_path):
+    """provenance['dlc_crops'] survives a save_slp + load_slp round-trip."""
+    source = tmp_path / "videos" / "vid1.mp4"  # absent on disk
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+        video_sets={str(source): {"crop": "10, 60, 20, 90"}},
+    )
+    labels = sio.load_dlc_project(config_path)
+    slp_path = tmp_path / "out.slp"
+    sio.save_slp(labels, slp_path)  # must not crash on a closed cropped source
+    reloaded = sio.load_slp(slp_path)
+    assert reloaded.provenance["dlc_crops"] == {str(source): [10, 20, 60, 90]}
+
+
+def test_dlc_crop_source_present_from_crop_view(tmp_path):
+    """With a real source mp4, source_video is a from_crop view (in-memory crop)."""
+    # Folder stem must match the source video stem for the link to resolve.
+    stem = Path(REAL_VIDEO).stem
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={stem: ["img000", "img001"]},
+        video_sets={str(Path(REAL_VIDEO).resolve()): {"crop": "10, 60, 20, 90"}},
+    )
+    labels = sio.load_dlc_project(config_path)
+    sv = labels.videos[0].source_video
+    assert sv.is_cropped is True
+    assert sv.crop_rect == (10, 20, 60, 90)
+    # to_source_coords adds the crop origin (10, 20).
+    pts = np.array([[1.0, 2.0]])
+    np.testing.assert_array_equal(sv.to_source_coords(pts), [[11.0, 22.0]])
+    # The labeled-data video itself stays uncropped.
+    assert labels.videos[0].is_cropped is False
+    # Provenance still records the persistent rect.
+    src_key = str(Path(REAL_VIDEO).resolve())
+    assert labels.provenance["dlc_crops"][src_key] == [10, 20, 60, 90]
+
+
+def test_dlc_crop_source_present_save_slp_strips_inmemory_crop(tmp_path):
+    """A from_crop source view does not crash save_slp; provenance persists."""
+    stem = Path(REAL_VIDEO).stem
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={stem: ["img000", "img001"]},
+        video_sets={str(Path(REAL_VIDEO).resolve()): {"crop": "10, 60, 20, 90"}},
+    )
+    labels = sio.load_dlc_project(config_path)
+    slp_path = tmp_path / "out.slp"
+    sio.save_slp(labels, slp_path)
+    reloaded = sio.load_slp(slp_path)
+    src_key = str(Path(REAL_VIDEO).resolve())
+    assert reloaded.provenance["dlc_crops"][src_key] == [10, 20, 60, 90]
+
+
+def test_dlc_crop_per_video_independent(tmp_path):
+    """Distinct crops per video are recorded independently in provenance."""
+    src1 = tmp_path / "videos" / "vid1.mp4"
+    src2 = tmp_path / "videos" / "vid2.mp4"
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000"], "vid2": ["img000"]},
+        video_sets={
+            str(src1): {"crop": "10, 60, 20, 90"},
+            str(src2): {"crop": "5, 25, 7, 47"},
+        },
+    )
+    labels = sio.load_dlc_project(config_path)
+    assert labels.provenance["dlc_crops"] == {
+        str(src1): [10, 20, 60, 90],
+        str(src2): [5, 7, 25, 47],
+    }
+
+
+def test_dlc_crop_single_csv_load_records_provenance(tmp_path):
+    """load_dlc (single CSV + config) also records dlc_crops provenance."""
+    source = tmp_path / "videos" / "vid1.mp4"
+    config_path = make_dlc_project(
+        tmp_path,
+        folders={"vid1": ["img000", "img001"]},
+        video_sets={str(source): {"crop": "10, 60, 20, 90"}},
+    )
+    csv = tmp_path / "labeled-data" / "vid1" / "CollectedData_LM.csv"
+    labels = sio.load_dlc(csv, config=config_path)
+    assert labels.provenance["dlc_crops"] == {str(source): [10, 20, 60, 90]}
+
+
+def test_dlc_identity_crop_records_no_provenance(tmp_path):
+    """The default identity crop (origin 0, 0) records no dlc_crops entry."""
+    config_path = make_dlc_project(tmp_path)  # default crop "0, 100, 0, 100"
+    labels = sio.load_dlc_project(config_path)
+    assert "dlc_crops" not in labels.provenance
+
+
+def test_dlc_madlc_230_config_no_crop_provenance(dlc_maudlc_testdata, dlc_config):
+    """The madlc_230 fixture's no-op 0,384,0,384 crop yields no provenance."""
+    labels = sio.load_dlc(dlc_maudlc_testdata, config=dlc_config)
+    assert "dlc_crops" not in labels.provenance

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -8187,6 +8187,82 @@ def test_crop_roundtrip_media_video(centered_pair_low_quality_path, tmp_path):
     assert np.array_equal(video[0], expected)
 
 
+def test_crop_tuple_fill_roundtrips_and_flattens(
+    centered_pair_low_quality_path, tmp_path
+):
+    """A tuple fill survives the SLP round-trip and still flattens a crop-of-crop.
+
+    /video_crops stores fill as JSON (a tuple becomes a list); the fill converter
+    normalizes it back so a reloaded crop with a tuple fill compares equal and
+    flattens against a tuple inner.fill.
+    """
+    source = Video.from_filename(centered_pair_low_quality_path, grayscale=False)
+    cropped = source.crop((10, 20, 110, 140), fill=(7, 8, 9))
+    labels = Labels(videos=[cropped])
+    path = str(tmp_path / "tuple_fill.slp")
+    write_labels(path, labels)
+
+    loaded = read_labels(path, open_videos=True)
+    v = loaded.videos[0]
+    # Fill is normalized to a tuple (not a list) after the JSON round-trip.
+    assert v.backend.fill == (7, 8, 9)
+    assert isinstance(v.backend.fill, tuple)
+    # A further in-bounds crop with the same tuple fill flattens (no nesting).
+    refined = v.crop((1, 1, 50, 50), fill=(7, 8, 9))
+    assert not isinstance(refined.backend.inner, CropVideoBackend)
+
+
+def test_reloaded_mosaic_tiles_own_their_inner(
+    centered_pair_low_quality_path, tmp_path
+):
+    """Each reloaded cropped tile owns its inner decoder so close() releases it."""
+    source = Video.from_filename(centered_pair_low_quality_path)
+    tiles = [source.crop((0, 0, 64, 64)), source.crop((64, 0, 128, 64))]
+    labels = Labels(videos=tiles)
+    path = str(tmp_path / "mosaic.slp")
+    write_labels(path, labels)
+
+    loaded = read_labels(path, open_videos=True)
+    for v in loaded.videos:
+        assert isinstance(v.backend, CropVideoBackend)
+        # Owns its inner (no leaked, unowned decoder on the reload path).
+        assert v.backend.owns_inner is True
+        _ = v[0]
+        v.close()  # cascades to the owned inner; no leak
+
+
+def test_apply_crops_sparse_embedded_raises(centered_pair_low_quality_path, tmp_path):
+    """Baking a crop over a sparsely-embedded video raises (would break frame_idx).
+
+    Embedding labeled frames at non-contiguous indices then reloading yields a crop
+    whose inner is an embedded HDF5Video with a sparse frame_map; baking it would
+    compact frames to a contiguous range and dangle the labeled-frame references,
+    so apply_crop / apply_crops must refuse with a clear error.
+    """
+    source = Video.from_filename(centered_pair_low_quality_path)
+    cropped = source.crop((10, 10, 74, 74))
+    skel = Skeleton(["a"])
+    lfs = [
+        LabeledFrame(
+            video=cropped,
+            frame_idx=idx,
+            instances=[Instance.from_numpy(np.array([[5.0, 5.0]]), skeleton=skel)],
+        )
+        for idx in (5, 9)  # non-contiguous source indices
+    ]
+    labels = Labels(videos=[cropped], skeletons=[skel], labeled_frames=lfs)
+    pkg = str(tmp_path / "sparse.pkg.slp")
+    write_labels(pkg, labels, embed=True)
+
+    reloaded = read_labels(pkg, open_videos=True)
+    rv = reloaded.videos[0]
+    assert rv.backend.inner.frame_map  # sparse embedded inner
+    with pytest.raises(ValueError, match="sparsely embedded"):
+        rv.apply_crop(str(tmp_path / "baked.mp4"))
+    with pytest.raises(ValueError, match="sparsely embedded"):
+        reloaded.apply_crops(video_dir=str(tmp_path / "baked"))
+
+
 def test_crop_roundtrip_image_video(centered_pair_frame_paths, tmp_path):
     """An ImageVideo crop round-trips through /video_crops."""
     source = Video.from_filename(centered_pair_frame_paths)

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -77,6 +77,7 @@ from sleap_io.io.slp import (
     read_skeletons,
     read_suggestions,
     read_tracks,
+    read_video_crops,
     read_videos,
     session_to_dict,
     video_to_dict,
@@ -89,10 +90,16 @@ from sleap_io.io.slp import (
     write_sessions,
     write_suggestions,
     write_tracks,
+    write_video_crops,
     write_videos,
 )
 from sleap_io.io.utils import read_hdf5_attrs, read_hdf5_dataset
-from sleap_io.io.video_reading import HDF5Video, ImageVideo, MediaVideo
+from sleap_io.io.video_reading import (
+    CropVideoBackend,
+    HDF5Video,
+    ImageVideo,
+    MediaVideo,
+)
 from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
 from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 from sleap_io.model.identity import Identity
@@ -103,6 +110,7 @@ from sleap_io.model.mask import (
     UserSegmentationMask,
 )
 from sleap_io.model.roi import PredictedROI, UserROI
+from sleap_io.transform.frame import crop_frame
 
 
 def test_read_labels(slp_typical, slp_simple_skel, slp_minimal):
@@ -8150,3 +8158,300 @@ def test_read_labels_threads_single_open(slp_minimal_pkg):
 
     assert type(labels) is Labels
     assert open_count <= 3
+
+
+# ---------------------------------------------------------------------------
+# Virtual crop serialization (UNIT U4, §6)
+# ---------------------------------------------------------------------------
+
+
+def test_crop_roundtrip_media_video(centered_pair_low_quality_path, tmp_path):
+    """A MediaVideo crop round-trips: crop, cropped shape, uncropped source."""
+    source = Video.from_filename(centered_pair_low_quality_path)
+    crop = (10, 20, 110, 140)
+    expected = crop_frame(source[0], crop, fill=0)
+
+    cropped = source.crop(crop)
+    labels = Labels(videos=[cropped])
+    path = str(tmp_path / "media_crop.slp")
+    write_labels(path, labels)
+
+    loaded = read_labels(path, open_videos=True)
+    video = loaded.videos[0]
+
+    assert isinstance(video.backend, CropVideoBackend)
+    assert video._crop_tuple() == crop
+    # Cropped shape on the facade; uncropped on the provenance source.
+    assert video.shape == (source.shape[0], 120, 100, source.shape[3])
+    assert video.source_video.shape == source.shape
+    assert np.array_equal(video[0], expected)
+
+
+def test_crop_roundtrip_image_video(centered_pair_frame_paths, tmp_path):
+    """An ImageVideo crop round-trips through /video_crops."""
+    source = Video.from_filename(centered_pair_frame_paths)
+    crop = (5, 5, 55, 65)
+    expected = crop_frame(source[0], crop, fill=0)
+
+    cropped = source.crop(crop)
+    labels = Labels(videos=[cropped])
+    path = str(tmp_path / "image_crop.slp")
+    write_labels(path, labels)
+
+    loaded = read_labels(path, open_videos=True)
+    video = loaded.videos[0]
+
+    assert isinstance(video.backend, CropVideoBackend)
+    assert isinstance(video.backend.inner, ImageVideo)
+    assert video._crop_tuple() == crop
+    assert video.shape == (source.shape[0], 60, 50, source.shape[3])
+    assert video.source_video.shape == source.shape
+    assert np.array_equal(video[0], expected)
+
+
+def test_crop_write_video_crops_dataset(centered_pair_low_quality_path, tmp_path):
+    """The /video_crops dataset is written with the crop tuple and fill."""
+    source = Video.from_filename(centered_pair_low_quality_path)
+    cropped = source.crop((10, 20, 110, 140), fill=7)
+    labels = Labels(videos=[cropped])
+    path = str(tmp_path / "crop_dataset.slp")
+    write_labels(path, labels)
+
+    crops = read_video_crops(path)
+    assert crops == {0: {"video": 0, "crop": [10, 20, 110, 140], "fill": 7}}
+
+
+def test_uncropped_writes_no_video_crops_and_golden_videos_json(slp_minimal, tmp_path):
+    """Uncropped labels stay byte-identical and bump nothing.
+
+    Uncropped labels write no /video_crops, keep format_id <= 2.2, and the
+    videos_json bytes are identical to a baseline save (golden compare).
+    """
+    labels = read_labels(slp_minimal)
+
+    baseline = str(tmp_path / "baseline.slp")
+    candidate = str(tmp_path / "candidate.slp")
+    write_labels(baseline, labels)
+    write_labels(candidate, labels)
+
+    # No /video_crops dataset for an uncropped file.
+    with pytest.raises(KeyError):
+        read_hdf5_dataset(candidate, "video_crops")
+    assert read_video_crops(candidate) == {}
+
+    with h5py.File(candidate, "r") as f:
+        assert "video_crops" not in f
+        assert f["metadata"].attrs["format_id"] <= 2.2
+
+    # videos_json is byte-identical to a baseline save.
+    with h5py.File(baseline, "r") as f1, h5py.File(candidate, "r") as f2:
+        assert f1["videos_json"][:].tobytes() == f2["videos_json"][:].tobytes()
+
+
+def test_crop_format_id_bumped_only_with_crop(
+    slp_minimal, centered_pair_low_quality_path, tmp_path
+):
+    """format_id becomes 2.3 only when a crop is present."""
+    uncropped = read_labels(slp_minimal)
+    uncropped_path = str(tmp_path / "uncropped.slp")
+    write_labels(uncropped_path, uncropped)
+    with h5py.File(uncropped_path, "r") as f:
+        assert f["metadata"].attrs["format_id"] < 2.3
+
+    cropped_video = Video.from_filename(centered_pair_low_quality_path).crop(
+        (0, 0, 100, 100)
+    )
+    cropped = Labels(videos=[cropped_video])
+    cropped_path = str(tmp_path / "cropped.slp")
+    write_labels(cropped_path, cropped)
+    with h5py.File(cropped_path, "r") as f:
+        assert f["metadata"].attrs["format_id"] == 2.3
+
+
+def test_crop_old_reader_degrades_without_video_crops(
+    centered_pair_low_quality_path, tmp_path
+):
+    """A file with /video_crops deleted loads the uncropped source (old reader)."""
+    source = Video.from_filename(centered_pair_low_quality_path)
+    cropped = source.crop((10, 20, 110, 140))
+    labels = Labels(videos=[cropped])
+    path = str(tmp_path / "degrade.slp")
+    write_labels(path, labels)
+
+    with h5py.File(path, "a") as f:
+        del f["video_crops"]
+
+    loaded = read_labels(path, open_videos=True)
+    video = loaded.videos[0]
+
+    # No crop record -> the full uncropped source is reconstructed.
+    assert not isinstance(video.backend, CropVideoBackend)
+    assert video._crop_tuple() is None
+    assert video.shape == source.shape
+    assert np.array_equal(video[0], source[0])
+
+
+def test_crop_load_modify_save_load_preserves_crop(
+    centered_pair_low_quality_path, tmp_path
+):
+    """Round-trip through an in-place edit preserves the crop (the GUI footgun)."""
+    source = Video.from_filename(centered_pair_low_quality_path)
+    crop = (10, 20, 110, 140)
+    expected = crop_frame(source[0], crop, fill=0)
+
+    labels = Labels(videos=[source.crop(crop)])
+    first = str(tmp_path / "first.slp")
+    write_labels(first, labels)
+
+    reloaded = read_labels(first, open_videos=True)
+    reloaded.provenance["edited"] = True  # an innocuous in-place modification
+    second = str(tmp_path / "second.slp")
+    write_labels(second, reloaded)
+
+    final = read_labels(second, open_videos=True)
+    video = final.videos[0]
+    assert video._crop_tuple() == crop
+    assert video.shape == (source.shape[0], 120, 100, source.shape[3])
+    assert video.source_video.shape == source.shape
+    assert np.array_equal(video[0], expected)
+
+
+def test_crop_closed_load_reports_cropped_shape_and_reserializes(
+    centered_pair_low_quality_path, tmp_path
+):
+    """Closed load reports cropped shape and re-serializes the crop.
+
+    With open_backend=False the closed load reports the cropped shape and
+    re-serializes the crop; the re-serialized videos_json describes the
+    uncropped source.
+    """
+    source = Video.from_filename(centered_pair_low_quality_path)
+    crop = (10, 20, 110, 140)
+    labels = Labels(videos=[source.crop(crop)])
+    path = str(tmp_path / "closed.slp")
+    write_labels(path, labels)
+
+    closed = read_labels(path, open_videos=False)
+    video = closed.videos[0]
+
+    # Closed path: no live backend, but the cropped shape and crop are reported.
+    assert video.backend is None
+    assert video.shape == (source.shape[0], 120, 100, source.shape[3])
+    assert video._crop_tuple() == crop
+
+    # Re-serializing the closed labels preserves the crop and keeps videos_json
+    # describing the uncropped source frame.
+    out = str(tmp_path / "closed_reserialized.slp")
+    write_labels(out, closed)
+    assert read_video_crops(out) == {0: {"video": 0, "crop": list(crop), "fill": 0}}
+    with h5py.File(out, "r") as f:
+        video_json = json.loads(f["videos_json"][0])
+    assert list(video_json["backend"]["shape"]) == list(source.shape)
+
+
+def test_crop_over_embedded_pkg_roundtrip(slp_minimal_pkg, tmp_path):
+    """A crop over an embedded .pkg.slp video round-trips.
+
+    The crop-aware reader gets cropped embedded frames with no KeyError, and the
+    embedded frames are stored uncropped (so the crop is applied exactly once).
+    """
+    labels = read_labels(slp_minimal_pkg)
+    source = labels.video
+    crop = (100, 100, 200, 250)
+    expected = crop_frame(source[0], crop, fill=0)
+
+    cropped = source.crop(crop)
+    labels.videos[0] = cropped
+    for lf in labels.labeled_frames:
+        lf.video = cropped
+
+    path = str(tmp_path / "cropped.pkg.slp")
+    write_labels(path, labels)
+
+    # Crop rides /video_crops; the embedded video group still exists.
+    assert read_video_crops(path) == {0: {"video": 0, "crop": list(crop), "fill": 0}}
+    with h5py.File(path, "r") as f:
+        assert "video0/video" in f
+
+    loaded = read_labels(path, open_videos=True)
+    video = loaded.videos[0]
+    assert isinstance(video.backend, CropVideoBackend)
+    assert isinstance(video.backend.inner, HDF5Video)
+    assert video.backend.inner.has_embedded_images
+    # Inner holds the UNCROPPED embedded frame; the crop is applied exactly once.
+    assert video.backend.inner.shape == source.shape
+    assert video.shape == (source.shape[0], 150, 100, source.shape[3])
+    assert np.array_equal(video[0], expected)
+
+
+def test_crop_over_media_embed_true_roundtrip(centered_pair_low_quality_path, tmp_path):
+    """Crop over a MediaVideo saved with embed=True embeds UNCROPPED + keeps the crop.
+
+    The crop is preserved in /video_crops (not baked away), the embedded frames are
+    full-source frames, and reload yields a CropVideoBackend applying the crop once.
+    """
+    source = Video.from_filename(centered_pair_low_quality_path)
+    crop = (20, 30, 100, 110)
+    expected = crop_frame(source[0], crop, fill=0)
+    cropped = source.crop(crop)
+
+    skel = Skeleton(["a"])
+    lf = LabeledFrame(
+        video=cropped,
+        frame_idx=0,
+        instances=[Instance.from_numpy(np.array([[5.0, 5.0]]), skeleton=skel)],
+    )
+    labels = Labels(videos=[cropped], skeletons=[skel], labeled_frames=[lf])
+
+    path = str(tmp_path / "crop_embed.pkg.slp")
+    write_labels(path, labels, embed=True)
+
+    assert read_video_crops(path) == {0: {"video": 0, "crop": list(crop), "fill": 0}}
+
+    loaded = read_labels(path, open_videos=True)
+    v = loaded.videos[0]
+    assert isinstance(v.backend, CropVideoBackend)
+    assert v.backend.inner.has_embedded_images
+    # Inner holds the UNCROPPED embedded frame; crop applied exactly once.
+    assert v.backend.inner.shape[1:3] == source.shape[1:3]
+    assert v.shape[1:3] == (80, 80)
+    assert np.array_equal(v[0], expected)
+
+
+def test_nested_crop_serialization_raises(centered_pair_low_quality_path):
+    """A nested (un-flattened) crop-of-crop raises a clear error at serialize time."""
+    source = Video.from_filename(centered_pair_low_quality_path)
+    inner = source.crop((10, 10, 60, 60))
+    # Differing fills force a NEST (wrap cannot flatten) -> unrepresentable on disk.
+    nested = inner.crop((1, 1, 20, 20), fill=9)
+    assert isinstance(nested.backend.inner, CropVideoBackend)
+    with pytest.raises(ValueError, match="nested crop-of-crop"):
+        video_to_dict(nested)
+
+
+def test_video_to_dict_crop_serializes_uncropped_source(
+    centered_pair_low_quality_path,
+):
+    """video_to_dict on a cropped Video emits the UNCROPPED source backend dict."""
+    source = Video.from_filename(centered_pair_low_quality_path)
+    cropped = source.crop((10, 20, 110, 140))
+
+    result = video_to_dict(cropped)
+
+    # The backend dict describes the uncropped MediaVideo source, not the crop.
+    assert result["backend"]["type"] == "MediaVideo"
+    assert list(result["backend"]["shape"]) == list(source.shape)
+    assert "crop" not in result["backend"]
+    assert "crop_fill" not in result["backend"]
+
+
+def test_write_video_crops_omitted_when_no_crops(slp_minimal, tmp_path):
+    """write_video_crops writes nothing when no video is cropped."""
+    labels = read_labels(slp_minimal)
+    path = str(tmp_path / "no_crops.slp")
+    write_labels(path, labels)
+
+    # Calling write_video_crops directly on uncropped labels is a no-op.
+    write_video_crops(path, labels)
+    with h5py.File(path, "r") as f:
+        assert "video_crops" not in f

--- a/tests/io/test_video_reading.py
+++ b/tests/io/test_video_reading.py
@@ -1,5 +1,6 @@
 """Tests for methods in the sleap_io.io.video_reading file."""
 
+import copy
 import pickle
 from pathlib import Path
 
@@ -12,12 +13,14 @@ from pytest_httpserver import HTTPServer
 
 import sleap_io as sio
 from sleap_io.io.video_reading import (
+    CropVideoBackend,
     HDF5Video,
     ImageVideo,
     MediaVideo,
     TiffVideo,
     VideoBackend,
 )
+from sleap_io.transform.frame import crop_frame
 
 try:
     import cv2
@@ -1774,3 +1777,485 @@ def test_is_pyav_available_when_installed():
     from sleap_io.io.video_reading import _is_pyav_available
 
     assert _is_pyav_available() is True
+
+
+# ---------------------------------------------------------------------------
+# CropVideoBackend
+# ---------------------------------------------------------------------------
+
+
+def _make_chunked_hdf5(path, data, input_format="channels_last", chunks=None):
+    """Write a raw rank-4 HDF5 dataset and return an HDF5Video over it.
+
+    Args:
+        path: Destination file path.
+        data: Rank-4 array to store (on-disk layout matching ``input_format``).
+        input_format: Either "channels_last" or "channels_first".
+        chunks: Chunk shape passed to ``create_dataset`` (None = whole-frame).
+
+    Returns:
+        An ``HDF5Video`` opened over the written dataset.
+    """
+    with h5py.File(path, "w") as f:
+        f.create_dataset("video", data=data, chunks=chunks)
+    return HDF5Video(filename=str(path), dataset="video", input_format=input_format)
+
+
+def test_crop_backend_basic_shape(centered_pair_low_quality_path):
+    """Cropped img_shape/shape/len/num_frames report the cropped view."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    crop = (10, 20, 110, 120)
+    cb = CropVideoBackend.wrap(inner, crop)
+
+    assert isinstance(cb, VideoBackend)
+    assert cb.num_frames == inner.num_frames
+    assert cb.img_shape == (100, 100, 1)
+    assert cb.shape == (inner.num_frames, 100, 100, 1)
+    assert len(cb) == inner.num_frames
+    assert cb.filename == centered_pair_low_quality_path
+
+
+def test_crop_backend_byte_parity(centered_pair_low_quality_path):
+    """Cropped frame is byte-identical to crop_frame(full, rect)."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    crop = (30, 40, 130, 150)
+    cb = CropVideoBackend.wrap(inner, crop)
+
+    full = inner.get_frame(0)
+    ref = crop_frame(full, crop)
+    assert_equal(cb[0], ref)
+
+
+def test_crop_backend_oob_negative_pads(centered_pair_low_quality_path):
+    """Negative-origin crop pads with the fill value."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    crop = (-10, -5, 20, 25)
+    cb = CropVideoBackend.wrap(inner, crop, fill=7)
+
+    full = inner.get_frame(0)
+    ref = crop_frame(full, crop, fill=7)
+    assert cb[0].shape == (30, 30, 1)
+    assert_equal(cb[0], ref)
+
+
+def test_crop_backend_oob_oversized_pads(centered_pair_low_quality_path):
+    """Oversized crop (beyond source bounds) pads with the fill value."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    crop = (360, 360, 420, 420)
+    cb = CropVideoBackend.wrap(inner, crop, fill=3)
+
+    full = inner.get_frame(0)
+    ref = crop_frame(full, crop, fill=3)
+    assert cb[0].shape == (60, 60, 1)
+    assert_equal(cb[0], ref)
+
+
+def test_crop_backend_grayscale_full_frame_detection(
+    centered_pair_low_quality_path,
+):
+    """Grayscale is detected on the UNCROPPED frame, even for a 1px-wide crop."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    cb = CropVideoBackend.wrap(inner, (10, 10, 11, 60))  # 1px wide
+    # Construction is lazy: grayscale is unresolved until first access (no decode).
+    assert cb.grayscale is None
+    # img_shape resolves grayscale on the inner's full frame and reports the crop.
+    assert cb.img_shape == (50, 1, 1)
+    assert cb.grayscale is True
+    # detect_grayscale resolves from the inner full frame, not the crop.
+    assert cb.detect_grayscale() is True
+    # read_test_frame returns the UNCROPPED inner frame.
+    assert cb.read_test_frame().shape[0] == inner.read_test_frame().shape[0]
+
+
+def test_crop_backend_getitem_scalar_list_slice(
+    centered_pair_low_quality_path,
+):
+    """Scalar/list/slice __getitem__ all return the cropped view."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    cb = CropVideoBackend.wrap(inner, (0, 0, 50, 50))
+
+    assert cb[0].shape == (50, 50, 1)
+    assert cb[[0, 1, 2]].shape == (3, 50, 50, 1)
+    assert cb[0:3].shape == (3, 50, 50, 1)
+
+    full = inner.get_frames([0, 1, 2])
+    ref = np.stack([crop_frame(f, (0, 0, 50, 50)) for f in full], axis=0)
+    assert_equal(cb[[0, 1, 2]], ref)
+
+
+def test_crop_backend_has_frame_delegates(centered_pair_low_quality_path):
+    """has_frame delegates to the inner backend."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    cb = CropVideoBackend.wrap(inner, (0, 0, 50, 50))
+    assert cb.has_frame(0) is True
+    assert cb.has_frame(10**9) is False
+
+
+@pytest.mark.parametrize("crop", [(5, 5, 55, 65), (-5, -5, 45, 45)])
+def test_crop_backend_batched_image_video_parity(centered_pair_frame_paths, crop):
+    """Batched crop over an ImageVideo (base-default _read_frames) is byte-parity.
+
+    The in-bounds rect exercises the fast slice+copy path; the OOB rect exercises the
+    np.stack(crop_frame) padded fallback that the MediaVideo batched test never hits.
+    ImageVideo uses the base-default _read_frames (applies grayscale early), so this
+    also guards the D-114 idempotent-grayscale invariant.
+    """
+    inner = VideoBackend.from_filename(centered_pair_frame_paths)
+    assert isinstance(inner, ImageVideo)
+    cb = CropVideoBackend.wrap(inner, crop, fill=7)
+    full = inner.get_frames([0, 1, 2])
+    ref = np.stack([crop_frame(f, crop, fill=7) for f in full], axis=0)
+    out = cb[[0, 1, 2]]
+    assert out.dtype != object
+    assert_equal(out, ref)
+
+
+def test_crop_backend_deepcopy_roundtrip(centered_pair_low_quality_path):
+    """Deepcopy preserves crop/fill and frame parity."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path, keep_open=False)
+    cb = CropVideoBackend.wrap(inner, (5, 6, 55, 66), fill=4)
+    ref = cb[0].copy()
+
+    cc = copy.deepcopy(cb)
+    assert cc.crop == (5, 6, 55, 66)
+    assert cc.fill == 4
+    assert cc.owns_inner is True
+    assert_equal(cc[0], ref)
+
+
+def test_crop_backend_pickle_roundtrip(centered_pair_low_quality_path):
+    """Pickle preserves crop/fill/filename and frame parity."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path, keep_open=False)
+    cb = CropVideoBackend.wrap(inner, (5, 6, 55, 66), fill=4)
+    ref = cb[0].copy()
+
+    pk = pickle.loads(pickle.dumps(cb))
+    assert pk.crop == (5, 6, 55, 66)
+    assert pk.fill == 4
+    assert pk.filename == centered_pair_low_quality_path
+    assert_equal(pk[0], ref)
+
+
+def test_crop_backend_identity_equality(centered_pair_low_quality_path):
+    """Equality is by object identity (eq=False), robust to cache state."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    a = CropVideoBackend.wrap(inner, (0, 0, 50, 50))
+    b = CropVideoBackend.wrap(inner, (0, 0, 50, 50))
+    _ = a.shape  # populate a's cached shape only
+    assert a == a
+    assert a != b  # distinct instances despite identical crop/fill
+
+
+def test_crop_backend_channels_first_parity(tmp_path):
+    """channels_first synthetic HDF5 crop matches crop_frame byte-for-byte."""
+    n, h, w, c = 3, 32, 40, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    disk = np.transpose(data, (0, 3, 2, 1)).copy()  # (N, C, W, H)
+    inner = _make_chunked_hdf5(
+        tmp_path / "cf.h5", disk, "channels_first", chunks=(1, c, 8, 8)
+    )
+    cb = CropVideoBackend.wrap(inner, (5, 6, 25, 26))
+
+    ref = crop_frame(inner._read_frame(0), (5, 6, 25, 26))
+    assert_equal(cb[0], ref)
+
+
+def test_crop_backend_flatten_byte_parity(centered_pair_low_quality_path):
+    """crop-of-crop FLATTENS (inner not a crop) with byte-parity to nested."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    c1 = CropVideoBackend.wrap(inner, (10, 10, 110, 110))
+    c2 = CropVideoBackend.wrap(c1, (5, 5, 40, 40))
+
+    # Flattened: inner is the original (never a crop), crop is composed.
+    assert not isinstance(c2.inner, CropVideoBackend)
+    assert c2.crop == (15, 15, 50, 50)
+
+    full = inner.get_frame(0)
+    nested = crop_frame(crop_frame(full, (10, 10, 110, 110)), (5, 5, 40, 40))
+    assert_equal(c2[0], nested)
+
+
+def test_crop_backend_nest_when_outer_exceeds_inner(
+    centered_pair_low_quality_path,
+):
+    """F-2: outer crop exceeding the inner frame must NEST (byte-parity)."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    c1 = CropVideoBackend.wrap(inner, (10, 10, 110, 110))  # 100x100 frame
+    c2 = CropVideoBackend.wrap(c1, (-1, -1, 40, 40))  # exceeds [0,100]x[0,100]
+
+    assert isinstance(c2.inner, CropVideoBackend)
+
+    full = inner.get_frame(0)
+    nested = crop_frame(crop_frame(full, (10, 10, 110, 110)), (-1, -1, 40, 40))
+    assert_equal(c2[0], nested)
+
+
+def test_crop_backend_nest_when_fill_mismatch(centered_pair_low_quality_path):
+    """Crop-of-crop with mismatched fills must NEST (byte-parity)."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    c1 = CropVideoBackend.wrap(inner, (10, 10, 110, 110), fill=0)
+    c2 = CropVideoBackend.wrap(c1, (-2, -2, 40, 40), fill=9)
+
+    assert isinstance(c2.inner, CropVideoBackend)
+
+    full = inner.get_frame(0)
+    nested = crop_frame(
+        crop_frame(full, (10, 10, 110, 110), fill=0), (-2, -2, 40, 40), fill=9
+    )
+    assert_equal(c2[0], nested)
+
+
+def test_crop_backend_owns_inner_false_does_not_close(tmp_path):
+    """owns_inner=False: close does NOT close the (shared) inner."""
+    data = np.arange(4 * 16 * 16 * 3, dtype=np.uint8).reshape(4, 16, 16, 3)
+    inner = _make_chunked_hdf5(
+        tmp_path / "v.h5", data, "channels_last", chunks=(1, 4, 4, 3)
+    )
+    _ = inner._read_frame(0)
+    assert inner._open_reader is not None
+
+    cb = CropVideoBackend.wrap(inner, (2, 2, 12, 12), owns_inner=False)
+    cb.close()
+    assert inner._open_reader is not None  # sibling-safe: inner stays open
+
+
+def test_crop_backend_owns_inner_true_closes(tmp_path):
+    """owns_inner=True (default): close cascades to the inner."""
+    data = np.arange(4 * 16 * 16 * 3, dtype=np.uint8).reshape(4, 16, 16, 3)
+    inner = _make_chunked_hdf5(
+        tmp_path / "v.h5", data, "channels_last", chunks=(1, 4, 4, 3)
+    )
+    _ = inner._read_frame(0)
+    assert inner._open_reader is not None
+
+    cb = CropVideoBackend.wrap(inner, (2, 2, 12, 12))
+    cb.close()
+    assert inner._open_reader is None
+
+
+def test_crop_backend_dataset_delegation(slp_minimal_pkg):
+    """dataset/input_format delegate to the inner backend."""
+    inner = VideoBackend.from_filename(slp_minimal_pkg)
+    cb = CropVideoBackend.wrap(inner, (5, 5, 55, 55))
+    assert cb.dataset == inner.dataset
+    assert cb.input_format == inner.input_format
+
+
+def test_crop_backend_to_crop_to_source_coords(centered_pair_low_quality_path):
+    """to_crop_coords / to_source_coords translate by (x1, y1) and invert."""
+    inner = VideoBackend.from_filename(centered_pair_low_quality_path)
+    cb = CropVideoBackend.wrap(inner, (10, 20, 110, 120))
+
+    pts = np.array([[15.0, 25.0], [np.nan, np.nan], [110.0, 120.0]])
+    cropped = cb.to_crop_coords(pts)
+    assert_equal(cropped[0], np.array([5.0, 5.0]))
+    assert np.isnan(cropped[1]).all()
+    # Round-trip back to source coordinates.
+    back = cb.to_source_coords(cropped)
+    assert_equal(back[0], pts[0])
+    assert np.isnan(back[1]).all()
+    assert_equal(back[2], pts[2])
+
+
+# ---------------------------------------------------------------------------
+# HDF5 pushdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "crop",
+    [(5, 5, 30, 30), (-3, -4, 12, 11), (40, 30, 60, 47), (-4, -4, 47, 47)],
+)
+def test_hdf5_read_crop_channels_last_parity(tmp_path, crop):
+    """read_crop byte-parity with crop_frame (channels_last, sub-frame chunks).
+
+    Covers inside, off-each-edge, and straddle cases. Crops are chosen so the
+    reference ``crop_frame`` has a non-empty valid source region on both axes
+    (it does not support a crop wholly beyond the frame on one axis); the
+    fully-outside pushdown case is exercised separately in
+    :func:`test_hdf5_pushdown_fully_outside_all_fill`.
+    """
+    n, h, w, c = 3, 48, 64, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    inner = _make_chunked_hdf5(
+        tmp_path / "cl.h5", data, "channels_last", chunks=(1, 16, 16, c)
+    )
+    assert inner._can_push_crop is True
+
+    ref = crop_frame(inner._read_frame(0), crop, fill=9)
+    out = inner.read_crop(0, crop, fill=9)
+    assert out is not None
+    assert out.dtype == data.dtype
+    assert_equal(out, ref)
+
+
+def test_hdf5_pushdown_fully_outside_all_fill(tmp_path):
+    """A crop wholly outside the frame pushes down to an all-fill array."""
+    n, h, w, c = 2, 48, 64, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    inner = _make_chunked_hdf5(
+        tmp_path / "v.h5", data, "channels_last", chunks=(1, 16, 16, c)
+    )
+    crop = (-30, -30, -10, -10)  # entirely above/left of the frame
+    out = inner.read_crop(0, crop, fill=4)
+    assert out is not None
+    assert_equal(out, np.full((20, 20, c), 4, dtype=data.dtype))
+
+
+@pytest.mark.parametrize(
+    "crop",
+    [(5, 6, 30, 31), (-3, -4, 12, 11), (60, 40, 90, 70)],
+)
+def test_hdf5_read_crop_channels_first_parity(tmp_path, crop):
+    """read_crop byte-parity with crop_frame (channels_first, sub-frame chunks)."""
+    n, h, w, c = 3, 48, 64, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    disk = np.transpose(data, (0, 3, 2, 1)).copy()  # (N, C, W, H)
+    inner = _make_chunked_hdf5(
+        tmp_path / "cf.h5", disk, "channels_first", chunks=(1, c, 16, 16)
+    )
+    assert inner._can_push_crop is True
+
+    ref = crop_frame(inner._read_frame(0), crop, fill=9)
+    out = inner.read_crop(0, crop, fill=9)
+    assert out is not None
+    assert_equal(out, ref)
+
+
+def test_hdf5_read_crops_batched_parity(tmp_path):
+    """Batched read_crops byte-parity with stacked per-frame crop_frame."""
+    n, h, w, c = 4, 48, 64, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    inner = _make_chunked_hdf5(
+        tmp_path / "cl.h5", data, "channels_last", chunks=(1, 16, 16, c)
+    )
+    crop = (5, 5, 30, 30)
+    out = inner.read_crops([0, 1, 2], crop, fill=2)
+    ref = np.stack(
+        [crop_frame(inner._read_frame(i), crop, fill=2) for i in range(3)], axis=0
+    )
+    assert out is not None
+    assert_equal(out, ref)
+
+
+def test_hdf5_pushdown_whole_frame_chunk_falls_back(tmp_path):
+    """Whole-frame chunking disables pushdown (dataset-level gate)."""
+    n, h, w, c = 2, 32, 40, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    inner = _make_chunked_hdf5(
+        tmp_path / "whole.h5", data, "channels_last", chunks=(1, h, w, c)
+    )
+    assert inner._can_push_crop is False
+    assert inner.read_crop(0, (5, 5, 20, 20)) is None
+
+
+def test_hdf5_pushdown_unchunked_falls_back(tmp_path):
+    """Contiguous (unchunked) datasets disable pushdown."""
+    n, h, w, c = 2, 32, 40, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    inner = _make_chunked_hdf5(
+        tmp_path / "contig.h5", data, "channels_last", chunks=None
+    )
+    assert inner._can_push_crop is False
+    assert inner.read_crop(0, (5, 5, 20, 20)) is None
+
+
+def test_hdf5_pushdown_per_call_gate_full_span_falls_back(tmp_path):
+    """A crop as large as the chunk-spanned frame falls back (per-call gate)."""
+    n, h, w, c = 2, 32, 40, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    inner = _make_chunked_hdf5(
+        tmp_path / "v.h5", data, "channels_last", chunks=(1, 16, 16, c)
+    )
+    assert inner._can_push_crop is True
+    # A crop covering the entire frame spans every chunk -> no benefit -> None.
+    assert inner.read_crop(0, (0, 0, w, h)) is None
+
+
+def test_hdf5_read_crops_per_call_gate_full_span_falls_back(tmp_path):
+    """Batched read_crops returns a clean None (not an object array) on gate decline.
+
+    Regression: a full-span crop makes every per-frame read_crop return None; the
+    batched path must return None (so the wrapper falls back to full decode + crop),
+    never ``np.stack([None, None])`` which yields a corrupt object array.
+    """
+    n, h, w, c = 3, 32, 40, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    inner = _make_chunked_hdf5(
+        tmp_path / "v.h5", data, "channels_last", chunks=(1, 16, 16, c)
+    )
+    assert inner._can_push_crop is True
+    assert inner.read_crops([0, 1, 2], (0, 0, w, h)) is None
+    # keep_open=False reopen branch must also fall back cleanly.
+    inner_ko = _make_chunked_hdf5(
+        tmp_path / "v2.h5", data, "channels_last", chunks=(1, 16, 16, c)
+    )
+    inner_ko.keep_open = False
+    assert inner_ko.read_crops([0, 1], (0, 0, w, h)) is None
+
+
+def test_crop_backend_batched_full_span_fallback_parity(tmp_path):
+    """Wrapper batched read over a full-span crop returns a real array, not object."""
+    n, h, w, c = 3, 32, 40, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    inner = _make_chunked_hdf5(
+        tmp_path / "v.h5", data, "channels_last", chunks=(1, 16, 16, c)
+    )
+    cb = CropVideoBackend.wrap(inner, (0, 0, w, h))  # no-op crop, spans all chunks
+    out = cb[[0, 1, 2]]
+    assert out.dtype != object
+    assert out.dtype == data.dtype
+    ref = np.stack(
+        [crop_frame(inner._read_frame(i), (0, 0, w, h)) for i in range(3)], axis=0
+    )
+    assert_equal(out, ref[..., [0]] if cb.grayscale else ref)
+
+
+def test_hdf5_pushdown_oob_parity(tmp_path):
+    """Out-of-bounds pushdown crop pads exactly as crop_frame."""
+    n, h, w, c = 2, 48, 64, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    inner = _make_chunked_hdf5(
+        tmp_path / "v.h5", data, "channels_last", chunks=(1, 16, 16, c)
+    )
+    crop = (-8, -8, 8, 8)
+    out = inner.read_crop(0, crop, fill=5)
+    ref = crop_frame(inner._read_frame(0), crop, fill=5)
+    assert out is not None
+    assert out.shape == (16, 16, c)
+    assert_equal(out, ref)
+
+
+def test_hdf5_pushdown_keep_open_false_parity(tmp_path):
+    """Pushdown works with keep_open=False (reopens per call)."""
+    n, h, w, c = 2, 48, 64, 3
+    data = np.arange(n * h * w * c, dtype=np.uint8).reshape(n, h, w, c)
+    with h5py.File(tmp_path / "v.h5", "w") as f:
+        f.create_dataset("video", data=data, chunks=(1, 16, 16, c))
+    inner = HDF5Video(filename=str(tmp_path / "v.h5"), dataset="video", keep_open=False)
+    crop = (5, 5, 30, 30)
+    out = inner.read_crop(0, crop)
+    ref = crop_frame(inner._read_frame(0), crop)
+    assert out is not None
+    assert_equal(out, ref)
+    out_b = inner.read_crops([0, 1], crop)
+    assert out_b is not None
+    assert out_b.shape == (2, 25, 25, c)
+
+
+def test_hdf5_pushdown_embedded_falls_back(slp_minimal_pkg):
+    """Embedded/frame_map inner disables pushdown; crop still works via fallback."""
+    inner = VideoBackend.from_filename(slp_minimal_pkg)
+    assert inner.frame_map  # embedded subset with a frame map
+    assert inner._can_push_crop is False
+
+    fidx = list(inner.frame_map.keys())[0]
+    assert inner.read_crop(fidx, (5, 5, 30, 30)) is None
+    assert inner.read_crops([fidx], (5, 5, 30, 30)) is None
+
+    # The crop view still works (full decode + crop_frame), shape/grayscale safe.
+    cb = CropVideoBackend.wrap(inner, (5, 5, 55, 55))
+    assert cb.img_shape == (50, 50, 1)
+    assert cb.grayscale is True
+    ref = crop_frame(inner._read_frame(fidx), (5, 5, 55, 55))
+    assert_equal(cb[fidx], ref[..., [0]])

--- a/tests/io/test_video_reading.py
+++ b/tests/io/test_video_reading.py
@@ -1858,11 +1858,13 @@ def test_crop_backend_grayscale_full_frame_detection(
     cb = CropVideoBackend.wrap(inner, (10, 10, 11, 60))  # 1px wide
     # Construction is lazy: grayscale is unresolved until first access (no decode).
     assert cb.grayscale is None
-    # img_shape resolves grayscale on the inner's full frame and reports the crop.
+    # img_shape mirrors the inner's channel count (1 here) WITHOUT forcing the
+    # wrapper's own grayscale resolution or a decode.
     assert cb.img_shape == (50, 1, 1)
-    assert cb.grayscale is True
+    assert cb.grayscale is None
     # detect_grayscale resolves from the inner full frame, not the crop.
     assert cb.detect_grayscale() is True
+    assert cb.grayscale is True
     # read_test_frame returns the UNCROPPED inner frame.
     assert cb.read_test_frame().shape[0] == inner.read_test_frame().shape[0]
 
@@ -2255,7 +2257,7 @@ def test_hdf5_pushdown_embedded_falls_back(slp_minimal_pkg):
 
     # The crop view still works (full decode + crop_frame), shape/grayscale safe.
     cb = CropVideoBackend.wrap(inner, (5, 5, 55, 55))
-    assert cb.img_shape == (50, 50, 1)
-    assert cb.grayscale is True
+    assert cb.img_shape == (50, 50, 1)  # channel count mirrors the inner
+    assert cb.detect_grayscale() is True
     ref = crop_frame(inner._read_frame(fidx), (5, 5, 55, 55))
     assert_equal(cb[fidx], ref[..., [0]])

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -5104,7 +5104,7 @@ def test_apply_crops_updates_references_to_baked_files(tmp_path):
 
     labels.apply_crops(video_dir=out_dir)
 
-    cropped_videos = [v for v in labels.videos if v.filename.startswith(str(out_dir))]
+    cropped_videos = [v for v in labels.videos if Path(v.filename).parent == out_dir]
     assert len(cropped_videos) == n_tiles
     for v in cropped_videos:
         # No longer a virtual crop: backend is a plain media backend.
@@ -5125,7 +5125,7 @@ def test_apply_crops_preserves_source_provenance(tmp_path):
 
     labels.apply_crops(video_dir=out_dir)
 
-    baked = [v for v in labels.videos if v.filename.startswith(str(out_dir))]
+    baked = [v for v in labels.videos if Path(v.filename).parent == out_dir]
     for v in baked:
         assert v.source_video is not None
         # Cropped shape (32x32) differs from uncropped source shape (32x64).

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -23,6 +23,7 @@ from sleap_io import (
     load_slp,
     save_slp,
 )
+from sleap_io.io.video_reading import CropVideoBackend
 from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
 from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 from sleap_io.model.label_image import (
@@ -5046,6 +5047,148 @@ def test_labels_match_result_import():
     assert isinstance(result.video_map, dict)
     assert isinstance(result.skeleton_map, dict)
     assert isinstance(result.track_map, dict)
+
+
+def _synthetic_mosaic_labels(tmp_path):
+    """Build labels with a 2-tile mosaic of one source plus an uncropped video.
+
+    Returns ``(labels, src, n_tiles, inst_points)`` where ``src`` is the
+    uncropped source video for the mosaic, ``n_tiles`` is the number of cropped
+    tiles, and ``inst_points`` is the point array placed on the first tile.
+    """
+    rng = np.random.default_rng(0)
+    frames = rng.integers(0, 255, size=(4, 32, 64, 3), dtype=np.uint8)
+    src_path = tmp_path / "src.mp4"
+    sleap_io.save_video(frames, src_path)
+
+    src = Video.from_filename(src_path.as_posix())
+    left = src.crop((0, 0, 32, 32))
+    right = src.crop((32, 0, 64, 32))
+
+    other_frames = rng.integers(0, 255, size=(3, 16, 16, 3), dtype=np.uint8)
+    other_path = tmp_path / "other.mp4"
+    sleap_io.save_video(other_frames, other_path)
+    other = Video.from_filename(other_path.as_posix())
+
+    skel = Skeleton(["A", "B"])
+    inst_points = np.array([[1.0, 2.0], [3.0, 4.0]])
+    lf = LabeledFrame(
+        video=left,
+        frame_idx=0,
+        instances=[Instance.from_numpy(inst_points.copy(), skeleton=skel)],
+    )
+    labels = Labels(videos=[left, right, other], labeled_frames=[lf], skeletons=[skel])
+    return labels, src, 2, inst_points
+
+
+def test_apply_crops_mosaic_bakes_unique_files(tmp_path):
+    """apply_crops bakes each mosaic tile to a unique file in video_dir."""
+    labels, src, n_tiles, _ = _synthetic_mosaic_labels(tmp_path)
+    out_dir = tmp_path / "baked"
+
+    labels.apply_crops(video_dir=out_dir)
+
+    baked_files = sorted(out_dir.glob("*.mp4"))
+    # Both tiles share the stem "src", so they must be disambiguated.
+    assert len(baked_files) == n_tiles
+    names = [p.name for p in baked_files]
+    assert len(set(names)) == n_tiles  # unique names
+    assert all(p.exists() for p in baked_files)
+    assert all(name.startswith("src_crop") for name in names)
+
+
+def test_apply_crops_updates_references_to_baked_files(tmp_path):
+    """apply_crops rewires labels.videos to baked files, dropping crop backends."""
+    labels, src, n_tiles, _ = _synthetic_mosaic_labels(tmp_path)
+    out_dir = tmp_path / "baked"
+
+    labels.apply_crops(video_dir=out_dir)
+
+    cropped_videos = [v for v in labels.videos if v.filename.startswith(str(out_dir))]
+    assert len(cropped_videos) == n_tiles
+    for v in cropped_videos:
+        # No longer a virtual crop: backend is a plain media backend.
+        assert not isinstance(v.backend, CropVideoBackend)
+        assert v._crop_tuple() is None
+        assert Path(v.filename).parent == out_dir
+        # The labeled frame now points at the baked file.
+    # The labeled frame's video reference was updated to a baked file.
+    lf_video = labels[0].video
+    assert lf_video in labels.videos
+    assert not isinstance(lf_video.backend, CropVideoBackend)
+
+
+def test_apply_crops_preserves_source_provenance(tmp_path):
+    """Baked videos keep source_video pointing at the uncropped original."""
+    labels, src, n_tiles, _ = _synthetic_mosaic_labels(tmp_path)
+    out_dir = tmp_path / "baked"
+
+    labels.apply_crops(video_dir=out_dir)
+
+    baked = [v for v in labels.videos if v.filename.startswith(str(out_dir))]
+    for v in baked:
+        assert v.source_video is not None
+        # Cropped shape (32x32) differs from uncropped source shape (32x64).
+        assert v.shape[1:3] == (32, 32)
+        assert v.source_video.shape[1:3] == (32, 64)
+
+
+def test_apply_crops_leaves_uncropped_video_untouched(tmp_path):
+    """Uncropped videos are not rewritten or replaced by apply_crops."""
+    labels, src, n_tiles, _ = _synthetic_mosaic_labels(tmp_path)
+    other_before = labels.videos[2]
+    out_dir = tmp_path / "baked"
+
+    labels.apply_crops(video_dir=out_dir)
+
+    # The uncropped video object is the same instance, untouched.
+    assert other_before in labels.videos
+    assert labels.videos[2] is other_before
+    assert other_before.filename.endswith("other.mp4")
+    # No baked file was created for the uncropped video.
+    assert not (out_dir / "other_crop.mp4").exists()
+
+
+def test_apply_crops_coordinates_unchanged(tmp_path):
+    """Instance point coordinates are unchanged after baking (coord-neutral)."""
+    labels, src, n_tiles, inst_points = _synthetic_mosaic_labels(tmp_path)
+    out_dir = tmp_path / "baked"
+
+    labels.apply_crops(video_dir=out_dir)
+
+    baked_points = labels[0].instances[0].numpy()
+    assert_allclose(baked_points, inst_points)
+
+
+def test_apply_crops_default_dir_beside_source(tmp_path):
+    """Without video_dir, baked files are written next to the source video."""
+    labels, src, n_tiles, _ = _synthetic_mosaic_labels(tmp_path)
+
+    labels.apply_crops()
+
+    baked = [v for v in labels.videos if "_crop" in Path(v.filename).name]
+    assert len(baked) == n_tiles
+    for v in baked:
+        assert Path(v.filename).parent == tmp_path
+        assert Path(v.filename).exists()
+
+
+def test_apply_crops_empty_suffix_refuses_to_overwrite_source(tmp_path):
+    """An empty suffix next to the source would overwrite it; apply_crops raises."""
+    # Single cropped tile over one source so the baked name is "{stem}{suffix}.mp4"
+    # with no index disambiguation; an empty suffix collides with the source file.
+    rng = np.random.default_rng(0)
+    frames = rng.integers(0, 255, size=(4, 32, 64, 3), dtype=np.uint8)
+    src_path = tmp_path / "src.mp4"
+    sleap_io.save_video(frames, src_path)
+    src = Video.from_filename(src_path.as_posix())
+    tile = src.crop((0, 0, 32, 32))
+    labels = Labels(videos=[tile])
+
+    with pytest.raises(ValueError, match="overwrite a source video"):
+        labels.apply_crops(suffix="")
+    # The source file is left intact and no replacement happened.
+    assert isinstance(labels.videos[0].backend, CropVideoBackend)
 
 
 def test_labels_match_with_matcher_objects():

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -758,6 +758,81 @@ def test_match_video_image_sequence(centered_pair_frame_paths):
     assert labels.match_video(partial) is None
 
 
+def test_match_video_distinct_crops(centered_pair_low_quality_path):
+    """match_video keeps mosaic tiles distinct and resolves each correctly.
+
+    Two equal-size crops of one physical file share a root file. Without
+    crop-aware path rungs, a query for one tile would mis-resolve to the other
+    (or raise an ambiguity error). It must resolve to the matching tile.
+    """
+    src = Video.from_filename(centered_pair_low_quality_path)
+    left = src.crop((0, 0, 192, 384))
+    right = src.crop((192, 0, 384, 384))
+    labels = Labels(videos=[left, right])
+
+    # A fresh right-equivalent crop resolves to right, not left, no ambiguity.
+    right_eq = src.crop((192, 0, 384, 384))
+    assert labels.match_video(right_eq) is right
+    # And a left-equivalent resolves to left.
+    left_eq = src.crop((0, 0, 192, 384))
+    assert labels.match_video(left_eq) is left
+
+
+def test_match_video_identical_crop(centered_pair_low_quality_path):
+    """match_video resolves an identical crop to the stored crop."""
+    src = Video.from_filename(centered_pair_low_quality_path)
+    a = src.crop((0, 0, 192, 384))
+    labels = Labels(videos=[a])
+
+    a_eq = src.crop((0, 0, 192, 384))
+    assert labels.match_video(a_eq) is a
+
+
+def test_match_video_crop_not_basename_shadowed(centered_pair_low_quality_path):
+    """A crop query is not basename-matched to a different crop of one file."""
+    src = Video.from_filename(centered_pair_low_quality_path)
+    left = src.crop((0, 0, 192, 384))
+    labels = Labels(videos=[left])
+
+    # A different crop of the same source must not resolve to the left tile.
+    right = src.crop((192, 0, 384, 384))
+    assert labels.match_video(right) is None
+
+
+def test_add_video_distinct_crops_not_collapsed(centered_pair_low_quality_path):
+    """add_video keeps two distinct crops of one file as separate videos."""
+    src = Video.from_filename(centered_pair_low_quality_path)
+    left = src.crop((0, 0, 192, 384))
+    right = src.crop((192, 0, 384, 384))
+    labels = Labels()
+    labels.add_video(left)
+    labels.add_video(right)
+    assert len(labels.videos) == 2
+
+
+def test_add_video_identical_crops_dedup(centered_pair_low_quality_path):
+    """add_video dedups two identical crops of one file to a single video."""
+    src = Video.from_filename(centered_pair_low_quality_path)
+    a = src.crop((0, 0, 192, 384))
+    a_eq = src.crop((0, 0, 192, 384))
+    labels = Labels()
+    labels.add_video(a)
+    returned = labels.add_video(a_eq)
+    assert len(labels.videos) == 1
+    assert returned is a
+
+
+def test_add_video_noncrop_same_file_dedup(centered_pair_low_quality_path):
+    """add_video still dedups non-crop videos of the same file (additive)."""
+    v1 = Video.from_filename(centered_pair_low_quality_path)
+    v2 = Video.from_filename(centered_pair_low_quality_path)
+    labels = Labels()
+    labels.add_video(v1)
+    returned = labels.add_video(v2)
+    assert len(labels.videos) == 1
+    assert returned is v1
+
+
 def test_labels_save(tmp_path, slp_typical):
     labels = load_slp(slp_typical)
     labels.save(tmp_path / "test.slp")

--- a/tests/model/test_matching.py
+++ b/tests/model/test_matching.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from sleap_io.model.instance import Instance, Track
 from sleap_io.model.labeled_frame import LabeledFrame
+from sleap_io.model.labels import Labels
 from sleap_io.model.matching import (
     ConflictResolution,
     ErrorMode,
@@ -20,7 +21,9 @@ from sleap_io.model.matching import (
     TrackMatchMethod,
     VideoMatcher,
     VideoMatchMethod,
+    _crop_key,
     _is_same_file_direct,
+    _same_file_different_crop,
     is_same_file,
 )
 from sleap_io.model.skeleton import Skeleton
@@ -2764,3 +2767,163 @@ class TestFindMatchWithLabels:
         result = matcher.find_match(video_incoming, [video_candidate])
         # Should return None since paths don't match (covers line 1030)
         assert result is None
+
+
+class TestVideoMatcherCropAware:
+    """Crop-aware matching/dedup for mosaic tiles (D-127/D-128).
+
+    Two equal-size crops of ONE physical file (mosaic tiles) share a root file,
+    so without crop awareness they collapse into a single video across the four
+    dedup sites (add_video, match_video, VideoMatcher.match, find_match). These
+    tests pin the crop-disambiguated behavior while asserting non-crop videos
+    are unaffected.
+    """
+
+    def _tiles(self, src_path):
+        """Build two equal-size left/right tiles of one source video."""
+        src = Video.from_filename(src_path)
+        w, h = 384, 384
+        w2 = w // 2
+        left = src.crop((0, 0, w2, h))
+        right = src.crop((w2, 0, w, h))
+        return src, left, right
+
+    def test_crop_key_reads_crop_tuple(self, centered_pair_low_quality_path):
+        """_crop_key returns the crop rect for crops and None otherwise."""
+        src, left, right = self._tiles(centered_pair_low_quality_path)
+        assert _crop_key(left) == (0, 0, 192, 384)
+        assert _crop_key(right) == (192, 0, 384, 384)
+        assert _crop_key(src) is None
+
+    def test_crop_key_defensive_no_method(self):
+        """_crop_key tolerates objects without _crop_tuple (returns None)."""
+
+        class NoCrop:
+            pass
+
+        assert _crop_key(NoCrop()) is None
+
+    def test_is_same_file_different_crops(self, centered_pair_low_quality_path):
+        """Two distinct crops of one file are NOT the same file (D-127)."""
+        src, left, right = self._tiles(centered_pair_low_quality_path)
+        assert not is_same_file(left, right)
+
+    def test_is_same_file_identical_crops(self, centered_pair_low_quality_path):
+        """Two identical crops of one file ARE the same file (D-127)."""
+        src = Video.from_filename(centered_pair_low_quality_path)
+        a = src.crop((0, 0, 192, 384))
+        b = src.crop((0, 0, 192, 384))
+        assert is_same_file(a, b)
+
+    def test_is_same_file_noncrop_unchanged(self, centered_pair_low_quality_path):
+        """Non-crop videos of the same file still match (additive guard)."""
+        v1 = Video.from_filename(centered_pair_low_quality_path)
+        v2 = Video.from_filename(centered_pair_low_quality_path)
+        assert is_same_file(v1, v2)
+
+    def test_same_file_different_crop_helper(self, centered_pair_low_quality_path):
+        """_same_file_different_crop is True only for differing crops of one file."""
+        src, left, right = self._tiles(centered_pair_low_quality_path)
+        assert _same_file_different_crop(left, right)
+        # Identical crops: not "different crop".
+        same = src.crop((0, 0, 192, 384))
+        assert not _same_file_different_crop(left, same)
+        # Non-crop same file: not "different crop".
+        v1 = Video.from_filename(centered_pair_low_quality_path)
+        v2 = Video.from_filename(centered_pair_low_quality_path)
+        assert not _same_file_different_crop(v1, v2)
+
+    def test_same_file_different_crop_via_basename(
+        self, centered_pair_low_quality_path
+    ):
+        """Shared root basename + differing crops disambiguates even unresolved."""
+        src = Video.from_filename(centered_pair_low_quality_path)
+        left = src.crop((0, 0, 192, 384))
+        # A crop of a same-basename file in a different directory: roots are not
+        # verifiably the same file, but the basename rung could re-match them.
+        other = Video(filename="/elsewhere/centered_pair_low_quality.mp4")
+        other_crop = Video(
+            filename="/elsewhere/centered_pair_low_quality.mp4",
+            source_video=other,
+        )
+        other_crop.backend_metadata = {"crop": [192, 0, 384, 384]}
+        assert _same_file_different_crop(left, other_crop)
+
+    def test_match_rejects_different_crops(self, centered_pair_low_quality_path):
+        """VideoMatcher.match(tileA, tileB) is False for differing crops (c)."""
+        src, left, right = self._tiles(centered_pair_low_quality_path)
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert not matcher.match(left, right)
+
+    def test_match_accepts_identical_crops(self, centered_pair_low_quality_path):
+        """VideoMatcher.match accepts identical crops of one file (d)."""
+        src = Video.from_filename(centered_pair_low_quality_path)
+        a = src.crop((0, 0, 192, 384))
+        b = src.crop((0, 0, 192, 384))
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.match(a, b)
+
+    def test_match_noncrop_same_file(self, centered_pair_low_quality_path):
+        """VideoMatcher.match still matches non-crop same-file videos (e)."""
+        v1 = Video.from_filename(centered_pair_low_quality_path)
+        v2 = Video.from_filename(centered_pair_low_quality_path)
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.match(v1, v2)
+
+    def test_find_match_drops_different_crop(self, centered_pair_low_quality_path):
+        """find_match(tileB, [tileA]) does NOT return tileA (c)."""
+        src, left, right = self._tiles(centered_pair_low_quality_path)
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.find_match(right, [left]) is None
+
+    def test_find_match_picks_correct_crop(self, centered_pair_low_quality_path):
+        """find_match resolves to the matching tile, never the other (c)."""
+        src, left, right = self._tiles(centered_pair_low_quality_path)
+        right_eq = src.crop((192, 0, 384, 384))
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        # Among both tiles, the right-equivalent resolves to right, not left.
+        assert matcher.find_match(right_eq, [left, right]) is right
+
+    def test_find_match_identical_crop(self, centered_pair_low_quality_path):
+        """find_match matches an identical crop (d)."""
+        src = Video.from_filename(centered_pair_low_quality_path)
+        a = src.crop((0, 0, 192, 384))
+        a_eq = src.crop((0, 0, 192, 384))
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.find_match(a_eq, [a]) is a
+
+    def test_find_match_noncrop_same_file(self, centered_pair_low_quality_path):
+        """find_match still matches non-crop same-file videos (e)."""
+        v1 = Video.from_filename(centered_pair_low_quality_path)
+        v2 = Video.from_filename(centered_pair_low_quality_path)
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.find_match(v1, [v2]) is v2
+
+    def test_add_video_keeps_distinct_tiles(self, centered_pair_low_quality_path):
+        """Labels.add_video keeps two distinct tiles separate (a)."""
+        src, left, right = self._tiles(centered_pair_low_quality_path)
+        labels = Labels()
+        labels.add_video(left)
+        labels.add_video(right)
+        assert len(labels.videos) == 2
+
+    def test_add_video_dedups_identical_crop(self, centered_pair_low_quality_path):
+        """Labels.add_video dedups identical crops to one (d)."""
+        src = Video.from_filename(centered_pair_low_quality_path)
+        a = src.crop((0, 0, 192, 384))
+        a_eq = src.crop((0, 0, 192, 384))
+        labels = Labels()
+        labels.add_video(a)
+        returned = labels.add_video(a_eq)
+        assert len(labels.videos) == 1
+        assert returned is a
+
+    def test_add_video_dedups_noncrop_same_file(self, centered_pair_low_quality_path):
+        """Labels.add_video still dedups non-crop same-file videos (e)."""
+        v1 = Video.from_filename(centered_pair_low_quality_path)
+        v2 = Video.from_filename(centered_pair_low_quality_path)
+        labels = Labels()
+        labels.add_video(v1)
+        returned = labels.add_video(v2)
+        assert len(labels.videos) == 1
+        assert returned is v1

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -1416,3 +1416,139 @@ def test_video_crop_tuple(small_robot_path):
     # Closed path reads the crop from backend_metadata.
     c.close()
     assert c._crop_tuple() == rect
+
+
+# ---------------------------------------------------------------------------
+# Video.apply_crop (bake virtual crop to disk)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_crop_shape_and_open(small_robot_path, tmp_path):
+    """apply_crop bakes the cropped shape into a file that opens to that shape."""
+    v = Video.from_filename(small_robot_path)
+    # Dimensions divisible by 16 so libx264 macro-block padding is a no-op and
+    # the baked shape is exactly the cropped shape.
+    rect = (16, 16, 112, 112)
+    c = v.crop(rect)
+    assert c.shape == (3, 96, 96, 3)
+
+    out = tmp_path / "baked.mp4"
+    baked = c.apply_crop(out)
+
+    assert out.exists()
+    # The crop is now physical: no CropVideoBackend.
+    assert not isinstance(baked.backend, CropVideoBackend)
+    # Baked video opens and its frame shape matches the cropped (h, w).
+    assert baked.shape[1:3] == (96, 96)
+    assert baked[0].shape[:2] == (96, 96)
+    assert len(baked) == len(c)
+
+
+def test_apply_crop_byte_parity(small_robot_path, tmp_path):
+    """Baked frames match the in-memory crop within codec tolerance."""
+    v = Video.from_filename(small_robot_path)
+    rect = (16, 16, 112, 112)
+    c = v.crop(rect)
+    h, w = rect[3] - rect[1], rect[2] - rect[0]
+
+    out = tmp_path / "baked.mp4"
+    # Near-lossless encode for the tightest parity the writer can provide.
+    baked = c.apply_crop(out, video_kwargs={"crf": 0, "preset": "veryslow"})
+
+    for i in range(len(c)):
+        got = baked[i]
+        expected = crop_frame(v[i], rect)
+        assert got.shape == expected.shape
+        # Compare the content region (libx264 pads bottom/right, preserving the
+        # top-left, but here the crop is macro-block aligned so no padding).
+        got = got[:h, :w]
+        # H.264 colorspace conversion is not bit-exact even at crf=0; allow a
+        # small per-pixel tolerance.
+        assert np.abs(got.astype(np.int16) - expected.astype(np.int16)).max() <= 6
+
+
+def test_apply_crop_source_video_provenance(small_robot_path, tmp_path):
+    """Baked video's source_video is the uncropped original with full shape."""
+    v = Video.from_filename(small_robot_path)
+    full_shape = v.shape
+    rect = (16, 16, 112, 112)
+    c = v.crop(rect)
+
+    out = tmp_path / "baked.mp4"
+    baked = c.apply_crop(out)
+
+    # c.source_video is v (the uncropped original), so baked inherits it.
+    assert baked.source_video is v
+    assert baked.source_video.shape == full_shape
+    # Baked shape is the cropped (h, w); source is the full frame.
+    assert baked.shape[1:3] == (rect[3] - rect[1], rect[2] - rect[0])
+    assert baked.source_video.shape[1:3] == full_shape[1:3]
+
+
+def test_apply_crop_provenance_reconstructs_uncropped_source(
+    small_robot_path, tmp_path
+):
+    """When the cropped video has no source_video, baked source is an uncropped view."""
+    v = Video.from_filename(small_robot_path)
+    full_shape = v.shape
+    rect = (10, 20, 100, 120)
+    c = v.crop(rect)
+    # Detach the source so the fallback branch (source_video is None) is taken.
+    c.source_video = None
+
+    out = tmp_path / "baked.mp4"
+    baked = c.apply_crop(out)
+
+    # The fallback reconstructs an UNCROPPED source from the crop backend's inner,
+    # never the cropped video itself.
+    assert baked.source_video is not c
+    assert baked.source_video._crop_tuple() is None
+    assert baked.source_video.shape[1:3] == full_shape[1:3]
+
+
+def test_apply_crop_raises_when_uncropped(small_robot_path, tmp_path):
+    """apply_crop raises on an uncropped video and does not write a file."""
+    v = Video.from_filename(small_robot_path)
+    assert v._crop_tuple() is None
+
+    out = tmp_path / "baked.mp4"
+    with pytest.raises(ValueError, match="requires a cropped video"):
+        v.apply_crop(out)
+    assert not out.exists()
+
+
+def test_apply_crop_carries_grayscale(centered_pair_low_quality_path, tmp_path):
+    """Baked video carries grayscale from the cropped source."""
+    v = Video.from_filename(centered_pair_low_quality_path)
+    assert v.grayscale is True
+    c = v.crop((0, 0, 96, 96))
+
+    out = tmp_path / "baked.mp4"
+    baked = c.apply_crop(out)
+
+    assert baked.grayscale is True
+    assert baked.shape[1:3] == (96, 96)
+
+
+def test_apply_crop_uses_source_fps(centered_pair_low_quality_path, tmp_path):
+    """apply_crop defaults output FPS to the cropped video's FPS."""
+    v = Video.from_filename(centered_pair_low_quality_path)
+    v.fps = 15.0
+    c = v.crop((0, 0, 100, 100))
+
+    out = tmp_path / "baked.mp4"
+    baked = c.apply_crop(out, frame_inds=[0, 1, 2])
+
+    assert baked.fps == 15.0
+    assert len(baked) == 3
+
+
+def test_apply_crop_custom_fps(small_robot_path, tmp_path):
+    """apply_crop honors an explicit fps argument."""
+    v = Video.from_filename(small_robot_path)
+    c = v.crop((10, 20, 100, 120))
+
+    out = tmp_path / "baked.mp4"
+    baked = c.apply_crop(out, fps=30.0)
+
+    assert baked.fps == 30.0

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -1144,6 +1144,27 @@ def test_from_crop_fill_forwarded(small_robot_path):
     assert np.array_equal(c[0], crop_frame(src[0], (-5, -5, 10, 10), fill=3))
 
 
+def test_from_crop_forwards_region_specs(small_robot_path):
+    """from_crop forwards bbox/center+size region specs (not only `crop`)."""
+    c = Video.from_crop(small_robot_path, bbox=(10.0, 20.0, 100.0, 120.0))
+    assert c.is_cropped
+    assert c.crop_rect == (10, 20, 100, 120)
+    c2 = Video.from_crop(small_robot_path, center=(50, 50), size=(40, 40))
+    assert c2.shape[1:3] == (40, 40)
+
+
+def test_public_crop_accessors(small_robot_path):
+    """is_cropped / crop_rect / crop_fill expose crop state publicly."""
+    v = Video.from_filename(small_robot_path)
+    assert v.is_cropped is False
+    assert v.crop_rect is None
+    assert v.crop_fill == 0
+    c = v.crop((2, 3, 12, 13), fill=5)
+    assert c.is_cropped is True
+    assert c.crop_rect == (2, 3, 12, 13)
+    assert c.crop_fill == 5
+
+
 def test_resolve_crop_rect_bbox():
     """The bbox spec floors mins / ceils maxs to an integer rect."""
     assert _resolve_crop_rect(bbox=(1.2, 2.8, 10.4, 20.1)) == (1, 2, 11, 21)

--- a/tests/model/test_video.py
+++ b/tests/model/test_video.py
@@ -7,7 +7,14 @@ import numpy as np
 import pytest
 
 from sleap_io import Video
-from sleap_io.io.video_reading import HDF5Video, ImageVideo, MediaVideo
+from sleap_io.io.video_reading import (
+    CropVideoBackend,
+    HDF5Video,
+    ImageVideo,
+    MediaVideo,
+)
+from sleap_io.model.video import _resolve_crop_rect
+from sleap_io.transform.frame import crop_frame
 
 
 def test_video_class():
@@ -1048,3 +1055,364 @@ def test_video_save_custom_fps(centered_pair_low_quality_path, tmp_path):
 
     # New video should have custom FPS
     assert new_video.fps == 30.0
+
+
+# ---------------------------------------------------------------------------
+# Video crop facade (UNIT U3)
+# ---------------------------------------------------------------------------
+
+
+def test_crop_facade_shape_len_grayscale(small_robot_path):
+    """Cropped video reports cropped shape/len and inherits grayscale intent."""
+    v = Video.from_filename(small_robot_path)
+    assert v.shape == (3, 320, 560, 3)
+
+    rect = (10, 20, 100, 120)
+    c = v.crop(rect)
+
+    assert isinstance(c.backend, CropVideoBackend)
+    assert c.backend.crop == rect
+    # Width = 100 - 10 = 90, height = 120 - 20 = 100, frames/channels preserved.
+    assert c.shape == (3, 100, 90, 3)
+    assert len(c) == 3
+    assert c.grayscale is False
+    assert c.source_video is v
+
+
+def test_crop_facade_grayscale_video(centered_pair_low_quality_path):
+    """A crop of a grayscale video stays grayscale."""
+    v = Video.from_filename(centered_pair_low_quality_path)
+    assert v.grayscale is True
+
+    c = v.crop((0, 0, 100, 100))
+    assert c.shape == (1100, 100, 100, 1)
+    assert c.grayscale is True
+
+
+def test_crop_byte_parity(small_robot_path):
+    """Cropped frames are byte-identical to crop_frame(full_frame, rect)."""
+    v = Video.from_filename(small_robot_path)
+    rect = (10, 20, 100, 120)
+    c = v.crop(rect)
+
+    for i in range(len(v)):
+        got = c[i]
+        expected = crop_frame(v[i], rect)
+        assert np.array_equal(got, expected)
+        assert got.dtype == expected.dtype
+
+
+def test_crop_byte_parity_out_of_bounds(small_robot_path):
+    """An out-of-bounds crop pads with fill, byte-identical to crop_frame."""
+    v = Video.from_filename(small_robot_path)
+    rect = (-10, -5, 30, 40)
+    c = v.crop(rect, fill=7)
+
+    got = c[0]
+    expected = crop_frame(v[0], rect, fill=7)
+    assert got.shape == (45, 40, 3)
+    assert np.array_equal(got, expected)
+
+
+def test_from_crop_path(small_robot_path):
+    """from_crop opens a path and returns a virtual crop."""
+    rect = (10, 20, 100, 120)
+    c = Video.from_crop(small_robot_path, rect)
+
+    assert isinstance(c.backend, CropVideoBackend)
+    assert c.backend.crop == rect
+    assert c.shape == (3, 100, 90, 3)
+    src = Video.from_filename(small_robot_path)
+    assert np.array_equal(c[0], crop_frame(src[0], rect))
+
+
+def test_from_crop_video(small_robot_path):
+    """from_crop accepts an existing Video and sets it as the source."""
+    v = Video.from_filename(small_robot_path)
+    rect = (10, 20, 100, 120)
+    c = Video.from_crop(v, rect)
+
+    assert c.source_video is v
+    assert c.backend.crop == rect
+
+
+def test_from_crop_fill_forwarded(small_robot_path):
+    """from_crop forwards the fill value to the crop."""
+    c = Video.from_crop(small_robot_path, (-5, -5, 10, 10), fill=3)
+    assert c.backend.fill == 3
+    src = Video.from_filename(small_robot_path)
+    assert np.array_equal(c[0], crop_frame(src[0], (-5, -5, 10, 10), fill=3))
+
+
+def test_resolve_crop_rect_bbox():
+    """The bbox spec floors mins / ceils maxs to an integer rect."""
+    assert _resolve_crop_rect(bbox=(1.2, 2.8, 10.4, 20.1)) == (1, 2, 11, 21)
+
+
+def test_resolve_crop_rect_roi_margin():
+    """The roi spec uses axis-aligned .bounds (floor/ceil) plus a margin."""
+    from shapely.geometry import box
+
+    roi = box(1.5, 2.5, 10.5, 20.5)
+    assert _resolve_crop_rect(roi=roi, margin=2) == (-1, 0, 13, 23)
+
+
+def test_resolve_crop_rect_center_size():
+    """center+size yields a fixed output shape rect (round, not truncate)."""
+    # cx - w/2 = 50 - 10 = 40, cy - h/2 = 60 - 15 = 45.
+    rect = _resolve_crop_rect(center=(50, 60), size=(20, 30))
+    assert rect == (40, 45, 60, 75)
+    assert rect[2] - rect[0] == 20
+    assert rect[3] - rect[1] == 30
+
+
+def test_resolve_crop_rect_explicit():
+    """An explicit crop rect is returned as integers without truncation."""
+    assert _resolve_crop_rect(crop=(1, 2, 3, 4)) == (1, 2, 3, 4)
+
+
+def test_resolve_crop_rect_exactly_one_required():
+    """Not providing exactly one region spec raises ValueError."""
+    with pytest.raises(ValueError):
+        _resolve_crop_rect()
+    with pytest.raises(ValueError):
+        _resolve_crop_rect(crop=(0, 0, 5, 5), bbox=(0, 0, 5, 5))
+    # center without size is not a complete spec.
+    with pytest.raises(ValueError):
+        _resolve_crop_rect(center=(5, 5))
+
+
+def test_resolve_crop_rect_stray_center_or_size():
+    """A lone center or size alongside another spec is rejected, not dropped."""
+    with pytest.raises(ValueError, match="center and size"):
+        _resolve_crop_rect(crop=(0, 0, 5, 5), center=(99, 99))
+    with pytest.raises(ValueError, match="center and size"):
+        _resolve_crop_rect(bbox=(0, 0, 5, 5), size=(99, 99))
+
+
+def test_resolve_crop_rect_inverted_raises():
+    """Inverted crop rects (x2<x1 / y2<y1) raise rather than yield a negative shape."""
+    with pytest.raises(ValueError, match="Inverted crop"):
+        _resolve_crop_rect(crop=(100, 100, 50, 200))
+    with pytest.raises(ValueError, match="Inverted crop"):
+        _resolve_crop_rect(bbox=(100.0, 100.0, 50.0, 200.0))
+
+
+def test_resolve_crop_rect_size_rounds_not_truncates():
+    """Float size is rounded (not int()-truncated) so output shape matches size."""
+    assert _resolve_crop_rect(center=(5, 5), size=(3.9, 3.9)) == (3, 3, 7, 7)
+
+
+def test_crop_closed_video_no_backend_raises():
+    """Cropping a video with no openable backend raises a clear ValueError."""
+    v = Video(filename="/nonexistent_video.mp4", open_backend=False)
+    assert v.backend is None
+    with pytest.raises(ValueError, match="no open backend"):
+        v.crop((0, 0, 10, 10))
+
+
+def test_crop_persists_source_shape_and_fill(small_robot_path):
+    """Video.crop records the uncropped source_shape and exposes _crop_fill."""
+    v = Video.from_filename(small_robot_path)
+    c = v.crop((2, 3, 12, 13), fill=7)
+    assert tuple(c.backend_metadata["source_shape"]) == tuple(v.shape)
+    assert c._crop_fill() == 7
+    assert v._crop_fill() == 0  # uncropped
+
+
+def test_crop_center_size_fixed_shape(small_robot_path):
+    """A center+size crop produces a fixed output shape even partly OOB."""
+    v = Video.from_filename(small_robot_path)
+    # Center near the top-left corner so the window runs off the edge.
+    c = v.crop(center=(5, 5), size=(40, 40))
+    assert c.shape[1:3] == (40, 40)
+
+
+def test_crop_validation_error_on_video(small_robot_path):
+    """Video.crop surfaces the exactly-one-spec validation error."""
+    v = Video.from_filename(small_robot_path)
+    with pytest.raises(ValueError):
+        v.crop()
+    with pytest.raises(ValueError):
+        v.crop((0, 0, 5, 5), bbox=(0, 0, 5, 5))
+
+
+def test_crop_close_open_preserves_crop_and_shape(small_robot_path):
+    """close()/open() on a cropped media video preserves crop + cropped shape."""
+    v = Video.from_filename(small_robot_path)
+    rect = (10, 20, 100, 120)
+    c = v.crop(rect)
+    expected = crop_frame(v[0], rect)
+
+    c.close()
+    # Closed video reports the cropped shape from metadata (no double-crop).
+    assert c.shape == (3, 100, 90, 3)
+    assert c.backend is None
+    assert c.backend_metadata["crop"] == list(rect)
+
+    # Reading reopens and re-wraps exactly once.
+    got = c[0]
+    assert isinstance(c.backend, CropVideoBackend)
+    assert c.backend.crop == rect
+    assert np.array_equal(got, expected)
+
+
+def test_crop_close_open_preserves_dataset_hdf5(slp_minimal_pkg):
+    """A cropped HDF5 video keeps its dataset across close()/open() (D-116)."""
+    import sleap_io as sio
+
+    labels = sio.load_slp(slp_minimal_pkg)
+    v = labels.videos[0]
+    rect = (5, 10, 50, 60)
+    c = v.crop(rect)
+    expected = crop_frame(v[0], rect)
+    assert c.backend.dataset == v.backend.dataset
+
+    c.close()
+    assert c.backend_metadata["dataset"] == v.backend.dataset
+
+    got = c[0]
+    assert isinstance(c.backend, CropVideoBackend)
+    # Dataset delegates to the inner backend after reopen.
+    assert c.backend.dataset == v.backend.dataset
+    assert np.array_equal(got, expected)
+
+
+def test_crop_deepcopy_preserves_crop_and_reads(small_robot_path):
+    """A deepcopy of a cropped video preserves the crop and reads correctly."""
+    v = Video.from_filename(small_robot_path)
+    rect = (10, 20, 100, 120)
+    c = v.crop(rect)
+    expected = crop_frame(v[0], rect)
+
+    d = copy.deepcopy(c)
+    assert isinstance(d.backend, CropVideoBackend)
+    assert d.backend.crop == rect
+    assert d.backend_metadata["crop"] == list(rect)
+    assert np.array_equal(d[0], expected)
+
+
+def test_crop_mosaic_shared_inner_close_one_keeps_sibling(small_robot_path):
+    """Mosaic tiles share the source's inner; closing one keeps the others."""
+    src = Video.from_filename(small_robot_path)
+    W, H = src.shape[2], src.shape[1]
+    W2 = W // 2
+
+    t1 = src.crop((0, 0, W2, H))
+    t2 = src.crop((W2, 0, W, H))
+
+    # Both tiles reuse the source's backend instance as the shared inner.
+    assert t1.backend.inner is src.backend
+    assert t2.backend.inner is src.backend
+    # Shared-decode tiles do not own the shared decoder.
+    assert t1.backend.owns_inner is False
+    assert t2.backend.owns_inner is False
+
+    # Prime the shared reader, then close one tile.
+    _ = t1[0]
+    t1.close()
+
+    # The shared decoder is untouched: the source and sibling still read.
+    assert src.backend._open_reader is not None
+    assert src[0].shape == (H, W, 3)
+    assert t2[0].shape == (H, W2, 3)
+
+
+def test_crop_no_share_decode_owns_inner(small_robot_path):
+    """share_decode=False reuses the source backend as inner but TAKES ownership."""
+    src = Video.from_filename(small_robot_path)
+    t = src.crop((0, 0, 100, 100), share_decode=False)
+    assert t.backend.owns_inner is True
+    # share_decode=False still reuses self.backend as the inner, but the tile owns
+    # it, so closing the tile cascades close() into the shared source backend.
+    assert t.backend.inner is src.backend
+    _ = src[0]
+    t.close()
+    # owns_inner=True released the shared inner's reader...
+    assert src.backend._open_reader is None
+    # ...but the source transparently re-opens on the next read (lazy reopen).
+    assert src[0].shape[0] > 0
+
+
+def test_crop_closed_video_reports_cropped_shape(small_robot_path):
+    """A never-opened cropped video reports the cropped shape from metadata."""
+    v = Video.from_filename(small_robot_path)
+    c = v.crop((10, 20, 100, 120))
+    # Drop the backend so shape must come from backend_metadata.
+    c.close()
+    assert c.backend is None
+    assert c.shape == (3, 100, 90, 3)
+    assert c.grayscale is False
+
+
+def test_crop_of_crop_composition(small_robot_path):
+    """crop-of-crop flattens to a composed source rect (backend + metadata)."""
+    v = Video.from_filename(small_robot_path)
+    c1 = v.crop((10, 20, 110, 120))
+    c2 = c1.crop((5, 5, 50, 50))
+
+    # Composed source rect: (10+5, 20+5, 10+50, 20+50).
+    assert c2.backend.crop == (15, 25, 60, 70)
+    assert c2.backend_metadata["crop"] == [15, 25, 60, 70]
+    # Flattened: the inner is the plain source backend, never another crop.
+    assert not isinstance(c2.backend.inner, CropVideoBackend)
+
+    # Byte-identical to a direct composed crop on the source.
+    direct = v.crop((15, 25, 60, 70))
+    assert np.array_equal(c2[0], direct[0])
+
+
+def test_crop_of_crop_byte_parity_via_nested_frames(small_robot_path):
+    """crop-of-crop equals cropping the already-cropped frame."""
+    v = Video.from_filename(small_robot_path)
+    c1 = v.crop((10, 20, 110, 120))
+    c2 = c1.crop((5, 5, 50, 50))
+    expected = crop_frame(c1[0], (5, 5, 50, 50))
+    assert np.array_equal(c2[0], expected)
+
+
+def test_video_to_crop_and_source_coords(small_robot_path):
+    """to_crop_coords/to_source_coords translate by the crop origin."""
+    v = Video.from_filename(small_robot_path)
+    rect = (10, 20, 100, 120)
+    c = v.crop(rect)
+
+    pts = np.array([[15.0, 25.0], [np.nan, 5.0]])
+    in_crop = c.to_crop_coords(pts)
+    assert np.array_equal(in_crop[0], np.array([5.0, 5.0]))
+    # NaN x is preserved; y shifts by -y1.
+    assert np.isnan(in_crop[1, 0])
+    assert in_crop[1, 1] == -15.0
+
+    # Round-trip back to source coordinates.
+    back = c.to_source_coords(in_crop)
+    valid = ~np.isnan(pts)
+    assert np.allclose(back[valid], pts[valid])
+
+
+def test_video_coords_uncropped_passthrough(small_robot_path):
+    """Coordinate methods are identity copies on an uncropped video."""
+    v = Video.from_filename(small_robot_path)
+    pts = np.array([[15.0, 25.0], [3.0, 4.0]])
+
+    out_c = v.to_crop_coords(pts)
+    out_s = v.to_source_coords(pts)
+    assert np.array_equal(out_c, pts)
+    assert np.array_equal(out_s, pts)
+    # Copies, not the same object (no accidental in-place aliasing).
+    assert out_c is not pts
+    assert out_s is not pts
+
+
+def test_video_crop_tuple(small_robot_path):
+    """_crop_tuple returns the rect for a crop and None when uncropped."""
+    v = Video.from_filename(small_robot_path)
+    assert v._crop_tuple() is None
+
+    rect = (10, 20, 100, 120)
+    c = v.crop(rect)
+    assert c._crop_tuple() == rect
+
+    # Closed path reads the crop from backend_metadata.
+    c.close()
+    assert c._crop_tuple() == rect

--- a/tests/transform/test_points.py
+++ b/tests/transform/test_points.py
@@ -1,0 +1,86 @@
+"""Tests for point coordinate transformation functions."""
+
+import numpy as np
+
+from sleap_io.transform.points import crop_points, uncrop_points
+
+
+def test_uncrop_points_basic():
+    """Test mapping crop-local points back to source coordinates."""
+    points = np.array([[50, 20], [100, 80]])
+    result = uncrop_points(points, (100, 100, 300, 300))
+    np.testing.assert_array_equal(result, [[150, 120], [200, 180]])
+
+
+def test_uncrop_points_round_trip():
+    """Test uncrop_points inverts crop_points exactly."""
+    points = np.array([[150.5, 120.25], [200.0, 180.75], [0.0, 0.0]])
+    crop = (100, 100, 300, 300)
+    result = uncrop_points(crop_points(points, crop), crop)
+    np.testing.assert_allclose(result, points)
+
+
+def test_uncrop_points_round_trip_negative_origin():
+    """Test round-trip with a negative crop origin."""
+    points = np.array([[12.0, -7.0], [3.5, 4.5]])
+    crop = (-40, -25, 60, 35)
+    result = uncrop_points(crop_points(points, crop), crop)
+    np.testing.assert_allclose(result, points)
+
+
+def test_uncrop_points_round_trip_large_origin():
+    """Test round-trip with a large crop origin."""
+    points = np.array([[1500.0, 2400.0], [1234.5, 5678.25]])
+    crop = (1000, 2000, 1640, 2480)
+    result = uncrop_points(crop_points(points, crop), crop)
+    np.testing.assert_allclose(result, points)
+
+
+def test_uncrop_points_preserves_nan():
+    """Test NaN coordinates are preserved through uncrop_points."""
+    points = np.array([[50.0, 20.0], [np.nan, np.nan], [np.nan, 30.0]])
+    result = uncrop_points(points, (100, 100, 300, 300))
+    np.testing.assert_array_equal(result[0], [150.0, 120.0])
+    assert np.isnan(result[1, 0])
+    assert np.isnan(result[1, 1])
+    assert np.isnan(result[2, 0])
+    np.testing.assert_array_equal(result[2, 1], 130.0)
+
+
+def test_uncrop_points_nan_survives_round_trip():
+    """Test NaN stays NaN through crop_points then uncrop_points."""
+    points = np.array([[150.0, 120.0], [np.nan, np.nan], [np.nan, 50.0]])
+    crop = (100, 100, 300, 300)
+    result = uncrop_points(crop_points(points, crop), crop)
+    np.testing.assert_array_equal(result[0], points[0])
+    assert np.isnan(result[1]).all()
+    assert np.isnan(result[2, 0])
+    np.testing.assert_array_equal(result[2, 1], points[2, 1])
+
+
+def test_uncrop_points_preserves_shape():
+    """Test uncrop_points preserves the input shape."""
+    points = np.zeros((7, 2))
+    result = uncrop_points(points, (10, 20, 110, 120))
+    assert result.shape == points.shape
+
+
+def test_uncrop_points_batched_shape():
+    """Test uncrop_points works on a batched (..., 2) shape."""
+    rng = np.random.default_rng(0)
+    points = rng.random((4, 3, 2)) * 100.0
+    crop = (15, 25, 215, 225)
+    result = uncrop_points(points, crop)
+    assert result.shape == points.shape
+    np.testing.assert_allclose(result[..., 0], points[..., 0] + 15)
+    np.testing.assert_allclose(result[..., 1], points[..., 1] + 25)
+    # Round-trip on the batched shape.
+    np.testing.assert_allclose(uncrop_points(crop_points(points, crop), crop), points)
+
+
+def test_uncrop_points_copies_input():
+    """Test uncrop_points does not mutate the input array."""
+    points = np.array([[50.0, 20.0], [100.0, 80.0]])
+    original = points.copy()
+    uncrop_points(points, (100, 100, 300, 300))
+    np.testing.assert_array_equal(points, original)

--- a/tests/transform/test_transform.py
+++ b/tests/transform/test_transform.py
@@ -463,6 +463,30 @@ class TestFrameTransformsGrayscale:
         # Some interior should have original values
         assert result[15, 15, 0] == 255
 
+    def test_crop_frame_wholly_outside_one_axis(self):
+        """Crop wholly beyond the frame on one axis returns an all-fill region.
+
+        Regression: a crop with no source overlap on an axis (e.g. x in [100, 120)
+        for a 24-wide frame) previously raised a broadcast ValueError. It must now
+        return a correctly shaped, fully-filled array.
+        """
+        frame = np.arange(20 * 24 * 3, dtype=np.uint8).reshape(20, 24, 3)
+
+        # Wholly beyond on x (positive), straddling on y.
+        result = crop_frame(frame, (100, 5, 120, 12), fill=7)
+        assert result.shape == (7, 20, 3)
+        assert np.all(result == 7)
+
+        # Wholly beyond on x (negative), wholly beyond on y (negative).
+        result = crop_frame(frame, (-200, -30, -100, -10), fill=3)
+        assert result.shape == (20, 100, 3)
+        assert np.all(result == 3)
+
+        # 2D (grayscale) frame, wholly beyond on x.
+        result = crop_frame(frame[..., 0], (30, 5, 50, 12), fill=0)
+        assert result.shape == (7, 20)
+        assert np.all(result == 0)
+
     def test_pad_frame_with_tuple_fill(self):
         """Test pad_frame with tuple fill color."""
         frame = np.zeros((50, 50, 3), dtype=np.uint8)


### PR DESCRIPTION
## Summary

Adds **virtual on-read video cropping** — a `Video` can expose a virtual, axis-aligned, on-read crop of an inner video without copying or re-encoding pixels. Frames are decoded by the inner backend and sliced/padded in memory (byte-identical to `transform.frame.crop_frame`). It is the lazy, non-destructive dual of the materializing `Transform(crop=...)` pipeline. Closes #451.

```python
full = sio.load_video("session.mp4")              # (1000, 1080, 1920, 3)
view = full.crop((320, 200, 576, 456))            # (x1,y1,x2,y2), x2/y2 exclusive
view.shape                                         # (1000, 256, 256, 3)
view.source_video is full                          # True
```

## Key Changes

- **`CropVideoBackend(VideoBackend)`** (`io/video_reading.py`): wraps an inner backend, reports the cropped shape, and returns cropped frames; `shape`/`len`/`grayscale`/indexing/matching all report the cropped view with no edits to existing `Video` read methods. `wrap()` flattens crop-of-crop when fills match and the outer rect is in-bounds, else nests. `owns_inner` controls the `close()` cascade for shared-decoder mosaics.
- **`Video.crop(...)` / `Video.from_crop(...)`** (`model/video.py`): create a cropped view from an explicit rect, a `bbox`, an `roi` (+`margin`), or a `center`+`size` fixed window. `to_crop_coords`/`to_source_coords` map landmarks between source and cropped frames (NaN-preserving, identity when uncropped).
- **SLP round-trip** (`io/slp.py`): crop rects live in a dedicated top-level `/video_crops` JSON dataset, written only when a crop is present; `videos_json` describes the uncropped source. `format_id` bumps to **2.3** only when a crop exists; uncropped files stay byte-identical and unbumped. Older readers ignore `/video_crops` and load the uncropped source (graceful degrade). Embedding a cropped video stores the **uncropped** source frames and keeps the crop in `/video_crops` so it applies exactly once on reload.
- **Crop-aware matching** (`model/matching.py`, `model/labels.py`): `is_same_file` plus the matcher/`add_video`/`match_video` path rungs now key identity on `(root file, crop)`, so distinct mosaic tiles of one file are not collapsed (identical crops still dedup; non-crop behavior unchanged).
- **HDF5 pushdown**: for raw, sub-frame-chunked rank-4 HDF5, `read_crop`/`read_crops` hyperslab-read only the crop region (real I/O savings); every other backend decodes the full frame then slices (byte-identical), documented honestly.
- **Helpers/fixes**: `transform.points.uncrop_points`; `crop_frame` no longer raises on a wholly-out-of-bounds-on-one-axis crop.
- **Docs**: new Virtual cropping guide, Video reference section, `/video_crops` format spec.

## Example Usage

```python
# Mosaic: many crops of one file, one decode per frame
tiles = [full.crop((x, y, x+128, y+128))
         for y in range(0, 1080-128, 128) for x in range(0, 1920-128, 128)]
labels = sio.Labels(videos=tiles)
sio.save_file(labels, "mosaic.slp")               # crop in /video_crops; tiles not collapsed
labels2 = sio.load_file("mosaic.slp")
labels2.videos[0]._crop_tuple()                    # (0, 0, 128, 128)

# Fixed-size centroid-following window (off-frame regions padded)
view = full.crop(center=(cx, cy), size=(128, 128), fill=0)

# Bake later — pixel-identical to the virtual view
sio.transform_video(full, "baked.mp4", sio.Transform(crop=(320, 200, 576, 456)))
```

## API Changes

- New: `sio.CropVideoBackend`, `Video.crop`, `Video.from_crop`, `Video.to_crop_coords`, `Video.to_source_coords`, `CropVideoBackend.wrap`, `transform.points.uncrop_points`.
- `Video.crop` raises `ValueError` for inverted rects, lone `center`/`size`, or a video with no openable backend.
- SLP `format_id` 2.3 (crop-gated, additive); new optional `/video_crops` dataset.
- No breaking changes; uncropped files are byte-identical to before.

## Testing

- New focused tests across `tests/io/test_video_reading.py`, `tests/io/test_slp.py`, `tests/model/test_video.py`, `tests/model/test_matching.py`, `tests/model/test_labels.py`, `tests/transform/test_points.py`, `tests/transform/test_transform.py`: pixel parity vs `crop_frame`, OOB padding, grayscale on degenerate crops, pickle/deepcopy, channels_first + HDF5 pushdown parity and fallback, SLP round-trip + byte-identical uncropped + old-reader degrade + crop-over-embedded/media embed, mosaic dedup across all four sites.
- Full suite: **3513 passed, 1 skipped**; `ruff` clean.

## Design Decisions

- **Wrapper backend** (not a Video field): `Video.shape`/`__getitem__` are pure delegations and the grayscale slice runs in the base `get_frame`, so a wrapper substitutes through every seam with minimal `Video` edits.
- **Crop in a dedicated `/video_crops` dataset** (not `videos_json`): the typed-backend whitelist silently drops unknown keys; a separate dataset is the rois/bboxes precedent and gives old-reader degrade for free.
- **Embed stores the uncropped source + keeps the crop** so embedding never silently bakes/double-applies a crop.
- **Pushdown only where it pays** (sub-frame-chunked raw HDF5); everywhere else the crop is a free post-decode view, documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — apply (bake) a virtual crop to disk

Added helpers to **materialize** an existing virtual crop into a real video file, with `Video` metadata updated to the baked file and `source_video` provenance preserved (coordinate-neutral — a virtual crop already presents cropped-frame coordinates).

```python
view  = full.crop((320, 200, 576, 456))
baked = view.apply_crop("crop.mp4")          # new Video over the baked file
baked.shape                                  # cropped, now physical
baked.source_video.shape                     # uncropped original (provenance)
baked._crop_tuple()                          # None — materialized, not virtual

labels.apply_crops(video_dir="baked/")       # batch-bake every cropped video, rewire refs
```

CLI:
```bash
sio apply-crops mosaic.slp -o baked.slp --video-dir baked_videos/
```

- New: `Video.apply_crop`, `Labels.apply_crops`, `sio apply-crops`. Distinct from `sio transform --crop` (which applies a *new* crop and adjusts coordinates); `apply_crop` bakes an *existing* virtual crop.
- `Video.apply_crop` raises if the video is not cropped; `Labels.apply_crops` refuses to overwrite a source file and gives mosaic tiles unique baked names.
- Tests: +23 (full suite 3536 passed, 1 skipped; ruff clean). Adversarial review fixed 3 findings (source-overwrite guard, provenance fallback to an uncropped view, encoder-padding docs).
