### PR TITLE
fix(render): auto-draw SegmentationMask overlays + fix grayscale crash (#461)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1778,7 +1778,12 @@ sio render predictions.slp --lf 0               # -> predictions.lf=0.png
 sio render predictions.slp --background black
 sio render predictions.slp --background "#333"
 
-# Overlay a segmentation mask on rendered poses
+# Segmentation predictions are drawn automatically (no --overlay needed):
+# label_images take precedence, falling back to SegmentationMask annotations.
+# Works on RGB and single-channel grayscale video.
+sio render predictions.slp -o out.mp4
+
+# Overlay a segmentation mask on rendered poses (explicit overlay overrides auto)
 sio render predictions.slp --overlay masks.tif --overlay-alpha 0.4
 
 # Overlay-only mode: render masks on images without a labels file

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -681,6 +681,16 @@ img = sio.render_image(
 
 Overlay segmentation masks on images via `render_image`/`render_video` or standalone functions.
 
+!!! tip "Masks and label images are drawn automatically"
+    When no explicit `overlay` is passed and the labels carry annotations,
+    `render_video` (and `sio render`) auto-draw them: **label images take
+    precedence**, falling back to `SegmentationMask` annotations
+    (`labels.get_masks(video=...)`, routed to the correct frame). `render_image`
+    auto-draws the frame's `masks` when no overlay is given. So
+    `sio render preds.slp -o out.mp4` draws segmentation predictions out of the
+    box. Pass an explicit `overlay` to override. Auto-drawing works on both RGB
+    and single-channel grayscale `(H, W, 1)` video.
+
 ### Using render_image / render_video
 
 The `overlay` parameter on `render_image` and `render_video` accepts label images, `SegmentationMask`, `ROI`, or `BoundingBox` objects:

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -1142,6 +1142,20 @@ def render_image(
             f"or None, got {type(source)}"
         )
 
+    # Auto-use the frame's segmentation masks as overlay when no explicit
+    # overlay is given and the frame carries masks. Mirrors render_video's
+    # auto-overlay behavior so a segmentation-only frame still draws its masks.
+    # Only masks are auto-resolved here (not label_images): label_image overlays
+    # are a Labels/render_video-level concept and _apply_overlay does not accept a
+    # list[LabelImage] in the single-frame path. An explicit overlay always wins.
+    if (
+        overlay is None
+        and isinstance(source, (Labels, LabeledFrame))
+        and lf is not None
+        and lf.masks
+    ):
+        overlay = list(lf.masks)
+
     # Apply cropping if specified
     render_image_data = image
     render_points = instances_points
@@ -1555,6 +1569,23 @@ def render_video(
                 if include_unlabeled is None:
                     include_unlabeled = True
 
+        # Auto-use segmentation masks as overlay when no explicit overlay (and
+        # no label images) resolved. Masks live on specific frames at arbitrary
+        # frame indices, so resolve them per-frame via a callable rather than a
+        # positional list. label_images take precedence (resolved above).
+        if overlay is None and labels.masks:
+            video_masks = labels.get_masks(video=target_video)
+            if video_masks:
+                _auto_labels = labels
+                _auto_video = target_video
+
+                def overlay(fidx: int) -> list["SegmentationMask"]:
+                    """Resolve segmentation masks for a single frame index."""
+                    return _auto_labels.get_masks(video=_auto_video, frame_idx=fidx)
+
+                if include_unlabeled is None:
+                    include_unlabeled = True
+
         # Check if centroids exist for this video (per-frame access via lf).
         if show_centroids and labels.centroids:
             _has_video_centroids = bool(labels.get_centroids(video=target_video))
@@ -1764,6 +1795,8 @@ def render_video(
             return image
         if image.ndim == 2:
             image = np.stack([image] * 3, axis=-1)
+        elif image.ndim == 3 and image.shape[-1] == 1:
+            image = np.repeat(image, 3, axis=-1)
         # Crop overlay to match cropped image region
         cropped_overlay = frame_overlay
         if crop_bounds is not None:
@@ -1823,6 +1856,8 @@ def render_video(
         # Ensure RGB.
         if image.ndim == 2:
             image = np.stack([image] * 3, axis=-1)
+        elif image.ndim == 3 and image.shape[-1] == 1:
+            image = np.repeat(image, 3, axis=-1)
 
         # Assign colors by track using pre-built index map.
         centroid_colors = []

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -3109,6 +3109,297 @@ def test_render_video_overlay_out_of_bounds():
 
 
 # ============================================================================
+# Issue #461: auto-draw segmentation masks + grayscale (H,W,1) support
+# ============================================================================
+
+
+def _make_mask_labels(n_frames=2, h=64, w=64, mask_box=(40, 60, 40, 60)):
+    """Create synthetic Labels whose frames carry segmentation masks.
+
+    Each frame gets one ``UserSegmentationMask`` covering ``mask_box`` (given as
+    ``(y0, y1, x0, x1)``) attached to the frame's ``masks`` list. The mask region
+    is deliberately kept away from the poses so rendering changes there can be
+    attributed to the mask and not pose markers.
+    """
+    skeleton = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    video = sio.Video(filename="dummy.mp4")
+    pts = np.array([[5, 5], [10, 10]], dtype=np.float32)
+    y0, y1, x0, x1 = mask_box
+
+    labeled_frames = []
+    for i in range(n_frames):
+        binary = np.zeros((h, w), dtype=bool)
+        binary[y0:y1, x0:x1] = True
+        mask = UserSegmentationMask.from_numpy(binary)
+        lf = sio.LabeledFrame(
+            video=video,
+            frame_idx=i,
+            instances=[sio.Instance.from_numpy(pts, skeleton=skeleton)],
+        )
+        lf.masks.append(mask)
+        labeled_frames.append(lf)
+
+    return sio.Labels(
+        labeled_frames=labeled_frames, videos=[video], skeletons=[skeleton]
+    )
+
+
+def test_render_video_auto_draws_masks():
+    """render_video auto-draws labels.masks when no overlay is passed."""
+    labels = _make_mask_labels(n_frames=2, h=64, w=64)
+
+    frames = render_video(
+        labels,
+        save_path=None,
+        background=(128, 128, 128),
+        overlay_alpha=0.6,
+        fps=30,
+        show_progress=False,
+    )
+
+    assert len(frames) == 2
+    for i, frame in enumerate(frames):
+        # Masked region (50, 50) differs from the plain background.
+        assert not np.array_equal(frame[50, 50], [128, 128, 128]), (
+            f"Frame {i}: mask was not auto-drawn"
+        )
+        # Region outside the mask is untouched background.
+        assert np.array_equal(frame[0, 0], [128, 128, 128])
+
+
+def test_render_video_no_masks_leaves_background():
+    """Without masks (and no overlay), the background region is unchanged."""
+    labels = _make_synthetic_labels(n_frames=1, h=64, w=64)
+
+    frames = render_video(
+        labels,
+        save_path=None,
+        background=(128, 128, 128),
+        overlay_alpha=0.6,
+        fps=30,
+        show_progress=False,
+    )
+
+    assert len(frames) == 1
+    # No mask -> a region away from the poses stays the plain background.
+    assert np.array_equal(frames[0][60, 5], [128, 128, 128])
+
+
+def test_render_video_explicit_overlay_takes_precedence_over_masks():
+    """An explicit overlay is used even when labels.masks exist."""
+    labels = _make_mask_labels(n_frames=1, h=64, w=64, mask_box=(40, 60, 40, 60))
+
+    # Explicit overlay marks a different region (top-left); mask is bottom-right.
+    overlay = np.zeros((64, 64), dtype=np.int32)
+    overlay[5:25, 5:25] = 1
+
+    frames = render_video(
+        labels,
+        save_path=None,
+        background=(128, 128, 128),
+        overlay=overlay,
+        overlay_alpha=0.6,
+        fps=30,
+        show_progress=False,
+    )
+
+    assert len(frames) == 1
+    # Explicit overlay region is colored.
+    assert not np.array_equal(frames[0][15, 15], [128, 128, 128])
+    # Mask region is NOT drawn since an explicit overlay was provided.
+    assert np.array_equal(frames[0][50, 50], [128, 128, 128])
+
+
+def test_render_video_label_images_take_precedence_over_masks():
+    """label_images auto-overlay wins over masks (precedence unchanged)."""
+    skeleton = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    video = sio.Video(filename="dummy.mp4")
+
+    # label image marks top-left; mask marks bottom-right.
+    data = np.zeros((64, 64), dtype=np.int32)
+    data[5:25, 5:25] = 1
+    li = UserLabelImage(data=data)
+
+    binary = np.zeros((64, 64), dtype=bool)
+    binary[40:60, 40:60] = True
+    mask = UserSegmentationMask.from_numpy(binary)
+
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    lf.label_images.append(li)
+    lf.masks.append(mask)
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    frames = render_video(
+        labels,
+        save_path=None,
+        background=(128, 128, 128),
+        overlay_alpha=0.6,
+        fps=30,
+        show_progress=False,
+    )
+
+    assert len(frames) == 1
+    # Label image region (top-left) is colored.
+    assert not np.array_equal(frames[0][15, 15], [128, 128, 128])
+    # Mask region (bottom-right) is NOT drawn since label_images take precedence.
+    assert np.array_equal(frames[0][50, 50], [128, 128, 128])
+
+
+def test_render_image_auto_draws_masks():
+    """render_image auto-draws the frame's masks when no overlay is passed."""
+    labels = _make_mask_labels(n_frames=1, h=64, w=64)
+    lf = labels.labeled_frames[0]
+
+    result = render_image(lf, background=(128, 128, 128))
+
+    assert result.shape == (64, 64, 3)
+    # Masked region is colored.
+    assert not np.array_equal(result[50, 50], [128, 128, 128])
+    # Background outside the mask is unchanged.
+    assert np.array_equal(result[0, 0], [128, 128, 128])
+
+
+def test_render_image_no_masks_no_overlay_leaves_background():
+    """render_image without masks/overlay leaves the background untouched."""
+    skeleton = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    video = sio.Video(filename="dummy.mp4")
+    pts = np.array([[5, 5], [10, 10]], dtype=np.float32)
+    lf = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        instances=[sio.Instance.from_numpy(pts, skeleton=skeleton)],
+    )
+    sio.Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    result = render_image(lf, background=(128, 128, 128))
+    # No mask -> region away from the pose stays the plain background.
+    assert np.array_equal(result[50, 50], [128, 128, 128])
+
+
+def test_render_video_grayscale_single_channel_auto_masks(
+    tiff_image_sequence_path,
+):
+    """(H,W,1) grayscale video + auto masks does not crash and draws the mask."""
+    video = sio.Video.from_filename(tiff_image_sequence_path)
+    assert video[0].shape == (128, 128, 1)
+
+    skeleton = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    binary = np.zeros((128, 128), dtype=bool)
+    binary[80:110, 80:110] = True  # corner region away from poses
+    mask = UserSegmentationMask.from_numpy(binary)
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(mask)
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    # Reference: grayscale frame promoted to RGB (what the renderer starts from).
+    ref = np.repeat(video[0], 3, axis=-1)
+
+    frames = render_video(
+        labels,
+        save_path=None,
+        overlay_alpha=0.6,
+        fps=30,
+        show_progress=False,
+    )
+
+    # Auto-overlay enables include_unlabeled, so every video frame is rendered.
+    assert len(frames) == len(video)
+    assert frames[0].shape == (128, 128, 3)
+    # Masked region on the labeled frame changed vs the promoted grayscale frame.
+    assert not np.array_equal(frames[0][95, 95], ref[95, 95])
+
+
+def test_render_video_grayscale_single_channel_explicit_overlay(
+    tiff_image_sequence_path,
+):
+    """(H,W,1) grayscale video + explicit overlay callback does not crash."""
+    video = sio.Video.from_filename(tiff_image_sequence_path)
+    assert video[0].shape == (128, 128, 1)
+
+    skeleton = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    binary = np.zeros((128, 128), dtype=bool)
+    binary[80:110, 80:110] = True
+    mask = UserSegmentationMask.from_numpy(binary)
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    masks_by_frame = {0: [mask]}
+    ref = np.repeat(video[0], 3, axis=-1)
+
+    # Previously raised: ValueError: shape mismatch ... (N,3) vs (N,1).
+    frames = render_video(
+        labels,
+        save_path=None,
+        overlay=lambda i: masks_by_frame.get(i, []),
+        overlay_alpha=0.6,
+        fps=30,
+        show_progress=False,
+    )
+
+    assert len(frames) == 1
+    assert frames[0].shape == (128, 128, 3)
+    assert not np.array_equal(frames[0][95, 95], ref[95, 95])
+
+
+def test_render_image_grayscale_single_channel_auto_masks(
+    tiff_image_sequence_path,
+):
+    """render_image on a (H,W,1) frame auto-draws masks without crashing."""
+    video = sio.Video.from_filename(tiff_image_sequence_path)
+    assert video[0].shape == (128, 128, 1)
+
+    binary = np.zeros((128, 128), dtype=bool)
+    binary[80:110, 80:110] = True
+    mask = UserSegmentationMask.from_numpy(binary)
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(mask)
+
+    ref = np.repeat(video[0], 3, axis=-1)
+    result = render_image(lf)
+
+    assert result.shape == (128, 128, 3)
+    assert not np.array_equal(result[95, 95], ref[95, 95])
+
+
+def test_render_video_grayscale_single_channel_centroids_no_overlay(
+    tiff_image_sequence_path,
+):
+    """(H,W,1) grayscale video + centroids (no overlay) promotes to RGB and draws.
+
+    Exercises the single-channel->RGB conversion in the centroid path (no overlay
+    promotes the image first), which the mask/overlay tests do not reach.
+    """
+    from sleap_io.model.centroid import UserCentroid
+    from sleap_io.model.instance import Track
+
+    video = sio.Video.from_filename(tiff_image_sequence_path)
+    assert video[0].shape == (128, 128, 1)
+
+    track = Track(name="t1")
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    lf.centroids.append(UserCentroid(x=95.0, y=95.0, track=track))
+    labels = sio.Labels(
+        labeled_frames=[lf],
+        videos=[video],
+        skeletons=[sio.Skeleton(["A"])],
+        tracks=[track],
+    )
+
+    ref = np.repeat(video[0], 3, axis=-1)
+    frames = render_video(
+        labels,
+        save_path=None,
+        show_centroids=True,
+        marker_size=8.0,
+        show_progress=False,
+    )
+
+    assert frames[0].shape == (128, 128, 3)
+    # The centroid marker region changed vs the promoted grayscale frame.
+    assert not np.array_equal(frames[0][88:103, 88:103], ref[88:103, 88:103])
+
+
+# ============================================================================
 # _apply_overlay TypeError for unknown list element types
 # ============================================================================
 

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -3185,6 +3185,67 @@ def test_render_video_no_masks_leaves_background():
     assert np.array_equal(frames[0][60, 5], [128, 128, 128])
 
 
+def test_render_video_masks_for_other_video_not_drawn():
+    """Masks present on a DIFFERENT video are not auto-drawn for the target video.
+
+    Exercises the `if video_masks:` false branch: labels.masks is non-empty but
+    get_masks(video=target) is empty, so no auto-overlay is resolved.
+    """
+    skeleton = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    vid_a = sio.Video(filename="a.mp4")
+    vid_b = sio.Video(filename="b.mp4")
+    pts = np.array([[5, 5], [10, 10]], dtype=np.float32)
+
+    # vid_a has a labeled frame but NO mask; the only mask lives on vid_b.
+    lf_a = sio.LabeledFrame(
+        video=vid_a,
+        frame_idx=0,
+        instances=[sio.Instance.from_numpy(pts, skeleton=skeleton)],
+    )
+    binary = np.zeros((64, 64), dtype=bool)
+    binary[40:60, 40:60] = True
+    lf_b = sio.LabeledFrame(video=vid_b, frame_idx=0)
+    lf_b.masks.append(UserSegmentationMask.from_numpy(binary))
+    labels = sio.Labels(
+        labeled_frames=[lf_a, lf_b], videos=[vid_a, vid_b], skeletons=[skeleton]
+    )
+
+    frames = render_video(
+        labels,
+        save_path=None,
+        video=0,  # render vid_a, whose masks are empty
+        background=(128, 128, 128),
+        overlay_alpha=0.6,
+        show_progress=False,
+    )
+
+    assert len(frames) == 1
+    # No mask for vid_a -> the would-be mask region stays plain background.
+    assert np.array_equal(frames[0][50, 50], [128, 128, 128])
+
+
+def test_render_video_auto_masks_with_explicit_include_unlabeled():
+    """Auto-mask resolution respects an explicitly-set include_unlabeled.
+
+    Exercises the `if include_unlabeled is None:` false branch inside the mask
+    block: masks resolve for the video AND include_unlabeled was passed.
+    """
+    labels = _make_mask_labels(n_frames=2, h=64, w=64)
+
+    frames = render_video(
+        labels,
+        save_path=None,
+        background=(128, 128, 128),
+        include_unlabeled=False,  # explicit -> not None when masks resolve
+        overlay_alpha=0.6,
+        show_progress=False,
+    )
+
+    # Only labeled frames render (include_unlabeled=False), masks still drawn.
+    assert len(frames) == 2
+    assert not np.array_equal(frames[0][50, 50], [128, 128, 128])
+
+
 def test_render_video_explicit_overlay_takes_precedence_over_masks():
     """An explicit overlay is used even when labels.masks exist."""
     labels = _make_mask_labels(n_frames=1, h=64, w=64, mask_box=(40, 60, 40, 60))


### PR DESCRIPTION
## Summary

Fixes #461. `render_video` / `render_image` / `sio render` now **auto-draw `SegmentationMask` annotations** (`labels.masks` / per-frame `LabeledFrame.masks`), and mask/label-image overlays no longer **crash on single-channel `(H, W, 1)` video**.

Previously only `LabelImage` was auto-resolved as an overlay, so rendering a `.slp` whose only annotations are `PredictedSegmentationMask`/`UserSegmentationMask` (e.g. from `sleap-nn`'s segmentation predictor) produced background-only output.

## Changes

- **Auto-draw masks** (`sleap_io/rendering/core.py`):
  - `render_video`: when no explicit `overlay` is given and no `label_images` overlay was resolved, auto-resolve masks via a per-frame callable that queries `labels.get_masks(video=..., frame_idx=...)`. **Precedence: explicit overlay > label_images > masks.** (A per-frame callable, not a flat list, so masks at arbitrary frame indices map to the correct frame.)
  - `render_image`: auto-draws the frame's `masks` when no overlay is given. (Only masks are auto-resolved here — label-image overlays are a `Labels`/`render_video`-level concept; an explicit overlay always wins.)
- **Grayscale `(H, W, 1)` fix**: the overlay and centroid paths now promote single-channel frames to RGB (`np.repeat(img, 3, -1)`), not just 2-D grayscale — so a `(N, 3)` mask color no longer broadcasts into an `(N, 1)` region.

## Testing

- New tests (`tests/rendering/test_rendering.py`): auto-draw masks in `render_video` and `render_image`; explicit-overlay and label-image **precedence**; grayscale `(H, W, 1)` for masks (auto + explicit callback), centroids (no overlay), and `render_image`; background-unchanged when no annotations. Tests assert masks are actually **drawn** (pixels changed) at regions away from poses, not just "no crash".
- Reproduced the original `ValueError` on a stashed fix to confirm root cause.
- Full suite: **3575 passed, 1 skipped**; `ruff` + `codespell` clean.

## Docs

Documented the auto-draw behavior (with precedence and grayscale support) in `docs/rendering.md` and `docs/cli.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
