### PR TITLE
fix(deps): pin scipy<1.18 to keep pymatreader (LEAP reader) working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,13 +49,17 @@ readme = {file = ["README.md"], content-type="text/markdown"}
 # PEP 621: End-user installable extras
 opencv = ["opencv-python"]
 pyav = ["av<16.0.0"]
-mat = ["pymatreader"]
+# scipy<1.18 pinned: scipy 1.18 breaks pymatreader 1.2.3's mat-struct parsing,
+# which fails the LEAP .mat reader. Drop once pymatreader supports scipy>=1.18.
+# See https://github.com/talmolab/sleap-io/issues/484.
+mat = ["pymatreader", "scipy<1.18"]
 polars = ["polars", "pyarrow"]
 cloud = ["s3fs>=2024.10.0", "gcsfs>=2024.10.0", "adlfs>=2024.10.0"]
 all = [
     "opencv-python",
     "av<16.0.0",
     "pymatreader",
+    "scipy<1.18",  # see `mat` extra / issue #484
     "polars",
     "pyarrow",
     "s3fs>=2024.10.0",


### PR DESCRIPTION
## Summary

`scipy 1.18.0` broke `pymatreader 1.2.3`'s mat-struct parsing, which fails the LEAP
`.mat` reader (`sleap_io.io.leap.read_labels`) and 4 tests on Python 3.13. Pin
`scipy<1.18` alongside `pymatreader` in the `mat`/`all` extras until pymatreader ships
a `scipy>=1.18`-compatible release.

Refs #484. (Issue stays open to track removing the pin.)

## Why this is unrelated to any code change

`uv.lock` is gitignored, so CI re-resolves dependencies on every run. A no-op
`workflow_dispatch` run on **`main` with no changes**
([run 27969824124](https://github.com/talmolab/sleap-io/actions/runs/27969824124))
is red the same way:

- ✅ Tests — Python **3.10** (macOS/Ubuntu/Windows)
- ❌ Tests — Python **3.13** (macOS/Ubuntu/Windows) — `4 failed, 3667 passed, 1 skipped`
  (all 4 in `tests/io/test_leap.py`, `ValueError: truth value of an array ... ambiguous`
  raised inside `pymatreader/utils.py`)

Dependency diff between the last green `main` run (2026-06-11) and the first red run
(2026-06-21) — pymatreader unchanged, **scipy** is the regression vector:

| | numpy | scipy | pymatreader |
|---|---|---|---|
| green | 2.4.6 | **1.17.1** | 1.2.3 |
| red | 2.5.0 | **1.18.0** | 1.2.3 |

## Verification

With the pin, `uv` resolves `scipy 1.17.1` (numpy stays `2.5.0`) and the LEAP tests pass:

```
$ uv run --all-extras python -c "import scipy; print(scipy.__version__)"
1.17.1
$ uv run --all-extras pytest tests/io/test_leap.py -q
11 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)