### PR TITLE
fix(merge): preserve mask/instance from_predicted provenance across merge

### DIFF
--- a/sleap_io/model/labeled_frame.py
+++ b/sleap_io/model/labeled_frame.py
@@ -136,6 +136,53 @@ def _find_annotation_link_matches(
     return matches
 
 
+def _copy_with_memo(item: Any, memo: dict[int, Any]) -> Any:
+    """Shallow-copy an annotation, recording ``{id(original): copy}`` in ``memo``.
+
+    The memo lets a later :func:`_relink_from_predicted` pass repair
+    ``from_predicted`` provenance links: when both a predicted annotation and the
+    user annotation that adopted it are copied independently during a merge, the
+    user copy's ``from_predicted`` still points at the *original* predicted object
+    rather than its copy now living in the merged frame. Recording the
+    original->copy mapping here lets the link be rewritten to the in-frame copy.
+
+    Args:
+        item: The annotation to copy.
+        memo: Mapping from the id of an original annotation to its copy. Mutated
+            in place to register this copy.
+
+    Returns:
+        The shallow copy of ``item``.
+    """
+    item_copy = copy(item)
+    memo[id(item)] = item_copy
+    return item_copy
+
+
+def _relink_from_predicted(annotations: list, memo: dict[int, Any]) -> None:
+    """Rewrite ``from_predicted`` links to copied sources within a merged frame.
+
+    After annotations are copied into a merged frame, a user annotation's
+    ``from_predicted`` may still reference the *original* predicted source rather
+    than the copy that was placed in the frame. This pass redirects each such link
+    to the copied source (looked up in ``memo``) so the provenance link points at
+    the in-frame object and survives serialization (which resolves links by object
+    identity). Links whose source was not copied (not in ``memo``) are left
+    unchanged.
+
+    Args:
+        annotations: The merged annotation list to repair in place.
+        memo: Mapping from the id of an original annotation to its copy, as built
+            by :func:`_copy_with_memo`.
+    """
+    for ann in annotations:
+        src = getattr(ann, "from_predicted", None)
+        if src is not None:
+            replacement = memo.get(id(src))
+            if replacement is not None:
+                ann.from_predicted = replacement
+
+
 def _resolve_annotation_auto(
     self_list: list,
     other_list: list,
@@ -159,6 +206,9 @@ def _resolve_annotation_auto(
     """
     merged = []
     used_self_indices: set[int] = set()
+    # Track copied annotations so ``from_predicted`` links can be repaired to
+    # point at the in-frame copy of their source rather than the original.
+    memo: dict[int, Any] = {}
 
     # 1. Keep all user annotations from self
     for ann in self_list:
@@ -197,21 +247,25 @@ def _resolve_annotation_auto(
                 pass
             elif self_ann.is_predicted and not other_ann.is_predicted:
                 # predicted + user → replace with other's user
-                merged.append(copy(other_ann))
+                merged.append(_copy_with_memo(other_ann, memo))
             elif not self_ann.is_predicted and other_ann.is_predicted:
                 # user + predicted → keep self (already in merged)
                 pass
             else:
                 # predicted + predicted → keep other's (newer)
-                merged.append(copy(other_ann))
+                merged.append(_copy_with_memo(other_ann, memo))
         else:
             # No match → add from other
-            merged.append(copy(other_ann))
+            merged.append(_copy_with_memo(other_ann, memo))
 
     # 5. Keep unmatched predictions from self
     for self_idx, self_ann in enumerate(self_list):
         if self_ann.is_predicted and self_idx not in used_self_indices:
             merged.append(self_ann)
+
+    # Repair ``from_predicted`` links so a copied user annotation references the
+    # copied source prediction now in the merged frame, not the original.
+    _relink_from_predicted(merged, memo)
 
     return merged
 
@@ -825,15 +879,22 @@ class LabeledFrame:
 
         if strategy == "keep_new":
             for attr in attrs:
-                setattr(self, attr, [copy(item) for item in getattr(other, attr)])
+                memo: dict[int, Any] = {}
+                new_list = [
+                    _copy_with_memo(item, memo) for item in getattr(other, attr)
+                ]
+                _relink_from_predicted(new_list, memo)
+                setattr(self, attr, new_list)
             return
 
         if strategy == "replace_predictions":
             for attr in attrs:
+                memo = {}
                 kept = [a for a in getattr(self, attr) if not a.is_predicted]
                 for item in getattr(other, attr):
                     if item.is_predicted:
-                        kept.append(copy(item))
+                        kept.append(_copy_with_memo(item, memo))
+                _relink_from_predicted(kept, memo)
                 setattr(self, attr, kept)
             return
 
@@ -857,7 +918,10 @@ class LabeledFrame:
 
         # "keep_both" (default)
         for attr in attrs:
-            existing_ids = set(id(x) for x in getattr(self, attr))
+            memo = {}
+            target = getattr(self, attr)
+            existing_ids = set(id(x) for x in target)
             for item in getattr(other, attr):
                 if id(item) not in existing_ids:
-                    getattr(self, attr).append(copy(item))
+                    target.append(_copy_with_memo(item, memo))
+            _relink_from_predicted(target, memo)

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -24,7 +24,11 @@ from sleap_io.io.utils import sanitize_filename
 from sleap_io.model.camera import RecordingSession
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, PredictedInstance, Track
-from sleap_io.model.labeled_frame import LabeledFrame, _resolve_merged_is_negative
+from sleap_io.model.labeled_frame import (
+    LabeledFrame,
+    _relink_from_predicted,
+    _resolve_merged_is_negative,
+)
 from sleap_io.model.skeleton import NodeOrIndex, Skeleton
 from sleap_io.model.suggestions import SuggestionFrame
 from sleap_io.model.video import Video
@@ -3674,10 +3678,15 @@ class Labels:
                     )
 
                     # Map instances to new skeleton/track
+                    instance_memo: dict[int, Instance | PredictedInstance] = {}
                     for inst in other_frame.instances:
-                        new_inst = self._map_instance(inst, skeleton_map, track_map)
+                        new_inst = self._map_instance(
+                            inst, skeleton_map, track_map, memo=instance_memo
+                        )
                         new_frame.instances.append(new_inst)
                         result.instances_added += 1
+                    # Repair ``from_predicted`` links to the remapped source.
+                    _relink_from_predicted(new_frame.instances, instance_memo)
 
                     # Copy annotations from other frame and remap references
                     new_frame._merge_annotations(other_frame)
@@ -3702,17 +3711,21 @@ class Labels:
 
                     # Remap skeleton and track references for instances from other frame
                     remapped_instances = []
+                    instance_memo = {}
                     for inst in merged_instances:
                         # Check if instance needs remapping (from other_frame)
                         if inst.skeleton in skeleton_map:
                             # Instance needs remapping
                             remapped_inst = self._map_instance(
-                                inst, skeleton_map, track_map
+                                inst, skeleton_map, track_map, memo=instance_memo
                             )
                             remapped_instances.append(remapped_inst)
                         else:
                             # Instance already has correct skeleton (from self_frame)
                             remapped_instances.append(inst)
+                    # Repair ``from_predicted`` links so a remapped user instance
+                    # references the remapped source prediction in this frame.
+                    _relink_from_predicted(remapped_instances, instance_memo)
                     merged_instances = remapped_instances
 
                     # Count changes
@@ -3940,6 +3953,7 @@ class Labels:
         instance: Instance | PredictedInstance,
         skeleton_map: dict[Skeleton, Skeleton],
         track_map: dict[Track, Track],
+        memo: dict[int, Instance | PredictedInstance] | None = None,
     ) -> Instance | PredictedInstance:
         """Map an instance to use mapped skeleton and track.
 
@@ -3947,6 +3961,11 @@ class Labels:
             instance: Instance to map.
             skeleton_map: Dictionary mapping old skeletons to new ones.
             track_map: Dictionary mapping old tracks to new ones.
+            memo: Optional mapping from the id of the source instance to the new
+                instance, mutated in place. Used to repair ``from_predicted``
+                links so a remapped user instance references the remapped source
+                prediction now in the merged frame (see
+                ``_relink_from_predicted``).
 
         Returns:
             New instance with mapped skeleton and track.
@@ -3980,7 +3999,7 @@ class Labels:
             mapped_points["name"] = mapped_skeleton.node_names
 
         if type(instance) is PredictedInstance:
-            return PredictedInstance(
+            new_instance: Instance | PredictedInstance = PredictedInstance(
                 points=mapped_points,
                 skeleton=mapped_skeleton,
                 score=instance.score,
@@ -3989,13 +4008,16 @@ class Labels:
                 from_predicted=instance.from_predicted,
             )
         else:
-            return Instance(
+            new_instance = Instance(
                 points=mapped_points,
                 skeleton=mapped_skeleton,
                 track=mapped_track,
                 tracking_score=instance.tracking_score,
                 from_predicted=instance.from_predicted,
             )
+        if memo is not None:
+            memo[id(instance)] = new_instance
+        return new_instance
 
     def set_video_plugin(self, plugin: str) -> None:
         """Reopen all media videos with the specified plugin.

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -6883,6 +6883,74 @@ def test_slp_mask_from_predicted_with_instance_link(tmp_path):
     assert loaded_user.instance is loaded.labeled_frames[0].instances[0]
 
 
+def test_slp_mask_from_predicted_survives_merge(tmp_path):
+    """A mask from_predicted link survives an auto merge + save/load.
+
+    Regression for the merge copy path dropping mask provenance: the predicted
+    mask and the user mask adopted from it are copied independently during
+    ``merge(frame="auto")``, but the copied user mask's ``from_predicted`` must
+    be relinked to the copied prediction now in the merged frame. Otherwise the
+    saved index resolves to ``-1`` and the link is lost on reload.
+    """
+    arr = np.ones((5, 5), dtype=bool)
+    pred = PredictedSegmentationMask.from_numpy(arr, score=0.9)
+    user = pred.to_user()
+    assert user.from_predicted is pred
+
+    dst = Labels([LabeledFrame(video=Video("v.mp4"), frame_idx=0, masks=[])])
+    src = Labels([LabeledFrame(video=Video("v.mp4"), frame_idx=0, masks=[pred, user])])
+    dst.merge(src, frame="auto")
+
+    path = str(tmp_path / "merged_mask_provenance.slp")
+    dst.save(path)
+    reloaded = load_file(path)
+
+    reloaded_pred = next(
+        m for m in reloaded.masks if isinstance(m, PredictedSegmentationMask)
+    )
+    reloaded_user = next(
+        m for m in reloaded.masks if isinstance(m, UserSegmentationMask)
+    )
+    assert reloaded_user.from_predicted is reloaded_pred
+
+
+def test_slp_instance_from_predicted_survives_merge(tmp_path):
+    """An instance from_predicted link survives an auto merge + save/load.
+
+    The merge remap path (``_map_instance``) rebuilds instances and must relink
+    a remapped user instance to the remapped source prediction in the same
+    frame, mirroring the mask fix.
+    """
+    skeleton = Skeleton(nodes=["A", "B"])
+    pts = np.array([[1.0, 2.0], [3.0, 4.0]])
+    pred = PredictedInstance.from_numpy(points_data=pts, skeleton=skeleton, score=0.9)
+    user = Instance.from_numpy(points_data=pts, skeleton=skeleton)
+    user.from_predicted = pred
+    assert user.from_predicted is pred
+
+    video = Video("v.mp4")
+    dst = Labels(
+        videos=[video],
+        skeletons=[skeleton],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0, instances=[])],
+    )
+    src = Labels(
+        videos=[video],
+        skeletons=[skeleton],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0, instances=[pred, user])],
+    )
+    dst.merge(src, frame="auto")
+
+    path = str(tmp_path / "merged_instance_provenance.slp")
+    dst.save(path)
+    reloaded = load_file(path)
+
+    reloaded_insts = reloaded.labeled_frames[0].instances
+    reloaded_pred = next(i for i in reloaded_insts if type(i) is PredictedInstance)
+    reloaded_user = next(i for i in reloaded_insts if type(i) is Instance)
+    assert reloaded_user.from_predicted is reloaded_pred
+
+
 def test_slp_predicted_mask_score_map_roundtrip(tmp_path):
     """PredictedSegmentationMask with score_map survives round-trip."""
     video = Video(filename="test.mp4")

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -6951,6 +6951,50 @@ def test_slp_instance_from_predicted_survives_merge(tmp_path):
     assert reloaded_user.from_predicted is reloaded_pred
 
 
+def test_slp_instance_from_predicted_survives_new_frame_merge(tmp_path):
+    """An instance from_predicted link survives an auto merge that creates a frame.
+
+    This covers the NEW-frame merge branch in ``Labels.merge`` (where no matching
+    destination frame exists, so a brand-new ``LabeledFrame`` is built and the
+    instances are remapped via ``_map_instance`` then relinked with
+    ``_relink_from_predicted``). The sibling test
+    ``test_slp_instance_from_predicted_survives_merge`` covers the
+    existing/overlapping-frame branch instead; here the destination has no frame
+    at the source's ``frame_idx`` so the merge takes the new-frame path.
+    """
+    skeleton = Skeleton(nodes=["A", "B"])
+    pts = np.array([[1.0, 2.0], [3.0, 4.0]])
+    pred = PredictedInstance.from_numpy(points_data=pts, skeleton=skeleton, score=0.9)
+    user = Instance.from_numpy(points_data=pts, skeleton=skeleton)
+    user.from_predicted = pred
+    assert user.from_predicted is pred
+
+    video = Video("v.mp4")
+    # Destination has a frame at a DIFFERENT frame_idx, so merging the source
+    # frame (at frame_idx=0) creates a brand-new LabeledFrame (new-frame path).
+    dst = Labels(
+        videos=[video],
+        skeletons=[skeleton],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=99, instances=[])],
+    )
+    src = Labels(
+        videos=[video],
+        skeletons=[skeleton],
+        labeled_frames=[LabeledFrame(video=video, frame_idx=0, instances=[pred, user])],
+    )
+    dst.merge(src, frame="auto")
+
+    path = str(tmp_path / "merged_new_frame_instance_provenance.slp")
+    dst.save(path)
+    reloaded = load_file(path)
+
+    new_frame = next(lf for lf in reloaded.labeled_frames if lf.frame_idx == 0)
+    reloaded_insts = new_frame.instances
+    reloaded_pred = next(i for i in reloaded_insts if type(i) is PredictedInstance)
+    reloaded_user = next(i for i in reloaded_insts if type(i) is Instance)
+    assert reloaded_user.from_predicted is reloaded_pred
+
+
 def test_slp_predicted_mask_score_map_roundtrip(tmp_path):
     """PredictedSegmentationMask with score_map survives round-trip."""
     video = Video(filename="test.mp4")

--- a/tests/model/test_labeled_frame.py
+++ b/tests/model/test_labeled_frame.py
@@ -1667,6 +1667,71 @@ def test_merge_annotations_auto_masks_link_source_absent():
     assert all(not m.is_predicted for m in lf1.masks)
 
 
+def test_merge_annotations_auto_mask_from_predicted_relinked():
+    """Auto merge relinks a copied user mask to the copied source prediction.
+
+    Both the prediction and the user correction adopted from it live in the
+    incoming frame, so both are copied into the merged frame. The copied user
+    mask's ``from_predicted`` must point at the copied prediction now in the
+    frame, not the original object outside it (which would resolve to ``-1`` and
+    drop the link on save).
+    """
+    video = Video(filename="test.mp4", open_backend=False)
+    mask_data = np.ones((10, 10), dtype=bool)
+    pred = PredictedSegmentationMask.from_numpy(mask_data, score=0.9, offset=(5.0, 5.0))
+    user = pred.to_user()
+    user.offset = (500.0, 500.0)  # far enough to require the link, not spatial
+
+    lf1 = LabeledFrame(video=video, frame_idx=0, masks=[])
+    lf2 = LabeledFrame(video=video, frame_idx=0, masks=[pred, user])
+
+    lf1._merge_annotations(lf2, strategy="auto")
+
+    merged_preds = [m for m in lf1.masks if m.is_predicted]
+    merged_users = [m for m in lf1.masks if not m.is_predicted]
+    assert len(merged_preds) == 1
+    assert len(merged_users) == 1
+    # The link points at the in-frame copy, not the original object.
+    assert merged_users[0].from_predicted is merged_preds[0]
+    assert merged_users[0].from_predicted is not pred
+
+
+def test_merge_annotations_keep_both_mask_from_predicted_relinked():
+    """keep_both relinks a copied user mask to the copied source prediction."""
+    video = Video(filename="test.mp4", open_backend=False)
+    mask_data = np.ones((10, 10), dtype=bool)
+    pred = PredictedSegmentationMask.from_numpy(mask_data, score=0.9)
+    user = pred.to_user()
+
+    lf1 = LabeledFrame(video=video, frame_idx=0, masks=[])
+    lf2 = LabeledFrame(video=video, frame_idx=0, masks=[pred, user])
+
+    lf1._merge_annotations(lf2, strategy="keep_both")
+
+    merged_preds = [m for m in lf1.masks if m.is_predicted]
+    merged_users = [m for m in lf1.masks if not m.is_predicted]
+    assert merged_users[0].from_predicted is merged_preds[0]
+    assert merged_users[0].from_predicted is not pred
+
+
+def test_merge_annotations_keep_new_mask_from_predicted_relinked():
+    """keep_new relinks a copied user mask to the copied source prediction."""
+    video = Video(filename="test.mp4", open_backend=False)
+    mask_data = np.ones((10, 10), dtype=bool)
+    pred = PredictedSegmentationMask.from_numpy(mask_data, score=0.9)
+    user = pred.to_user()
+
+    lf1 = LabeledFrame(video=video, frame_idx=0, masks=[])
+    lf2 = LabeledFrame(video=video, frame_idx=0, masks=[pred, user])
+
+    lf1._merge_annotations(lf2, strategy="keep_new")
+
+    merged_preds = [m for m in lf1.masks if m.is_predicted]
+    merged_users = [m for m in lf1.masks if not m.is_predicted]
+    assert merged_users[0].from_predicted is merged_preds[0]
+    assert merged_users[0].from_predicted is not pred
+
+
 def test_merge_annotations_update_tracks_cascades():
     """Update_tracks updates annotation tracks from spatially matched other."""
     from sleap_io.model.centroid import UserCentroid


### PR DESCRIPTION
## Summary

Auto-merge (and other merge strategies) silently dropped the `from_predicted` provenance link on save. After `Labels.merge(..., frame="auto")`, a `UserSegmentationMask.from_predicted` (and `Instance.from_predicted`) round-tripped through `.save()` / `load_file()` as `None`. A direct save without a merge preserves it. This is a gap in the mask-provenance work from #472/#475.

## Problem

The merge copy path shallow-copies a predicted annotation and the user annotation that adopted it **independently**. The copied user annotation's `from_predicted` still references the **original** predicted object, not the copy now living in the merged frame.

At write time, `sleap_io/io/slp.py` resolves the link by object identity:

```python
mask_id_to_idx.get(id(from_predicted_src), -1)   # write_masks (~slp.py:4208)
inst_to_id.get(id(from_predicted), -1)            # write_lfs   (~slp.py:2289)
```

The original source object is not in `labels.masks`/`labels` (only its copy is), so the lookup returns `-1` and the link is lost on the next round-trip. The same bug affects instances: a merged `Instance.from_predicted` is dropped identically (the merge remap in `Labels._map_instance` rebuilds both the prediction and the user instance but keeps `from_predicted` pointing at the original).

## Fix

Remap `from_predicted` during merge so a copied user annotation links to the copied predicted source within the same frame:

- `sleap_io/model/labeled_frame.py`: new `_copy_with_memo` records `{id(original): copy}` while copying; new `_relink_from_predicted` rewrites each user annotation's `from_predicted` to the in-frame copy. Wired into all copying merge strategies (`auto`, `keep_new`, `keep_both`, `replace_predictions`).
- `sleap_io/model/labels.py`: `_map_instance` accepts an optional `memo` and records the source→remapped mapping; both instance-remap sites in `merge()` (new-frame and existing-frame branches) relink afterward.

The relink only ever redirects to an object actually present in the merged list (sources not copied are left unchanged), so existing copy semantics and non-merge direct saves are untouched (rasters/points are not deep-copied; the targeted id-remap suffices).

## Regression tests

- `tests/io/test_slp.py::test_slp_mask_from_predicted_survives_merge` — the exact blocker repro (merge + save + load) asserting the mask link survives.
- `tests/io/test_slp.py::test_slp_instance_from_predicted_survives_merge` — analogous instance round-trip.
- `tests/model/test_labeled_frame.py` — `test_merge_annotations_auto_mask_from_predicted_relinked`, `..._keep_both_...`, `..._keep_new_...` assert the link points at the in-frame copy (identity), not the original.

All five fail without the fix and pass with it (verified by stashing the source change).

## Testing

```
uv run pytest tests/model/test_labeled_frame.py tests/io/test_slp.py -p no:cacheprovider -q -k "merge or from_predicted or mask"
# 87 passed
```

Full `tests/model/test_labeled_frame.py` + `tests/io/test_slp.py` pass except 6 pre-existing `cv2`/opencv-plugin embed tests that fail identically on a clean checkout (opencv not installed in the fresh venv) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV