### PR TITLE
fix(coco): decode compressed (string-counts) RLE segmentation

### DIFF
--- a/sleap_io/io/coco.py
+++ b/sleap_io/io/coco.py
@@ -178,19 +178,66 @@ def decode_keypoints(
     return np.array(points, dtype=np.float32)
 
 
-def _decode_coco_rle(counts: list[int], size: list[int]) -> np.ndarray:
+def _decode_compressed_rle_counts(counts: str | bytes) -> list[int]:
+    """Decode COCO compressed (LEB128) RLE counts to a list of run lengths.
+
+    Standard COCO/pycocotools stores RLE ``counts`` in a compressed form: a
+    string (or bytes) where each run length is LEB128-encoded with 6 bits per
+    byte (offset by 48 to stay in printable ASCII), and each run after the first
+    two is stored as a delta from the run two positions earlier. This is the
+    canonical decode used by ``pycocotools.mask.frString``.
+
+    Args:
+        counts: Compressed RLE counts as an ASCII string or bytes.
+
+    Returns:
+        The decoded run lengths as a list of ints (alternating runs of 0s and
+        1s, starting with 0s), suitable for the uncompressed decode path.
+    """
+    if isinstance(counts, str):
+        counts = counts.encode("ascii")
+    run_lengths: list[int] = []
+    p = 0
+    m = 0
+    while p < len(counts):
+        x = 0
+        k = 0
+        more = 1
+        while more:
+            c = counts[p] - 48
+            x |= (c & 0x1F) << (5 * k)
+            more = c & 0x20
+            p += 1
+            k += 1
+            if not more and (c & 0x10):
+                x |= -1 << (5 * k)
+        if m > 2:
+            x += run_lengths[m - 2]
+        run_lengths.append(x)
+        m += 1
+    return run_lengths
+
+
+def _decode_coco_rle(counts: list[int] | str | bytes, size: list[int]) -> np.ndarray:
     """Decode COCO RLE segmentation to a binary mask.
 
     COCO RLE uses column-major (Fortran) order. This function decodes the RLE
-    counts and returns a row-major numpy array.
+    counts and returns a row-major numpy array. Both uncompressed counts (a list
+    of run-length ints) and compressed counts (a LEB128-encoded string/bytes, as
+    emitted by pycocotools) are supported; compressed counts are first decoded to
+    run lengths via `_decode_compressed_rle_counts`.
 
     Args:
-        counts: RLE counts (alternating runs of 0s and 1s, starting with 0s).
+        counts: RLE counts (alternating runs of 0s and 1s, starting with 0s),
+            either as a list of ints (uncompressed) or as a LEB128-encoded
+            string/bytes (compressed).
         size: Mask dimensions as [height, width].
 
     Returns:
         A 2D boolean numpy array of shape (height, width).
     """
+    if isinstance(counts, (str, bytes)):
+        counts = _decode_compressed_rle_counts(counts)
     height, width = size
     total = height * width
     flat = np.zeros(total, dtype=bool)

--- a/tests/io/test_coco.py
+++ b/tests/io/test_coco.py
@@ -1865,6 +1865,124 @@ class TestCOCOROIMaskIO:
         decoded = coco._decode_coco_rle(rle["counts"], rle["size"])
         np.testing.assert_array_equal(decoded, mask)
 
+    def test_coco_compressed_rle_known_value(self):
+        """Compressed (LEB128) RLE counts decode to the expected mask.
+
+        ``b"01;000"`` is the pycocotools-compressed encoding of a 5x5 mask with
+        True pixels on the main diagonal at (0, 0), (2, 2) and (4, 4). This pins
+        decode correctness against a known-good pycocotools value, not just
+        round-trip symmetry.
+        """
+        expected = np.zeros((5, 5), dtype=bool)
+        expected[0, 0] = True
+        expected[2, 2] = True
+        expected[4, 4] = True
+
+        # Both bytes and str forms must decode identically.
+        decoded_bytes = coco._decode_coco_rle(b"01;000", [5, 5])
+        np.testing.assert_array_equal(decoded_bytes, expected)
+
+        decoded_str = coco._decode_coco_rle("01;000", [5, 5])
+        np.testing.assert_array_equal(decoded_str, expected)
+
+    def test_coco_compressed_rle_full_column_known_value(self):
+        """Compressed RLE for a full first column decodes correctly.
+
+        ``b"05d0"`` is the pycocotools-compressed encoding of a 5x5 mask whose
+        entire first column is True (column-major order).
+        """
+        expected = np.zeros((5, 5), dtype=bool)
+        expected[:, 0] = True
+
+        decoded = coco._decode_coco_rle(b"05d0", [5, 5])
+        np.testing.assert_array_equal(decoded, expected)
+
+    def test_coco_compressed_rle_counts_decoder(self):
+        """The LEB128 counts decoder returns the expected run lengths."""
+        # ``b"05d0"`` -> [0, 5, 20] (0-run of 0, then 5 True for the full first
+        # column, then 20 False to fill the remaining 4 columns of a 5x5
+        # column-major mask).
+        assert coco._decode_compressed_rle_counts(b"05d0") == [0, 5, 20]
+        # String input must match bytes input.
+        assert coco._decode_compressed_rle_counts("05d0") == [0, 5, 20]
+
+    def test_coco_compressed_rle_roundtrip(self):
+        """Uncompressed counts -> compressed string -> decode equals original."""
+
+        def encode_compressed(run_lengths: list[int]) -> bytes:
+            """Inverse of ``_decode_compressed_rle_counts`` (pycocotools scheme)."""
+            out = bytearray()
+            for i, x in enumerate(run_lengths):
+                v = int(x)
+                if i > 2:
+                    v -= int(run_lengths[i - 2])
+                more = True
+                while more:
+                    c = v & 0x1F
+                    v >>= 5
+                    if c & 0x10:
+                        more = v != -1
+                    else:
+                        more = v != 0
+                    if more:
+                        c |= 0x20
+                    out.append(c + 48)
+            return bytes(out)
+
+        mask = np.zeros((4, 6), dtype=bool)
+        mask[0, 0:3] = True
+        mask[1, 0] = True
+
+        rle = coco._encode_coco_rle(mask)
+        compressed = encode_compressed(rle["counts"])
+        decoded = coco._decode_coco_rle(compressed, rle["size"])
+        np.testing.assert_array_equal(decoded, mask)
+
+    def test_coco_load_compressed_rle_no_crash(self, tmp_path):
+        """load_coco must not crash on compressed (string-counts) RLE.
+
+        Regression for the case where a real on-disk image resolves and the
+        compressed RLE annotation is decoded (previously raised
+        ``TypeError: unsupported operand type(s) for +=: 'int' and 'str'``).
+        """
+        img_path = tmp_path / "img.png"
+        img_path.touch()
+
+        data = {
+            "images": [
+                {"id": 1, "file_name": "img.png", "height": 5, "width": 5},
+            ],
+            "annotations": [
+                {
+                    "id": 1,
+                    "image_id": 1,
+                    "category_id": 1,
+                    # pycocotools-compressed RLE for a known 5x5 diagonal mask.
+                    "segmentation": {"counts": "01;000", "size": [5, 5]},
+                    "iscrowd": 0,
+                },
+            ],
+            "categories": [{"id": 1, "name": "cell"}],
+        }
+
+        json_path = tmp_path / "compressed_rle.json"
+        with open(json_path, "w") as f:
+            json.dump(data, f)
+
+        labels = sio.load_coco(json_path, dataset_root=tmp_path)
+
+        assert len(labels.masks) == 1
+        mask = labels.masks[0]
+        assert mask.category == "cell"
+        assert mask.height == 5
+        assert mask.width == 5
+
+        expected = np.zeros((5, 5), dtype=bool)
+        expected[0, 0] = True
+        expected[2, 2] = True
+        expected[4, 4] = True
+        np.testing.assert_array_equal(mask.data.astype(bool), expected)
+
     def test_coco_detection_empty_segmentation_fallback_to_bbox(self, tmp_path):
         """Test that annotations with segmentation=[] fall back to bbox ROI."""
         img_path = tmp_path / "img.png"


### PR DESCRIPTION
## Problem

Standard COCO / pycocotools commonly stores RLE segmentation in **compressed** form, where the `counts` field is a LEB128-encoded ASCII string (e.g. `"01;000"`) rather than a list of run-length ints. `sleap_io/io/coco.py:_decode_coco_rle` assumed `counts` was `list[int]` and executed `pos += count`, so loading such a dataset crashed:

```
TypeError: unsupported operand type(s) for +=: 'int' and 'str'
```

The crash only manifests once the referenced image resolves on disk (otherwise the annotation is skipped before decode), i.e. the normal case for a real dataset. This is release-blocker **B2** (HIGH), new in #479.

## Fix

- Add `_decode_compressed_rle_counts(counts)` — a faithful port of the canonical pycocotools `frString` LEB128 decoder (6 bits/byte, offset 48, delta-from-two-positions-back). Operates on bytes; accepts `str` or `bytes`.
- Dispatch to it from `_decode_coco_rle` when `counts` is `str`/`bytes`, then feed the decoded `list[int]` into the existing (correct) column-major decode. The uncompressed `list[int]` path is **byte-for-byte unchanged**.
- Updated docstrings to note compressed counts are now supported.

## Regression tests (`tests/io/test_coco.py`)

These fail without the fix (with the exact `TypeError` above) and pass with it:

- `test_coco_compressed_rle_known_value` — `"01;000"` decodes to a known 5x5 diagonal mask (value verified against pycocotools `mask.encode`). Checks both `str` and `bytes` inputs.
- `test_coco_compressed_rle_full_column_known_value` — `"05d0"` decodes to a known full-first-column 5x5 mask.
- `test_coco_compressed_rle_counts_decoder` — pins the decoder's run-length output `[0, 5, 20]` and str/bytes parity.
- `test_coco_compressed_rle_roundtrip` — uncompressed counts → compressed string (inverse encoder) → decode equals the original mask.
- `test_coco_load_compressed_rle_no_crash` — end-to-end `sio.load_coco` with an on-disk image and a compressed RLE annotation (the exact B2 repro); asserts the resulting mask equals the expected diagonal.

The known compressed strings (`01;000`, `05d0`) and decoder output were validated against `pycocotools.mask` directly during development, so the tests pin correctness, not just round-trip symmetry. Existing uncompressed `_encode_coco_rle`/`_decode_coco_rle` tests remain green; full `tests/io/test_coco.py` passes (95 tests).

## References

- Blocker B2, new in #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV