### PR TITLE
fix(render): render instance-less frames via Labels path when no skeletons exist (#466)

### DIFF
--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -992,13 +992,28 @@ def render_image(
 
         if lf is not None:
             instances = list(lf.instances)
-            skeleton = instances[0].skeleton if instances else source.skeletons[0]
-            edge_inds = skeleton.edge_inds
-            node_names = [n.name for n in skeleton.nodes]
+            if instances:
+                skeleton = instances[0].skeleton
+            elif source.skeletons:
+                # No instances but skeletons exist: use the first skeleton for
+                # pose-rendering metadata (e.g. trail node resolution).
+                skeleton = source.skeletons[0]
+            else:
+                # No instances and no skeletons — segmentation/overlay-only
+                # frame (e.g. bottom-up mask tracking). Fall through with empty
+                # pose state so the background and any overlay (masks, label
+                # images, ROIs, bboxes) still render instead of crashing.
+                # Mirrors the LabeledFrame branch below.
+                skeleton = None
+            edge_inds = skeleton.edge_inds if skeleton is not None else []
+            node_names = (
+                [n.name for n in skeleton.nodes] if skeleton is not None else []
+            )
             fidx_for_callback = lf.frame_idx
         else:
             # Centroid-only / spatial-only mode: no labeled frames.
             instances = []
+            skeleton = None
             edge_inds = []
             node_names = []
             fidx_for_callback = frame_idx if frame_idx is not None else 0
@@ -1197,7 +1212,12 @@ def render_image(
     # context, so they are only drawn when the source is a Labels object. They
     # are drawn even when the current frame has no instances, since past frames
     # may still contribute (matching render_video).
-    if show_trails and isinstance(source, Labels) and trail_length > 0:
+    if (
+        show_trails
+        and isinstance(source, Labels)
+        and trail_length > 0
+        and skeleton is not None
+    ):
         from sleap_io.rendering.overlays import draw_trails as _draw_trails
 
         trail_targets = _resolve_trail_node(trail_node, skeleton)

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 from click.testing import CliRunner
 
-from sleap_io import load_slp, save_video
+from sleap_io import load_slp, save_slp, save_video
 from sleap_io.io.cli import (
     _get_ffmpeg_version,
     _is_ffmpeg_available,
@@ -26,6 +26,7 @@ from sleap_io.io.cli import (
 from sleap_io.model.instance import Instance, PredictedInstance
 from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
+from sleap_io.model.mask import PredictedSegmentationMask
 from sleap_io.model.skeleton import Skeleton
 from sleap_io.model.video import Video
 from sleap_io.version import __version__
@@ -4383,6 +4384,45 @@ def test_filenames_save_failure(tmp_path, slp_typical):
 # ============================================================================
 # Render command crop tests
 # ============================================================================
+
+
+@pytest.mark.parametrize("specifier", [["--lf", "0"], ["--frame", "0"]])
+def test_render_single_frame_masks_only_no_skeleton(specifier, tmp_path):
+    """``sio render --lf/--frame`` works on a mask-only, skeleton-less .slp.
+
+    Regression test for issue #466: bottom-up segmentation tracking output has
+    zero skeletons and frames carrying only ``PredictedSegmentationMask`` (no
+    instances). The single-image CLI modes used to fail with
+    ``Failed to render: list index out of range`` while ``--start/--end``
+    (``render_video``) worked. Both ``--lf`` and ``--frame`` must now render.
+    """
+    m = np.zeros((64, 64), dtype=bool)
+    m[10:30, 10:30] = True
+    mask = PredictedSegmentationMask.from_numpy(m, score=0.9)
+    video = Video(filename="dummy.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[], masks=[mask])
+    labels = Labels(labeled_frames=[lf], videos=[video])
+    slp_path = tmp_path / "masks_only.slp"
+    save_slp(labels, str(slp_path))
+
+    output_path = tmp_path / "frame.png"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            str(slp_path),
+            *specifier,
+            "--background",
+            "black",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Rendered:" in result.output
+    assert output_path.exists()
 
 
 def test_render_crop_pixel(centered_pair, tmp_path):

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -1207,6 +1207,155 @@ class TestRenderImage:
         assert isinstance(rendered_bg, np.ndarray)
         assert rendered_bg.ndim == 3 and rendered_bg.shape[-1] == 3
 
+    def test_render_image_labels_instanceless_no_skeleton_lf_ind(self):
+        """``render_image(labels, lf_ind=...)`` works for a mask-only frame.
+
+        Bottom-up segmentation tracking produces ``Labels`` with zero skeletons
+        and frames that carry only ``PredictedSegmentationMask`` objects (no
+        ``Instance``s). The ``Labels`` branch previously indexed
+        ``source.skeletons[0]`` unconditionally and crashed with ``IndexError``
+        on these frames (issue #466). It should now fall through to empty pose
+        state and still draw the masks, mirroring the ``LabeledFrame`` path.
+        """
+        m = np.zeros((64, 64), dtype=bool)
+        m[10:30, 10:30] = True
+        mask = sio.PredictedSegmentationMask.from_numpy(m, score=0.9)
+        video = sio.Video(filename="dummy.mp4")
+        lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[], masks=[mask])
+        labels = sio.Labels(labeled_frames=[lf], videos=[video])
+        assert len(labels.skeletons) == 0
+
+        rendered = render_image(labels, lf_ind=0, background="black")
+        assert isinstance(rendered, np.ndarray)
+        assert rendered.ndim == 3 and rendered.shape[-1] == 3
+        # The mask should actually be drawn (not just a blank background).
+        assert rendered.sum() > 0
+
+    def test_render_image_labels_instanceless_no_skeleton_video_frame_idx(self):
+        """``render_image(labels, video=, frame_idx=)`` works for a mask-only frame.
+
+        Same instance-less, skeleton-less case as the ``lf_ind`` path but reached
+        via the ``video`` + ``frame_idx`` specifier (the ``sio render --frame``
+        CLI surface). Both must avoid the ``IndexError`` from issue #466.
+        """
+        m = np.zeros((64, 64), dtype=bool)
+        m[10:30, 10:30] = True
+        mask = sio.PredictedSegmentationMask.from_numpy(m, score=0.9)
+        video = sio.Video(filename="dummy.mp4")
+        lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[], masks=[mask])
+        labels = sio.Labels(labeled_frames=[lf], videos=[video])
+
+        rendered = render_image(labels, video=0, frame_idx=0, background="black")
+        assert isinstance(rendered, np.ndarray)
+        assert rendered.ndim == 3 and rendered.shape[-1] == 3
+        assert rendered.sum() > 0
+
+    def test_render_image_labels_instanceless_no_skeleton_default_frame(self):
+        """``render_image(labels)`` defaults to the first frame for a mask-only file.
+
+        With no frame specifier the ``Labels`` branch defaults to the first
+        labeled frame. A skeleton-less, instance-less first frame must not crash.
+        """
+        m = np.zeros((64, 64), dtype=bool)
+        m[10:30, 10:30] = True
+        mask = sio.PredictedSegmentationMask.from_numpy(m, score=0.9)
+        video = sio.Video(filename="dummy.mp4")
+        lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[], masks=[mask])
+        labels = sio.Labels(labeled_frames=[lf], videos=[video])
+
+        rendered = render_image(labels, background="black")
+        assert isinstance(rendered, np.ndarray)
+        assert rendered.ndim == 3 and rendered.shape[-1] == 3
+        assert rendered.sum() > 0
+
+    def test_render_image_labels_instanceless_matches_labeled_frame_path(self):
+        """The ``Labels`` and ``LabeledFrame`` paths render identically.
+
+        Issue #466 was an asymmetry: a mask-only frame rendered fine when passed
+        as a ``LabeledFrame`` but crashed when reached through ``Labels``. With a
+        known video shape (the real mask-tracking case), all ``Labels`` entry
+        points must produce pixel-identical output to the ``LabeledFrame`` path.
+        """
+        m = np.zeros((64, 64), dtype=bool)
+        m[10:30, 10:30] = True
+        mask = sio.PredictedSegmentationMask.from_numpy(m, score=0.9)
+        video = sio.Video(
+            filename="dummy.mp4", backend_metadata={"shape": (1, 64, 64, 3)}
+        )
+        lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[], masks=[mask])
+        labels = sio.Labels(labeled_frames=[lf], videos=[video])
+
+        from_lf = render_image(lf, background="black")
+        from_lf_ind = render_image(labels, lf_ind=0, background="black")
+        from_video_frame = render_image(
+            labels, video=0, frame_idx=0, background="black"
+        )
+
+        assert np.array_equal(from_lf, from_lf_ind)
+        assert np.array_equal(from_lf, from_video_frame)
+
+    def test_render_image_labels_instanceless_show_trails_skipped(self):
+        """``show_trails=True`` on a skeleton-less mask-only frame is a no-op.
+
+        The trails block is guarded on ``skeleton is not None`` (mirroring
+        ``render_video``). With no skeleton the whole block is skipped *before*
+        ``trail_node`` is ever resolved, so the frame still renders its masks and
+        the ``trail_node`` value is inert: an unresolvable named node produces
+        the same image as the default centroid trail rather than crashing.
+        Without the guard this path raised (``IndexError`` before the skeleton
+        fallback, ``AttributeError`` from ``None.index`` after it).
+        """
+        m = np.zeros((64, 64), dtype=bool)
+        m[10:30, 10:30] = True
+        mask = sio.PredictedSegmentationMask.from_numpy(m, score=0.9)
+        video = sio.Video(filename="dummy.mp4")
+        lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[], masks=[mask])
+        labels = sio.Labels(labeled_frames=[lf], videos=[video])
+
+        rendered = render_image(labels, lf_ind=0, background="black", show_trails=True)
+        assert rendered.sum() > 0  # masks still drawn
+        # trail_node is never resolved (block skipped), so an unresolvable named
+        # node yields the exact same image as the default centroid trail.
+        rendered_named = render_image(
+            labels, lf_ind=0, background="black", show_trails=True, trail_node="nose"
+        )
+        assert np.array_equal(rendered, rendered_named)
+
+    def test_render_image_spatial_only_no_labeled_frame(self):
+        """``render_image`` renders a frame with no ``LabeledFrame`` (centroid-only).
+
+        When a ``Labels`` carries centroids but the requested ``frame_idx`` has no
+        ``LabeledFrame``, the ``Labels`` branch resolves ``lf`` to ``None`` and
+        enters the spatial-only path (no instances, no skeleton). This must
+        render the background without error. With ``show_trails=True`` this path
+        also exercises the ``skeleton is not None`` trails guard: ``skeleton`` is
+        ``None`` here, so trails are skipped rather than dereferencing an unset
+        skeleton.
+        """
+        from sleap_io.model.centroid import UserCentroid
+        from sleap_io.model.instance import Track
+
+        track = Track(name="t1")
+        video = sio.Video(
+            filename="dummy.mp4", backend_metadata={"shape": (10, 64, 64, 3)}
+        )
+        lf0 = sio.LabeledFrame(video=video, frame_idx=0)
+        lf0.centroids.append(UserCentroid(x=10.0, y=10.0, track=track))
+        labels = sio.Labels(
+            labeled_frames=[lf0], skeletons=[sio.Skeleton(["A"])], tracks=[track]
+        )
+
+        # frame_idx 5 has no LabeledFrame -> spatial-only (lf is None) path.
+        rendered = render_image(labels, video=video, frame_idx=5, background="black")
+        assert isinstance(rendered, np.ndarray)
+        assert rendered.shape == (64, 64, 3)
+
+        # show_trails on the lf-less path must not crash (skeleton is None).
+        rendered_trails = render_image(
+            labels, video=video, frame_idx=5, background="black", show_trails=True
+        )
+        assert isinstance(rendered_trails, np.ndarray)
+
     def test_render_image_video_unavailable_with_background(self, labels_predictions):
         """Test frame size estimation from keypoints when video unavailable."""
         # Make a copy so we don't modify the fixture


### PR DESCRIPTION
## Summary

Fixes #466. `render_image()` — and therefore the `sio render --lf` / `--frame` single-image CLI modes — crashed with `IndexError: list index out of range` when asked to render a `LabeledFrame` that has **no keypoint instances** while the parent `Labels` has **no skeletons**. This is exactly the shape of bottom-up segmentation mask tracking output: every frame carries `PredictedSegmentationMask` objects in `LabeledFrame.masks`, zero `Instance`s, and the `Labels` has zero skeletons.

The same frame rendered fine when passed as a `LabeledFrame` directly, and the whole video rendered fine via `render_video` — so this was an **asymmetry between two code paths**, not a fundamental limitation.

## Root cause

In the `Labels` branch of `render_image`, the skeleton was resolved by indexing `source.skeletons[0]` unconditionally whenever the frame had no instances:

```python
skeleton = instances[0].skeleton if instances else source.skeletons[0]
```

When `lf.instances` is empty **and** `source.skeletons` is also empty, `source.skeletons[0]` raised `IndexError`. The `LabeledFrame` branch already guarded the identical situation (`#461`), but the `Labels` branch did not.

## Key Changes

- **`sleap_io/rendering/core.py`** — Guard the `Labels`-branch skeleton lookup:
  - `instances` present → use `instances[0].skeleton` (unchanged).
  - no instances but `source.skeletons` present → use `source.skeletons[0]` (unchanged behavior, now explicit).
  - no instances **and** no skeletons → `skeleton = None`, `edge_inds = []`, `node_names = []` — render background + overlays with empty pose state (mirrors the `LabeledFrame` branch).
- Bind `skeleton = None` in the centroid-only (`lf is None`) branch so the variable is always defined in the `Labels` path.
- Add `skeleton is not None` to the trails guard, matching `render_video`. This also fixes a **latent `NameError`/`AttributeError`** on the `show_trails=True` + skeleton-less path (`skeleton` was previously unbound there, or `None.index()` would have been called for a named `trail_node`).

## Example Usage

```python
import sleap_io as sio
import numpy as np

mask = sio.PredictedSegmentationMask.from_numpy(np.random.rand(256, 256) > 0.5, score=0.9)
lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[], masks=[mask])
labels = sio.Labels(labeled_frames=[lf], videos=[video])

sio.render_image(lf, background="black")                            # already worked
sio.render_image(labels, lf_ind=0, background="black")              # now works (was IndexError)
sio.render_image(labels, video=0, frame_idx=0, background="black")  # now works (was IndexError)
```

```bash
sio render preds.slp --lf 0 -o frame.png      # now works
sio render preds.slp --frame 0 -o frame.png   # now works
```

## API Changes

None. Behavior change is strictly: a case that previously raised `IndexError` now renders successfully (matching the `LabeledFrame` path).

## Testing

- `tests/rendering/test_rendering.py` — 6 new tests: the `lf_ind`, `video`+`frame_idx`, and default-frame entry points on a mask-only/skeleton-less `Labels`; **pixel-identity** between the `Labels` and `LabeledFrame` paths (with a known video shape); `show_trails=True` is a safe no-op when there is no skeleton; and the centroid-only/spatial-only (`lf is None`) path.
- `tests/io/test_cli.py` — parametrized end-to-end test of `sio render --lf 0` / `--frame 0` on a saved mask-only `.slp` (the exact reported CLI symptom).
- All changed lines are covered (file coverage 93.9% → 94.6%); `ruff check`/`format` clean; full `tests/rendering` + `tests/io/test_cli.py` suites pass (758 tests).

## Design Decisions

- **Mirror the existing `LabeledFrame` fallback** rather than inventing new behavior — the two paths should be symmetric for instance-less frames, and the pixel-identity test locks that in.
- **Guard the trails block** (`skeleton is not None`) the same way `render_video` already does, instead of leaving `skeleton` possibly-`None` to be dereferenced downstream.
- **Out of scope (deferred to separate cleanup PRs, surfaced by adversarial review):** (1) the pre-existing shapeless-video default-canvas-size divergence (`Labels` → 512×512 vs `LabeledFrame` → 64×64; only when `video.shape is None`); (2) a pre-existing cross-video centroid bleed in the centroid-drawing block (`get_centroids(frame_idx=...)` lacks a `video=` filter). Neither is introduced or touched by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)