### PR TITLE
fix(csv): Analysis CSV / DataFrame export should span the full video

### DIFF
--- a/docs/formats/csv.md
+++ b/docs/formats/csv.md
@@ -167,6 +167,12 @@ sio.save_csv(labels, "sparse.csv", include_empty=False)
 sio.save_csv(labels, "clip.csv", start_frame=100, end_frame=500)
 ```
 
+When `include_empty=True` and no explicit `end_frame` is given, padding spans the
+full video length when it is known (e.g. instances stopping at frame 1000 in a
+2000-frame video still export rows through frame 1999). This matches the Analysis
+HDF5 export. If the video length cannot be resolved, padding falls back to the last
+labeled frame.
+
 ## Metadata Sidecar
 
 CSV files cannot store all Labels information (skeleton edges, symmetries, suggestions). To enable full round-trip reconstruction, use `save_metadata=True`:

--- a/sleap_io/codecs/dataframe.py
+++ b/sleap_io/codecs/dataframe.py
@@ -155,7 +155,7 @@ def to_dataframe(
         start_frame: Start frame index (inclusive) for frame padding. If None, starts
             from 0 when all_frames=True, or from first labeled frame otherwise.
         end_frame: End frame index (exclusive) for frame padding. If None, ends at
-            last labeled frame + 1.
+            the full video length when known, otherwise at last labeled frame + 1.
 
     Returns:
         DataFrame in the specified format. Type depends on backend parameter.
@@ -1148,9 +1148,19 @@ def _to_instances_df(  # noqa: D417
                 # No labeled frames for this video - skip padding
                 continue
 
-            # Determine range
+            # Determine range. Default to the full video length (when known) so the
+            # output spans the whole video, mirroring the numpy/Analysis-HDF5 path
+            # (see sleap_io/codecs/numpy.py). len(vid) is an exclusive end (a frame
+            # count), and returns 0 when the shape can't be resolved, preserving the
+            # fallback to the last labeled frame.
             first = start_frame if start_frame is not None else 0
-            last = end_frame if end_frame is not None else max(vid_frame_idxs) + 1
+            if end_frame is not None:
+                last = end_frame
+            else:
+                last = max(vid_frame_idxs) + 1
+                video_length = len(vid)
+                if video_length > 0:
+                    last = max(last, video_length)
 
             # Add empty rows for missing frames
             for frame_idx in range(first, last):
@@ -1478,8 +1488,8 @@ def _to_frames_df(  # noqa: D417
         all_frames: If True, include rows for empty frames in the specified range.
         start_frame: Start frame index (inclusive) for padding. Default: 0 if
             all_frames=True, else first labeled frame.
-        end_frame: End frame index (exclusive) for padding. Default: last labeled
-            frame + 1.
+        end_frame: End frame index (exclusive) for padding. Default: the full video
+            length when known, otherwise last labeled frame + 1.
 
     Column structure (instance_id="index"):
         frame_idx | video | inst0.track | inst0.track_score | inst0.score |
@@ -1558,9 +1568,19 @@ def _to_frames_df(  # noqa: D417
                 # No labeled frames for this video - skip padding
                 continue
 
-            # Determine range
+            # Determine range. Default to the full video length (when known) so the
+            # output spans the whole video, mirroring the numpy/Analysis-HDF5 path
+            # (see sleap_io/codecs/numpy.py). len(vid) is an exclusive end (a frame
+            # count), and returns 0 when the shape can't be resolved, preserving the
+            # fallback to the last labeled frame.
             first = start_frame if start_frame is not None else 0
-            last = end_frame if end_frame is not None else max(vid_frame_idxs) + 1
+            if end_frame is not None:
+                last = end_frame
+            else:
+                last = max(vid_frame_idxs) + 1
+                video_length = len(vid)
+                if video_length > 0:
+                    last = max(last, video_length)
 
             # Add empty entries for missing frames
             for frame_idx in range(first, last):

--- a/sleap_io/io/csv.py
+++ b/sleap_io/io/csv.py
@@ -154,8 +154,8 @@ def write_labels(
             Default False.
         start_frame: Start frame index (inclusive) for output. If None, starts
             from 0 when include_empty=True, or from first labeled frame otherwise.
-        end_frame: End frame index (exclusive) for output. If None, ends at
-            last labeled frame + 1.
+        end_frame: End frame index (exclusive) for output. If None, ends at the
+            full video length when known, otherwise at last labeled frame + 1.
         chunk_size: Number of rows per chunk for memory-efficient writing. If None
             (default), writes entire DataFrame at once. Useful for large datasets
             that don't fit in memory. Not supported for DLC format.

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -398,7 +398,8 @@ def save_analysis_h5(
         video: Video to export. If None, uses first video. Can be a Video
             object or an integer index.
         labels_path: Source labels path (stored as metadata).
-        all_frames: Include all frames from 0 to last labeled frame.
+        all_frames: Include all frames from 0 to the end of the video (falling back
+            to the last labeled frame when the video length is unknown).
             Default True.
         min_occupancy: Minimum track occupancy ratio (0-1) to keep.
             0 = keep all non-empty tracks (SLEAP default).
@@ -851,8 +852,8 @@ def save_csv(
             Default False. Only applies to "frames" and "instances" formats.
         start_frame: Start frame index (inclusive) for output. If None, starts
             from 0 when include_empty=True, or from first labeled frame otherwise.
-        end_frame: End frame index (exclusive) for output. If None, ends at
-            last labeled frame + 1.
+        end_frame: End frame index (exclusive) for output. If None, ends at the
+            full video length when known, otherwise at last labeled frame + 1.
         scorer: Scorer name for DLC format. Default "sleap-io".
         save_metadata: Save JSON metadata file alongside CSV that enables
             full round-trip reconstruction. Default False.

--- a/tests/codecs/test_dataframe.py
+++ b/tests/codecs/test_dataframe.py
@@ -4164,3 +4164,89 @@ def test_to_dataframe_frames_all_frames_multi_video_with_empty():
     assert list(df["frame_idx"]) == [0, 1, 2]
     # All rows should be from video1
     assert all(df["video_path"] == "video1.mp4")
+
+
+def _labels_with_known_length(format_nodes, frame_idxs, video_length):
+    """Build Labels over a video whose length is known via backend_metadata."""
+    skeleton = Skeleton(format_nodes)
+    video = Video(filename="fake.mp4")
+    video.backend_metadata = {"shape": (video_length, 64, 64, 1)}
+
+    labeled_frames = []
+    for frame_idx in frame_idxs:
+        inst = Instance.from_numpy(
+            np.array([[100.0, 200.0], [150.0, 250.0]]), skeleton=skeleton
+        )
+        labeled_frames.append(
+            LabeledFrame(video=video, frame_idx=frame_idx, instances=[inst])
+        )
+    return Labels(labeled_frames=labeled_frames), video
+
+
+def test_to_dataframe_frames_all_frames_spans_full_video():
+    """all_frames pads to the full video length, not just the last labeled frame."""
+    labels, video = _labels_with_known_length(["nose", "tail"], [2, 4], 10)
+    assert len(video) == 10
+
+    df = to_dataframe(labels, format="frames", all_frames=True)
+
+    # Should span 0..9 (len(video) - 1), not stop at the last labeled frame (4).
+    assert list(df["frame_idx"]) == list(range(10))
+
+
+def test_to_dataframe_instances_all_frames_spans_full_video():
+    """Instances format pads to the full video length when it is known."""
+    labels, video = _labels_with_known_length(["nose", "tail"], [1, 3], 8)
+    assert len(video) == 8
+
+    df = to_dataframe(labels, format="instances", all_frames=True)
+
+    assert set(df["frame_idx"]) == set(range(8))
+
+
+def test_to_dataframe_all_frames_unknown_video_length_unchanged():
+    """When video length is unknown, padding ends at the last labeled frame."""
+    skeleton = Skeleton(["nose", "tail"])
+    video = Video(filename="unknown.mp4")  # No resolvable shape.
+    assert len(video) == 0
+
+    labeled_frames = []
+    for frame_idx in [0, 2]:
+        inst = Instance.from_numpy(
+            np.array([[100.0, 200.0], [150.0, 250.0]]), skeleton=skeleton
+        )
+        labeled_frames.append(
+            LabeledFrame(video=video, frame_idx=frame_idx, instances=[inst])
+        )
+    labels = Labels(labeled_frames=labeled_frames)
+
+    df_frames = to_dataframe(labels, format="frames", all_frames=True)
+    assert list(df_frames["frame_idx"]) == [0, 1, 2]
+
+    df_instances = to_dataframe(labels, format="instances", all_frames=True)
+    assert set(df_instances["frame_idx"]) == {0, 1, 2}
+
+
+def test_to_dataframe_all_frames_explicit_end_overrides_video_length():
+    """Explicit end_frame still takes precedence over the video length."""
+    labels, _ = _labels_with_known_length(["nose", "tail"], [0, 2], 100)
+
+    df_frames = to_dataframe(labels, format="frames", all_frames=True, end_frame=5)
+    assert list(df_frames["frame_idx"]) == [0, 1, 2, 3, 4]
+
+    df_instances = to_dataframe(
+        labels, format="instances", all_frames=True, end_frame=5
+    )
+    assert set(df_instances["frame_idx"]) == {0, 1, 2, 3, 4}
+
+
+def test_to_dataframe_all_frames_video_shorter_than_labels():
+    """When labels extend past the known length, padding still covers all labels."""
+    # Embedded pkg.slp case: len(video) reflects an embedded subset that can be
+    # smaller than the largest labeled frame index. The range must still cover
+    # every labeled frame.
+    labels, video = _labels_with_known_length(["nose", "tail"], [0, 6], 3)
+    assert len(video) == 3
+
+    df = to_dataframe(labels, format="frames", all_frames=True)
+    assert list(df["frame_idx"]) == [0, 1, 2, 3, 4, 5, 6]

--- a/tests/io/test_csv.py
+++ b/tests/io/test_csv.py
@@ -724,6 +724,33 @@ class TestIncludeEmpty:
         # Should have frames 0, 1, 2, 3
         assert list(df["frame_idx"]) == [0, 1, 2, 3]
 
+    def test_include_empty_sleap_spans_full_video(self, tmp_path):
+        """Analysis CSV export spans the whole video, not just labeled frames.
+
+        Reproduces talmolab/sleap#2774: instances stop before the end of a longer
+        video, but the exported CSV should still run to the final frame.
+        """
+        skeleton = Skeleton(nodes=["a", "b"], edges=[("a", "b")])
+        video = Video(filename="fake.mp4")
+        video.backend_metadata = {"shape": (2000, 64, 64, 1)}
+        assert len(video) == 2000
+
+        labeled_frames = []
+        for frame_idx in range(100, 1001):  # Instances only in 100..1000.
+            inst = Instance(
+                points={"a": [1.0, 2.0], "b": [3.0, 4.0]}, skeleton=skeleton
+            )
+            labeled_frames.append(
+                LabeledFrame(video=video, frame_idx=frame_idx, instances=[inst])
+            )
+        labels = Labels(labeled_frames=labeled_frames)
+
+        csv_path = tmp_path / "full_video.csv"
+        csv.write_labels(labels, csv_path, format="sleap", include_empty=True)
+
+        df = pd.read_csv(csv_path)
+        assert df["frame_idx"].max() == 1999
+
 
 # =============================================================================
 # Chunked Writing Tests


### PR DESCRIPTION
## Summary

Exporting predictions to Analysis CSV (`sio.save_csv(..., format="sleap", include_empty=True)` — what SLEAP's GUI **Export Analysis CSV** calls) stopped at the last frame that contained an instance instead of running to the end of the video. A 2000-frame video with instances only in frames 100–1000 produced a CSV that ended at frame 1000.

This aligns the CSV/DataFrame export range with the numpy / Analysis-HDF5 export so **both span the full video**.

Refs **talmolab/sleap#2774** (the issue lives in `talmolab/sleap`; the fix is here in `sleap-io`).

## Root cause

The `all_frames` padding loops in the DataFrame codec computed the end of the frame range from the last *labeled* frame and never consulted the video length:

- `sleap_io/codecs/dataframe.py` — instances format (`_to_instances_df`)
- `sleap_io/codecs/dataframe.py` — frames format (`_to_frames_df`)

Both contained:
```python
first = start_frame if start_frame is not None else 0
last = end_frame if end_frame is not None else max(vid_frame_idxs) + 1
```

`max(vid_frame_idxs) + 1` is the last frame with an instance, so empty frames were only padded up to there. The numpy/Analysis-HDF5 path (`sleap_io/codecs/numpy.py`) already clamps to the full video length, so HDF5 analysis exports spanned the whole video while CSV exports did not.

The SLEAP Analysis CSV (`format="sleap"`) routes through `_write_sleap` → `to_dataframe(format="instances")`, so it hits the **instances** padding block; the **frames** block is the same fix for `format="frames"`.

## Key Changes

- **`sleap_io/codecs/dataframe.py`** — in both padding blocks, when no explicit `end_frame` is given, extend the default range end to `len(vid)` when the video length is known, mirroring the numpy path:
  ```python
  first = start_frame if start_frame is not None else 0
  if end_frame is not None:
      last = end_frame
  else:
      last = max(vid_frame_idxs) + 1
      video_length = len(vid)
      if video_length > 0:
          last = max(last, video_length)
  ```
- **Docstrings** (`dataframe.py`, `io/csv.py`, `io/main.py`) updated to describe the new default. The HDF5 `save_analysis_h5` `all_frames` docstring was also corrected — it already clamped to the video length but was documented as "to last labeled frame".
- **`docs/formats/csv.md`** — documents that `include_empty=True` padding now spans the full video, matching the HDF5 export.

## Example Usage

```python
import numpy as np
import sleap_io as sio
from sleap_io import Labels, LabeledFrame, Video, Skeleton, Instance, Track

skel = Skeleton(["a", "b"])
video = Video(filename="fake.mp4")
video.backend_metadata = {"shape": (2000, 64, 64, 1)}  # 2000-frame video

trk = Track("0")
lfs = [
    LabeledFrame(
        video=video, frame_idx=fi,
        instances=[Instance.from_numpy(np.array([[1.0, 2.0], [3.0, 4.0]]),
                                       skeleton=skel, track=trk)],
    )
    for fi in range(100, 1001)  # instances only in 100..1000
]
labels = Labels(labeled_frames=lfs, videos=[video], skeletons=[skel], tracks=[trk])

sio.save_csv(labels, "out.csv", format="sleap", include_empty=True)

import pandas as pd
print(pd.read_csv("out.csv")["frame_idx"].max())  # before: 1000  →  after: 1999
```

## API Changes

No signature changes. Behavior change only: with `include_empty=True`/`all_frames=True` and no explicit `end_frame`, padding now extends to the full video length when known. Explicit `start_frame`/`end_frame` still take precedence exactly as before; when the video length is unknown, behavior is unchanged (ends at the last labeled frame).

## Testing

New focused tests (all RED before the fix, GREEN after):

`tests/codecs/test_dataframe.py`
- `test_to_dataframe_frames_all_frames_spans_full_video`
- `test_to_dataframe_instances_all_frames_spans_full_video`
- `test_to_dataframe_all_frames_unknown_video_length_unchanged`
- `test_to_dataframe_all_frames_explicit_end_overrides_video_length`
- `test_to_dataframe_all_frames_video_shorter_than_labels` (embedded-subset guard)

`tests/io/test_csv.py`
- `TestIncludeEmpty::test_include_empty_sleap_spans_full_video` (the #2774 repro: max `frame_idx` is `1999`)

Full `tests/codecs/test_dataframe.py`, `tests/io/test_csv.py`, `tests/codecs/test_numpy.py`, `tests/io/test_analysis_h5.py` pass (315 passed, 16 pre-existing skips). `ruff format` / `ruff check` clean.

## Design Decisions

- **Use `len(vid)` as the exclusive range end.** `range(first, last)` is exclusive, so `len(vid)` (a frame count) is the exclusive end equivalent to the numpy path's inclusive `video_length - 1`. `len(vid)` returns `0` when the shape can't be resolved (missing file / no backend metadata), which automatically preserves the existing fallback to `max(vid_frame_idxs) + 1`.
- **`max(last, video_length)`**, not assignment, so a project whose labels extend past a (smaller) known length still covers every labeled frame — relevant to embedded `.pkg.slp`, where `len(video)` reflects the *embedded subset*, which can be smaller than the largest labeled frame index.
- **Embedded `.pkg.slp` caveat.** `len(video)` resolves to the embedded frame count, not the original video length (it does not walk the `source_video` chain). This fix therefore reaches the same ceiling as the Analysis-HDF5 export for embedded files — i.e. it makes CSV *consistent* with HDF5 rather than perfect for that edge case. Truly spanning the original video for embedded files would require resolving length through the source chain (cf. `_get_effective_shape` in `matching.py`) in *both* the numpy and dataframe paths, and is left as a follow-up.
- **Chunked path out of scope.** `save_csv(..., chunk_size=N)` routes through `to_dataframe_iter`, which does not accept `all_frames`/`start_frame`/`end_frame` and so does no empty-frame padding at all — a separate, pre-existing limitation. The GUI "Export Analysis CSV" uses the non-chunked path addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes https://github.com/talmolab/sleap/issues/2774