### PR TITLE
fix(cli): make stdout/stderr UTF-8 so sio fix and render --help work on cp1252 consoles

### DIFF
--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -34,6 +34,17 @@ from sleap_io.model.skeleton import Skeleton
 from sleap_io.model.video import Video
 from sleap_io.version import __version__
 
+# Ensure stdout/stderr can emit non-ASCII glyphs (e.g. ✓ ⚠ ℹ →) even on consoles
+# whose default encoding is cp1252 (Windows) or when output is piped. This must run
+# at import time because rich-click renders --help during argument parsing, before any
+# command body executes. Guarded so it never breaks import on exotic streams.
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except Exception:
+            pass
+
 
 @dataclass
 class VideoEncodingInfo:
@@ -3499,7 +3510,7 @@ def filenames(
     default=None,
     help="Force 3-D TIFF interpretation for --images: "
     "--images-stack treats as frame stack, --no-images-stack treats as single image. "
-    "Default: auto-detect (last dim 3 or 4 → single image, otherwise → stack).",
+    "Default: auto-detect (last dim 3 or 4 -> single image, otherwise -> stack).",
 )
 # Info options
 @click.option(

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -34,16 +34,36 @@ from sleap_io.model.skeleton import Skeleton
 from sleap_io.model.video import Video
 from sleap_io.version import __version__
 
-# Ensure stdout/stderr can emit non-ASCII glyphs (e.g. ✓ ⚠ ℹ →) even on consoles
-# whose default encoding is cp1252 (Windows) or when output is piped. This must run
-# at import time because rich-click renders --help during argument parsing, before any
-# command body executes. Guarded so it never breaks import on exotic streams.
-for _stream in (sys.stdout, sys.stderr):
-    if hasattr(_stream, "reconfigure"):
+
+def _ensure_utf8_streams(streams: "list[Any] | None" = None) -> None:
+    """Reconfigure text streams to UTF-8 so non-ASCII glyphs never crash output.
+
+    rich-click renders ``--help`` during argument parsing (before any command body
+    runs) and several commands print Unicode status glyphs (e.g. ``✓ ⚠ ℹ →``). On a
+    console whose default encoding is cp1252 (Windows) or when output is piped,
+    emitting those glyphs raises ``UnicodeEncodeError``. Reconfiguring the streams to
+    UTF-8 at import time avoids the crash. Guarded so it never breaks import on a
+    stream that cannot be reconfigured.
+
+    Args:
+        streams: Text streams to reconfigure. Defaults to
+            ``[sys.stdout, sys.stderr]`` when ``None``.
+    """
+    if streams is None:
+        streams = [sys.stdout, sys.stderr]
+    for stream in streams:
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
         try:
-            _stream.reconfigure(encoding="utf-8")
+            reconfigure(encoding="utf-8")
         except Exception:
             pass
+
+
+# Run at import time: rich-click renders --help during argument parsing, before any
+# command body executes, so this must take effect as soon as the module loads.
+_ensure_utf8_streams()
 
 
 @dataclass

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -18,6 +18,7 @@ from click.testing import CliRunner
 
 from sleap_io import load_slp, save_slp, save_video
 from sleap_io.io.cli import (
+    _ensure_utf8_streams,
     _get_ffmpeg_version,
     _is_ffmpeg_available,
     _load_images,
@@ -11476,3 +11477,39 @@ def test_fix_under_cp1252_console(tmp_path):
         env=env,
     )
     assert result.returncode == 0, result.stderr.decode("cp1252", errors="replace")
+
+
+def test_ensure_utf8_streams_reconfigures():
+    """Streams exposing ``reconfigure`` are switched to UTF-8."""
+
+    class FakeStream:
+        def __init__(self):
+            self.encoding = None
+
+        def reconfigure(self, encoding=None):
+            self.encoding = encoding
+
+    stream = FakeStream()
+    _ensure_utf8_streams([stream])
+    assert stream.encoding == "utf-8"
+
+
+def test_ensure_utf8_streams_skips_without_reconfigure():
+    """A stream lacking ``reconfigure`` is skipped without error."""
+
+    class NoReconfigure:
+        pass
+
+    # Must not raise.
+    _ensure_utf8_streams([NoReconfigure()])
+
+
+def test_ensure_utf8_streams_swallows_reconfigure_errors():
+    """An exception from ``reconfigure`` is swallowed (never breaks import)."""
+
+    class RaisingStream:
+        def reconfigure(self, encoding=None):
+            raise ValueError("cannot reconfigure")
+
+    # Must not raise.
+    _ensure_utf8_streams([RaisingStream()])

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -5,7 +5,9 @@ Covers summary output, labeled frame details, skeleton printing, and format conv
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -11424,3 +11426,53 @@ def test_apply_crops_quality_crf_mutually_exclusive(tmp_path):
     assert result.exit_code != 0
     output = _strip_ansi(result.output)
     assert "Cannot use both --quality and --crf" in output
+
+
+def test_render_help_under_cp1252_console():
+    """`sio render --help` must not crash on a cp1252 console.
+
+    rich-click renders --help (which embeds non-ASCII glyphs) at argument-parse
+    time, so the import-time stdout/stderr reconfigure must make it cp1252-safe.
+    Before the fix this raised UnicodeEncodeError and exited non-zero.
+    """
+    env = {**os.environ, "PYTHONIOENCODING": "cp1252"}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from sleap_io.io.cli import cli; cli()",
+            "render",
+            "--help",
+        ],
+        capture_output=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr.decode("cp1252", errors="replace")
+
+
+def test_fix_under_cp1252_console(tmp_path):
+    """`sio fix --dry-run` must not crash on a cp1252 console.
+
+    The fix command prints status glyphs via the rich console; on a cp1252
+    stdout these raised UnicodeEncodeError before the import-time reconfigure
+    made the stream UTF-8 capable.
+    """
+    src = _data_path("slp/minimal_instance.slp")
+    labels = load_slp(src)
+    slp_path = tmp_path / "minimal_instance.slp"
+    save_slp(labels, slp_path)
+
+    env = {**os.environ, "PYTHONIOENCODING": "cp1252"}
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from sleap_io.io.cli import cli; cli()",
+            "fix",
+            str(slp_path),
+            "--dry-run",
+        ],
+        capture_output=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr.decode("cp1252", errors="replace")


