### PR TITLE
fix(io): warn when DLC splits resolve to empty (labeled images missing)

### DIFF
--- a/sleap_io/io/dlc.py
+++ b/sleap_io/io/dlc.py
@@ -1046,11 +1046,12 @@ def load_dlc_splits(
 
     Notes:
         Splits require the labeled images to be present on disk so that each
-        merged frame maps to a loaded `LabeledFrame`. DLC stores split membership
-        as positional indices into a globally, lexicographically sorted merge of
-        all per-video annotations; this function reconstructs that order. For
-        non-zero-padded filenames, a warning is emitted because lexicographic and
-        numeric orderings diverge.
+        merged frame maps to a loaded `LabeledFrame`. If the images are missing,
+        the returned splits are empty and a warning is emitted. DLC stores split
+        membership as positional indices into a globally, lexicographically sorted
+        merge of all per-video annotations; this function reconstructs that order.
+        For non-zero-padded filenames, a warning is emitted because lexicographic
+        and numeric orderings diverge.
     """
     config_path = _resolve_project_config_path(config)
     cfg = _read_dlc_config(config_path)
@@ -1063,6 +1064,19 @@ def load_dlc_splits(
 
     merged = _dlc_merged_order(project_dir, cfg)
     _warn_if_nonlexicographic(merged)
+
+    # Splits require the labeled images to be present so each merged frame maps to
+    # a loaded LabeledFrame. If the merge is non-empty but no frames were loaded,
+    # the referenced images are missing on disk and both splits would be silently
+    # empty; warn so the caller can restore the images or pass search paths.
+    if merged and not labels.labeled_frames:
+        warnings.warn(
+            "DLC split import: the project's labeled images were not found on "
+            "disk, so no frames could be loaded and the train/test splits will be "
+            "empty. Restore the referenced images under 'labeled-data/' (or pass "
+            "video_search_paths) and try again.",
+            stacklevel=2,
+        )
 
     pickle_path = _select_documentation_pickle(
         project_dir, cfg, train_fraction, shuffle, iteration

--- a/tests/io/test_dlc.py
+++ b/tests/io/test_dlc.py
@@ -1,6 +1,7 @@
 """Tests for DeepLabCut I/O operations."""
 
 import pickle
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -880,6 +881,35 @@ def test_load_dlc_splits_selector_no_match(tmp_path):
     )
     with pytest.raises(FileNotFoundError):
         sio.load_dlc_splits(config_path, shuffle=99)
+
+
+def test_load_dlc_splits_warns_when_images_missing(tmp_path):
+    """Missing labeled images yield empty splits with a clear warning."""
+    config_path = make_dlc_project(
+        tmp_path,
+        train_indices=[0, 2, 4],
+        test_indices=[1, 3],
+        make_images=False,
+    )
+    with pytest.warns(UserWarning, match="labeled images were not found"):
+        splits = sio.load_dlc_splits(config_path)
+    assert _frame_keys(splits["train"]) == []
+    assert _frame_keys(splits["test"]) == []
+
+
+def test_load_dlc_splits_no_warning_when_images_present(tmp_path):
+    """Splits with images present resolve frames and do not warn about missing ones."""
+    config_path = make_dlc_project(
+        tmp_path,
+        train_indices=[0, 2, 4],
+        test_indices=[1, 3],
+        make_images=True,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        splits = sio.load_dlc_splits(config_path)
+    assert len(splits["train"].labeled_frames) == 3
+    assert len(splits["test"].labeled_frames) == 2
 
 
 def test_read_dlc_split_reads_indices(tmp_path):


### PR DESCRIPTION
## Problem

`load_dlc_splits` reconstructs DLC's merged frame order directly from the project CSVs (`_dlc_merged_order`), but it only maps split indices onto `LabeledFrame`s that were actually loaded by `load_dlc_project`. Loading a frame requires the referenced image to exist on disk (`dlc.py:567` only creates a `Video`/`LabeledFrame` when actual image files are found).

When a DLC project has real CSV rows and a `Documentation_data-*.pickle` encoding train/test indices, but the referenced `.png` files are absent on disk, the merged order is non-empty yet no frames load. Both the `train` and `test` `Labels` came back empty with **zero warnings** — the caller had no indication that the images were missing. `docs/formats/dlc.md` states images are required, but nothing warned at runtime.

This was a MEDIUM gap-api finding new in #424/#450.

## Fix

In `load_dlc_splits`, after building the merged order, emit a clear `warnings.warn(...)` when the merged order is non-empty but no `LabeledFrame`s were resolved. The message explains the labeled images were not found on disk (so splits will be empty) and how to fix it (restore images under `labeled-data/` or pass `video_search_paths`).

The empty-return contract is otherwise unchanged, and the populated (images-present) path is untouched and does not warn.

## Testing

Added two focused regression tests in `tests/io/test_dlc.py` (reusing the existing `make_dlc_project` helper with its `make_images` flag):

- `test_load_dlc_splits_warns_when_images_missing`: builds a project with `make_images=False`, asserts `pytest.warns(UserWarning, match="labeled images were not found")` and that both splits are empty.
- `test_load_dlc_splits_no_warning_when_images_present`: builds the same project with images, asserts no `UserWarning` is raised (`simplefilter("error")`) and that splits populate (train=3 / test=2).

Verified the warns-test FAILS without the fix ("DID NOT WARN") and PASSES with it. Full `tests/io/test_dlc.py` module is green (96 passed); `ruff format` / `ruff check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV