### PR TITLE
fix(model): resolve effective shape through source chain so embedded subsets match (#473)

### DIFF
--- a/docs/merging.md
+++ b/docs/merging.md
@@ -186,6 +186,8 @@ For each incoming video, AUTO runs these checks in order:
 
 **Shape is for rejection only.** Same resolution does NOT imply a match—it just means the videos aren't rejected. This prevents matching unrelated videos that happen to have the same dimensions.
 
+**Shape resolves through the source chain.** A derived video's effective shape is taken from the nearest video in its `source_video` chain that has a known shape (read from in-memory metadata — no file is opened). An **embedded subset** of frames therefore reports its **source's full shape**, so it is shape-compatible with that source and is not rejected on frame count before the definitive same-file check runs. This holds even when the deeper root shape is unknown (e.g. an embedded `.pkg.slp` whose deeper provenance file is not loaded). Genuine siblings that merely share a file but have no source relationship keep their own shapes and are still rejected when their frame counts differ.
+
 **Provenance conflict checking** only rejects when files can be verified on disk. If neither file exists (e.g., embedded videos in `.pkg.slp` files), the check is skipped to allow fall-through to content-based matching.
 
 ### Examples
@@ -216,6 +218,14 @@ Result: NOT MATCH — shape rejection (different frame counts)
 Base: project.slp with /data/fly.mp4
 Other: predictions.pkg.slp (embedded, original_video=/data/fly.mp4)
 Result: MATCH — provenance chain links to same file
+```
+
+**Embedded subset vs restored original (same file, fewer frames):**
+```
+Base:  labels.pkg.slp (embedded subset: 27 of 80 frames, source_video=/data/fly.mp4)
+Other: predictions.slp (restored original /data/fly.mp4: 80 frames)
+Result: MATCH — the subset resolves to its source's 80-frame shape, so it is
+        shape-compatible and the same-file check links them
 ```
 
 **Cross-platform embedded videos (pose matching):**

--- a/sleap_io/model/matching.py
+++ b/sleap_io/model/matching.py
@@ -562,21 +562,32 @@ def is_same_file(video1: Video, video2: Video) -> bool:
 def _get_effective_shape(video: Video) -> tuple | None:
     """Get the effective shape for comparison purposes.
 
-    For embedded videos with original_video, uses the original's shape
-    if available. Falls back to backend_metadata for videos without
-    loaded backends.
+    For embedded/derived videos, prefers the shape of the nearest video in the
+    ``source_video`` chain that has a known shape. An embedded subset's frames
+    are a subset of its source, so the source's full shape -- not the subset's
+    own (smaller) frame count -- is the right identity for shape comparison.
+    Falls back to ``backend_metadata`` for videos without loaded backends.
 
     Args:
         video: The video to get shape for.
 
     Returns:
         Shape tuple (frames, height, width, channels) or None if unavailable.
+
+    Notes:
+        Walks ``source_video`` nearest-first (rather than jumping to the root
+        ``original_video``) so an intermediate source with a known shape is used
+        even when the deeper root shape is unknown -- common for an embedded
+        ``.pkg.slp`` whose deeper provenance file is not loaded. This resolution
+        reads only in-memory metadata along the chain; the heavier ``is_same_file``
+        identity check (filesystem I/O) is reserved for the actual match.
     """
-    # For embedded videos, prefer original_video's shape
-    if video.original_video is not None:
-        original_shape = _get_effective_shape(video.original_video)
-        if original_shape is not None:
-            return original_shape
+    # Prefer the nearest source's shape (subset frame counts are a view of it).
+    source = video.source_video
+    if source is not None:
+        source_shape = _get_effective_shape(source)
+        if source_shape is not None:
+            return source_shape
 
     # Try backend_metadata first (for videos with open_backend=False)
     if "shape" in video.backend_metadata:

--- a/tests/model/test_matching.py
+++ b/tests/model/test_matching.py
@@ -2,7 +2,8 @@
 
 import numpy as np
 
-from sleap_io.model.instance import Instance, Track
+import sleap_io as sio
+from sleap_io.model.instance import Instance, PredictedInstance, Track
 from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
 from sleap_io.model.matching import (
@@ -22,9 +23,11 @@ from sleap_io.model.matching import (
     VideoMatcher,
     VideoMatchMethod,
     _crop_key,
+    _get_effective_shape,
     _is_same_file_direct,
     _same_file_different_crop,
     is_same_file,
+    shapes_compatible,
 )
 from sleap_io.model.skeleton import Skeleton
 from sleap_io.model.video import Video
@@ -2927,3 +2930,271 @@ class TestVideoMatcherCropAware:
         returned = labels.add_video(v2)
         assert len(labels.videos) == 1
         assert returned is v1
+
+
+class TestEmbeddedSubsetShapeMatching:
+    """Embedded subset vs restored original match in AUTO video matching (#473).
+
+    An embedded subset of frames and its restored original source are the same
+    underlying file but legitimately differ in frame count. The AUTO cascade
+    used the heuristic ``shapes_compatible`` REJECTION before the definitive
+    ``is_same_file`` check, so a same-file pair was discarded on frame count.
+
+    The fix resolves a derived video's effective shape from the *nearest source
+    in its ``source_video`` chain* (metadata only, no file I/O): an embedded
+    subset reports its source's full shape, so it is shape-compatible with that
+    source and survives to the identity check -- even when the deeper root shape
+    is unknown. Genuine siblings that share a file but have no source
+    relationship keep their own shapes and are still rejected on frame count.
+    """
+
+    @staticmethod
+    def _subset_chain():
+        """Build the issue's provenance chain with an unknown-shape root.
+
+        Returns ``(root, restored, embedded)`` where the root ``.pkg.slp`` has
+        unknown shape (the deeper provenance file is not loaded), the restored
+        original reports 80 frames, and the embedded subset reports 27 frames.
+        """
+        root = Video(filename="labeling/original.pkg.slp", open_backend=False)
+        restored = Video(
+            filename="restored_source.pkg.slp", source_video=root, open_backend=False
+        )
+        restored.backend_metadata["shape"] = (80, 1024, 1024, 1)
+        embedded = Video(
+            filename="embedded_subset.pkg.slp",
+            source_video=restored,
+            open_backend=False,
+        )
+        embedded.backend_metadata["shape"] = (27, 1024, 1024, 1)
+        return root, restored, embedded
+
+    def test_effective_shape_uses_nearest_known_source(self):
+        """A subset resolves to its source's shape, not its own subset count."""
+        root, restored, embedded = self._subset_chain()
+        # Root shape is unknown, but the intermediate `restored` knows (80,...).
+        assert _get_effective_shape(embedded) == (80, 1024, 1024, 1)
+        assert _get_effective_shape(restored) == (80, 1024, 1024, 1)
+
+    def test_shapes_compatible_subset_vs_source(self):
+        """The subset and its source are shape-compatible despite frame diff."""
+        _, restored, embedded = self._subset_chain()
+        assert shapes_compatible(embedded, restored) is True
+        assert is_same_file(embedded, restored)
+
+    def test_find_match_restored_finds_embedded_subset(self):
+        """find_match(restored, [embedded]) returns the same-file subset."""
+        _, restored, embedded = self._subset_chain()
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.find_match(restored, [embedded]) is embedded
+
+    def test_find_match_embedded_subset_finds_restored(self):
+        """find_match is symmetric: the subset resolves to the restored source."""
+        _, restored, embedded = self._subset_chain()
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.find_match(embedded, [restored]) is restored
+
+    def test_pairwise_match_subset_restored_both_directions(self):
+        """Pairwise match() also matches the pair (used by merge)."""
+        _, restored, embedded = self._subset_chain()
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.match(embedded, restored)
+        assert matcher.match(restored, embedded)
+
+    def test_different_files_incompatible_shape_still_rejected(self):
+        """Guard: unrelated files with incompatible shapes still do not match."""
+        a = Video(filename="/data/a.mp4", open_backend=False)
+        a.backend_metadata["shape"] = (100, 480, 640, 3)
+        b = Video(filename="/data/b.mp4", open_backend=False)
+        b.backend_metadata["shape"] = (50, 480, 640, 3)
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.find_match(a, [b]) is None
+        assert not matcher.match(a, b)
+
+    def test_same_file_siblings_no_source_chain_still_rejected_on_shape(self):
+        """Distinct same-file siblings with no source link stay shape-rejected.
+
+        Two videos sharing a file but with NO source relationship and different
+        frame counts (e.g. distinct HDF5 datasets in one ``.pkg.slp``) keep
+        their own shapes and are still rejected on shape. Source-shape
+        resolution must not over-reach to genuine siblings: only a derived video
+        (one with a ``source_video``) borrows its source's shape.
+        """
+        v0 = Video(filename="project.pkg.slp", open_backend=False)
+        v0.backend_metadata["shape"] = (4, 384, 384, 1)
+        v0.backend_metadata["dataset"] = "video0/video"
+        v1 = Video(filename="project.pkg.slp", open_backend=False)
+        v1.backend_metadata["shape"] = (1, 320, 560, 3)
+        v1.backend_metadata["dataset"] = "video1/video"
+        assert shapes_compatible(v0, v1) is False
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.find_match(v1, [v0]) is None
+        assert not matcher.match(v0, v1)
+
+    def test_provenance_conflict_still_rejected(self):
+        """Guard: distinct-root chains are still rejected despite same shape."""
+        root1 = Video(filename="/data/v1.mp4", open_backend=False)
+        e1 = Video(filename="e1.pkg.slp", source_video=root1, open_backend=False)
+        e1.backend_metadata["shape"] = (100, 480, 640, 3)
+        root2 = Video(filename="/data/v2.mp4", open_backend=False)
+        e2 = Video(filename="e2.pkg.slp", source_video=root2, open_backend=False)
+        e2.backend_metadata["shape"] = (100, 480, 640, 3)
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.find_match(e1, [e2]) is None
+        assert not matcher.match(e1, e2)
+
+    def test_distinct_crops_not_collapsed(self, centered_pair_low_quality_path):
+        """Guard: distinct mosaic tiles of one file are still not collapsed."""
+        src = Video.from_filename(centered_pair_low_quality_path)
+        left = src.crop((0, 0, 192, 384))
+        right = src.crop((192, 0, 384, 384))
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.find_match(right, [left]) is None
+        assert not matcher.match(left, right)
+
+    def test_find_match_imagevideo_same_file_subset(self):
+        """ImageVideo same-file subset matches its restored original (#473).
+
+        Exercises the list-filename path with differing frame counts.
+        """
+        images = ["f0.png", "f1.png", "f2.png", "f3.png"]
+        root = Video(filename=list(images), open_backend=False)
+        restored = Video(filename=list(images), source_video=root, open_backend=False)
+        restored.backend_metadata["shape"] = (4, 128, 128, 1)
+        embedded = Video(
+            filename=list(images), source_video=restored, open_backend=False
+        )
+        embedded.backend_metadata["shape"] = (2, 128, 128, 1)
+        assert shapes_compatible(embedded, restored) is True
+        assert is_same_file(embedded, restored)
+        matcher = VideoMatcher(method=VideoMatchMethod.AUTO)
+        assert matcher.find_match(restored, [embedded]) is embedded
+        assert matcher.match(embedded, restored)
+
+    def test_labels_match_embedded_subset_to_restored_original(self):
+        """End-to-end via Labels.match(): GT subset pairs with restored preds.
+
+        Without the fix, video_map is empty and any downstream per-frame pairing
+        is lost ("Empty Frame Pairs").
+        """
+        skel = Skeleton(["a", "b"])
+        _, restored, embedded = self._subset_chain()
+        gt = Labels(
+            videos=[embedded],
+            skeletons=[skel],
+            labeled_frames=[
+                LabeledFrame(
+                    video=embedded,
+                    frame_idx=i,
+                    instances=[
+                        Instance.from_numpy([[1.0, 1.0], [2.0, 2.0]], skeleton=skel)
+                    ],
+                )
+                for i in (0, 5, 10)
+            ],
+        )
+        pr = Labels(
+            videos=[restored],
+            skeletons=[skel],
+            labeled_frames=[
+                LabeledFrame(
+                    video=restored,
+                    frame_idx=i,
+                    instances=[
+                        PredictedInstance.from_numpy(
+                            [[1.0, 1.0], [2.0, 2.0]],
+                            point_scores=[1.0, 1.0],
+                            score=1.0,
+                            skeleton=skel,
+                        )
+                    ],
+                )
+                for i in (0, 5, 10)
+            ],
+        )
+        result = gt.match(pr)
+        assert result.video_map[restored] is embedded
+        assert result.all_videos_matched
+
+    def test_labels_merge_restored_preds_into_subset_gt_dedups_video(self):
+        """End-to-end via Labels.merge(): same file is not duplicated."""
+        skel = Skeleton(["a", "b"])
+        _, restored, embedded = self._subset_chain()
+        gt = Labels(
+            videos=[embedded],
+            skeletons=[skel],
+            labeled_frames=[
+                LabeledFrame(
+                    video=embedded,
+                    frame_idx=0,
+                    instances=[
+                        Instance.from_numpy([[1.0, 1.0], [2.0, 2.0]], skeleton=skel)
+                    ],
+                )
+            ],
+        )
+        pr = Labels(
+            videos=[restored],
+            skeletons=[skel],
+            labeled_frames=[
+                LabeledFrame(
+                    video=restored,
+                    frame_idx=1,
+                    instances=[
+                        PredictedInstance.from_numpy(
+                            [[3.0, 3.0], [4.0, 4.0]],
+                            point_scores=[1.0, 1.0],
+                            score=1.0,
+                            skeleton=skel,
+                        )
+                    ],
+                )
+            ],
+        )
+        gt.merge(pr)
+        assert len(gt.videos) == 1
+        assert len(gt.labeled_frames) == 2
+
+    def test_embed_subset_restore_original_match_pipeline(
+        self, tmp_path, centered_pair_low_quality_path
+    ):
+        """Full real-file pipeline: embed subset, restore original, then match.
+
+        Embeds a labeled subset as a GT ``.pkg.slp``, saves predictions restored
+        to the original source, and matches them end-to-end through real ``.slp``
+        I/O. The restored prediction (full frame count) matches the embedded GT
+        subset (fewer frames). Here the embedded video's serialized
+        ``source_video`` carries the original's full shape, so the subset
+        resolves to it and is shape-compatible with the restored original.
+        """
+        video = sio.load_video(centered_pair_low_quality_path)
+        skel = Skeleton(["a", "b"])
+        gt = Labels(
+            videos=[video],
+            skeletons=[skel],
+            labeled_frames=[
+                LabeledFrame(
+                    video=video,
+                    frame_idx=i,
+                    instances=[
+                        Instance.from_numpy([[10.0, 10.0], [20.0, 20.0]], skeleton=skel)
+                    ],
+                )
+                for i in (0, 5, 10)
+            ],
+        )
+        gt_path = tmp_path / "gt.pkg.slp"
+        gt.save(gt_path, embed="user")
+        labels_gt = sio.load_file(gt_path)
+        assert labels_gt.videos[0].source_video is not None
+        assert labels_gt.videos[0].shape[0] == 3  # embedded subset
+
+        pred_path = tmp_path / "pred.slp"
+        labels_gt.save(pred_path, embed=False)  # restore_original_videos=True
+        labels_pr = sio.load_file(pred_path)
+        assert labels_pr.videos[0].shape[0] == video.shape[0]  # restored original
+        assert labels_pr.videos[0].shape[0] != labels_gt.videos[0].shape[0]
+
+        result = labels_gt.match(labels_pr)
+        assert result.video_map[labels_pr.videos[0]] is labels_gt.videos[0]
+        assert result.all_videos_matched


### PR DESCRIPTION
## Summary

Fixes #473. `Labels.match()` / `Labels.merge()` (the AUTO `VideoMatcher`) failed to match two videos that refer to the **same underlying file** when their effective frame counts differ — e.g. an **embedded subset** of frames vs the **restored original** source.

The AUTO cascade applies the heuristic `shapes_compatible` **rejection** before the definitive `is_same_file` identity check. `_get_effective_shape` jumped straight to the **root** `original_video` and, when the root shape was unknown, fell back to the video's **own** (subset) frame count — so an embedded subset (e.g. 27 frames) and its restored source (e.g. 80 frames) reported different frame counts and were rejected on shape *before identity was ever checked*: `is_same_file(a, b) == True` yet `match()` produced no pairing.

This broke GT↔prediction video matching in the standard "**embed a labeled subset → predict → save with `restore_original_videos=True`**" workflow. In sleap-nn it surfaced as post-training segmentation/centroid eval logging *"Empty Frame Pairs. No match found for the video frames"* and skipping eval, even though GT and predictions are the same frames of the same videos.

## Key Changes

A single surgical fix in `_get_effective_shape` (`sleap_io/model/matching.py`), plus tests and docs:

- **`_get_effective_shape`** now walks the **`source_video` chain nearest-first** and returns the first known shape from **in-memory metadata**, instead of jumping to the root `original_video` and falling back to the video's own frame count. A derived video's effective shape is therefore its **source's full shape** (a subset's frames are a view of its source), so an embedded subset is shape-compatible with its source and survives to the definitive `is_same_file` check — even when the deeper root shape is unknown (common for an embedded `.pkg.slp` whose deeper provenance file isn't loaded, where an intermediate source still carries a known shape).
- The change reads only metadata along the chain — it never opens a file. The cascade order is unchanged: the cheap metadata-only shape check stays first, and the heavier `is_same_file` filesystem I/O (`exists()`/`resolve()`) is still reserved for the actual match.
- **Docs** (`docs/merging.md`): documented that a derived video's effective shape resolves through its `source_video` chain, with a worked "embedded subset vs restored original" example.

`tests/model/test_matching.py` adds the `TestEmbeddedSubsetShapeMatching` class. No other modules are touched.

## Example Usage

```python
from sleap_io import Video
from sleap_io.model.matching import shapes_compatible, _get_effective_shape, AUTO_VIDEO_MATCHER

# Provenance chain: root (shape unknown) <- restored source (80) <- embedded subset (27)
root = Video(filename="labeling/original.pkg.slp", open_backend=False)    # root; shape unknown
mid  = Video(filename="restored_source.pkg.slp", source_video=root, open_backend=False)
mid.backend_metadata["shape"] = (80, 1024, 1024, 1)                        # restored original
emb  = Video(filename="embedded_subset.pkg.slp", source_video=mid, open_backend=False)
emb.backend_metadata["shape"] = (27, 1024, 1024, 1)                        # embedded SUBSET

_get_effective_shape(emb)                  # (80, 1024, 1024, 1) — resolved via source chain
shapes_compatible(emb, mid)                # before: False  ->  after: True
AUTO_VIDEO_MATCHER.find_match(mid, [emb])  # before: None   ->  after: emb
```

Real-world workflow this restores (GT subset ↔ restored-original predictions):

```python
import sleap_io as sio

labels_gt = sio.load_file("ground_truth.pkg.slp")   # embedded subset of frames
labels_pr = sio.load_file("predictions.slp")        # restored to original source

result = labels_gt.match(labels_pr)
assert result.all_videos_matched                    # was empty before this fix
```

## API Changes

**None to public signatures.** The only code change is inside the private helper `_get_effective_shape`; its signature and return type are unchanged.

**Behavioral change** (intended): AUTO video matching (`Labels.match`, `Labels.merge`, `VideoMatcher.find_match`/`match`, and `shapes_compatible`) now treats an embedded subset and its source as shape-compatible, so they match where they previously did not. This is strictly more permissive at the shape rung and is backed by the unchanged authoritative `is_same_file`/path rungs, so it does not introduce false matches (see Design Decisions).

## Testing

New `TestEmbeddedSubsetShapeMatching` class in `tests/model/test_matching.py`:

- **Core fix**: `_get_effective_shape` resolves a subset to its nearest known source shape when the root is unknown; `shapes_compatible(subset, source)` is `True`.
- **Matching**: `find_match` + pairwise `match` in both directions; ImageVideo (list-filename) same-file subset path.
- **End-to-end**: `Labels.match()` (populates `video_map`, `all_videos_matched`) and `Labels.merge()` (dedups the video, keeps both frames) over a synthetic chain; plus a real-file embed→restore→match pipeline through actual `.slp` I/O.
- **Regression guards**: unrelated incompatible-shape files still rejected; provenance-conflict chains still rejected; distinct mosaic crops still **not** collapsed; and **same-file siblings with no source relationship and different frame counts (e.g. distinct HDF5 datasets in one `.pkg.slp`) are still rejected on shape** — confirming source-shape resolution does not over-reach to genuine siblings.

Full `tests/model/` + `tests/io/test_slp.py` suites pass. (The unrelated `test_samefile_with_symlink` requires Windows symlink-creation privileges and also fails on `main`.)

## Design Decisions

- **Fix the shape resolution, not the cascade order.** An earlier revision of this PR reordered the cascade to run `is_same_file` *before* shape rejection. That works, but it pays `is_same_file`'s filesystem I/O (`exists()`/`resolve()`, slow on network mounts) for **every** candidate up front, and — because it made `is_same_file` authoritative-first — it required extra hardening so that distinct HDF5 datasets in one `.pkg.slp` (whose dataset a *closed* backend hides) weren't collapsed. Resolving the effective shape through the source chain is smaller, keeps the cheap metadata check as the first filter, and needs none of that hardening. (Per maintainer feedback: prefer using available shape metadata over moving heavier file I/O earlier.)

- **Walk `source_video` nearest-first, not `original_video` (root).** The root can have an unknown shape while an intermediate source carries a known one. Using the nearest known shape resolves the issue's exact scenario (deeper provenance file not loaded) using only metadata.

- **Shape stays a permissive pre-filter; identity stays authoritative.** Making the shape check more permissive only avoids *rejecting* source-linked videos — it never *causes* a match. The authoritative `is_same_file` and path rungs are unchanged, so two distinct originals that happen to share a shape do not produce a false match (verified by a regression test), and genuine same-file siblings without a source relationship are still rejected on frame count. This preserves the library's false-positive-averse contract (a wrong match is worse than a missed one).

- **Known limitation (out of scope).** If a derived video's *entire* source chain has no known shape (only its own subset count is available), it still falls back to that subset count and can be shape-rejected against its source. In practice the immediate source carries a shape (it is serialized into the `.pkg.slp`), so this does not arise in the reported workflow; matching across truly shape-less, path-divergent (e.g. cross-platform) chains continues to rely on the pose-matching rung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
