### PR TITLE
fix(render): color segmentation masks (and ROI/bbox) by track identity

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -691,6 +691,15 @@ Overlay segmentation masks on images via `render_image`/`render_video` or standa
     box. Pass an explicit `overlay` to override. Auto-drawing works on both RGB
     and single-channel grayscale `(H, W, 1)` video.
 
+!!! note "Coloring overlays by track"
+    With `color_by="track"` (the default `"auto"` when the labels carry tracks),
+    `SegmentationMask`, `ROI`, and `BoundingBox` overlays are colored by their
+    `.track` identity using the pose `palette`, so a tracked object keeps a
+    stable color across frames and matches its poses, centroids, and trails.
+    Untracked elements use the first palette color. When `color_by` is not
+    `"track"` (or the overlay carries no tracks), elements fall back to
+    positional coloring from `overlay_palette` (default `"distinct"`).
+
 ### Using render_image / render_video
 
 The `overlay` parameter on `render_image` and `render_video` accepts label images, `SegmentationMask`, `ROI`, or `BoundingBox` objects:

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -481,6 +481,7 @@ def _apply_overlay(
     outline: bool = False,
     outline_width: int = 1,
     outline_color: tuple[int, int, int] | None = None,
+    colors: list[tuple[int, int, int]] | None = None,
 ) -> np.ndarray:
     """Apply an annotation overlay to an image, dispatching by type.
 
@@ -502,6 +503,10 @@ def _apply_overlay(
         outline: Draw outlines (only used for label images).
         outline_width: Outline width in pixels.
         outline_color: Uniform outline color, or ``None`` for auto-darkened.
+        colors: Optional per-element RGB colors for a ``list`` overlay. When
+            provided, overrides the positional ``palette`` coloring (used by
+            callers to color overlays by track identity). Must match the length
+            of ``overlay``. Ignored for label-image overlays.
 
     Returns:
         The modified image array.
@@ -549,7 +554,8 @@ def _apply_overlay(
                 "happen at the render_video level."
             )
 
-        colors = get_palette(palette, len(overlay))
+        if colors is None:
+            colors = get_palette(palette, len(overlay))
 
         if isinstance(first, SegmentationMask):
             draw_masks(image, overlay, colors=colors, alpha=alpha)
@@ -1171,6 +1177,15 @@ def render_image(
     ):
         overlay = list(lf.masks)
 
+    # Determine color scheme up front so track-colored overlays (masks/ROIs/
+    # bboxes) can match the pose/centroid/trail track colors. Consumed below by
+    # both the overlay block and the pose render_frame call.
+    resolved_scheme = determine_color_scheme(
+        has_tracks=has_tracks,
+        is_single_image=True,
+        scheme=color_by,
+    )
+
     # Apply cropping if specified
     render_image_data = image
     render_points = instances_points
@@ -1198,6 +1213,27 @@ def render_image(
             x1, y1, x2, y2 = crop_bounds
             oh, ow = overlay.shape[:2]
             render_overlay = overlay[max(0, y1) : min(oh, y2), max(0, x1) : min(ow, x2)]
+        # Color overlay elements (masks/ROIs/bboxes) by track identity when
+        # color_by resolves to "track", matching poses/centroids/trails (same
+        # `palette`). Otherwise fall through to positional `overlay_palette`
+        # coloring. Gated on a Labels source since only that branch builds the
+        # track index map; untracked elements fall back to the first color.
+        overlay_colors = None
+        if (
+            resolved_scheme == "track"
+            and isinstance(source, Labels)
+            and isinstance(render_overlay, list)
+            and render_overlay
+            and not _is_label_image(render_overlay[0])
+        ):
+            ov_pal = get_palette(palette, max(len(source.tracks), 1))
+            overlay_colors = []
+            for el in render_overlay:
+                t = getattr(el, "track", None)
+                tidx = img_track_idx_map.get(id(t)) if t is not None else None
+                overlay_colors.append(
+                    ov_pal[tidx % len(ov_pal)] if tidx is not None else ov_pal[0]
+                )
         _apply_overlay(
             render_image_data,
             render_overlay,
@@ -1206,6 +1242,7 @@ def render_image(
             outline=overlay_outline,
             outline_width=overlay_outline_width,
             outline_color=overlay_outline_color,
+            colors=overlay_colors,
         )
 
     # Draw motion trails behind the poses and centroids. Trails need temporal
@@ -1317,13 +1354,6 @@ def render_image(
         if hasattr(inst, "score"):
             meta["confidence"] = inst.score
         instance_metadata.append(meta)
-
-    # Determine color scheme
-    resolved_scheme = determine_color_scheme(
-        has_tracks=has_tracks,
-        is_single_image=True,
-        scheme=color_by,
-    )
 
     # Render
     rendered = render_frame(
@@ -1857,6 +1887,27 @@ def render_video(
                     kwargs["score"] = frame_overlay.score
                     kwargs["score_map"] = frame_overlay.score_map
                 cropped_overlay = type(frame_overlay)(**kwargs)
+        # Color overlay elements (masks/ROIs/bboxes) by track identity when
+        # color_by resolves to "track", matching poses/centroids/trails (same
+        # `palette`). Otherwise fall through to positional `overlay_palette`.
+        # Untracked elements fall back to the first palette color.
+        overlay_colors = None
+        if (
+            resolved_scheme == "track"
+            and _overlay_palette_by_track
+            and isinstance(cropped_overlay, list)
+            and cropped_overlay
+            and not _is_label_image(cropped_overlay[0])
+        ):
+            overlay_colors = []
+            for el in cropped_overlay:
+                t = getattr(el, "track", None)
+                tidx = _track_idx_map.get(id(t)) if t is not None else None
+                overlay_colors.append(
+                    _overlay_palette_by_track[tidx % len(_overlay_palette_by_track)]
+                    if tidx is not None
+                    else _overlay_palette_by_track[0]
+                )
         _apply_overlay(
             image,
             cropped_overlay,
@@ -1865,6 +1916,7 @@ def render_video(
             outline=overlay_outline,
             outline_width=overlay_outline_width,
             outline_color=overlay_outline_color,
+            colors=overlay_colors,
         )
         return image
 
@@ -1872,6 +1924,12 @@ def render_video(
     _track_idx_map: dict[int, int] = {}
     if labels is not None and has_tracks:
         _track_idx_map = {id(t): i for i, t in enumerate(labels.tracks)}
+
+    # Track-keyed palette for overlay (mask/ROI/bbox) coloring under
+    # color_by="track", matching centroids/poses/trails (same `palette`).
+    _overlay_palette_by_track: list[tuple[int, int, int]] = []
+    if labels is not None and has_tracks:
+        _overlay_palette_by_track = get_palette(palette, max(len(labels.tracks), 1))
 
     def _draw_frame_centroids(
         image: np.ndarray, fidx: int, crop_off: tuple[float, float] = (0.0, 0.0)

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -1216,12 +1216,15 @@ def render_image(
         # Color overlay elements (masks/ROIs/bboxes) by track identity when
         # color_by resolves to "track", matching poses/centroids/trails (same
         # `palette`). Otherwise fall through to positional `overlay_palette`
-        # coloring. Gated on a Labels source since only that branch builds the
-        # track index map; untracked elements fall back to the first color.
+        # coloring. Gated on a Labels source with tracks (only that branch builds
+        # the track index map; `has_tracks` mirrors render_video so track-less
+        # labels stay positional). Untracked elements fall back to the first
+        # color.
         overlay_colors = None
         if (
             resolved_scheme == "track"
             and isinstance(source, Labels)
+            and has_tracks
             and isinstance(render_overlay, list)
             and render_overlay
             and not _is_label_image(render_overlay[0])

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -12,10 +12,12 @@ from shapely.geometry import box
 
 import sleap_io as sio
 from sleap_io.model.bbox import UserBoundingBox
+from sleap_io.model.instance import Track
 from sleap_io.model.label_image import PredictedLabelImage, UserLabelImage
 from sleap_io.model.mask import UserSegmentationMask
 from sleap_io.model.roi import UserROI
 from sleap_io.rendering import render_video
+from sleap_io.rendering.colors import get_palette
 from sleap_io.rendering.core import render_image
 from sleap_io.rendering.overlays import (
     draw_bboxes,
@@ -3291,6 +3293,241 @@ def _make_mask_labels(n_frames=2, h=64, w=64, mask_box=(40, 60, 40, 60)):
     return sio.Labels(
         labeled_frames=labeled_frames, videos=[video], skeletons=[skeleton]
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #469: color_by="track" must color segmentation masks (and ROI/bbox) by
+# track identity, not by position in the frame's annotation list.
+# ---------------------------------------------------------------------------
+
+_BOX_A = (5, 20, 5, 20)
+_BOX_B = (40, 60, 40, 60)
+
+
+def _box_mask(box, track=None, h=64, w=64):
+    """A ``UserSegmentationMask`` covering ``box`` (y0, y1, x0, x1)."""
+    binary = np.zeros((h, w), dtype=bool)
+    y0, y1, x0, x1 = box
+    binary[y0:y1, x0:x1] = True
+    return UserSegmentationMask.from_numpy(binary, track=track)
+
+
+def _box_center_color(img, box):
+    """RGB tuple at the center of ``box`` (y0, y1, x0, x1)."""
+    y0, y1, x0, x1 = box
+    return tuple(int(v) for v in img[(y0 + y1) // 2, (x0 + x1) // 2])
+
+
+def test_render_video_masks_color_by_track_stable_under_position_shuffle():
+    """A track's mask keeps its color when its list position shuffles (#469).
+
+    This is the core regression: two tracked masks swap their order within
+    ``lf.masks`` between frames while their ``.track`` stays fixed. With
+    ``color_by="track"`` each track's region must render the same color across
+    frames (positional coloring would flicker).
+    """
+    track_a, track_b = Track(name="A"), Track(name="B")
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (2, 64, 64, 3)})
+    lf0 = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        masks=[_box_mask(_BOX_A, track_a), _box_mask(_BOX_B, track_b)],
+    )
+    # Frame 1: same pixel regions, but the list order is swapped.
+    lf1 = sio.LabeledFrame(
+        video=video,
+        frame_idx=1,
+        masks=[_box_mask(_BOX_B, track_b), _box_mask(_BOX_A, track_a)],
+    )
+    labels = sio.Labels(
+        labeled_frames=[lf0, lf1], videos=[video], tracks=[track_a, track_b]
+    )
+
+    frames = render_video(
+        labels,
+        color_by="track",
+        background="black",
+        overlay_alpha=1.0,
+        show_progress=False,
+        frame_inds=[0, 1],
+    )
+    a0, a1 = _box_center_color(frames[0], _BOX_A), _box_center_color(frames[1], _BOX_A)
+    b0, b1 = _box_center_color(frames[0], _BOX_B), _box_center_color(frames[1], _BOX_B)
+    assert a0 == a1, "track A mask flickered when its list position changed"
+    assert b0 == b1, "track B mask flickered when its list position changed"
+    assert a0 != b0, "distinct tracks should render distinct colors"
+
+
+def test_render_image_masks_color_by_track_keyed_not_positional():
+    """render_image colors masks by track index, not list position (#469).
+
+    Track A (index 0) is placed *last* in the mask list; it must still get
+    palette color 0, and the color must come from the pose ``palette``
+    ("standard"), matching poses/centroids/trails — not ``overlay_palette``.
+    """
+    track_a, track_b = Track(name="A"), Track(name="B")
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        # track_b first, track_a second — order is the reverse of track index.
+        masks=[_box_mask(_BOX_B, track_b), _box_mask(_BOX_A, track_a)],
+    )
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], tracks=[track_a, track_b])
+
+    img = render_image(
+        labels, lf_ind=0, color_by="track", background="black", overlay_alpha=1.0
+    )
+    pal = get_palette("standard", 2)
+    assert _box_center_color(img, _BOX_A) == pal[0]  # track A -> index 0
+    assert _box_center_color(img, _BOX_B) == pal[1]  # track B -> index 1
+
+
+def test_render_image_masks_untracked_and_mixed_fall_back_to_palette0():
+    """Untracked masks fall back to palette[0] under color_by="track" (#469).
+
+    A mask with ``track=None`` in a track-colored frame must not crash and must
+    render the first palette color, while a tracked mask in the same frame keeps
+    its own track color (mirrors centroid behavior).
+    """
+    track_a, track_b = Track(name="A"), Track(name="B")
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        masks=[_box_mask(_BOX_A, None), _box_mask(_BOX_B, track_b)],
+    )
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], tracks=[track_a, track_b])
+
+    img = render_image(
+        labels, lf_ind=0, color_by="track", background="black", overlay_alpha=1.0
+    )
+    pal = get_palette("standard", 2)
+    assert _box_center_color(img, _BOX_A) == pal[0]  # untracked -> palette[0]
+    assert _box_center_color(img, _BOX_B) == pal[1]  # track B -> its index
+
+
+def test_render_image_masks_positional_when_color_by_not_track():
+    """color_by != "track" keeps positional overlay_palette coloring (#469).
+
+    Regression guard: the non-track path must be byte-identical to the old
+    behavior — masks colored by list position from ``overlay_palette``.
+    """
+    track_a, track_b = Track(name="A"), Track(name="B")
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        masks=[_box_mask(_BOX_A, track_a), _box_mask(_BOX_B, track_b)],
+    )
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], tracks=[track_a, track_b])
+
+    img = render_image(
+        labels, lf_ind=0, color_by="instance", background="black", overlay_alpha=1.0
+    )
+    dist = get_palette("distinct", 2)  # default overlay_palette
+    assert _box_center_color(img, _BOX_A) == dist[0]  # first in list
+    assert _box_center_color(img, _BOX_B) == dist[1]  # second in list
+
+
+def test_render_image_track_colored_mask_matches_centroid_palette():
+    """A mask and a centroid on the same track render the same color (#469).
+
+    Locks the palette decision: track-colored masks use the pose ``palette``,
+    so track i's mask matches track i's centroid.
+    """
+    from sleap_io.model.centroid import UserCentroid
+
+    track_a, track_b = Track(name="A"), Track(name="B")
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = sio.LabeledFrame(video=video, frame_idx=0, masks=[_box_mask(_BOX_B, track_b)])
+    # Centroid on track B at the center of box B.
+    cy, cx = (sum(_BOX_B[:2]) // 2, sum(_BOX_B[2:]) // 2)
+    lf.centroids.append(UserCentroid(x=float(cx), y=float(cy), track=track_b))
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], tracks=[track_a, track_b])
+
+    img = render_image(
+        labels,
+        lf_ind=0,
+        color_by="track",
+        background="black",
+        overlay_alpha=1.0,
+        show_centroids=False,  # isolate the mask color
+    )
+    pal = get_palette("standard", 2)
+    # Mask for track B uses the same palette/index centroids use (core.py
+    # centroid block: get_palette(palette, max(len(tracks), 1))[track_idx]).
+    assert _box_center_color(img, _BOX_B) == pal[1]
+
+
+def test_render_image_labeled_frame_source_color_by_track_no_crash():
+    """color_by="track" on a LabeledFrame source falls back without crashing.
+
+    A bare ``LabeledFrame`` source builds no track index map, so the track
+    branch is skipped (guarded on a ``Labels`` source) and masks render
+    positionally — consistent with poses, which aren't track-colored there.
+    """
+    track_a = Track(name="A")
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = sio.LabeledFrame(video=video, frame_idx=0, masks=[_box_mask(_BOX_A, track_a)])
+
+    img = render_image(lf, color_by="track", background="black", overlay_alpha=1.0)
+    assert img.shape == (64, 64, 3)
+    assert _box_center_color(img, _BOX_A) != (0, 0, 0)  # mask still drawn
+
+
+def test_render_image_rois_color_by_track_keyed_not_positional():
+    """Explicit ROI overlays are track-colored, not positional (#469).
+
+    The mask fix is generic (keys off ``el.track`` for any overlay element), so
+    ROIs passed as an explicit overlay are track-colored too. Track A's ROI is
+    placed last in the list but still gets palette index 0.
+    """
+    track_a, track_b = Track(name="A"), Track(name="B")
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], tracks=[track_a, track_b])
+
+    def roi(b, t):
+        y0, y1, x0, x1 = b
+        return UserROI(geometry=box(x0, y0, x1, y1), track=t)
+
+    # track_b first, track_a second — reverse of track index.
+    img = render_image(
+        labels,
+        lf_ind=0,
+        overlay=[roi(_BOX_B, track_b), roi(_BOX_A, track_a)],
+        color_by="track",
+        background="black",
+        overlay_alpha=1.0,
+    )
+    pal = get_palette("standard", 2)
+    assert _box_center_color(img, _BOX_A) == pal[0]
+    assert _box_center_color(img, _BOX_B) == pal[1]
+
+
+def test_render_image_bboxes_color_by_track_keyed_not_positional():
+    """Explicit BoundingBox overlays are track-colored, not positional (#469)."""
+    track_a, track_b = Track(name="A"), Track(name="B")
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], tracks=[track_a, track_b])
+
+    def bb(b, t):
+        y0, y1, x0, x1 = b
+        return UserBoundingBox(x1=x0, y1=y0, x2=x1, y2=y1, track=t)
+
+    img = render_image(
+        labels,
+        lf_ind=0,
+        overlay=[bb(_BOX_B, track_b), bb(_BOX_A, track_a)],
+        color_by="track",
+        background="black",
+        overlay_alpha=1.0,
+    )
+    pal = get_palette("standard", 2)
+    assert _box_center_color(img, _BOX_A) == pal[0]
+    assert _box_center_color(img, _BOX_B) == pal[1]
 
 
 def test_render_video_auto_draws_masks():

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -3430,20 +3430,19 @@ def test_render_image_masks_positional_when_color_by_not_track():
     assert _box_center_color(img, _BOX_B) == dist[1]  # second in list
 
 
-def test_render_image_track_colored_mask_matches_centroid_palette():
-    """A mask and a centroid on the same track render the same color (#469).
+def test_render_image_track_colored_mask_matches_centroid():
+    """A mask and a centroid on the same track render the same pixel color (#469).
 
-    Locks the palette decision: track-colored masks use the pose ``palette``,
-    so track i's mask matches track i's centroid.
+    Locks the palette decision: track-colored masks use the pose ``palette``, so
+    track B's mask pixels equal track B's centroid marker pixels.
     """
     from sleap_io.model.centroid import UserCentroid
 
     track_a, track_b = Track(name="A"), Track(name="B")
     video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
     lf = sio.LabeledFrame(video=video, frame_idx=0, masks=[_box_mask(_BOX_B, track_b)])
-    # Centroid on track B at the center of box B.
-    cy, cx = (sum(_BOX_B[:2]) // 2, sum(_BOX_B[2:]) // 2)
-    lf.centroids.append(UserCentroid(x=float(cx), y=float(cy), track=track_b))
+    # Centroid on track B in a clear area away from the mask.
+    lf.centroids.append(UserCentroid(x=12.0, y=30.0, track=track_b))
     labels = sio.Labels(labeled_frames=[lf], videos=[video], tracks=[track_a, track_b])
 
     img = render_image(
@@ -3452,20 +3451,23 @@ def test_render_image_track_colored_mask_matches_centroid_palette():
         color_by="track",
         background="black",
         overlay_alpha=1.0,
-        show_centroids=False,  # isolate the mask color
+        show_centroids=True,
+        centroid_marker_size=6,
     )
     pal = get_palette("standard", 2)
-    # Mask for track B uses the same palette/index centroids use (core.py
-    # centroid block: get_palette(palette, max(len(tracks), 1))[track_idx]).
-    assert _box_center_color(img, _BOX_B) == pal[1]
+    mask_color = _box_center_color(img, _BOX_B)
+    centroid_color = tuple(int(v) for v in img[30, 12])  # centroid marker center
+    assert mask_color == pal[1]  # track B index
+    assert mask_color == centroid_color  # mask and centroid agree
 
 
-def test_render_image_labeled_frame_source_color_by_track_no_crash():
-    """color_by="track" on a LabeledFrame source falls back without crashing.
+def test_render_image_labeled_frame_source_color_by_track_positional():
+    """color_by="track" on a LabeledFrame source falls back to positional (#469).
 
     A bare ``LabeledFrame`` source builds no track index map, so the track
     branch is skipped (guarded on a ``Labels`` source) and masks render
-    positionally — consistent with poses, which aren't track-colored there.
+    positionally from ``overlay_palette`` — consistent with poses, which aren't
+    track-colored there.
     """
     track_a = Track(name="A")
     video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
@@ -3473,7 +3475,8 @@ def test_render_image_labeled_frame_source_color_by_track_no_crash():
 
     img = render_image(lf, color_by="track", background="black", overlay_alpha=1.0)
     assert img.shape == (64, 64, 3)
-    assert _box_center_color(img, _BOX_A) != (0, 0, 0)  # mask still drawn
+    # Positional: first (only) mask gets overlay_palette ("distinct") index 0.
+    assert _box_center_color(img, _BOX_A) == get_palette("distinct", 1)[0]
 
 
 def test_render_image_rois_color_by_track_keyed_not_positional():
@@ -3528,6 +3531,132 @@ def test_render_image_bboxes_color_by_track_keyed_not_positional():
     pal = get_palette("standard", 2)
     assert _box_center_color(img, _BOX_A) == pal[0]
     assert _box_center_color(img, _BOX_B) == pal[1]
+
+
+def test_render_video_masks_untracked_and_mixed_fall_back_to_palette0():
+    """render_video: untracked masks fall back to palette[0] under track (#469).
+
+    Exercises the ``_apply_frame_overlay`` else-arm: a mixed frame with one
+    untracked mask (``track=None``) and one tracked mask renders the untracked
+    one at the first palette color and the tracked one at its track color.
+    """
+    track_a, track_b = Track(name="A"), Track(name="B")
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        masks=[_box_mask(_BOX_A, None), _box_mask(_BOX_B, track_b)],
+    )
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], tracks=[track_a, track_b])
+
+    frames = render_video(
+        labels,
+        color_by="track",
+        background="black",
+        overlay_alpha=1.0,
+        show_progress=False,
+        frame_inds=[0],
+    )
+    pal = get_palette("standard", 2)
+    assert _box_center_color(frames[0], _BOX_A) == pal[0]  # untracked -> palette[0]
+    assert _box_center_color(frames[0], _BOX_B) == pal[1]  # track B -> its index
+
+
+def test_render_video_masks_positional_when_color_by_not_track():
+    """render_video keeps positional overlay_palette when color_by != track (#469).
+
+    Regression guard mirroring the render_image case: with ``color_by="instance"``
+    masks are colored by list position from ``overlay_palette`` ("distinct"),
+    even though tracks exist.
+    """
+    track_a, track_b = Track(name="A"), Track(name="B")
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        masks=[_box_mask(_BOX_A, track_a), _box_mask(_BOX_B, track_b)],
+    )
+    labels = sio.Labels(labeled_frames=[lf], videos=[video], tracks=[track_a, track_b])
+
+    frames = render_video(
+        labels,
+        color_by="instance",
+        background="black",
+        overlay_alpha=1.0,
+        show_progress=False,
+        frame_inds=[0],
+    )
+    dist = get_palette("distinct", 2)
+    assert _box_center_color(frames[0], _BOX_A) == dist[0]  # first in list
+    assert _box_center_color(frames[0], _BOX_B) == dist[1]  # second in list
+
+
+def test_render_image_and_video_agree_trackless_explicit_track():
+    """render_image and render_video agree for track-less explicit track (#469).
+
+    When ``color_by="track"`` is forced on a ``Labels`` with no tracks, both
+    renderers must fall through to positional ``overlay_palette`` coloring
+    (keeping masks distinguishable) rather than collapsing to one color.
+    """
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    lf = sio.LabeledFrame(
+        video=video,
+        frame_idx=0,
+        masks=[_box_mask(_BOX_A), _box_mask(_BOX_B)],  # untracked
+    )
+    labels = sio.Labels(labeled_frames=[lf], videos=[video])  # no tracks
+    assert len(labels.tracks) == 0
+
+    img = render_image(
+        labels, lf_ind=0, color_by="track", background="black", overlay_alpha=1.0
+    )
+    frames = render_video(
+        labels,
+        color_by="track",
+        background="black",
+        overlay_alpha=1.0,
+        show_progress=False,
+        frame_inds=[0],
+    )
+    dist = get_palette("distinct", 2)
+    for out in (img, frames[0]):
+        assert _box_center_color(out, _BOX_A) == dist[0]
+        assert _box_center_color(out, _BOX_B) == dist[1]
+
+
+def test_render_video_label_image_overlay_not_recolored_by_track():
+    """Label-image overlays are not track-recolored under color_by="track" (#469).
+
+    Label images color by integer object ID, never by track. The overlay-color
+    guard skips them, so a tracked project with a label-image overlay still
+    renders the label image normally (by ID) without crashing.
+    """
+    track_a = Track(name="A")
+    skeleton = sio.Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+    video = sio.Video(filename="v.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    data = np.zeros((64, 64), dtype=np.int32)
+    data[5:25, 5:25] = 1
+    inst = sio.Instance.from_numpy(
+        np.array([[50, 50], [55, 55]], dtype=np.float32),
+        skeleton=skeleton,
+        track=track_a,
+    )
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
+    lf.label_images.append(UserLabelImage(data=data))
+    labels = sio.Labels(
+        labeled_frames=[lf], videos=[video], skeletons=[skeleton], tracks=[track_a]
+    )
+
+    frames = render_video(
+        labels,
+        color_by="track",
+        background="black",
+        overlay_alpha=1.0,
+        show_progress=False,
+        frame_inds=[0],
+    )
+    # Label-image region (top-left) is drawn (by ID), not left as background.
+    assert _box_center_color(frames[0], (5, 25, 5, 25)) != (0, 0, 0)
 
 
 def test_render_video_auto_draws_masks():


### PR DESCRIPTION
## Summary

Closes #469. `color_by="track"` (and `sio render --color-by track`) did **not** color segmentation masks by track identity — it colored them by their **position in `LabeledFrame.masks`**. In tracked bottom-up-segmentation videos the same animal flickered colors whenever a mask's list index changed frame-to-frame, even though `mask.track` was stable and correct. Poses, centroids, and trails were all already track-colored; masks were the lone exception.

## Root cause

The mask overlay path never consulted `.track`. `_apply_overlay`'s `list` branch built positional colors:

```python
colors = get_palette(palette, len(overlay))   # indexed by LIST POSITION
draw_masks(image, overlay, colors=colors, alpha=alpha)
```

So `color_by="track"` only affected the pose render call, not the mask overlay.

## Key Changes (`sleap_io/rendering/core.py`)

- `_apply_overlay` gains an optional `colors` override (`if colors is None: colors = get_palette(...)`), so callers can supply per-element colors. `draw_masks`/`draw_rois`/`draw_bboxes` already accept `colors`.
- **render_image** and **render_video** compute per-element colors keyed by **track index** (reusing the same `{id(track): i}` map used for poses/centroids/trails) when the resolved scheme is `"track"` **and the labels have tracks**, and pass them into `_apply_overlay`. `determine_color_scheme` is hoisted above render_image's overlay block so the scheme is known when the overlay is drawn.
- **Palette**: the track path uses the **pose `palette`** (default `"standard"`), so a track's mask matches its poses/centroids/trails. The positional path is untouched (still `overlay_palette`, default `"distinct"`).
- **Untracked / mixed**: elements with `track=None` (or a track not in the map) fall back to `palette[0]`, mirroring centroids — never crashes.
- **Track-less labels**: forcing `color_by="track"` on a `Labels` with no tracks falls through to positional coloring in **both** renderers (the `has_tracks` guard), so masks stay distinguishable.
- **Generic**: the logic keys off `getattr(el, "track", None)`, so explicit `ROI` and `BoundingBox` overlays are track-colored too.

## Example

```python
# Before: mask color followed list position -> flickered on reorder.
# After:  mask color follows mask.track -> stable across frames.
sio.render_video(labels, "out.mp4", color_by="track")
```

```bash
sio render preds.slp --color-by track -o out.mp4   # masks now stable per track
```

## API Changes

None to public signatures. `_apply_overlay` (private) gains a `colors=` kwarg. Behavior change: under `color_by="track"` with tracks present, tracked overlays color by `palette`/track instead of `overlay_palette`/position. The positional path (`color_by != "track"`, or no tracks) is byte-identical.

## Testing

**12 new tests** in `tests/rendering/test_rendering.py`:
- **Core regression** — `render_video`: two tracked masks swap list order between frames; each track's region color is stable across the shuffle (and distinct per track).
- **Track-keyed not positional** — `render_image` masks (+ ROI + bbox): track A (index 0) placed *last* in the list still gets palette index 0.
- **Palette parity** — a mask and a centroid on the same track render the same pixel color.
- **Untracked / mixed** — `track=None` → `palette[0]` (both `render_image` and `render_video`); tracked sibling keeps its color.
- **Positional guards** — `color_by != "track"` keeps positional `overlay_palette` in both renderers.
- **Track-less + explicit track** — `render_image` and `render_video` agree (both positional, distinct).
- **Label-image overlays** — not track-recolored under `color_by="track"` (still colored by ID, no crash).
- **LabeledFrame source** — `color_by="track"` falls back to positional without crashing.

All changed lines covered; `ruff` clean; full `tests/rendering` suite passes (264 tests); docs tests pass (73). Updated `docs/rendering.md` with a track-coloring note.

## Design Decisions

Planned via a **multi-agent design workflow** (three independent proposals → synthesis), then **adversarially reviewed** by a second multi-agent workflow. The chosen approach computes colors **in the callers** and passes an explicit `colors=` override into a dumb `_apply_overlay`, mirroring the established centroid pattern. The review caught a regression in the first version — render_image collapsed track-less masks to one color while render_video kept them distinct — fixed by adding the `has_tracks` guard to render_image and adding the agreement test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)