### PR DESCRIPTION
## Problem

The `sio` CLI crashes on the default Windows console (cp1252) — and anywhere `sys.stdout.encoding` is cp1252 (PYTHONIOENCODING unset, or output piped):

- `sio fix` prints status glyphs (`✓` U+2713, `⚠` U+26A0, `ℹ` U+2139, `→` U+2192) through the rich `console` in all code paths (`sleap_io/io/cli.py:~4308-4478`).
- `sio render --help` embeds `→` U+2192 in the `--images-stack` help text (`sleap_io/io/cli.py:3502`).

On a cp1252 stream both raise `UnicodeEncodeError: 'charmap' codec can't encode character ...`, exiting non-zero. Because rich-click renders `--help` at argument-parse time (before any command body runs), a fix inside a command function would not help `--help` — the fix must take effect at import time.

## Fix

1. At module import time (right after imports in `sleap_io/io/cli.py`), reconfigure `sys.stdout` and `sys.stderr` to UTF-8 so both rich-click `--help` rendering and runtime `console.print` glyphs are cp1252-safe. Guarded to streams exposing `reconfigure` (Python `TextIOWrapper`) and wrapped in `try/except` so it never breaks import on exotic streams. This runs before `cli()` is invoked, so `--help` rendering is covered.
2. Defense-in-depth: replaced the literal `→` in the `--images-stack` help string with ASCII `->`. The `✓`/`⚠`/`ℹ` glyphs in `sio fix` are left as-is — they render fine once stdout is UTF-8.

## Regression tests

Added two portable subprocess tests in `tests/io/test_cli.py` that run the CLI under `PYTHONIOENCODING=cp1252` (reproduce the crash on Linux/CI as well as Windows):

- `test_render_help_under_cp1252_console` — `render --help`, asserts `returncode == 0`.
- `test_fix_under_cp1252_console` — `fix <minimal_instance.slp> --dry-run`, asserts `returncode == 0`.

Both genuinely fail before the fix (`UnicodeEncodeError` on `✓` / `→`, returncode 1) and pass after. Verified by stashing the `cli.py` change and re-running.

```
64 passed, 2 skipped, 445 deselected
```

Release-blocker B5 for the 0.8.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV