### PR TITLE
feat(slp): prefer recorded video metadata over decoding when serializing

### DIFF
--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -166,6 +166,7 @@ def save_slp(
     verbose: bool = True,
     plugin: str | None = None,
     progress_callback: Callable[[int, int], bool] | None = None,
+    prefer_metadata: bool = True,
 ):
     """Save a SLEAP dataset to a `.slp` file.
 
@@ -202,6 +203,12 @@ def save_slp(
             with `(current, total)` arguments. If it returns `False`, the operation
             is cancelled and `ExportCancelled` is raised. When provided, tqdm
             progress bar is disabled in favor of the callback.
+        prefer_metadata: If `True` (the default), serialize each uncropped video's
+            shape/grayscale/fps from its `backend_metadata` when recorded there
+            instead of querying the live backend. For an open `MediaVideo` this
+            avoids decoding a frame (and leaving a resident decoder) just to recompute
+            already-known metadata. Set to `False` to always read shape/grayscale/fps
+            through the live backend.
     """
     from sleap_io.io import slp
 
@@ -214,6 +221,7 @@ def save_slp(
         verbose=verbose,
         plugin=plugin,
         progress_callback=progress_callback,
+        prefer_metadata=prefer_metadata,
     )
 
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -491,13 +491,22 @@ def read_videos(
     return videos
 
 
-def video_to_dict(video: Video, labels_path: str | None = None) -> dict:
+def video_to_dict(
+    video: Video, labels_path: str | None = None, prefer_metadata: bool = True
+) -> dict:
     """Convert a `Video` object to a JSON-compatible dictionary.
 
     Args:
         video: A `Video` object to convert.
         labels_path: Path to the labels file being written. Used to determine if the
             video should use a self-reference (".") or external reference.
+        prefer_metadata: If `True` (the default), serialize an uncropped video's
+            shape/grayscale/fps from `video.backend_metadata` when recorded there (e.g.
+            a video loaded from a `.slp`) instead of querying the live backend. For an
+            open `MediaVideo` the backend read decodes a frame to recompute the shape
+            (and with `keep_open` leaves a resident decoder), so this avoids needless
+            decoding. Set to `False` to always read shape/grayscale/fps through the
+            live backend.
 
     Returns:
         A dictionary containing the video metadata.
@@ -545,11 +554,22 @@ def video_to_dict(video: Video, labels_path: str | None = None) -> dict:
         grayscale = inner.grayscale
         fps = inner.fps
     else:
-        # Uncropped path: read through the Video facade exactly as before so
-        # that uncropped serialization is unchanged (golden byte-identical).
-        shape = video.shape
-        grayscale = video.grayscale
-        fps = video.fps
+        # Uncropped path. When ``prefer_metadata`` is set and the shape was recorded
+        # in ``backend_metadata`` (e.g. a video loaded from a ``.slp``), serialize from
+        # that metadata instead of querying the live backend: for an open ``MediaVideo``
+        # the facade read below decodes a frame to recompute the shape (and with
+        # ``keep_open`` leaves a resident decoder), while the recorded values are
+        # identical and free. Otherwise read through the Video facade exactly as before
+        # so uncropped serialization stays golden byte-identical.
+        meta = video.backend_metadata
+        if prefer_metadata and meta.get("shape") is not None:
+            shape = meta["shape"]
+            grayscale = meta["grayscale"] if "grayscale" in meta else shape[-1] == 1
+            fps = meta.get("fps")
+        else:
+            shape = video.shape
+            grayscale = video.grayscale
+            fps = video.fps
 
     # Add backend metadata
     if video.backend is None:
@@ -640,7 +660,9 @@ def video_to_dict(video: Video, labels_path: str | None = None) -> dict:
 
     # Add source_video metadata if present
     if hasattr(video, "source_video") and video.source_video is not None:
-        result["source_video"] = video_to_dict(video.source_video, labels_path)
+        result["source_video"] = video_to_dict(
+            video.source_video, labels_path, prefer_metadata=prefer_metadata
+        )
 
     # Note: original_video is now a computed property derived from source_video,
     # so we don't store it. Legacy files with original_video are handled on load.
@@ -1249,6 +1271,7 @@ def write_videos(
     reference_mode: VideoReferenceMode | None = None,
     original_videos: list[Video] | None = None,
     verbose: bool = True,
+    prefer_metadata: bool = True,
 ):
     """Write video metadata to a SLEAP labels file.
 
@@ -1266,6 +1289,11 @@ def write_videos(
         original_videos: Optional list of original video objects before embedding.
             Used when reference_mode is EMBED to preserve metadata.
         verbose: If `True` (the default), display a progress bar when embedding frames.
+        prefer_metadata: If `True` (the default), serialize each uncropped video's
+            shape/grayscale/fps from its `backend_metadata` when recorded there instead
+            of querying the live backend (avoids decoding frames just to recompute
+            already-known metadata). Set to `False` to always read through the live
+            backend. See `video_to_dict`.
     """
     # Handle backwards compatibility
     if reference_mode is None:
@@ -1434,7 +1462,7 @@ def write_videos(
     # Write video metadata
     video_jsons = []
     for video_ind, video in sorted(videos_to_write, key=lambda x: x[0]):
-        video_json = video_to_dict(video, labels_path)
+        video_json = video_to_dict(video, labels_path, prefer_metadata=prefer_metadata)
         video_jsons.append(np.bytes_(json.dumps(video_json, separators=(",", ":"))))
 
     with h5py.File(labels_path, "a") as f:
@@ -1478,7 +1506,9 @@ def write_videos(
 
                 if "source_video" not in video_group:
                     source_grp = video_group.require_group("source_video")
-                    source_json = video_to_dict(source_to_save, labels_path)
+                    source_json = video_to_dict(
+                        source_to_save, labels_path, prefer_metadata=prefer_metadata
+                    )
                     source_grp.attrs["json"] = json.dumps(
                         source_json, separators=(",", ":")
                     )
@@ -5992,6 +6022,7 @@ def _write_labels_lazy(
     embed: bool | str | list[tuple[Video, int]] | None = None,
     restore_original_videos: bool = True,
     verbose: bool = True,
+    prefer_metadata: bool = True,
 ) -> None:
     """Write lazy Labels to SLP file using fast path.
 
@@ -6015,6 +6046,10 @@ def _write_labels_lazy(
         restore_original_videos: If `True` (default) and `embed=False`, use original
             video files.
         verbose: If `True` (the default), display progress information.
+        prefer_metadata: If `True` (the default), serialize each uncropped video's
+            shape/grayscale/fps from its `backend_metadata` when recorded there
+            instead of querying the live backend. Set to `False` to always read
+            through the live backend. See `video_to_dict`.
 
     Raises:
         ValueError: If labels is not lazy.
@@ -6043,6 +6078,7 @@ def _write_labels_lazy(
         reference_mode=reference_mode,
         original_videos=None,
         verbose=verbose,
+        prefer_metadata=prefer_metadata,
     )
     # Emit virtual crop records (after videos_json so indices line up).
     write_video_crops(labels_path, labels)
@@ -6157,6 +6193,7 @@ def write_labels(
     plugin: str | None = None,
     embed_all_videos: bool = True,
     progress_callback: Callable[[int, int], bool] | None = None,
+    prefer_metadata: bool = True,
 ):
     """Write a SLEAP labels file.
 
@@ -6196,6 +6233,12 @@ def write_labels(
         progress_callback: Optional callback function called during frame embedding
             with `(current, total)` arguments. If it returns `False`, the operation
             is cancelled and `ExportCancelled` is raised.
+        prefer_metadata: If `True` (the default), serialize each uncropped video's
+            shape/grayscale/fps from its `backend_metadata` when recorded there
+            instead of querying the live backend, avoiding frame decoding when the
+            metadata is already known (e.g. saving copies of labels loaded from a
+            `.slp`). Set to `False` to always read through the live backend. See
+            `video_to_dict`.
     """
     # Fast path for lazy labels (avoids materializing frames/instances)
     # Supported for simple embed modes: None, False, "source"
@@ -6224,6 +6267,7 @@ def write_labels(
                 embed=embed,
                 restore_original_videos=restore_original_videos,
                 verbose=verbose,
+                prefer_metadata=prefer_metadata,
             )
             return
 
@@ -6276,6 +6320,7 @@ def write_labels(
         reference_mode=reference_mode,
         original_videos=original_videos,
         verbose=verbose,
+        prefer_metadata=prefer_metadata,
     )
     # Emit virtual crop records (after videos_json so indices line up). Omitted
     # entirely when no video is cropped (uncropped files stay byte-identical).

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -9169,3 +9169,84 @@ def test_write_video_crops_omitted_when_no_crops(slp_minimal, tmp_path):
     write_video_crops(path, labels)
     with h5py.File(path, "r") as f:
         assert "video_crops" not in f
+
+
+def test_video_to_dict_prefer_metadata(centered_pair_low_quality_video):
+    """`prefer_metadata=True` serializes from backend_metadata without decoding.
+
+    For an open `MediaVideo`, reading shape/grayscale/fps through the Video facade
+    decodes a frame (and with `keep_open` leaves a resident decoder). When the values
+    are already recorded in `backend_metadata` (as they are for a video loaded from a
+    `.slp`), `prefer_metadata=True` must use them and never touch the backend.
+    """
+    video = centered_pair_low_quality_video
+    assert type(video.backend).__name__ == "MediaVideo"
+    # Freshly opened backend: nothing decoded yet.
+    assert video.backend._cached_shape is None
+    assert video.backend._open_reader is None
+
+    # Seed a sentinel metadata shape distinct from the real video so the path taken
+    # is unambiguous: the real decoded shape is (1100, 384, 384, 1).
+    video.backend_metadata["shape"] = [999, 12, 34, 1]
+    video.backend_metadata["grayscale"] = True
+    video.backend_metadata["fps"] = 25.0
+
+    result = video_to_dict(video, prefer_metadata=True)
+    # Serialized straight from metadata...
+    assert result["backend"]["type"] == "MediaVideo"
+    assert result["backend"]["shape"] == [999, 12, 34, 1]
+    assert result["backend"]["grayscale"] is True
+    assert result["backend"]["fps"] == 25.0
+    # ...with no frame decoded and no decoder left resident.
+    assert video.backend._cached_shape is None
+    assert video.backend._open_reader is None
+
+    # prefer_metadata=True is the default: a no-arg call behaves the same (and the
+    # backend is still pristine, proving no decode happened).
+    result_default = video_to_dict(video)
+    assert result_default["backend"]["shape"] == [999, 12, 34, 1]
+    assert video.backend._cached_shape is None
+    assert video.backend._open_reader is None
+
+    # Explicit prefer_metadata=False opts out and reads through the backend, decoding
+    # the real shape and ignoring the sentinel metadata.
+    result_optout = video_to_dict(video, prefer_metadata=False)
+    assert result_optout["backend"]["shape"] == video.shape
+    assert result_optout["backend"]["shape"] != [999, 12, 34, 1]
+
+
+def test_save_prefer_metadata_avoids_video_decode(tmp_path):
+    """Saving labels with open MediaVideo backends must not decode frames for shapes.
+
+    Regression for the OOM where saving reference/GT copies of labels re-opened and
+    decoded every referenced (high-resolution) video to recompute shapes already
+    present in `backend_metadata`. With `prefer_metadata=True`, the save reads those
+    shapes from metadata and never instantiates a decoder.
+    """
+    # Build minimal labels referencing the real media video and seed a `.slp` so its
+    # videos_json records the shape (mirrors a real load-from-.slp scenario).
+    video = Video.from_filename("tests/data/videos/centered_pair_low_quality.mp4")
+    labels = Labels(labeled_frames=[LabeledFrame(video=video, frame_idx=0)])
+    seed_path = tmp_path / "seed.slp"
+    labels.save(seed_path)
+
+    # Reload: each Video has an open MediaVideo backend and metadata-recorded shape,
+    # but nothing has been decoded yet.
+    reloaded = load_slp(seed_path)
+    video2 = reloaded.videos[0]
+    assert type(video2.backend).__name__ == "MediaVideo"
+    assert video2.backend_metadata.get("shape") is not None
+    assert video2.backend._cached_shape is None
+    assert video2.backend._open_reader is None
+
+    # Save a GT-style copy preferring metadata.
+    gt_path = tmp_path / "labels_gt.slp"
+    reloaded.save(gt_path, prefer_metadata=True)
+
+    # The save decoded nothing and left no resident decoder.
+    assert video2.backend._cached_shape is None, "save decoded a frame to get shape"
+    assert video2.backend._open_reader is None, "save left a resident video decoder"
+
+    # The serialized shape is correct (read straight from metadata).
+    gt = load_slp(gt_path)
+    assert list(gt.videos[0].backend_metadata["shape"]) == list(video.shape)


### PR DESCRIPTION
## Summary

Avoids decoding video frames just to recompute shape/grayscale/fps that are already
stored in `backend_metadata` when serializing labels. Adds a `prefer_metadata` flag,
**defaulting to `True`** (per @talmo), so every `Labels.save()` benefits.

Closes #482.

## Problem

When `Labels.save()` serializes a video whose backend is open, `video_to_dict` reads
`video.shape` → `_get_shape()` → `backend.shape`, which **decodes a test frame** to
recompute a shape that is already recorded in `backend_metadata` (read straight from
`videos_json` at load time). Because `MediaVideo` defaults to `keep_open=True`, each
opened decoder context (`cv2.VideoCapture` / ffmpeg reader) stays **resident** and is
never freed, so the cost accumulates across every referenced video and every save.

For a dataset referencing many high-resolution videos this balloons memory — in the
reported case (47 distinct 4K videos, three reference-label saves) it reached a ~58 GB
peak and was OOM-killed, all **before any frame was actually needed**.

## Change

A `prefer_metadata` flag (**default `True`**), threaded through:

```
Labels.save(**kwargs) → save_file(**kwargs) → save_slp → write_labels
    → _write_labels_lazy → write_videos → video_to_dict   (lazy path)
    → write_videos → video_to_dict                        (standard path)
```

In `video_to_dict`, for an **uncropped** video, when `prefer_metadata=True` (the
default) **and** the shape is recorded in `backend_metadata`, shape/grayscale/fps are
serialized straight from metadata — no frame decode, no resident decoder. Otherwise
(metadata absent, e.g. a `Video` built from a raw media file, or `prefer_metadata=False`)
it reads through the live backend exactly as before.

## Compatibility

- **Default `True`, but output is unchanged for round-tripped videos.** The recorded
  `backend_metadata` shape is authoritative for any video loaded from a `.slp` (it was
  written from that file), so the serialized bytes are identical — just without the
  decode. The **full suite (3673 passed, 1 skipped)** passes with the new default,
  including the golden byte-identical serialization tests.
- Falls back to the live backend whenever metadata is absent, so videos built from raw
  files are unaffected.
- Pass `prefer_metadata=False` to force the old decode-based behavior.
- Scope is intentionally narrow — the standard uncropped serialization path. Cropped
  videos and the embed-frame paths are unchanged.

## Testing

- New `test_video_to_dict_prefer_metadata`: with a sentinel metadata shape distinct from
  the real video, both the explicit `prefer_metadata=True` and the no-arg default
  serialize the metadata values and leave `backend._cached_shape` / `backend._open_reader`
  both `None` (zero decode, no resident decoder); `prefer_metadata=False` opts out and
  decodes the real shape.
- New `test_save_prefer_metadata_avoids_video_decode`: end-to-end load-`.slp` → save
  round-trip asserts the save decodes nothing, leaves no resident decoder, and preserves
  the correct shape.
- Full `tests/` suite passes with `--all-extras` (3673 passed, 1 skipped); `ruff check`
  and `ruff format --check` clean.

> Note: rebased onto `main` to include the `scipy<1.18` pin (#485, tracked in #484) that
> is required for CI to pass on Python 3.13 — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)