### PR TITLE
feat(coco): read instance-segmentation datasets (polygon→SegmentationMask, identity tracks)

### DIFF
--- a/docs/formats/coco.md
+++ b/docs/formats/coco.md
@@ -2,6 +2,17 @@
 
 [COCO](https://cocodataset.org/) (Common Objects in Context) format is widely used in computer vision and pose estimation. sleap-io provides full read and write support, making it compatible with tools like [mmpose](https://github.com/open-mmlab/mmpose), [CVAT](https://www.cvat.ai/), and other COCO-compatible frameworks.
 
+sleap-io reads all three COCO flavors:
+
+- **Pose** datasets (categories with `keypoints`) → `Instance` objects.
+- **Detection** datasets (annotations with `bbox`) → `BoundingBox` objects.
+- **Instance-segmentation** datasets (annotations with `segmentation`) →
+  `SegmentationMask` (or `ROI`) objects.
+
+These are not mutually exclusive: an annotation that carries both keypoints and a
+segmentation/bbox preserves all of them, with the segmentation/bbox linked back
+to the keypoint `Instance`.
+
 !!! note "Unannotated images become empty frames"
     `load_coco` creates a `LabeledFrame` for every entry in the `images` array,
     including images with zero annotations — these become **empty**
@@ -9,6 +20,56 @@
     round-trip losslessly. One caveat: an image whose file path cannot be resolved
     is skipped, so a 0-annotation image with a missing file is dropped rather than
     preserved.
+
+## Segmentation handling
+
+COCO encodes segmentation either as a polygon (a list of `[x1, y1, x2, y2, ...]`
+rings) or as RLE (a `{"counts": ..., "size": ...}` dict). RLE is always read as a
+[`SegmentationMask`][sleap_io.SegmentationMask]. Polygon handling is controlled by
+the `segmentation_format` argument of `load_coco` / `coco.read_labels`:
+
+- `"mask"` (the **default**): each annotation's polygon(s) are rasterized into a
+  single `SegmentationMask` at the image resolution. Multiple rings of one
+  annotation collapse into one object mask. This is the representation that
+  exercises the segmentation data model and round-trips through `.slp`.
+- `"roi"`: keep the native vector geometry as [`ROI`][sleap_io.ROI] objects (one
+  per ring), without rasterizing.
+
+```python
+import sleap_io as sio
+
+# Polygon segmentation -> SegmentationMask (default).
+labels = sio.load_file("annotations.coco.json")
+masks = labels.labeled_frames[0].masks
+
+# Keep polygons as vector ROIs instead.
+labels = sio.load_coco("annotations.coco.json", segmentation_format="roi")
+rois = labels.labeled_frames[0].rois
+```
+
+!!! note "Mask rasterization needs image dimensions"
+    Rasterizing a polygon requires the image `height`/`width` from the `images`
+    entry. In `"mask"` mode, a polygon whose image lacks those fields falls back
+    to an `ROI` since there is no extent to rasterize into. When written back to
+    COCO, `SegmentationMask` objects are exported as RLE.
+
+## Categories as identities
+
+In a standard COCO dataset the `category` is an object *class* (e.g. `"person"`,
+`"car"`). Some datasets instead use the category to encode a persistent
+*identity* — for example a multi-animal segmentation dataset where each animal is
+its own category. Set `category_as_track=True` to map each category to a shared
+[`Track`][sleap_io.Track] (named after the category) and assign it to every
+annotation of that category (masks, ROIs, bounding boxes, and keypoint instances
+without an explicit track id):
+
+```python
+labels = sio.load_coco("annotations.coco.json", category_as_track=True)
+[t.name for t in labels.tracks]      # one Track per category
+labels.labeled_frames[0].masks[0].track.name  # == that mask's category
+```
+
+The identity tracks are persisted to `.slp` and survive a save/load round-trip.
 
 ::: sleap_io.io.main.load_coco
 

--- a/sleap_io/io/coco.py
+++ b/sleap_io/io/coco.py
@@ -237,10 +237,85 @@ def _encode_coco_rle(mask: np.ndarray) -> dict:
     return {"counts": run_lengths, "size": [height, width]}
 
 
+def _decode_segmentation(
+    segmentation: dict | list | None,
+    height: int,
+    width: int,
+    segmentation_format: str,
+    **kwargs,
+) -> tuple[list, list]:
+    """Decode a COCO ``segmentation`` field into masks and/or ROIs.
+
+    COCO encodes segmentation either as RLE (a dict with ``counts``/``size``) or
+    as polygons (a list of flat ``[x1, y1, x2, y2, ...]`` rings, where multiple
+    rings belong to a single object). RLE is always materialized as a
+    `UserSegmentationMask`. Polygon handling depends on ``segmentation_format``:
+
+    - ``"mask"``: rasterize all rings of the annotation into a single
+      `UserSegmentationMask` at the image resolution. Requires positive
+      ``height`` and ``width``; if either is missing (``<= 0``), the polygon is
+      kept as ROI(s) instead since rasterization needs the image extent.
+    - ``"roi"``: keep the native vector geometry as one `UserROI` per ring.
+
+    Args:
+        segmentation: The COCO ``segmentation`` field (RLE dict, polygon list, or
+            ``None``).
+        height: Image height in pixels (used to rasterize polygons in mask mode).
+        width: Image width in pixels (used to rasterize polygons in mask mode).
+        segmentation_format: Either ``"mask"`` or ``"roi"``.
+        **kwargs: Metadata forwarded to the created mask/ROI objects (e.g.
+            ``category``, ``instance``).
+
+    Returns:
+        A ``(masks, rois)`` tuple of the decoded objects for this annotation.
+    """
+    masks = []
+    rois = []
+
+    if segmentation is None:
+        return masks, rois
+
+    if isinstance(segmentation, dict):
+        # RLE format: always materialize as a segmentation mask.
+        mask = _decode_coco_rle(segmentation["counts"], segmentation["size"])
+        masks.append(UserSegmentationMask.from_numpy(mask, **kwargs))
+        return masks, rois
+
+    if isinstance(segmentation, list) and len(segmentation) > 0:
+        # Polygon format: each entry is a flat [x1, y1, x2, y2, ...] ring. All
+        # rings of one annotation describe a single object. Skip degenerate rings
+        # with fewer than 3 vertices (points/lines), which cannot form a polygon.
+        polygons = []
+        for ring in segmentation:
+            coords = [
+                (float(ring[i]), float(ring[i + 1])) for i in range(0, len(ring) - 1, 2)
+            ]
+            if len(coords) >= 3:
+                polygons.append(coords)
+
+        if not polygons:
+            return masks, rois
+
+        if segmentation_format == "mask" and height > 0 and width > 0:
+            if len(polygons) == 1:
+                roi = UserROI.from_polygon(polygons[0], **kwargs)
+            else:
+                roi = UserROI.from_multi_polygon(polygons, **kwargs)
+            masks.append(roi.to_mask(height, width))
+        else:
+            # ROI mode, or mask mode without image dimensions to rasterize into.
+            for coords in polygons:
+                rois.append(UserROI.from_polygon(coords, **kwargs))
+
+    return masks, rois
+
+
 def read_labels(
     json_path: str | Path,
     dataset_root: str | Path | None = None,
     grayscale: bool = False,
+    segmentation_format: str = "mask",
+    category_as_track: bool = False,
 ) -> Labels:
     """Read COCO-style dataset and return a Labels object.
 
@@ -256,10 +331,42 @@ def read_labels(
                      of json_path.
         grayscale: If True, load images as grayscale (1 channel). If False, load as
                    RGB (3 channels). Default is False.
+        segmentation_format: How to represent polygon segmentation. ``"mask"`` (the
+            default) rasterizes each annotation's polygon(s) into a single
+            `SegmentationMask` at the image resolution; ``"roi"`` keeps the native
+            vector geometry as `ROI` objects. RLE segmentation is always read as a
+            `SegmentationMask` regardless of this setting. In ``"mask"`` mode,
+            polygons for images that lack ``height``/``width`` fall back to ROIs
+            since rasterization requires the image extent.
+        category_as_track: If True, treat each COCO category as a persistent
+            identity: one `Track` (named after the category) is created per
+            category and assigned to every annotation of that category (masks,
+            ROIs, bounding boxes, and keypoint instances without an explicit
+            track id). Useful for instance-segmentation datasets where the
+            category encodes identity rather than object class. Default is False.
 
     Returns:
         Parsed labels as a Labels instance.
+
+    Raises:
+        ValueError: If ``segmentation_format`` is not ``"mask"`` or ``"roi"``.
     """
+    if segmentation_format not in ("mask", "roi"):
+        raise ValueError(
+            f"segmentation_format must be 'mask' or 'roi', got {segmentation_format!r}."
+        )
+
+    # One shared Track per category name, created on first use.
+    category_track_dict: dict[str, Track] = {}
+
+    def _category_track(cat_name: str) -> Track | None:
+        """Return the shared Track for a category, creating it on first use."""
+        if not category_as_track or not cat_name:
+            return None
+        if cat_name not in category_track_dict:
+            category_track_dict[cat_name] = Track(name=cat_name)
+        return category_track_dict[cat_name]
+
     json_path = Path(json_path)
 
     if dataset_root is None:
@@ -355,6 +462,7 @@ def read_labels(
 
         # Get the video and frame index for this image
         shape_key = image_id_to_shape[image_id]
+        img_height, img_width = shape_key
         video = shape_to_video[shape_key]
         frame_idx = image_id_to_frame_idx[image_id]
 
@@ -382,6 +490,9 @@ def read_labels(
                         if track_id not in track_dict:
                             track_dict[track_id] = Track(name=f"track_{track_id}")
                         track = track_dict[track_id]
+                    else:
+                        # Fall back to category identity when requested.
+                        track = _category_track(cat_name)
 
                     keypoints_data = annotation["keypoints"]
                     expected_keypoints = len(skeleton.nodes)
@@ -397,33 +508,23 @@ def read_labels(
                     instances.append(instance)
 
                     # Also extract segmentation/bbox if present alongside
-                    # keypoints
+                    # keypoints. Linked annotations share the instance's track.
                     roi_kwargs = dict(
                         category=cat_name,
                         instance=instance,
+                        track=track,
                     )
 
                     segmentation = annotation.get("segmentation")
-                    if segmentation is not None:
-                        if isinstance(segmentation, dict):
-                            # RLE format
-                            mask = _decode_coco_rle(
-                                segmentation["counts"],
-                                segmentation["size"],
-                            )
-                            seg_mask = UserSegmentationMask.from_numpy(
-                                mask, **roi_kwargs
-                            )
-                            masks.append(seg_mask)
-                        elif isinstance(segmentation, list) and len(segmentation) > 0:
-                            # Polygon format
-                            for poly_flat in segmentation:
-                                coords = [
-                                    (poly_flat[i], poly_flat[i + 1])
-                                    for i in range(0, len(poly_flat), 2)
-                                ]
-                                roi = UserROI.from_polygon(coords, **roi_kwargs)
-                                rois.append(roi)
+                    seg_masks, seg_rois = _decode_segmentation(
+                        segmentation,
+                        img_height,
+                        img_width,
+                        segmentation_format,
+                        **roi_kwargs,
+                    )
+                    masks.extend(seg_masks)
+                    rois.extend(seg_rois)
 
                     # Create BoundingBox linked to instance if bbox present
                     bbox = annotation.get("bbox")
@@ -436,36 +537,27 @@ def read_labels(
                             h,
                             category=cat_name,
                             instance=instance,
+                            track=track,
                         )
                         bboxes.append(bbox_obj)
                 else:
                     # Detection-only annotation: create ROIs/masks/bboxes
                     roi_kwargs = dict(
                         category=cat_name,
+                        track=_category_track(cat_name),
                     )
 
                     # Handle segmentation field
                     segmentation = annotation.get("segmentation")
-                    if segmentation is not None:
-                        if isinstance(segmentation, dict):
-                            # RLE format
-                            mask = _decode_coco_rle(
-                                segmentation["counts"],
-                                segmentation["size"],
-                            )
-                            seg_mask = UserSegmentationMask.from_numpy(
-                                mask, **roi_kwargs
-                            )
-                            masks.append(seg_mask)
-                        elif isinstance(segmentation, list) and len(segmentation) > 0:
-                            # Polygon format
-                            for poly_flat in segmentation:
-                                coords = [
-                                    (poly_flat[i], poly_flat[i + 1])
-                                    for i in range(0, len(poly_flat), 2)
-                                ]
-                                roi = UserROI.from_polygon(coords, **roi_kwargs)
-                                rois.append(roi)
+                    seg_masks, seg_rois = _decode_segmentation(
+                        segmentation,
+                        img_height,
+                        img_width,
+                        segmentation_format,
+                        **roi_kwargs,
+                    )
+                    masks.extend(seg_masks)
+                    rois.extend(seg_rois)
 
                     # Create BoundingBox if no segmentation was processed
                     bbox = annotation.get("bbox")
@@ -511,6 +603,8 @@ def read_labels_set(
     dataset_path: str | Path,
     json_files: list[str] | None = None,
     grayscale: bool = False,
+    segmentation_format: str = "mask",
+    category_as_track: bool = False,
 ) -> dict[str, Labels]:
     """Read multiple COCO annotation files and return a dictionary of Labels.
 
@@ -523,6 +617,14 @@ def read_labels_set(
                    discovers all .json files in the dataset directory.
         grayscale: If True, load images as grayscale (1 channel). If False, load as
                    RGB (3 channels). Default is False.
+        segmentation_format: How to represent polygon segmentation. ``"mask"`` (the
+            default) rasterizes polygons into `SegmentationMask` objects; ``"roi"``
+            keeps them as vector `ROI` objects. RLE segmentation is always read as a
+            `SegmentationMask`. See `read_labels` for details.
+        category_as_track: If True, treat each COCO category as a persistent
+            identity, creating one `Track` per category and assigning it to that
+            category's annotations. See `read_labels` for details. Tracks are
+            created independently per split. Default is False.
 
     Returns:
         Dictionary mapping split names to Labels objects.
@@ -544,7 +646,13 @@ def read_labels_set(
         split_name = json_path.stem
 
         # Load labels for this split
-        labels = read_labels(json_path, dataset_root=dataset_path, grayscale=grayscale)
+        labels = read_labels(
+            json_path,
+            dataset_root=dataset_path,
+            grayscale=grayscale,
+            segmentation_format=segmentation_format,
+            category_as_track=category_as_track,
+        )
         labels_dict[split_name] = labels
 
     return labels_dict

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -681,27 +681,28 @@ def _is_alphatracker_data(data: object) -> bool:
 
 
 def _is_coco_data(data: object) -> bool:
-    """Classify already-parsed JSON data as COCO (pose) format.
+    """Classify already-parsed JSON data as COCO format.
+
+    Accepts pose (keypoint), detection (bbox), and instance-segmentation
+    (polygon or RLE) COCO datasets. COCO is a JSON *object* with ``images``,
+    ``annotations``, and ``categories`` arrays. Label Studio and AlphaTracker
+    exports are JSON *arrays*, so this dict-shaped check does not collide with
+    them; the presence of all three COCO arrays is an unambiguous signature.
 
     Args:
         data: The parsed JSON object.
 
     Returns:
-        True if the data matches the COCO pose schema, False otherwise.
+        True if the data matches the COCO schema, False otherwise.
     """
     if not isinstance(data, dict):
         return False
 
-    # COCO format has specific top-level fields
-    coco_fields = {"images", "annotations", "categories"}
-    has_coco_fields = all(field in data for field in coco_fields)
-
-    # Check if categories have keypoints (pose data)
-    has_keypoints = False
-    if "categories" in data:
-        has_keypoints = any("keypoints" in cat for cat in data["categories"])
-
-    return has_coco_fields and has_keypoints
+    # COCO stores images/annotations/categories as top-level arrays. Earlier
+    # versions also required keypoints, which excluded detection- and
+    # segmentation-only datasets; the array signature alone is sufficient.
+    coco_fields = ("images", "annotations", "categories")
+    return all(field in data and isinstance(data[field], list) for field in coco_fields)
 
 
 def _detect_alphatracker_format(json_path: str) -> bool:
@@ -858,9 +859,14 @@ def load_coco(
     json_path: str,
     dataset_root: str | None = None,
     grayscale: bool = False,
+    segmentation_format: str = "mask",
+    category_as_track: bool = False,
     **kwargs,
 ) -> Labels:
-    """Load a COCO-style pose dataset and return a Labels object.
+    """Load a COCO-style dataset and return a Labels object.
+
+    Supports pose (keypoint), detection (bbox), and instance-segmentation
+    (polygon or RLE) COCO datasets.
 
     Args:
         json_path: Path to the COCO annotation JSON file.
@@ -868,6 +874,14 @@ def load_coco(
                      of json_path.
         grayscale: If True, load images as grayscale (1 channel). If False, load as
                    RGB (3 channels). Default is False.
+        segmentation_format: How to represent polygon segmentation. ``"mask"`` (the
+            default) rasterizes polygons into `SegmentationMask` objects; ``"roi"``
+            keeps them as vector `ROI` objects. RLE segmentation is always read as a
+            `SegmentationMask`.
+        category_as_track: If True, treat each COCO category as a persistent
+            identity, creating one `Track` per category and assigning it to that
+            category's annotations. Useful for instance-segmentation datasets
+            where the category encodes identity. Default is False.
         **kwargs: Additional arguments (currently unused).
 
     Returns:
@@ -875,7 +889,13 @@ def load_coco(
     """
     from sleap_io.io import coco
 
-    return coco.read_labels(json_path, dataset_root=dataset_root, grayscale=grayscale)
+    return coco.read_labels(
+        json_path,
+        dataset_root=dataset_root,
+        grayscale=grayscale,
+        segmentation_format=segmentation_format,
+        category_as_track=category_as_track,
+    )
 
 
 def save_coco(
@@ -1086,6 +1106,11 @@ def load_file(
             - For "coco" format: dataset_root (Optional[str]): Root directory of the
               dataset. grayscale (bool): If True, load images as grayscale (1 channel).
               If False, load as RGB (3 channels). Default is False.
+              segmentation_format (str): How to represent polygon segmentation.
+              "mask" (default) rasterizes polygons into `SegmentationMask` objects;
+              "roi" keeps them as vector `ROI` objects. category_as_track (bool): If
+              True, treat each COCO category as a persistent identity, creating one
+              `Track` per category. Default is False.
             - For "jabs" format: skeleton (Optional[Skeleton]): Skeleton to use for
               the labels.
             - For "analysis_h5" format: video (Optional[Video | str]): Video to

--- a/tests/io/test_coco.py
+++ b/tests/io/test_coco.py
@@ -1780,13 +1780,24 @@ class TestCOCOROIMaskIO:
 
         labels = coco.read_labels(json_path, dataset_root=tmp_path)
 
-        # Should have created ROIs, masks, and bboxes, not instances
+        # Should have created masks and bboxes, not instances
         assert len(labels.labeled_frames) == 1
         assert len(labels.labeled_frames[0].instances) == 0
 
-        # Polygon annotation -> ROI (annotation 2 only)
-        assert len(labels.rois) == 1
-        assert labels.rois[0].category == "plant"
+        # Default segmentation_format="mask": polygon (annotation 2) and RLE
+        # (annotation 3) both become masks; no ROIs.
+        assert len(labels.rois) == 0
+        assert len(labels.masks) == 2
+        masks_by_cat = {m.category: m for m in labels.masks}
+        # Polygon annotation -> mask rasterized at the image resolution.
+        plant_mask = masks_by_cat["plant"]
+        assert plant_mask.height == 100
+        assert plant_mask.width == 200
+        assert plant_mask.area > 0
+        # RLE annotation -> mask at its native size.
+        animal_mask = masks_by_cat["animal"]
+        assert animal_mask.height == 5
+        assert animal_mask.width == 5
 
         # Bbox-only annotation -> BoundingBox (annotation 1)
         assert len(labels.bboxes) == 1
@@ -1798,11 +1809,15 @@ class TestCOCOROIMaskIO:
         assert h == pytest.approx(40.0)
         assert isinstance(labels.bboxes[0], UserBoundingBox)
 
-        # RLE annotation -> mask
-        assert len(labels.masks) == 1
-        assert labels.masks[0].category == "animal"
-        assert labels.masks[0].height == 5
-        assert labels.masks[0].width == 5
+        # segmentation_format="roi": polygon stays a vector ROI, RLE stays a mask.
+        labels_roi = coco.read_labels(
+            json_path, dataset_root=tmp_path, segmentation_format="roi"
+        )
+        assert len(labels_roi.rois) == 1
+        assert labels_roi.rois[0].category == "plant"
+        assert len(labels_roi.masks) == 1
+        assert labels_roi.masks[0].category == "animal"
+        assert len(labels_roi.bboxes) == 1
 
     def test_coco_category_preservation(self, tmp_path):
         """Test that category names roundtrip correctly."""
@@ -1892,7 +1907,7 @@ class TestCOCOROIMaskIO:
         assert h == pytest.approx(40.0)
 
     def test_coco_detection_with_polygon_read(self, tmp_path):
-        """Test reading polygon segmentation creates ROI with correct coords."""
+        """Polygon segmentation rasterizes to a mask by default (roi opt-out)."""
         img_path = tmp_path / "img.png"
         img_path.touch()
 
@@ -1918,12 +1933,30 @@ class TestCOCOROIMaskIO:
         with open(json_path, "w") as f:
             json.dump(data, f)
 
+        # Default segmentation_format="mask": polygon -> rasterized mask.
         labels = coco.read_labels(json_path, dataset_root=tmp_path)
+        assert len(labels.rois) == 0
+        assert len(labels.masks) == 1
+        mask = labels.masks[0]
+        assert isinstance(mask, UserSegmentationMask)
+        assert mask.category == "obj"
+        assert mask.height == 100
+        assert mask.width == 100
+        # Mask bbox (in image coords) matches the polygon extent within a pixel.
+        bx, by, bw, bh = mask.bbox
+        assert bx == pytest.approx(10.0, abs=1.0)
+        assert by == pytest.approx(10.0, abs=1.0)
+        assert (bx + bw) == pytest.approx(50.0, abs=1.0)
+        assert (by + bh) == pytest.approx(50.0, abs=1.0)
 
-        assert len(labels.rois) == 1
-        roi = labels.rois[0]
+        # segmentation_format="roi": keep native vector geometry.
+        labels_roi = coco.read_labels(
+            json_path, dataset_root=tmp_path, segmentation_format="roi"
+        )
+        assert len(labels_roi.masks) == 0
+        assert len(labels_roi.rois) == 1
+        roi = labels_roi.rois[0]
         assert roi.category == "obj"
-        # Check bounds approximately
         minx, miny, maxx, maxy = roi.bounds
         assert minx == pytest.approx(10.0)
         assert miny == pytest.approx(10.0)
@@ -1982,15 +2015,21 @@ def test_read_labels_keypoints_and_segmentation(tmp_path):
     assert points[1, 0] == pytest.approx(70.0)
     assert points[1, 1] == pytest.approx(70.0)
 
-    # Should also have ROI from segmentation polygon
-    assert len(labels.rois) == 1
-    roi = labels.rois[0]
-    assert roi.category == "animal"
-    minx, miny, maxx, maxy = roi.bounds
-    assert minx == pytest.approx(10.0)
-    assert miny == pytest.approx(10.0)
-    assert maxx == pytest.approx(90.0)
-    assert maxy == pytest.approx(90.0)
+    # Should also have a mask from the segmentation polygon (default mask mode),
+    # rasterized at the image resolution and linked to the same instance.
+    assert len(labels.rois) == 0
+    assert len(labels.masks) == 1
+    mask = labels.masks[0]
+    assert isinstance(mask, UserSegmentationMask)
+    assert mask.category == "animal"
+    assert mask.instance is instance
+    assert mask.height == 100
+    assert mask.width == 100
+    bx, by, bw, bh = mask.bbox
+    assert bx == pytest.approx(10.0, abs=1.0)
+    assert by == pytest.approx(10.0, abs=1.0)
+    assert (bx + bw) == pytest.approx(90.0, abs=1.0)
+    assert (by + bh) == pytest.approx(90.0, abs=1.0)
 
     # Should also have a BoundingBox linked to the instance
     assert len(labels.bboxes) == 1
@@ -2059,6 +2098,272 @@ def test_read_labels_keypoints_and_rle_segmentation(tmp_path):
     assert mask.width == 5
     # Mask should be linked to the instance
     assert mask.instance is labels.labeled_frames[0].instances[0]
+
+
+def test_coco_read_invalid_segmentation_format(tmp_path):
+    """An unknown segmentation_format raises ValueError."""
+    data = {
+        "images": [{"id": 1, "file_name": "img.png", "height": 10, "width": 10}],
+        "annotations": [],
+        "categories": [{"id": 1, "name": "obj"}],
+    }
+    json_path = tmp_path / "x.json"
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+    with pytest.raises(ValueError, match="segmentation_format"):
+        coco.read_labels(json_path, dataset_root=tmp_path, segmentation_format="bad")
+
+
+def test_coco_polygon_mask_falls_back_to_roi_without_dims(tmp_path):
+    """In mask mode, polygons fall back to ROI when image dims are missing."""
+    img_path = tmp_path / "img.png"
+    img_path.touch()
+    data = {
+        "images": [{"id": 1, "file_name": "img.png"}],  # no height/width
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "segmentation": [[1.0, 1.0, 5.0, 1.0, 5.0, 5.0, 1.0, 5.0]],
+            }
+        ],
+        "categories": [{"id": 1, "name": "obj"}],
+    }
+    json_path = tmp_path / "nodims.json"
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+    # Default mask mode cannot rasterize without dims, so it keeps the polygon.
+    labels = coco.read_labels(json_path, dataset_root=tmp_path)
+    assert len(labels.masks) == 0
+    assert len(labels.rois) == 1
+    assert labels.rois[0].category == "obj"
+
+
+def test_coco_multipolygon_annotation_single_mask(tmp_path):
+    """Multiple polygons in one annotation rasterize to a single mask."""
+    img_path = tmp_path / "img.png"
+    img_path.touch()
+    data = {
+        "images": [{"id": 1, "file_name": "img.png", "height": 50, "width": 50}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "segmentation": [
+                    [1.0, 1.0, 10.0, 1.0, 10.0, 10.0, 1.0, 10.0],
+                    [20.0, 20.0, 30.0, 20.0, 30.0, 30.0, 20.0, 30.0],
+                ],
+            }
+        ],
+        "categories": [{"id": 1, "name": "obj"}],
+    }
+    json_path = tmp_path / "multipoly.json"
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+    labels = coco.read_labels(json_path, dataset_root=tmp_path)
+    # Two disjoint rings of one annotation collapse into a single object mask
+    # spanning both squares.
+    assert len(labels.masks) == 1
+    m = labels.masks[0]
+    assert m.area > 0
+    bx, by, bw, bh = m.bbox
+    assert bx == pytest.approx(1.0, abs=1.0)
+    assert (bx + bw) == pytest.approx(30.0, abs=1.0)
+    assert by == pytest.approx(1.0, abs=1.0)
+    assert (by + bh) == pytest.approx(30.0, abs=1.0)
+
+
+def test_coco_polygon_degenerate_ring_skipped(tmp_path):
+    """A polygon ring with fewer than 3 vertices is skipped, not crashed on."""
+    img_path = tmp_path / "img.png"
+    img_path.touch()
+    data = {
+        "images": [{"id": 1, "file_name": "img.png", "height": 40, "width": 40}],
+        "annotations": [
+            # Degenerate ring (a single point): cannot form a polygon.
+            {"id": 1, "image_id": 1, "category_id": 1, "segmentation": [[5.0, 5.0]]},
+            # Valid ring alongside it on another object.
+            {
+                "id": 2,
+                "image_id": 1,
+                "category_id": 1,
+                "segmentation": [[1.0, 1.0, 10.0, 1.0, 10.0, 10.0, 1.0, 10.0]],
+            },
+        ],
+        "categories": [{"id": 1, "name": "obj"}],
+    }
+    json_path = tmp_path / "degenerate.json"
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+    # Does not raise; the degenerate ring yields no mask, the valid one does.
+    labels = coco.read_labels(json_path, dataset_root=tmp_path)
+    assert len(labels.masks) == 1
+    assert labels.masks[0].area > 0
+
+
+def test_coco_segmentation_load_file_and_slp_roundtrip(tmp_path):
+    """Keypoint-free segmentation COCO auto-detects and round-trips via .slp."""
+    img = np.zeros((20, 20, 3), dtype=np.uint8)
+    img_path = tmp_path / "frame.png"
+    iio.imwrite(str(img_path), img)
+    data = {
+        "images": [{"id": 1, "file_name": "frame.png", "height": 20, "width": 20}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "segmentation": [[2.0, 2.0, 15.0, 2.0, 15.0, 15.0, 2.0, 15.0]],
+                "bbox": [2, 2, 13, 13],
+                "area": 169,
+                "iscrowd": 0,
+            }
+        ],
+        "categories": [{"id": 1, "name": "critter"}],
+    }
+    json_path = tmp_path / "seg.coco.json"
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+
+    # load_file auto-detects COCO despite the absence of keypoints.
+    labels = sio.load_file(str(json_path))
+    assert sum(len(lf.masks) for lf in labels.labeled_frames) == 1
+    mask = labels.masks[0]
+    assert isinstance(mask, UserSegmentationMask)
+    assert mask.category == "critter"
+
+    # Round-trip through .slp preserves the mask, category, and area.
+    slp_path = tmp_path / "seg.slp"
+    sio.save_file(labels, str(slp_path))
+    reloaded = sio.load_file(str(slp_path))
+    rmasks = [m for lf in reloaded.labeled_frames for m in lf.masks]
+    assert len(rmasks) == 1
+    assert rmasks[0].category == "critter"
+    assert rmasks[0].area == mask.area
+
+
+def test_coco_load_file_forwards_kwargs(tmp_path):
+    """load_file forwards segmentation_format and category_as_track to load_coco."""
+    img_path = tmp_path / "frame.png"
+    img_path.touch()
+    data = {
+        "images": [{"id": 1, "file_name": "frame.png", "height": 30, "width": 30}],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "segmentation": [[2.0, 2.0, 15.0, 2.0, 15.0, 15.0, 2.0, 15.0]],
+            }
+        ],
+        "categories": [{"id": 1, "name": "critter"}],
+    }
+    json_path = tmp_path / "kw.coco.json"
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+
+    # segmentation_format="roi" forwarded -> polygon kept as vector ROI.
+    roi_labels = sio.load_file(str(json_path), segmentation_format="roi")
+    assert len(roi_labels.rois) == 1
+    assert len(roi_labels.masks) == 0
+
+    # category_as_track=True forwarded -> identity Track named after the category.
+    track_labels = sio.load_file(str(json_path), category_as_track=True)
+    assert {t.name for t in track_labels.tracks} == {"critter"}
+    assert track_labels.masks[0].track.name == "critter"
+
+
+def test_coco_category_as_track(tmp_path):
+    """category_as_track assigns one shared Track per category as identity."""
+    (tmp_path / "img1.png").touch()
+    (tmp_path / "img2.png").touch()
+    # Two categories ("a", "b") appearing across two frames.
+    data = {
+        "images": [
+            {"id": 1, "file_name": "img1.png", "height": 40, "width": 40},
+            {"id": 2, "file_name": "img2.png", "height": 40, "width": 40},
+        ],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "segmentation": [[1.0, 1.0, 10.0, 1.0, 10.0, 10.0, 1.0, 10.0]],
+            },
+            {
+                "id": 2,
+                "image_id": 1,
+                "category_id": 2,
+                "segmentation": [[20.0, 20.0, 30.0, 20.0, 30.0, 30.0, 20.0, 30.0]],
+            },
+            {
+                "id": 3,
+                "image_id": 2,
+                "category_id": 1,
+                "segmentation": [[2.0, 2.0, 12.0, 2.0, 12.0, 12.0, 2.0, 12.0]],
+            },
+            # A bbox-only annotation (no segmentation) for category "b".
+            {
+                "id": 4,
+                "image_id": 2,
+                "category_id": 2,
+                "bbox": [5.0, 5.0, 8.0, 8.0],
+            },
+        ],
+        "categories": [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}],
+    }
+    json_path = tmp_path / "ident.coco.json"
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+
+    labels = coco.read_labels(json_path, dataset_root=tmp_path, category_as_track=True)
+
+    # One Track per category, collected onto the Labels.
+    assert {t.name for t in labels.tracks} == {"a", "b"}
+    # Every mask's track name equals its category.
+    for m in labels.masks:
+        assert m.track is not None
+        assert m.track.name == m.category
+    # The bbox-only annotation also gets its category track.
+    assert len(labels.bboxes) == 1
+    assert labels.bboxes[0].track is not None
+    assert labels.bboxes[0].track.name == labels.bboxes[0].category == "b"
+    # The bbox and the masks of category "b" share the same Track object.
+    b_mask = next(m for m in labels.masks if m.category == "b")
+    assert labels.bboxes[0].track is b_mask.track
+    # The two "a" masks (different frames) share the same Track object.
+    a_masks = [m for m in labels.masks if m.category == "a"]
+    assert len(a_masks) == 2
+    assert a_masks[0].track is a_masks[1].track
+
+    # Identity tracks survive a .slp round-trip.
+    slp_path = tmp_path / "ident.slp"
+    sio.save_file(labels, str(slp_path))
+    reloaded = sio.load_file(str(slp_path))
+    assert {t.name for t in reloaded.tracks} == {"a", "b"}
+    for m in reloaded.masks:
+        assert m.track is not None
+        assert m.track.name == m.category
+
+    # roi mode also assigns category tracks to the vector ROIs.
+    roi_labels = coco.read_labels(
+        json_path,
+        dataset_root=tmp_path,
+        segmentation_format="roi",
+        category_as_track=True,
+    )
+    assert {t.name for t in roi_labels.tracks} == {"a", "b"}
+    for r in roi_labels.rois:
+        assert r.track is not None
+        assert r.track.name == r.category
+
+    # Default (category_as_track=False) leaves masks and bboxes untracked.
+    untracked = coco.read_labels(json_path, dataset_root=tmp_path)
+    assert len(untracked.tracks) == 0
+    assert all(m.track is None for m in untracked.masks)
+    assert all(b.track is None for b in untracked.bboxes)
 
 
 def test_coco_detection_reads_as_bbox(tmp_path):

--- a/tests/io/test_main.py
+++ b/tests/io/test_main.py
@@ -1247,6 +1247,26 @@ def test_gdrive_format_from_bytes_json_coco():
     assert _gdrive_format_from_bytes(coco) == "coco"
 
 
+def test_gdrive_format_from_bytes_json_coco_segmentation():
+    """A keypoint-free segmentation COCO JSON object is classified as coco."""
+    coco = json.dumps(
+        {
+            "images": [{"id": 1, "file_name": "a.png", "height": 4, "width": 4}],
+            "annotations": [
+                {
+                    "id": 1,
+                    "image_id": 1,
+                    "category_id": 1,
+                    "segmentation": [[0, 0, 3, 0, 3, 3, 0, 3]],
+                    "bbox": [0, 0, 3, 3],
+                }
+            ],
+            "categories": [{"id": 1, "name": "obj"}],
+        }
+    ).encode()
+    assert _gdrive_format_from_bytes(coco) == "coco"
+
+
 def test_gdrive_format_from_bytes_json_alphatracker():
     """An AlphaTracker JSON array is classified as alphatracker."""
     at = json.dumps(


### PR DESCRIPTION
## Summary

Adds first-class support for reading **COCO instance-segmentation** datasets (polygon or RLE) into the segmentation data model, and makes keypoint-free COCO datasets load through the normal auto-detection path. Previously, polygon `segmentation` was always read as a vector `UserROI` (only RLE became a `SegmentationMask`), and `load_file()` could not auto-detect a COCO file that lacked keypoints.

## Key Changes

- **Polygon segmentation → `SegmentationMask` by default.** `coco.read_labels` / `read_labels_set` / `load_coco` gain a `segmentation_format` argument:
  - `"mask"` (**new default**): each annotation's polygon(s) are rasterized into a single `UserSegmentationMask` at the image resolution. Multiple rings of one annotation collapse into one object mask.
  - `"roi"`: keeps the previous behavior (one `UserROI` per ring).
  - RLE segmentation is always read as a `SegmentationMask`, regardless of the setting.
- **Keypoint-free COCO auto-detection.** `_is_coco_data` now recognizes detection/segmentation-only COCO (a JSON object with `images`/`annotations`/`categories` arrays) instead of requiring keypoints. Label Studio and AlphaTracker exports are JSON *arrays*, so this dict-shaped signature does not collide with them.
- **Categories as identities.** A new `category_as_track` option creates one shared `Track` per COCO category (named after the category) and assigns it to that category's masks, ROIs, bounding boxes, and keypoint instances (when they have no explicit track id). Useful for instance-segmentation datasets where the category encodes identity rather than object class. Default `False`.

## Example Usage

```python
import sleap_io as sio

# Polygon segmentation -> SegmentationMask (new default), auto-detected even
# without keypoints:
labels = sio.load_file("annotations.coco.json")
masks = labels.labeled_frames[0].masks

# Keep polygons as vector ROIs instead:
labels = sio.load_coco("annotations.coco.json", segmentation_format="roi")

# Treat each category as a persistent identity track:
labels = sio.load_coco("annotations.coco.json", category_as_track=True)
[t.name for t in labels.tracks]                 # one Track per category
labels.labeled_frames[0].masks[0].track.name    # == that mask's category
```

Masks round-trip through `.slp` (RLE-compressed `mask_rle` dataset), with category and identity-track preserved.

## API Changes

- `coco.read_labels(..., segmentation_format="mask", category_as_track=False)` — new keyword args (back-compatible signature; **behavior default changed** for polygon segmentation, see below).
- `coco.read_labels_set(...)` and `main.load_coco(...)` — same two new keyword args, forwarded through; `load_file(..., segmentation_format=..., category_as_track=...)` forwards them too.
- `read_labels` raises `ValueError` for an unknown `segmentation_format`.

## Design Decisions

- **Polygon → mask is the new default (breaking).** COCO's `segmentation` field *is* the segmentation, so mapping it to the `SegmentationMask` model is the more faithful default and is what exercises the segmentation pipeline end-to-end. The previous polygon→ROI behavior remains available via `segmentation_format="roi"`. The existing polygon-read test was updated and a roi-mode test added.
- **Mask rasterization needs image dimensions.** Polygons are rasterized at the `images` entry's `height`/`width`. If those are missing, the polygon falls back to an `ROI` (there is no extent to rasterize into).
- **Degenerate polygon rings are skipped.** A ring with fewer than 3 vertices (a point/line, or a malformed odd-length ring) cannot form a polygon, so it is skipped rather than crashing Shapely.
- **Detection broadening is safe.** Only JSON *objects* with all three COCO arrays match; the array-shaped Label Studio / AlphaTracker formats are unaffected, and detection order is unchanged.

## Testing

- New/updated tests in `tests/io/test_coco.py`: mask-default vs roi-mode reads, multi-polygon→single mask (x and y extents), degenerate-ring skip, dims-fallback, invalid `segmentation_format`, `category_as_track` (masks + bboxes + roi-mode ROIs, shared Track objects, `.slp` round-trip, off-by-default), `load_file` kwarg forwarding, and a keypoint-free COCO `load_file` + `.slp` round-trip.
- New detection test in `tests/io/test_main.py` for keypoint-free segmentation COCO.
- Reviewed via an adversarial multi-agent pass (multi-dimension review + skeptic verification); confirmed findings applied.
- `ruff format`/`ruff check` clean; full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
