### PR TITLE
feat(slp): persist UserSegmentationMask.from_predicted (#474 Gap 2)

### DIFF
--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -1043,6 +1043,7 @@ mask_dtype = np.dtype([
     ("frame_idx", "i8"),        # Frame index (-1 for static masks)
     ("track", "i4"),            # Track index (-1 if none)
     ("instance", "i4"),         # Instance index (-1 if none) (Format 1.9+)
+    ("from_predicted", "i4"),   # Source prediction index into this mask list, -1 if none (Format 2.4+)
     ("is_predicted", "u1"),     # 0 = UserSegmentationMask, 1 = Predicted (Format 1.9+)
     ("score", "f4"),            # Confidence score (NaN for user masks) (Format 1.9+)
     ("tracking_score", "f4"),   # Tracking link confidence (NaN if unset)
@@ -1077,7 +1078,7 @@ The reader checks for these datasets first. For pre-1.9 files, it falls back to 
 
 The `/masks` and `/mask_rle` datasets are only written when the [`Labels`][sleap_io.Labels] object contains masks. On read, missing datasets default to empty lists.
 
-The [`UserSegmentationMask.from_predicted`][sleap_io.UserSegmentationMask] provenance link (set by [`PredictedSegmentationMask.to_user()`][sleap_io.PredictedSegmentationMask]) is an in-memory-only convenience and is **not** serialized; it reloads as `None`. The source `PredictedSegmentationMask`, if kept in `labels.masks`, is written and read back independently. This is unlike instance `from_predicted`, which is persisted as an index (see the Instances → Instance Linking section above).
+The [`UserSegmentationMask.from_predicted`][sleap_io.UserSegmentationMask] provenance link (set by [`PredictedSegmentationMask.to_user()`][sleap_io.PredictedSegmentationMask]) is persisted (Format 2.4+) in the `from_predicted` column as an index into the flat mask list, mirroring instance `from_predicted` (see the Instances → Instance Linking section above). On write, the linked `PredictedSegmentationMask` is resolved to its global mask index in a deferred pass; a `None` link or a source that is no longer in `labels.masks` is written as `-1`. On read, the index is resolved back to the mask object in a deferred pass after all masks are constructed; `-1` and out-of-range indices load as `None`. The column is gated on presence at read time, so files written before Format 2.4 (which lack the column) load `from_predicted` as `None`.
 
 ## Score Map Datasets
 
@@ -1311,7 +1312,7 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 - Triggered automatically when any mask or label image has non-trivial spatial transform; otherwise the format remains 1.x or 2.0
 - Backward compatible: older readers ignore the new fields; writers always emit them but set defaults for unset cases
 
-### Format 2.2 (Current)
+### Format 2.2
 
 **Chunked label image storage and lazy loading.**
 
@@ -1323,6 +1324,23 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 - New [`LabelImageWriter`][sleap_io.LabelImageWriter] enables streaming writes with constant memory
 - New [`merge_label_images()`][sleap_io.merge_label_images] copies raw compressed chunks between files (zero decompression for chunked sources)
 - Backward compatible: old files (v1.8-v2.1) remain fully readable; `data_start`/`data_end` fields are unused (set to 0) in chunked format
+
+### Format 2.3
+
+**Virtual on-read video crops.**
+
+- Optional `/video_crops` dataset stores per-video crop rectangles applied virtually on read (see [Virtual Crops](#virtual-crops-format-23) above)
+- Triggered only when a video carries a crop; uncropped files stay byte-identical and at `format_id <= 2.2`
+- Purely additive: does not cross the only legacy threshold (`< 1.4`)
+
+### Format 2.4 (Current)
+
+**Persisted mask `from_predicted` provenance.**
+
+- Added a `from_predicted` (`i4`) column to `mask_dtype` storing the index of the source [`PredictedSegmentationMask`][sleap_io.PredictedSegmentationMask] in the flat mask list (`-1` if none), mirroring instance `from_predicted`
+- Lets [`UserSegmentationMask.from_predicted`][sleap_io.UserSegmentationMask] (set by [`PredictedSegmentationMask.to_user()`][sleap_io.PredictedSegmentationMask]) survive a save/load round-trip when the source prediction is also saved
+- Triggered automatically when any mask records a `from_predicted` link; otherwise the format stays at whatever other state drives `format_id`
+- Backward compatible: the column is always written but reads are gated on its presence, so files written before 2.4 (which lack the column) load `from_predicted` as `None`
 
 ## Browser-side compatibility (h5wasm / sleap-io.js)
 

--- a/docs/model/segmentation.md
+++ b/docs/model/segmentation.md
@@ -130,9 +130,11 @@ and shared metadata (`track`, `instance`, `name`, `category`, `source`,
 
 ```
 
-Pass `to_user(link=False)` for an unlinked copy. The `from_predicted` link is an
-in-memory provenance pointer and is **not** persisted to the SLP format — it
-becomes `None` after a save/load round-trip.
+Pass `to_user(link=False)` for an unlinked copy. The `from_predicted` link is
+persisted to the SLP format as an index into the saved mask list (mirroring
+instance `from_predicted`), so it survives a save/load round-trip as long as the
+source prediction is also saved. Files written before this column existed load
+it as `None`.
 
 This mirrors the pose flow, where a user `Instance` is created from a
 `PredictedInstance` with `from_predicted=` set. To adopt a prediction within a

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -17,6 +17,8 @@ Format version history:
     - 2.1: Spatial transform metadata on dense annotations (masks/label images)
     - 2.2: Chunked label image data format (/label_image_data as rank-3 dataset)
     - 2.3: Virtual on-read video crops (/video_crops dataset)
+    - 2.4: Persisted mask from_predicted provenance (from_predicted column in
+            mask_dtype storing the source prediction's index in the mask list)
 """
 
 from __future__ import annotations
@@ -1893,6 +1895,16 @@ def write_metadata(labels_path: str, labels: Labels):
     # and only set when a crop is actually present (uncropped files stay <= 2.2).
     if any(v._crop_tuple() is not None for v in labels.videos):
         format_id = max(format_id, 2.3)
+
+    # Bump for persisted mask from_predicted provenance links (new in 2.4). Only
+    # set when a UserSegmentationMask actually records a source prediction; the
+    # column is always written but reads are gated on column presence, so files
+    # without any link stay <= 2.3.
+    has_mask_from_predicted = any(
+        getattr(m, "from_predicted", None) is not None for m in labels.masks
+    )
+    if has_mask_from_predicted:
+        format_id = max(format_id, 2.4)
 
     with h5py.File(labels_path, "a") as f:
         # Bump for chunked label image format (new in 2.2)
@@ -3979,6 +3991,7 @@ def read_masks(
                 score_map_spatial_by_idx[midx] = (sm_scale, sm_offset)
 
     masks = []
+    from_predicted_pairs = []
     for i, row in enumerate(mask_data):
         rle_start = int(row["rle_start"])
         rle_end = int(row["rle_end"])
@@ -4000,6 +4013,12 @@ def read_masks(
             instances[instance_idx]
             if instances is not None and 0 <= instance_idx < len(instances)
             else None
+        )
+
+        # Read from_predicted index (v2.4+). Resolved to an object in a deferred
+        # pass below, once all masks in this flat list have been constructed.
+        from_predicted_idx = (
+            int(row["from_predicted"]) if "from_predicted" in row.dtype.names else -1
         )
 
         # Read predicted flag (v1.9+)
@@ -4055,7 +4074,17 @@ def read_masks(
             mask = UserSegmentationMask(**kwargs)
 
         mask._instance_idx = instance_idx
+        # Only user masks carry a from_predicted link; queue it for re-linking.
+        if not is_predicted and from_predicted_idx >= 0:
+            from_predicted_pairs.append((i, from_predicted_idx))
         masks.append((mask, video_idx, frame_idx_val))
+
+    # Re-link from_predicted provenance now that every mask exists. The stored
+    # value is a global index into this flat list (see write_masks); out-of-range
+    # indices (corrupt/edited files) are skipped, leaving from_predicted as None.
+    for i, fp_idx in from_predicted_pairs:
+        if 0 <= fp_idx < len(masks):
+            masks[i][0].from_predicted = masks[fp_idx][0]
 
     return masks
 
@@ -4095,6 +4124,7 @@ def write_masks(
             ("frame_idx", "i8"),
             ("track", "i4"),
             ("instance", "i4"),
+            ("from_predicted", "i4"),  # Format 2.4+: index into this mask list
             ("is_predicted", "u1"),
             ("score", "f4"),
             ("tracking_score", "f4"),
@@ -4113,6 +4143,12 @@ def write_masks(
     categories = []
     names = []
     sources = []
+
+    # Map each mask object to its global index so a UserSegmentationMask's
+    # ``from_predicted`` link can be persisted as an index into this flat list,
+    # mirroring the instance ``from_predicted`` mechanism. The source prediction
+    # lives in the same frame and so is also present in this same list.
+    mask_id_to_idx = {id(mask): i for i, mask in enumerate(masks)}
 
     for i_mask, mask in enumerate(masks):
         # Pack uint32 RLE counts as raw bytes (uint8)
@@ -4133,6 +4169,16 @@ def write_masks(
             except ValueError:
                 pass  # Keep stored _instance_idx
 
+        # Resolve the ``from_predicted`` provenance link to a global mask index
+        # (-1 if absent, or if the source prediction was removed from the
+        # labels). Only UserSegmentationMask carries this attribute.
+        from_predicted_src = getattr(mask, "from_predicted", None)
+        from_predicted_idx = (
+            mask_id_to_idx.get(id(from_predicted_src), -1)
+            if from_predicted_src is not None
+            else -1
+        )
+
         is_predicted = isinstance(mask, PredictedSegmentationMask)
         score = mask.score if is_predicted else float("nan")
         tracking_score = (
@@ -4148,6 +4194,7 @@ def write_masks(
                 frame_idx,
                 track_idx,
                 instance_idx,
+                from_predicted_idx,
                 int(is_predicted),
                 score,
                 tracking_score,

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -4146,8 +4146,9 @@ def write_masks(
 
     # Map each mask object to its global index so a UserSegmentationMask's
     # ``from_predicted`` link can be persisted as an index into this flat list,
-    # mirroring the instance ``from_predicted`` mechanism. The source prediction
-    # lives in the same frame and so is also present in this same list.
+    # mirroring the instance ``from_predicted`` mechanism. The link resolves as
+    # long as the source prediction is anywhere in this list (typically the same
+    # frame); a source absent from the saved labels resolves to -1.
     mask_id_to_idx = {id(mask): i for i, mask in enumerate(masks)}
 
     for i_mask, mask in enumerate(masks):

--- a/sleap_io/model/mask.py
+++ b/sleap_io/model/mask.py
@@ -210,6 +210,10 @@ class SegmentationMask:
             scale=(1.0, 1.0),
             offset=(0.0, 0.0),
         )
+        if isinstance(self, UserSegmentationMask):
+            # Preserve the provenance link so resampling a corrected mask keeps
+            # its source prediction (mirrors track/instance preservation above).
+            kwargs["from_predicted"] = self.from_predicted
         if isinstance(self, PredictedSegmentationMask):
             kwargs["score"] = self.score
             if self.score_map is not None:

--- a/sleap_io/model/mask.py
+++ b/sleap_io/model/mask.py
@@ -405,8 +405,10 @@ class UserSegmentationMask(SegmentationMask):
             mask was initialized from, recorded by
             `PredictedSegmentationMask.to_user()` for human-in-the-loop
             correction workflows. `None` if the mask was created directly. This
-            is an in-memory provenance link and is **not** persisted to the SLP
-            format (it becomes `None` after a save/load round-trip).
+            provenance link is persisted to the SLP format as an index into the
+            saved mask list (mirroring instance `from_predicted`), so it survives
+            a save/load round-trip as long as the source prediction is also
+            saved. Files written before this column existed load it as `None`.
     """
 
     from_predicted: "PredictedSegmentationMask | None" = attrs.field(
@@ -458,8 +460,9 @@ class PredictedSegmentationMask(SegmentationMask):
         Notes:
             The `track` and `instance` references are shared (not copied), so
             mutating them affects both masks. The `from_predicted` link is
-            in-memory only and is **not** persisted to the SLP format; it
-            becomes `None` after a save/load round-trip.
+            persisted to the SLP format (as an index into the saved mask list);
+            it survives a save/load round-trip as long as this source prediction
+            is also saved.
         """
         user = UserSegmentationMask(
             rle_counts=self.rle_counts.copy(),

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -6472,11 +6472,12 @@ def test_slp_predicted_mask_roundtrip(tmp_path):
     assert format_id == 1.9
 
 
-def test_slp_mask_from_predicted_not_persisted(tmp_path):
-    """UserSegmentationMask.from_predicted is in-memory only (drops on reload).
+def test_slp_mask_from_predicted_persisted(tmp_path):
+    """UserSegmentationMask.from_predicted round-trips through the SLP format.
 
-    Both masks survive the round-trip, but the provenance link is intentionally
-    not serialized (documented behavior), so it reloads as ``None``.
+    The provenance link is serialized as an index into the saved mask list
+    (mirroring instance ``from_predicted``); on reload the user mask points back
+    at the reloaded source prediction object.
     """
     video = Video(filename="test.mp4")
     skeleton = Skeleton(nodes=["A"])
@@ -6496,6 +6497,9 @@ def test_slp_mask_from_predicted_not_persisted(tmp_path):
     path = str(tmp_path / "mask_provenance.slp")
     save_slp(labels, path)
 
+    # A persisted link bumps the format to 2.4.
+    assert read_hdf5_attrs(path, "metadata", "format_id") >= 2.4
+
     loaded = load_slp(path, open_videos=False)
     assert len(loaded.masks) == 2
     # Both subtypes survive intact in a mixed pred+user frame.
@@ -6507,8 +6511,376 @@ def test_slp_mask_from_predicted_not_persisted(tmp_path):
     np.testing.assert_array_equal(loaded_pred.data, np.ones((5, 5), dtype=bool))
     loaded_user = next(m for m in loaded.masks if isinstance(m, UserSegmentationMask))
     np.testing.assert_array_equal(loaded_user.data, np.ones((5, 5), dtype=bool))
-    # The provenance link is intentionally not persisted.
+    # The provenance link is restored and points at the reloaded source object.
+    assert loaded_user.from_predicted is loaded_pred
+
+
+def test_slp_mask_from_predicted_none_roundtrip(tmp_path):
+    """An unlinked user mask (``to_user(link=False)``) stays ``None`` on reload.
+
+    With no link recorded, the format is not bumped to 2.4 and ``from_predicted``
+    is written as the ``-1`` sentinel.
+    """
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+
+    pred = PredictedSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool), score=0.9)
+    user = pred.to_user(link=False)
+    assert user.from_predicted is None
+
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.extend([pred, user])
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    path = str(tmp_path / "mask_unlinked.slp")
+    save_slp(labels, path)
+
+    # No link present, so the format is not bumped to 2.4.
+    assert read_hdf5_attrs(path, "metadata", "format_id") < 2.4
+
+    loaded = load_slp(path, open_videos=False)
+    loaded_user = next(m for m in loaded.masks if isinstance(m, UserSegmentationMask))
     assert loaded_user.from_predicted is None
+
+
+def test_slp_mask_from_predicted_shared_source(tmp_path):
+    """Multiple user masks adopting the same prediction all relink to it."""
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+
+    pred = PredictedSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool), score=0.8)
+    user1 = pred.to_user()
+    user2 = pred.to_user()
+    assert user1.from_predicted is user2.from_predicted is pred
+
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.extend([pred, user1, user2])
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    path = str(tmp_path / "mask_shared_source.slp")
+    save_slp(labels, path)
+
+    loaded = load_slp(path, open_videos=False)
+    loaded_pred = next(
+        m for m in loaded.masks if isinstance(m, PredictedSegmentationMask)
+    )
+    loaded_users = [m for m in loaded.masks if isinstance(m, UserSegmentationMask)]
+    assert len(loaded_users) == 2
+    assert all(u.from_predicted is loaded_pred for u in loaded_users)
+
+
+def test_slp_mask_from_predicted_dangling_source(tmp_path):
+    """A link to a prediction absent from the labels is written as ``-1``.
+
+    Adopting a prediction but keeping only the user mask (the source prediction
+    is not in ``labels.masks``) cannot resolve to an index, so it serializes to
+    ``-1`` and reloads as ``None``.
+    """
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+
+    pred = PredictedSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool), score=0.7)
+    user = pred.to_user()
+    assert user.from_predicted is pred
+
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.append(user)  # Source prediction intentionally omitted.
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    path = str(tmp_path / "mask_dangling.slp")
+    save_slp(labels, path)
+
+    loaded = load_slp(path, open_videos=False)
+    assert len(loaded.masks) == 1
+    assert loaded.masks[0].from_predicted is None
+
+
+def test_slp_mask_from_predicted_persisted_lazy(tmp_path):
+    """The link round-trips through the lazy write path too.
+
+    The lazy path does not pass an ``instances`` list to ``write_masks``, but
+    ``from_predicted`` links mask-to-mask (resolved from the mask list itself),
+    so it persists regardless.
+    """
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+
+    pred = PredictedSegmentationMask.from_numpy(np.ones((6, 6), dtype=bool), score=0.95)
+    user = pred.to_user()
+
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.extend([pred, user])
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    path = str(tmp_path / "mask_lazy_src.slp")
+    save_slp(labels, path)
+
+    lazy_labels = load_slp(path, lazy=True)
+    assert lazy_labels.is_lazy
+    assert len(lazy_labels.masks) == 2
+
+    path2 = str(tmp_path / "mask_lazy_resaved.slp")
+    save_slp(lazy_labels, path2)
+
+    reloaded = load_slp(path2, open_videos=False)
+    reloaded_pred = next(
+        m for m in reloaded.masks if isinstance(m, PredictedSegmentationMask)
+    )
+    reloaded_user = next(
+        m for m in reloaded.masks if isinstance(m, UserSegmentationMask)
+    )
+    assert reloaded_user.from_predicted is reloaded_pred
+
+
+def test_slp_mask_from_predicted_legacy_none(tmp_path):
+    """Files written before the from_predicted column load the link as ``None``.
+
+    Synthesizes a pre-2.4 ``masks`` dataset (current spatial schema but without
+    the ``from_predicted`` column) and confirms the read path's column-presence
+    gate defaults the link to ``None``.
+    """
+    from sleap_io.model.mask import _encode_rle
+
+    path = str(tmp_path / "legacy_masks.slp")
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+    save_slp(Labels(videos=[video], skeletons=[skeleton]), path)
+
+    # Pre-2.4 mask dtype: has instance/is_predicted/scale columns but NO
+    # from_predicted column.
+    legacy_mask_dtype = np.dtype(
+        [
+            ("height", "u4"),
+            ("width", "u4"),
+            ("annotation_type", "u1"),
+            ("video", "i4"),
+            ("frame_idx", "i8"),
+            ("track", "i4"),
+            ("instance", "i4"),
+            ("is_predicted", "u1"),
+            ("score", "f4"),
+            ("tracking_score", "f4"),
+            ("rle_start", "u8"),
+            ("rle_end", "u8"),
+            ("scale_x", "f4"),
+            ("scale_y", "f4"),
+            ("offset_x", "f4"),
+            ("offset_y", "f4"),
+        ]
+    )
+    rle = _encode_rle(np.ones((5, 5), dtype=bool))
+    rle_flat = np.frombuffer(rle.astype(np.uint32).tobytes(), dtype=np.uint8)
+    rle_end = len(rle_flat)
+    # One predicted mask and one user mask, both in frame (video 0, frame 0).
+    rows = np.array(
+        [
+            (5, 5, 2, 0, 0, -1, -1, 1, 0.9, float("nan"), 0, rle_end, 1, 1, 0, 0),
+            (
+                5,
+                5,
+                2,
+                0,
+                0,
+                -1,
+                -1,
+                0,
+                float("nan"),
+                float("nan"),
+                0,
+                rle_end,
+                1,
+                1,
+                0,
+                0,
+            ),
+        ],
+        dtype=legacy_mask_dtype,
+    )
+
+    str_dt = h5py.special_dtype(vlen=str)
+    with h5py.File(path, "a") as f:
+        f.create_dataset("masks", data=rows, dtype=legacy_mask_dtype)
+        f.create_dataset("mask_rle", data=rle_flat, dtype=np.uint8)
+        f.create_dataset("mask_categories", data=["", ""], dtype=str_dt)
+        f.create_dataset("mask_names", data=["", ""], dtype=str_dt)
+        f.create_dataset("mask_sources", data=["", ""], dtype=str_dt)
+
+    loaded = load_slp(path, open_videos=False)
+    assert len(loaded.masks) == 2
+    loaded_user = next(m for m in loaded.masks if isinstance(m, UserSegmentationMask))
+    assert loaded_user.from_predicted is None
+
+
+def test_slp_mask_from_predicted_out_of_range(tmp_path):
+    """An out-of-range from_predicted index (corrupt/edited file) loads as None.
+
+    The deferred re-link pass bounds-checks the stored index, so a dangling
+    index degrades gracefully instead of raising ``IndexError``.
+    """
+    from sleap_io.model.mask import _encode_rle
+
+    path = str(tmp_path / "corrupt_from_predicted.slp")
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+    save_slp(Labels(videos=[video], skeletons=[skeleton]), path)
+
+    # Current (2.4) mask dtype, including the from_predicted column.
+    mask_dtype = np.dtype(
+        [
+            ("height", "u4"),
+            ("width", "u4"),
+            ("annotation_type", "u1"),
+            ("video", "i4"),
+            ("frame_idx", "i8"),
+            ("track", "i4"),
+            ("instance", "i4"),
+            ("from_predicted", "i4"),
+            ("is_predicted", "u1"),
+            ("score", "f4"),
+            ("tracking_score", "f4"),
+            ("rle_start", "u8"),
+            ("rle_end", "u8"),
+            ("scale_x", "f4"),
+            ("scale_y", "f4"),
+            ("offset_x", "f4"),
+            ("offset_y", "f4"),
+        ]
+    )
+    rle = _encode_rle(np.ones((5, 5), dtype=bool))
+    rle_flat = np.frombuffer(rle.astype(np.uint32).tobytes(), dtype=np.uint8)
+    rle_end = len(rle_flat)
+    # A single user mask whose from_predicted index (999) points past the list.
+    rows = np.array(
+        [
+            (
+                5,
+                5,
+                2,
+                0,
+                0,
+                -1,
+                -1,
+                999,
+                0,
+                float("nan"),
+                float("nan"),
+                0,
+                rle_end,
+                1,
+                1,
+                0,
+                0,
+            )
+        ],
+        dtype=mask_dtype,
+    )
+
+    str_dt = h5py.special_dtype(vlen=str)
+    with h5py.File(path, "a") as f:
+        f.create_dataset("masks", data=rows, dtype=mask_dtype)
+        f.create_dataset("mask_rle", data=rle_flat, dtype=np.uint8)
+        f.create_dataset("mask_categories", data=[""], dtype=str_dt)
+        f.create_dataset("mask_names", data=[""], dtype=str_dt)
+        f.create_dataset("mask_sources", data=[""], dtype=str_dt)
+
+    loaded = load_slp(path, open_videos=False)
+    assert len(loaded.masks) == 1
+    assert loaded.masks[0].from_predicted is None
+
+
+def test_slp_mask_from_predicted_multi_frame(tmp_path):
+    """The global mask index links each user mask to the prediction in its frame.
+
+    With masks spread across multiple frames, the persisted index must
+    disambiguate which prediction each user mask was adopted from (not merely
+    "some prediction"). Distinct raster contents make the link unambiguous.
+    """
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+
+    data0 = np.zeros((6, 6), dtype=bool)
+    data0[1:3, 1:3] = True
+    data1 = np.zeros((6, 6), dtype=bool)
+    data1[4:6, 4:6] = True
+
+    pred0 = PredictedSegmentationMask.from_numpy(data0, score=0.6)
+    user0 = pred0.to_user()
+    pred1 = PredictedSegmentationMask.from_numpy(data1, score=0.7)
+    user1 = pred1.to_user()
+
+    lf0 = LabeledFrame(video=video, frame_idx=0)
+    lf0.masks.extend([pred0, user0])
+    lf1 = LabeledFrame(video=video, frame_idx=1)
+    lf1.masks.extend([pred1, user1])
+    labels = Labels(labeled_frames=[lf0, lf1], videos=[video], skeletons=[skeleton])
+
+    path = str(tmp_path / "mask_multi_frame.slp")
+    save_slp(labels, path)
+
+    loaded = load_slp(path, open_videos=False)
+    # Pair each loaded user mask with the prediction sharing its raster.
+    for um in (m for m in loaded.masks if isinstance(m, UserSegmentationMask)):
+        assert um.from_predicted is not None
+        np.testing.assert_array_equal(um.data, um.from_predicted.data)
+        # The link points at the prediction in the SAME frame, not the other one.
+        assert um.from_predicted.is_predicted
+
+
+def test_slp_mask_from_predicted_double_roundtrip(tmp_path):
+    """A persisted link stays intact across a second save/load (non-lazy)."""
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A"])
+
+    pred = PredictedSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool), score=0.9)
+    user = pred.to_user()
+    lf = LabeledFrame(video=video, frame_idx=0)
+    lf.masks.extend([pred, user])
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    path1 = str(tmp_path / "mask_dbl_1.slp")
+    save_slp(labels, path1)
+    loaded1 = load_slp(path1, open_videos=False)
+
+    path2 = str(tmp_path / "mask_dbl_2.slp")
+    save_slp(loaded1, path2)
+    loaded2 = load_slp(path2, open_videos=False)
+
+    loaded_pred = next(
+        m for m in loaded2.masks if isinstance(m, PredictedSegmentationMask)
+    )
+    loaded_user = next(m for m in loaded2.masks if isinstance(m, UserSegmentationMask))
+    assert loaded_user.from_predicted is loaded_pred
+
+
+def test_slp_mask_from_predicted_with_instance_link(tmp_path):
+    """from_predicted and instance associations coexist (two deferred passes).
+
+    Both ``mask.instance`` (resolved via ``_instance_idx``) and
+    ``mask.from_predicted`` are re-linked on read; setting both confirms the two
+    deferred passes do not interfere.
+    """
+    video = Video(filename="test.mp4")
+    skeleton = Skeleton(nodes=["A", "B"])
+    inst = Instance.from_numpy(np.array([[1.0, 2.0], [3.0, 4.0]]), skeleton=skeleton)
+
+    pred = PredictedSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool), score=0.9)
+    user = pred.to_user()
+    user.instance = inst
+
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst])
+    lf.masks.extend([pred, user])
+    labels = Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+    path = str(tmp_path / "mask_with_instance.slp")
+    save_slp(labels, path)
+
+    loaded = load_slp(path, open_videos=False)
+    loaded_pred = next(
+        m for m in loaded.masks if isinstance(m, PredictedSegmentationMask)
+    )
+    loaded_user = next(m for m in loaded.masks if isinstance(m, UserSegmentationMask))
+    assert loaded_user.from_predicted is loaded_pred
+    assert loaded_user.instance is loaded.labeled_frames[0].instances[0]
 
 
 def test_slp_predicted_mask_score_map_roundtrip(tmp_path):

--- a/tests/model/test_mask.py
+++ b/tests/model/test_mask.py
@@ -349,6 +349,30 @@ def test_predicted_segmentation_mask_resampled():
     assert resampled.score_map_offset == (0.0, 0.0)
 
 
+def test_resampled_preserves_from_predicted():
+    """resampled() keeps the from_predicted provenance link on user masks."""
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 3:7] = True
+    pred = PredictedSegmentationMask.from_numpy(data, score=0.9, scale=(0.5, 0.5))
+    user = pred.to_user()
+    assert user.from_predicted is pred
+
+    resampled = user.resampled(20, 20)
+    assert isinstance(resampled, UserSegmentationMask)
+    assert resampled.from_predicted is pred
+
+
+def test_resampled_unlinked_stays_none():
+    """resampled() leaves from_predicted as None when there is no link."""
+    data = np.zeros((6, 6), dtype=bool)
+    data[1:3, 1:3] = True
+    user = UserSegmentationMask.from_numpy(data, scale=(0.5, 0.5))
+    assert user.from_predicted is None
+
+    resampled = user.resampled(12, 12)
+    assert resampled.from_predicted is None
+
+
 def test_predicted_segmentation_mask_score_map_spatial():
     mask = PredictedSegmentationMask.from_numpy(
         np.zeros((5, 5), dtype=bool),


### PR DESCRIPTION
## Summary

Addresses **Gap 2** of #474: persist `UserSegmentationMask.from_predicted` to the SLP format.

#472 added the in-memory predicted → user adoption path for masks (`PredictedSegmentationMask.to_user()` + `UserSegmentationMask.from_predicted`), but the provenance link was in-memory only and dropped to `None` on save/load. This PR makes it round-trip, mirroring the instance `from_predicted` mechanism exactly. Gap 1 (mask-aware `unused_predictions` / merge semantics) is intentionally left for a separate PR, as the issue notes the two gaps are independent.

## Key Changes

- **`mask_dtype`**: new `("from_predicted", "i4")` column with a `-1` sentinel, placed alongside `instance` (matches the mask dtype's existing `i4` index columns).
- **`write_masks`**: builds an `{id(mask): global_index}` map over the flat mask list and resolves each `UserSegmentationMask.from_predicted` to the source prediction's index. A `None` link — or a source that was removed from `labels.masks` — serializes as `-1`. Works on both the eager and lazy write paths (the link is mask→mask, so it does not depend on the `instances` argument).
- **`read_masks`**: a deferred re-link pass resolves the stored index back to the mask object once all masks in the frame's flat list are constructed. The read is **gated on column presence** (`"from_predicted" in row.dtype.names`) so pre-2.4 files load as `None`, and **bounds-checked** so corrupt/edited indices degrade to `None` rather than raising.
- **`write_metadata`**: bumps `format_id` to **2.4**, but only when a mask actually records a link (uncropped/link-free files stay ≤ 2.3).
- **Docs/docstrings**: flipped the "not persisted / reloads as None" notes in `mask.py` (class + `to_user()`), `docs/model/segmentation.md`, and `docs/formats/slp.md` (dtype table, prose, and version history — also backfilled the previously-missing 2.3 entry).

## Example Usage

```python
import numpy as np
import sleap_io as sio

pred = sio.PredictedSegmentationMask.from_numpy(np.ones((5, 5), bool), score=0.9)
user = pred.to_user()              # records user.from_predicted = pred

lf = sio.LabeledFrame(video=video, frame_idx=0)
lf.masks.extend([pred, user])      # keep the source prediction in the frame
labels = sio.Labels(labeled_frames=[lf], videos=[video], skeletons=[skel])
sio.save_slp(labels, "labels.slp")

loaded = sio.load_slp("labels.slp")
u = next(m for m in loaded.masks if isinstance(m, sio.UserSegmentationMask))
p = next(m for m in loaded.masks if isinstance(m, sio.PredictedSegmentationMask))
assert u.from_predicted is p       # link survives the round-trip
```

## API Changes

- No public Python API surface changes. `UserSegmentationMask.from_predicted` already existed; it now persists.
- **SLP format**: new `from_predicted` column in `mask_dtype` and new format version **2.4**. Fully backward/forward compatible — the column is always written but reads are presence-gated, and the bump is additive (does not cross the only legacy threshold, `< 1.4`).

## Testing

Ten focused tests in `tests/io/test_slp.py` (`test_slp_mask_from_predicted_*`):
- round-trip with link intact (eager **and** lazy write paths)
- `None` / `to_user(link=False)` → `-1` → `None` (and format stays < 2.4)
- shared source (multiple user masks adopting one prediction)
- dangling source (prediction omitted from labels) → `None`
- **multi-frame global-index disambiguation** (each user mask links to the prediction in its own frame)
- double round-trip stability
- coexistence with `mask.instance` association (two deferred passes)
- legacy file without the column → `None`
- out-of-range index (corrupt file) → `None`, no crash

All new lines are covered; full `tests/io/test_slp.py` + `tests/model/test_mask.py` pass (359).

## Design Decisions

- **Global flat index, not per-frame.** The source prediction always lives in the same frame as the user mask, and masks are written/read as one flat list in frame order, so a global index round-trips identically to instance `from_predicted` (which uses the global `instance_id`).
- **`i4` vs instance's `i8`.** Instance stores a globally-unique `instance_id` (itself `i8`); masks store an array index, consistent with the mask dtype's other `i4` index columns (`video`/`track`/`instance`). `i4` covers ~2.1B masks.
- **Presence-gated read, no `format_id` gate.** The mask reader already gates every newer column (`instance`, `is_predicted`, `scale_*`, …) on `in row.dtype.names`; this follows that pattern rather than branching on `format_id`.
- **Bounds-checked deferred read.** The mask path is slightly more defensive than the instance path (which would `KeyError` on a corrupt index). The pre-existing instance asymmetry is left untouched to keep this PR focused; it could be a small follow-up.

Refs: #471, #472. Closes Gap 2 of #474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
