### PR TITLE
fix(merge): reorder points by node name when matched skeletons differ in order

### DIFF
--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -3950,15 +3950,38 @@ class Labels:
 
         Returns:
             New instance with mapped skeleton and track.
+
+        Notes:
+            When the source instance's node order differs from the mapped skeleton's
+            node order (e.g. the default structure matcher matched ``[A, B, C]`` with
+            ``[C, B, A]``), the points are reordered by node name so that each node's
+            coordinates and score follow its name rather than its position. When the
+            node orders are identical (the common case), the points are copied as-is to
+            avoid any overhead on the hot path.
         """
         mapped_skeleton = skeleton_map.get(instance.skeleton, instance.skeleton)
         mapped_track = (
             track_map.get(instance.track, instance.track) if instance.track else None
         )
 
+        # Reorder points by node name when the source order differs from the mapped
+        # skeleton's order, otherwise the per-node coordinates/scores would be carried
+        # over positionally and silently misaligned (see #447). Reuse the source array
+        # type (e.g. PredictedPointsArray) so per-point scores are preserved.
+        source_points = instance.points
+        if list(source_points["name"]) == mapped_skeleton.node_names:
+            mapped_points = source_points.copy()
+        else:
+            new_node_inds, old_node_inds = mapped_skeleton.match_nodes(
+                source_points["name"]
+            )
+            mapped_points = type(source_points).empty(len(mapped_skeleton))
+            mapped_points[new_node_inds] = source_points[old_node_inds]
+            mapped_points["name"] = mapped_skeleton.node_names
+
         if type(instance) is PredictedInstance:
             return PredictedInstance(
-                points=instance.points.copy(),
+                points=mapped_points,
                 skeleton=mapped_skeleton,
                 score=instance.score,
                 track=mapped_track,
@@ -3967,7 +3990,7 @@ class Labels:
             )
         else:
             return Instance(
-                points=instance.points.copy(),
+                points=mapped_points,
                 skeleton=mapped_skeleton,
                 track=mapped_track,
                 tracking_score=instance.tracking_score,

--- a/tests/model/test_merging_integration.py
+++ b/tests/model/test_merging_integration.py
@@ -2156,3 +2156,207 @@ class TestTrackNameDivergenceWarning:
         # Both incoming track_0 objects collide onto self's single track_0 and
         # both diverge, so one warning per colliding other_track (two total).
         assert len(divergence) == 2
+
+
+class TestMergeNodeOrderReorder:
+    """Regression tests for point reorder when matched skeletons differ in order.
+
+    The default skeleton matcher uses STRUCTURE matching with
+    ``require_same_order=False``, so a skeleton ``[A, B, C]`` matches a
+    structurally-equal ``[C, B, A]``. Previously ``Labels._map_instance`` copied
+    points positionally, silently misaligning each node's coordinates/scores with
+    its name (see PR #447 acknowledgment of this latent hazard).
+    """
+
+    def test_new_frame_reorder_by_name(self):
+        """Reordered skeleton on a new-frame merge maps points by node name."""
+        base_skel = Skeleton(["A", "B", "C"])
+        other_skel = Skeleton(["C", "B", "A"])
+        video = Video(filename="test.mp4", open_backend=False)
+
+        base = Labels()
+        base.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    Instance.from_numpy(
+                        np.array([[1, 1], [2, 2], [3, 3]]), skeleton=base_skel
+                    )
+                ],
+            )
+        )
+
+        # Built from rows in [C, B, A] order -> C=(10,10), B=(11,11), A=(12,12).
+        other = Labels()
+        other.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=1,
+                instances=[
+                    Instance.from_numpy(
+                        np.array([[10, 10], [11, 11], [12, 12]]), skeleton=other_skel
+                    )
+                ],
+            )
+        )
+
+        base.merge(other)
+
+        merged = base.labeled_frames[1].instances[0]
+        # Merged instance adopts the base skeleton's node order.
+        assert merged.skeleton.node_names == ["A", "B", "C"]
+        idx = merged.skeleton.index
+        pts = merged.numpy()
+        # Each node's coordinates must follow its name, not its original position.
+        np.testing.assert_array_equal(pts[idx("A")], [12, 12])
+        np.testing.assert_array_equal(pts[idx("B")], [11, 11])
+        np.testing.assert_array_equal(pts[idx("C")], [10, 10])
+
+    def test_overlapping_frame_reorder_by_name(self):
+        """Reordered skeleton merged into an existing frame maps points by name."""
+        base_skel = Skeleton(["A", "B", "C"])
+        other_skel = Skeleton(["C", "B", "A"])
+        video = Video(filename="test.mp4", open_backend=False)
+
+        base = Labels()
+        base.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    Instance.from_numpy(
+                        np.array([[1, 1], [2, 2], [3, 3]]), skeleton=base_skel
+                    )
+                ],
+            )
+        )
+
+        # Same frame_idx so the instance is merged into the existing frame. Built in
+        # [C, B, A] order -> C=(10,10), B=(11,11), A=(12,12). Placed far from the base
+        # instance so the matcher keeps it as a distinct instance.
+        other = Labels()
+        other.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    Instance.from_numpy(
+                        np.array([[10, 10], [11, 11], [12, 12]]), skeleton=other_skel
+                    )
+                ],
+            )
+        )
+
+        base.merge(other, frame="keep_both")
+
+        frame = base.labeled_frames[0]
+        assert len(frame.instances) == 2
+        # Locate the merged-in instance (the one carrying the other's coordinates).
+        merged = [
+            i
+            for i in frame.instances
+            if i.numpy()[i.skeleton.index("A")].tolist() == [12, 12]
+        ]
+        assert len(merged) == 1
+        m = merged[0]
+        assert m.skeleton.node_names == ["A", "B", "C"]
+        idx = m.skeleton.index
+        pts = m.numpy()
+        np.testing.assert_array_equal(pts[idx("A")], [12, 12])
+        np.testing.assert_array_equal(pts[idx("B")], [11, 11])
+        np.testing.assert_array_equal(pts[idx("C")], [10, 10])
+
+    def test_predicted_reorder_preserves_scores(self):
+        """Reordering a PredictedInstance keeps per-node scores aligned by name."""
+        base_skel = Skeleton(["A", "B", "C"])
+        other_skel = Skeleton(["C", "B", "A"])
+        video = Video(filename="test.mp4", open_backend=False)
+
+        base = Labels()
+        base.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    PredictedInstance.from_numpy(
+                        np.array([[1, 1], [2, 2], [3, 3]]),
+                        skeleton=base_skel,
+                        score=0.5,
+                    )
+                ],
+            )
+        )
+
+        # Built in [C, B, A] order with matching per-node scores.
+        other = Labels()
+        other.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=1,
+                instances=[
+                    PredictedInstance.from_numpy(
+                        np.array([[10, 10], [11, 11], [12, 12]]),
+                        skeleton=other_skel,
+                        point_scores=np.array([0.1, 0.2, 0.3]),
+                        score=0.9,
+                    )
+                ],
+            )
+        )
+
+        base.merge(other)
+
+        merged = base.labeled_frames[1].instances[0]
+        assert isinstance(merged, PredictedInstance)
+        assert merged.skeleton.node_names == ["A", "B", "C"]
+        idx = merged.skeleton.index
+        pts = merged.numpy()
+        np.testing.assert_array_equal(pts[idx("A")], [12, 12])
+        np.testing.assert_array_equal(pts[idx("C")], [10, 10])
+        # Scores follow node name: A->0.3, B->0.2, C->0.1.
+        assert merged.points["score"][idx("A")] == 0.3
+        assert merged.points["score"][idx("B")] == 0.2
+        assert merged.points["score"][idx("C")] == 0.1
+        # Instance-level metadata is preserved exactly.
+        assert merged.score == 0.9
+
+    def test_identical_node_order_unchanged(self):
+        """Control: identical node order leaves points untouched."""
+        skel1 = Skeleton(["A", "B", "C"])
+        skel2 = Skeleton(["A", "B", "C"])
+        video = Video(filename="test.mp4", open_backend=False)
+
+        base = Labels()
+        base.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    Instance.from_numpy(
+                        np.array([[1, 1], [2, 2], [3, 3]]), skeleton=skel1
+                    )
+                ],
+            )
+        )
+
+        other = Labels()
+        other.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=1,
+                instances=[
+                    Instance.from_numpy(
+                        np.array([[7, 7], [8, 8], [9, 9]]), skeleton=skel2
+                    )
+                ],
+            )
+        )
+
+        base.merge(other)
+
+        merged = base.labeled_frames[1].instances[0]
+        assert merged.skeleton.node_names == ["A", "B", "C"]
+        np.testing.assert_array_equal(
+            merged.numpy(), np.array([[7, 7], [8, 8], [9, 9]])
+        )


### PR DESCRIPTION
## Problem

`Labels.merge()` could **silently corrupt per-node point data** when the matched skeletons had different node order.

The default skeleton matcher is `STRUCTURE` with `require_same_order=False`, so a skeleton `[A, B, C]` matches a structurally-equal `[C, B, A]` (and `docs/merging.md` advertises structure matching as working "regardless of order"). But `Labels._map_instance` (`sleap_io/model/labels.py`) built the new instance with the mapped skeleton while copying `instance.points.copy()` **positionally**, with no reorder. The merged instance's skeleton node order and its per-node xy/score therefore disagreed.

### Reproduction
```python
base_skel = Skeleton(["A", "B", "C"]); other_skel = Skeleton(["C", "B", "A"])
# base instance A=(1,1), B=(2,2), C=(3,3)
# other instance built in [C,B,A] order = C=(10,10), B=(11,11), A=(12,12)
base.merge(other)  # default skeleton="structure"
```
Before the fix the merged instance reported `A == [10,10]`, `C == [12,12]` (**swapped**). Correct: `A == [12,12]`, `C == [10,10]`.

## Fix

`_map_instance` now reorders points by **node-name correspondence** (mirroring the validated `Instance.replace_skeleton` / `update_skeleton` machinery in `sleap_io/model/instance.py`) whenever the source instance's node order differs from the mapped skeleton's order:

- Reuses the source array type via `type(source_points).empty(...)` so `PredictedInstance` per-point **scores** are preserved (`PredictedPointsArray`).
- When node orders are **identical** (the common case), points are copied as-is — no overhead on the hot path, behavior unchanged.
- Handles **both** the `PredictedInstance` and `Instance` branches; `score`, `track`, `tracking_score`, `from_predicted` preserved exactly as before.

This makes the implementation honor what the docs already promise; no docs change needed.

## Regression tests

Added `TestMergeNodeOrderReorder` to `tests/model/test_merging_integration.py`:
- `test_new_frame_reorder_by_name` — `[A,B,C]` vs `[C,B,A]` on a new-frame merge.
- `test_overlapping_frame_reorder_by_name` — same swap merged into an existing frame (`keep_both`).
- `test_predicted_reorder_preserves_scores` — predicted instance, per-node scores follow the node name.
- `test_identical_node_order_unchanged` — control: identical order leaves points untouched.

The three reorder tests fail without the fix and pass with it. Full `tests/model/test_merging_integration.py tests/model/test_labels.py tests/model/test_matching.py` is green (501 passed; the one Windows-only `test_samefile_with_symlink` failure is a pre-existing local privilege limitation unrelated to this change and passes on CI).

## References
- PR #447 commit body acknowledged this latent hazard.
- `docs/merging.md` advertises structure matching "regardless of order".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV