### PR TITLE
fix(model): invalidate stale shape/grayscale/fps on resolution-changing relink

### DIFF
--- a/sleap_io/model/video.py
+++ b/sleap_io/model/video.py
@@ -967,6 +967,16 @@ class Video:
                 p.as_posix() if isinstance(p, Path) else p for p in new_filename
             ]
 
+        # A relink to a different file makes the recorded shape/grayscale/fps in
+        # ``backend_metadata`` stale: they describe the OLD file but the new file
+        # may have a different resolution/channels/frame rate. They must not be
+        # serialized under the new filename (regression from #483, where
+        # ``save_slp(prefer_metadata=True)`` prefers these recorded values), so
+        # invalidate them on a real relink and let them be recomputed from the new
+        # backend. The no-relink path leaves metadata untouched so golden
+        # byte-identical saves stay byte-identical.
+        filename_changed = new_filename != self.filename
+
         self.filename = new_filename
         self.backend_metadata["filename"] = new_filename
         # Invalidate any cached URL existence results for the previous filename.
@@ -977,6 +987,13 @@ class Video:
                 self.open()
             else:
                 self.close()
+
+        # Drop stale metadata AFTER (re)opening: ``open()`` internally calls
+        # ``close()``, which would otherwise re-stamp the OLD backend's
+        # shape/grayscale/fps back into ``backend_metadata``.
+        if filename_changed:
+            for key in ("shape", "grayscale", "fps"):
+                self.backend_metadata.pop(key, None)
 
     def matches_path(self, other: "Video", strict: bool = False) -> bool:
         """Check if this video has the same path as another video.

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -9250,3 +9250,39 @@ def test_save_prefer_metadata_avoids_video_decode(tmp_path):
     # The serialized shape is correct (read straight from metadata).
     gt = load_slp(gt_path)
     assert list(gt.videos[0].backend_metadata["shape"]) == list(video.shape)
+
+
+def test_save_prefer_metadata_after_resolution_changing_relink(
+    tmp_path, centered_pair_low_quality_path, small_robot_path
+):
+    """Default save (prefer_metadata=True) must serialize the relinked file's shape.
+
+    Regression for #483: `save_slp(prefer_metadata=True)` serializes the shape
+    recorded in `backend_metadata` to avoid decoding. After a `replace_filenames`
+    relink to a different-resolution file, that recorded shape describes the OLD
+    file and is now stale; `replace_filename` must invalidate it so the default
+    save serializes the NEW file's true shape, not the old one.
+    """
+    # Seed a .slp so videos_json records the original (centered_pair) shape.
+    out1 = tmp_path / "orig.slp"
+    Labels(videos=[Video.from_filename(centered_pair_low_quality_path)]).save(out1)
+
+    reloaded = load_slp(out1)
+    assert reloaded.videos[0].backend_metadata["shape"] == [1100, 384, 384, 1]
+
+    # Relink to a different-resolution file (small_robot is 3 frames, 320x560).
+    reloaded.replace_filenames(
+        filename_map={centered_pair_low_quality_path: small_robot_path}
+    )
+
+    # Save with the default prefer_metadata=True and reload without opening videos
+    # so the serialized shape is read straight from videos_json.
+    out2 = tmp_path / "relinked.slp"
+    reloaded.save(out2)
+    serialized_shape = load_slp(out2, open_videos=False).videos[0].shape
+
+    # The serialized shape must match the relinked video's true (live) shape, not
+    # the stale centered_pair shape.
+    assert list(serialized_shape) == list(reloaded.videos[0].shape)
+    assert list(serialized_shape) != [1100, 384, 384, 1]
+    assert list(serialized_shape[1:3]) == [320, 560]


### PR DESCRIPTION
## Problem

Regression from #483. `save_slp`'s new default `prefer_metadata=True` serializes a video's `shape`/`grayscale`/`fps` from `backend_metadata` (when recorded, e.g. for a video loaded from a `.slp`) to avoid decoding a frame. But after a resolution-changing `Video.replace_filename` relink, those recorded values still describe the **old** file:

- `replace_filename` (`sleap_io/model/video.py`) updated `filename`/`backend_metadata["filename"]` but never refreshed `shape`/`grayscale`/`fps`.
- `open()` rebuilds the backend after a relink but never refreshes those metadata keys; only `close()` writes them, and it writes them from the **old** backend.

So after relinking to a different-resolution file, the default save serialized the wrong (old) shape under the new filename.

### Reproduction

```python
v = Video.from_filename("tests/data/videos/centered_pair_low_quality.mp4")  # (1100, 384, 384, 1)
lab = Labels(videos=[v]); lab.save(out1)
lab2 = load_slp(out1)  # backend_metadata["shape"] = [1100, 384, 384, 1]
lab2.replace_filenames(filename_map={
    ".../centered_pair_low_quality.mp4": "tests/data/videos/small_robot_3_frame.mp4"  # (3, 320, 560, 1)
})
lab2.save(out2)  # DEFAULT prefer_metadata=True
load_slp(out2, open_videos=False).videos[0].shape
# BUG: [1100, 384, 384, 1]; with prefer_metadata=False -> correct [3, 320, 560, 1]
```

## Fix

In `Video.replace_filename`, when the underlying filename actually changes, drop the now-stale `shape`/`grayscale`/`fps` from `backend_metadata`. The drop happens **after** the `open()`/`close()` because `open()` internally calls `close()`, which would otherwise re-stamp the old backend's values back into the metadata. The values are then recomputed lazily from the new backend at serialization time (`video_to_dict` falls through to `video.shape` when `backend_metadata["shape"]` is absent).

The no-relink path is untouched, so golden byte-identical saves and the existing #483 `prefer_metadata` tests stay green.

### Why this approach (vs. refreshing in `open()`)

Refreshing `shape`/`grayscale`/`fps` from the freshly built backend inside `open()` would force an eager frame decode on **every** load (reading `backend.shape` computes `num_frames`/`img_shape`), which directly defeats #483's intent of avoiding decodes. The `replace_filename` invalidation only touches the relink path and triggers a single recompute at save time, exactly when it is needed.

## Regression test

`tests/io/test_slp.py::test_save_prefer_metadata_after_resolution_changing_relink`: after a resolution-changing `replace_filenames` + default save + `reload(open_videos=False)`, asserts the serialized shape equals the relinked file's true shape (320x560) and not the stale `[1100, 384, 384, 1]`. Verified it fails without the fix and passes with it.

## Testing

- `uv run pytest tests/io/test_slp.py tests/model/test_video.py -p no:cacheprovider -q`: 385 passed. The 6 failures are pre-existing `opencv`/`cv2` plugin `KeyError`s in `test_embed_*` (verified identical on the clean tree, unrelated to this change).
- Existing #483 tests (`test_video_to_dict_prefer_metadata`, `test_save_prefer_metadata_avoids_video_decode`) stay green.

Refs #483.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV