### PR TITLE
fix(render): scope render_image centroids to the rendered video

### DIFF
--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -1260,7 +1260,22 @@ def render_image(
         from sleap_io.rendering.overlays import draw_centroids as _draw_centroids
 
         render_fidx = fidx_for_callback
-        frame_centroids = source.get_centroids(frame_idx=render_fidx)
+        if lf is not None:
+            # Scope to the rendered frame's own video. A centroid on a
+            # *different* video that happens to share this frame index must not
+            # bleed in, so read this frame's centroids directly (mirroring
+            # render_video's per-frame `lf.centroids`).
+            frame_centroids = list(lf.centroids)
+        else:
+            # No labeled frame resolved — only reachable via an explicit
+            # video+frame_idx that matched no frame, so `video` is a concrete
+            # spec. Scope centroids to it so a *different* video's centroid that
+            # shares this frame index can't bleed in (mirrors render_video's
+            # get_centroids(video=target_video)).
+            target_video = source.videos[video] if isinstance(video, int) else video
+            frame_centroids = source.get_centroids(
+                video=target_video, frame_idx=render_fidx
+            )
         if frame_centroids:
             if render_image_data.ndim == 2:
                 render_image_data = np.stack([render_image_data] * 3, axis=-1)

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -3943,6 +3943,124 @@ def test_render_image_with_centroids():
     assert non_white.sum() > 0
 
 
+def test_render_image_centroids_scoped_to_rendered_video():
+    """render_image only draws centroids from the rendered frame's own video.
+
+    In a multi-video Labels where two videos share a frame index, the centroid
+    block used to query ``get_centroids(frame_idx=...)`` without a ``video=``
+    filter, so a centroid from a *different* video at the same frame index bled
+    onto the rendered frame. The query is now scoped to the rendered frame's
+    video (read from ``lf.centroids``), matching ``render_video``.
+    """
+    from sleap_io.model.centroid import UserCentroid
+    from sleap_io.model.instance import Track
+
+    video_a = sio.Video(filename="A.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    video_b = sio.Video(filename="B.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    track_a, track_b = Track(name="a"), Track(name="b")
+    lf_a = sio.LabeledFrame(video=video_a, frame_idx=0)
+    lf_a.centroids.append(UserCentroid(x=10.0, y=10.0, track=track_a))
+    lf_b = sio.LabeledFrame(video=video_b, frame_idx=0)
+    lf_b.centroids.append(UserCentroid(x=50.0, y=50.0, track=track_b))
+    labels = sio.Labels(
+        labeled_frames=[lf_a, lf_b],
+        videos=[video_a, video_b],
+        tracks=[track_a, track_b],
+    )
+
+    # Render video B's frame 0 by every entry point; video A's centroid at
+    # (10, 10) must never appear while video B's at (50, 50) must.
+    for kwargs in (
+        {"video": video_b, "frame_idx": 0},  # Video object
+        {"video": 1, "frame_idx": 0},  # video index
+        {"lf_ind": 1},  # labeled-frame index
+    ):
+        rendered = render_image(
+            labels, background="black", show_centroids=True, **kwargs
+        )
+        a_region = rendered[0:25, 0:25].sum()  # around video A's (10, 10)
+        b_region = rendered[40:64, 40:64].sum()  # around video B's (50, 50)
+        assert a_region == 0, f"video A centroid bled in via {kwargs}"
+        assert b_region > 0, f"video B centroid missing via {kwargs}"
+
+    # And the symmetric case: rendering video A shows A's centroid, not B's.
+    rendered_a = render_image(
+        labels, video=video_a, frame_idx=0, background="black", show_centroids=True
+    )
+    assert rendered_a[0:25, 0:25].sum() > 0
+    assert rendered_a[40:64, 40:64].sum() == 0
+
+
+def test_render_image_centroids_scoped_when_no_labeled_frame():
+    """Centroid scoping holds even when the requested frame has no LabeledFrame.
+
+    When ``video`` + ``frame_idx`` resolve to no ``LabeledFrame`` (so ``lf`` is
+    None) but the ``Labels`` still has centroids on another video at that frame
+    index, the spatial-only centroid query must be scoped to the requested
+    video. Otherwise the other video's centroid bleeds onto the rendered frame
+    (the same bug as the concrete-``lf`` path, via a different entry point).
+    """
+    from sleap_io.model.centroid import UserCentroid
+
+    video_a = sio.Video(filename="A.mp4", backend_metadata={"shape": (10, 64, 64, 3)})
+    video_b = sio.Video(filename="B.mp4", backend_metadata={"shape": (10, 64, 64, 3)})
+    lf_a = sio.LabeledFrame(video=video_a, frame_idx=5)
+    lf_a.centroids.append(UserCentroid(x=10.0, y=10.0))
+    # video_b has no LabeledFrame at frame 5.
+    labels = sio.Labels(labeled_frames=[lf_a], videos=[video_a, video_b])
+
+    # Render video B's (absent) frame 5: video A's centroid must not appear.
+    for video_spec in (video_b, 1):
+        rendered = render_image(
+            labels,
+            video=video_spec,
+            frame_idx=5,
+            background="black",
+            show_centroids=True,
+        )
+        assert rendered[0:25, 0:25].sum() == 0
+
+    # Rendering video A's own frame 5 still draws its centroid.
+    rendered_a = render_image(
+        labels, video=video_a, frame_idx=5, background="black", show_centroids=True
+    )
+    assert rendered_a[0:25, 0:25].sum() > 0
+
+
+def test_render_image_centroids_scoped_lazy_roundtrip(tmp_path):
+    """Centroid video-scoping survives a lazy ``.slp`` round-trip.
+
+    Hardens the scoped centroid path against regressions in lazy frame
+    materialization: a multi-video Labels saved and reloaded with ``lazy=True``
+    must still render only the requested video's centroid.
+    """
+    from sleap_io.model.centroid import UserCentroid
+    from sleap_io.model.instance import Track
+
+    video_a = sio.Video(filename="A.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    video_b = sio.Video(filename="B.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    track_a, track_b = Track(name="a"), Track(name="b")
+    lf_a = sio.LabeledFrame(video=video_a, frame_idx=0)
+    lf_a.centroids.append(UserCentroid(x=10.0, y=10.0, track=track_a))
+    lf_b = sio.LabeledFrame(video=video_b, frame_idx=0)
+    lf_b.centroids.append(UserCentroid(x=50.0, y=50.0, track=track_b))
+    labels = sio.Labels(
+        labeled_frames=[lf_a, lf_b],
+        videos=[video_a, video_b],
+        tracks=[track_a, track_b],
+    )
+    slp_path = tmp_path / "multivideo_centroids.slp"
+    sio.save_slp(labels, str(slp_path))
+    reloaded = sio.load_slp(str(slp_path), lazy=True)
+    assert reloaded.is_lazy
+
+    rendered = render_image(
+        reloaded, video=1, frame_idx=0, background="black", show_centroids=True
+    )
+    assert rendered[0:25, 0:25].sum() == 0  # video A's centroid not drawn
+    assert rendered[40:64, 40:64].sum() > 0  # video B's centroid drawn
+
+
 def test_render_video_centroids_only():
     """render_video works with centroid-only Labels (no labeled frames)."""
     from sleap_io.model.centroid import UserCentroid


### PR DESCRIPTION
## Summary

Fixes a cross-video centroid bleed in `render_image`, surfaced by the adversarial review of #467.

`render_image`'s centroid-drawing block queried `Labels.get_centroids(frame_idx=...)` **without a `video=` filter**. In a multi-video `Labels` where two videos share a frame index, centroids belonging to a *different* video at the same frame index were drawn onto the rendered frame. `render_video` was unaffected — it reads per-frame `lf.centroids` directly.

## Root cause

```python
# sleap_io/rendering/core.py — centroid-drawing block
frame_centroids = source.get_centroids(frame_idx=render_fidx)  # no video filter
```

`get_centroids(frame_idx=N)` (without `video=`) scans **all** videos for frames matching that index, so a centroid on video A at frame N is returned when rendering video B's frame N.

## Key Changes

Scope the centroid query to the rendered frame's video (`sleap_io/rendering/core.py`):

- **Concrete `LabeledFrame` resolved** (`lf_ind`, `video`+`frame_idx` matching a frame, default-first-frame): read its own `lf.centroids` directly — video-scoped by construction, mirroring `render_video`'s `_draw_frame_centroids`.
- **No `LabeledFrame` resolved** (spatial-only mode — only reachable via an explicit `video`+`frame_idx` that matched no frame): scope `get_centroids` to the requested `video`, so another video's centroid at that frame index can't bleed in.

## Example

```python
# Two videos sharing frame index 0, each with its own centroid.
labels = sio.Labels(labeled_frames=[lf_a, lf_b], videos=[video_a, video_b], ...)

# Before: video A's centroid bled onto video B's rendered frame.
# After:  only video B's centroid is drawn.
sio.render_image(labels, video=video_b, frame_idx=0, show_centroids=True)
```

## API Changes

None. Behavior change only: centroids are now correctly scoped to the rendered video (previously over-inclusive in multi-video projects). Single-video projects are unaffected.

## Testing

Three new tests in `tests/rendering/test_rendering.py`:
- `test_render_image_centroids_scoped_to_rendered_video` — multi-video, both videos have a frame at the shared index; asserts no bleed across all three concrete-`lf` entry points (Video object / video index / `lf_ind`) plus the symmetric case.
- `test_render_image_centroids_scoped_when_no_labeled_frame` — the `lf is None` path: video B has **no** `LabeledFrame` at the rendered frame while video A does; asserts A's centroid does not bleed in and A's own render still draws it.
- `test_render_image_centroids_scoped_lazy_roundtrip` — multi-video `save_slp` → `load_slp(lazy=True)` → render; confirms scoping survives lazy frame materialization.

All changed lines covered; `ruff` clean; full `tests/rendering` suite passes (252 tests).

## Design Decisions

- **Read `lf.centroids` directly** when a frame is resolved rather than re-querying — simplest, avoids any duplicate-frame ambiguity, and matches how `render_video` already draws centroids.
- **Re-resolve `target_video` from the `video` parameter** inside the spatial-only branch (rather than relying on an outer binding) to keep the fix self-contained; the branch is only reachable when `video` is a concrete spec.
- **Adversarially reviewed**: an initial version scoped only the concrete-`lf` path; a multi-agent review caught that the spatial-only (`lf is None`) branch retained the identical bleed via the `video`+`frame_idx`-with-no-matching-frame entry point. This PR scopes both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)