### PR TITLE
perf(slp): gzip-compress the roi_wkb dataset when writing .slp

### DIFF
--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -77,7 +77,7 @@ file.slp
 │   ├── @categories              # Attribute: JSON array (legacy fallback)
 │   ├── @names                   # Attribute: JSON array (legacy fallback)
 │   └── @sources                 # Attribute: JSON array (legacy fallback)
-├── /roi_wkb                     # Dataset: Packed WKB geometry bytes (uint8 array)
+├── /roi_wkb                     # Dataset: Packed WKB geometry bytes (uint8 array, gzip-compressed)
 ├── /roi_categories              # Dataset: vlen string, one per ROI (Format 1.9+)
 ├── /roi_names                   # Dataset: vlen string, one per ROI (Format 1.9+)
 ├── /roi_sources                 # Dataset: vlen string, one per ROI (Format 1.9+)
@@ -952,9 +952,11 @@ The `/centroids/` group is only written when the [`Labels`][sleap_io.Labels] obj
 ROI data is stored across two datasets:
 
 - `/rois`: Structured array containing ROI metadata and byte offsets into the geometry data
-- `/roi_wkb`: Packed `uint8` array of [WKB (Well-Known Binary)](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary) geometry bytes
+- `/roi_wkb`: Packed `uint8` array of [WKB (Well-Known Binary)](https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry#Well-known_binary) geometry bytes, gzip-compressed (`compression_opts=1`)
 
 Each ROI's geometry is stored as a WKB blob in `/roi_wkb`, with `/rois` providing the byte range via `wkb_start` and `wkb_end` offsets.
+
+`/roi_wkb` is stored with the HDF5 gzip filter (`compression="gzip", compression_opts=1`), a transparent on-disk storage detail: readers decompress it automatically, byte ranges are unchanged, and no `format_id` bump is required. This is lossless and typically shrinks `/roi_wkb` ~2x on polygon-heavy ROI sets. Browser/h5wasm readers must support the deflate filter, which is already required for the format's gzip-filtered `/mask_rle` and embedded video frames (and the v2.2 chunked `/label_image_data`).
 
 ### ROI Dtype
 
@@ -1324,7 +1326,7 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 
 [`sleap-io.js`](https://github.com/talmolab/sleap-io.js) is the browser port of this library and writes SLP files via [h5wasm](https://github.com/usnistgov/h5wasm). h5wasm cannot create HDF5 compound (structured) datasets, so it stores the `points`, `pred_points`, `instances`, and `frames` datasets as **flat 2D arrays** with the same per-row field layout as the structured dtype. The Python reader in v0.7.0 detects this representation (via shape and dataset attributes) and auto-converts on the fly, so files written by sleap-io.js round-trip cleanly through the Python library without requiring a manual conversion step. Multiple HDF5 string encodings are also tolerated (PR #378).
 
-The `/mask_rle` dataset is stored with the HDF5 gzip (deflate) filter. Readers must support deflate to read masks — this is already required for the SLP format's embedded video frames and `/label_image_data` (both gzip-filtered), and h5wasm bundles zlib, so no additional reader capability is introduced.
+The `/mask_rle` dataset is stored with the HDF5 gzip (deflate) filter. Readers must support deflate to read masks — this is already required for the SLP format's embedded video frames (and the v2.2 chunked `/label_image_data`), and h5wasm bundles zlib, so no additional reader capability is introduced.
 
 ## API
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -3371,11 +3371,19 @@ def write_rois(
         f.create_dataset("roi_categories", data=categories, dtype=str_dt)
         f.create_dataset("roi_names", data=names, dtype=str_dt)
         f.create_dataset("roi_sources", data=sources, dtype=str_dt)
+        # Gzip-compress the packed WKB geometry bytes (lossless, transparent on
+        # read). Mirrors the gzip used for mask_rle / video / label-image data;
+        # ~2x smaller on polygon-heavy ROI sets. wkb_flat is always non-empty
+        # here: write_rois returns early on empty input and every geometry
+        # serializes to >=9 WKB bytes (even an empty polygon is a 9-byte
+        # header), so no empty-dataset guard is needed.
         f.create_dataset(
             "roi_wkb",
             data=wkb_flat,
             dtype=np.uint8,
-            **({"chunks": True} if len(wkb_flat) > 0 else {}),
+            chunks=True,
+            compression="gzip",
+            compression_opts=1,
         )
 
 

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -4392,6 +4392,133 @@ def test_slp_roi_roundtrip(tmp_path):
     assert triangle.track is loaded.tracks[0]
 
 
+def _polygon_heavy_rois(n_rois=100, n_verts=64):
+    """An ROI set of many-vertex polygons with a sizable, compressible WKB blob."""
+    video = Video(filename="test.mp4")
+    ang = np.linspace(0, 2 * np.pi, n_verts, endpoint=False)
+    base = np.stack([500 + 400 * np.cos(ang), 500 + 400 * np.sin(ang)], 1)
+    rois = [
+        UserROI.from_polygon((base + i * 0.13).tolist(), video=video, name=f"r{i}")
+        for i in range(n_rois)
+    ]
+    skeleton = Skeleton(nodes=["A"])
+    return Labels(videos=[video], skeletons=[skeleton], rois=rois)
+
+
+def test_slp_roi_wkb_gzip_compressed(tmp_path):
+    """`roi_wkb` is written with gzip compression (follow-up to #463)."""
+    labels = _polygon_heavy_rois(n_rois=5, n_verts=8)
+    path = str(tmp_path / "gzip_rois.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        wkb = f["roi_wkb"]
+        assert wkb.compression == "gzip"
+        assert wkb.compression_opts == 1
+        assert wkb.chunks is not None  # gzip requires a chunked layout
+
+
+def test_slp_roi_wkb_compression_reduces_size(tmp_path):
+    """Gzip meaningfully shrinks `roi_wkb` on disk vs. its raw byte size."""
+    labels = _polygon_heavy_rois(n_rois=100, n_verts=64)
+    path = str(tmp_path / "compressed_rois.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        wkb = f["roi_wkb"]
+        on_disk = wkb.id.get_storage_size()
+        raw = wkb.nbytes
+    # A polygon-heavy ROI set packs ~100 KB of WKB; gzip beats it ~2x.
+    assert raw > 10240
+    assert on_disk < raw * 0.8
+
+
+def test_slp_roi_wkb_roundtrip_bit_identical(tmp_path):
+    """Gzip is lossless: ROI geometry survives a round-trip with identical WKB."""
+    labels = _polygon_heavy_rois(n_rois=20, n_verts=32)
+    original_wkb = sorted(r.geometry.wkb for r in labels.rois)
+
+    path = str(tmp_path / "roundtrip_rois.slp")
+    save_slp(labels, path)
+    loaded = load_slp(path)
+
+    assert len(loaded.rois) == len(labels.rois)
+    reloaded_wkb = sorted(r.geometry.wkb for r in loaded.rois)
+    assert reloaded_wkb == original_wkb
+
+
+def test_slp_roi_wkb_roundtrip_geometry_types(tmp_path):
+    """Gzip round-trip preserves WKB + type across ROI geometry kinds.
+
+    Covers a UserROI polygon, a PredictedROI (with score), and a MultiPolygon —
+    all share the generic WKB serialize/deserialize path. Non-rectangular shapes
+    avoid the rectangle->BoundingBox migration.
+    """
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+    rois = [
+        UserROI(
+            geometry=shapely.Polygon([(0, 0), (10, 0), (10, 10), (5, 15), (0, 10)]),
+            video=video,
+            category="user",
+        ),
+        PredictedROI(
+            geometry=shapely.Polygon([(20, 20), (30, 20), (25, 35)]),
+            video=video,
+            category="pred",
+            score=0.85,
+        ),
+        UserROI(
+            geometry=shapely.MultiPolygon(
+                [
+                    shapely.Polygon([(0, 0), (5, 0), (5, 5)]),
+                    shapely.Polygon([(10, 10), (15, 10), (15, 15)]),
+                ]
+            ),
+            video=video,
+            category="multi",
+        ),
+    ]
+    original_wkb = {r.category: r.geometry.wkb for r in rois}
+
+    path = str(tmp_path / "roi_geom_types.slp")
+    save_slp(Labels(videos=[video], skeletons=[skeleton], rois=rois), path)
+    loaded = load_slp(path, open_videos=False)
+
+    assert len(loaded.rois) == 3
+    by_cat = {r.category: r for r in loaded.rois}
+    assert isinstance(by_cat["pred"], PredictedROI)
+    assert by_cat["pred"].score == pytest.approx(0.85, abs=1e-5)
+    assert isinstance(by_cat["user"], UserROI)
+    assert by_cat["multi"].geometry.geom_type == "MultiPolygon"
+    for cat, wkb in original_wkb.items():
+        assert by_cat[cat].geometry.wkb == wkb
+
+
+def test_slp_roi_wkb_empty_geometry(tmp_path):
+    """An empty-geometry ROI still packs non-empty WKB and round-trips gzip.
+
+    Pins the invariant that lets ``write_rois`` always gzip ``roi_wkb`` with no
+    empty-dataset guard: every geometry — even an empty polygon — serializes to
+    a non-empty WKB header, so ``wkb_flat`` is never empty when ROIs exist.
+    """
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+    roi = UserROI(geometry=shapely.Polygon(), video=video, category="empty")
+    labels = Labels(videos=[video], skeletons=[skeleton], rois=[roi])
+
+    path = str(tmp_path / "empty_geom_roi.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        assert f["roi_wkb"].compression == "gzip"
+        assert f["roi_wkb"].nbytes > 0
+
+    loaded = load_slp(path, open_videos=False)
+    assert len(loaded.rois) == 1
+    assert loaded.rois[0].geometry.is_empty
+
+
 def test_slp_mask_roundtrip(tmp_path):
     """Test SLP round-trip with segmentation masks."""
     video = Video(filename="test.mp4")


### PR DESCRIPTION
## Summary

Follow-up to #463 / #464 (which gzip-compressed `/mask_rle`). That PR's adversarial review flagged that the sibling `/roi_wkb` dataset — packed shapely WKB polygon geometry — uses the **same uncompressed `chunks=True`-only pattern**. This applies the HDF5 gzip filter to `/roi_wkb` for a lossless size reduction, completing the consistency pass over packed-byte annotation datasets.

The change is **lossless, transparent on read, and backward/forward-compatible** — same properties as #464.

## Key changes

- `sleap_io/io/slp.py` (`write_rois`): `/roi_wkb` is now created with `compression="gzip", compression_opts=1`.
- **Dropped the empty-dataset guard** (unlike `mask_rle`, which kept it). For `roi_wkb` the guard was provably *dead code*: `write_rois` early-returns on empty input, and every geometry — even an empty `Polygon()` — serializes to ≥9 WKB bytes, so `wkb_flat` is always non-empty here. Keeping it would be an untestable branch and an uncoverable patch line. (`mask_rle` kept its guard because a zero-dimension mask yields genuinely empty RLE — a reachable branch.)
- `tests/io/test_slp.py`: five focused tests.
- `docs/formats/slp.md`: documented `roi_wkb` compression and tightened the `label_image_data` gzip wording inherited from #464.

## Benchmark

The real `preds_of_clip.slp` from #463/#464 has **no ROIs**, so ROI geometry is benchmarked on synthetic polygon sets (circles). WKB is mostly high-entropy float64 coordinates, so it compresses less than `mask_rle`'s 8× — but the ~2× win is real and grows with ROI count/complexity:

| n_rois | n_verts | raw | on-disk | ratio | round-trip |
|--------|---------|-----|---------|-------|------------|
| 5 | 8 | 785 B | 352 B | 2.23× | bit-identical |
| 50 | 30 | 24.9 KB | 15.4 KB | 1.61× | bit-identical |
| 200 | 50 | 161.9 KB | 102.1 KB | 1.59× | bit-identical |
| 2000 | 100 | 3.1 MB | 1.4 MB | 2.24× | bit-identical |

All ROI geometry round-trips with **bit-identical WKB**.

## Example usage

No API change — compression is automatic:

```python
import sleap_io as sio
labels = sio.load_slp("with_rois.slp")
sio.save_slp(labels, "compressed.slp")  # /roi_wkb now gzip-compressed
```

## API changes

None. Transparent on-disk storage detail.

## Testing

- New: `test_slp_roi_wkb_gzip_compressed`, `test_slp_roi_wkb_compression_reduces_size`, `test_slp_roi_wkb_roundtrip_bit_identical`, `test_slp_roi_wkb_roundtrip_geometry_types` (UserROI / PredictedROI / MultiPolygon), `test_slp_roi_wkb_empty_geometry` (pins the dropped-guard invariant).
- Full `tests/io/test_slp.py`: **289 passed**. `ruff` clean. Changed region fully covered (no dead branch).
- Backward-compat read of an uncompressed `roi_wkb` is already covered by the existing `test_slp_backward_compat_roi_json_attrs`.

## Design decisions

- **`compression_opts=1`** — mirrors `/mask_rle` and `/label_image_data`.
- **No `format_id` bump** — gzip is a transparent HDF5 filter; the format already gzip-filters `/mask_rle`, embedded video, and chunked `/label_image_data`, so no reader gains a new capability requirement.
- **Scope** — only `/roi_wkb`. The remaining uncompressed packed-byte datasets (`/mask_score_maps`, `/label_image_score_maps`, legacy blob `/label_image_data`) are intentionally left alone: their payloads are already zlib-compressed at the application level, so the HDF5 gzip filter on top would waste CPU for ~0 gain. `roi_wkb` was the only raw-bytes target left.

## Adversarial review

Reviewed via a multi-agent workflow (6 dimensions × adversarial verification + completeness critic). **No blockers.** Every verifier independently confirmed the dropped-guard is safe (`wkb_flat` always ≥9 bytes). All confirmed findings — a comment-precision nit, a doc-wording imprecision, and ROI-type/empty-geometry test gaps — were addressed in this PR; one false-positive finding was rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)