### PR TITLE
fix(coco): fall back to bbox when degenerate polygon yields no geometry

### DIFF
--- a/sleap_io/io/coco.py
+++ b/sleap_io/io/coco.py
@@ -619,9 +619,12 @@ def read_labels(
                     masks.extend(seg_masks)
                     rois.extend(seg_rois)
 
-                    # Create BoundingBox if no segmentation was processed
+                    # Create BoundingBox if segmentation yielded no geometry. We
+                    # key off the decoded results rather than raw ``segmentation``
+                    # truthiness so that a degenerate ring (e.g. a single point)
+                    # still falls back to the bbox instead of being dropped.
                     bbox = annotation.get("bbox")
-                    if bbox is not None and not segmentation:
+                    if bbox is not None and not seg_masks and not seg_rois:
                         x, y, w, h = bbox
                         # COCO score field is only present in prediction results,
                         # so its presence distinguishes predicted from user

--- a/tests/io/test_coco.py
+++ b/tests/io/test_coco.py
@@ -2129,6 +2129,84 @@ class TestCOCOROIMaskIO:
         assert maxx == pytest.approx(50.0)
         assert maxy == pytest.approx(50.0)
 
+    def test_coco_detection_degenerate_segmentation_fallback_to_bbox(self, tmp_path):
+        """Degenerate (sub-polygon) segmentation falls back to bbox, not dropped."""
+        img_path = tmp_path / "img.png"
+        img_path.touch()
+
+        data = {
+            "images": [
+                {"id": 1, "file_name": "img.png", "height": 100, "width": 200},
+            ],
+            "annotations": [
+                {
+                    "id": 1,
+                    "image_id": 1,
+                    "category_id": 1,
+                    # Single-point ring: truthy but cannot form a polygon, so
+                    # _decode_segmentation yields no geometry.
+                    "segmentation": [[5.0, 5.0]],
+                    "bbox": [2, 2, 10, 10],
+                    "area": 100,
+                    "iscrowd": 0,
+                },
+            ],
+            "categories": [{"id": 1, "name": "animal"}],
+        }
+
+        json_path = tmp_path / "degenerate_bbox.json"
+        with open(json_path, "w") as f:
+            json.dump(data, f)
+
+        labels = coco.read_labels(json_path, dataset_root=tmp_path)
+
+        # No mask/roi geometry, but the bbox is preserved.
+        assert len(labels.masks) == 0
+        assert len(labels.rois) == 0
+        assert len(labels.bboxes) == 1
+        bbox = labels.bboxes[0]
+        assert isinstance(bbox, UserBoundingBox)
+        assert bbox.category == "animal"
+        x, y, w, h = bbox.xywh
+        assert x == pytest.approx(2.0)
+        assert y == pytest.approx(2.0)
+        assert w == pytest.approx(10.0)
+        assert h == pytest.approx(10.0)
+
+    def test_coco_detection_valid_polygon_no_spurious_bbox(self, tmp_path):
+        """A valid polygon yields a mask and does not also emit a bbox."""
+        img_path = tmp_path / "img.png"
+        img_path.touch()
+
+        data = {
+            "images": [
+                {"id": 1, "file_name": "img.png", "height": 100, "width": 100},
+            ],
+            "annotations": [
+                {
+                    "id": 1,
+                    "image_id": 1,
+                    "category_id": 1,
+                    "segmentation": [[10.0, 10.0, 50.0, 10.0, 50.0, 50.0, 10.0, 50.0]],
+                    "bbox": [10, 10, 40, 40],
+                    "area": 1600,
+                    "iscrowd": 0,
+                },
+            ],
+            "categories": [{"id": 1, "name": "obj"}],
+        }
+
+        json_path = tmp_path / "valid_poly_no_bbox.json"
+        with open(json_path, "w") as f:
+            json.dump(data, f)
+
+        labels = coco.read_labels(json_path, dataset_root=tmp_path)
+
+        # Geometry was decoded, so the bbox fallback must not fire.
+        assert len(labels.masks) == 1
+        assert len(labels.rois) == 0
+        assert len(labels.bboxes) == 0
+
 
 def test_read_labels_keypoints_and_segmentation(tmp_path):
     """Annotations with both keypoints and segmentation should preserve both."""


### PR DESCRIPTION
## Problem

A detection-only COCO annotation that combines a **degenerate** (sub-3-vertex) but non-empty polygon with a **valid `bbox`** was silently dropped on import (data loss, introduced in #479).

The bbox fallback in the detection-only branch (`sleap_io/io/coco.py:564`) guarded on the raw `segmentation` field's truthiness:

```python
if bbox is not None and not segmentation:
```

A degenerate ring such as `[[5.0, 5.0]]` is truthy, so the fallback was skipped. But `_decode_segmentation` (coco.py:284-297) skips rings with fewer than 3 vertices, so it produced **no** geometry. The annotation ended up with `masks=0`, `rois=0`, and `bboxes=0` — the bbox was lost.

### Repro

A COCO JSON with one annotation `{"image_id":1,"category_id":1,"segmentation":[[5.0,5.0]],"bbox":[2,2,10,10]}` (and a matching image entry) produced `bboxes=0`. With `segmentation: []` or the key absent, the same input correctly produced `bboxes=1`.

## Fix

Key the bbox fallback off the **decoded** results rather than raw segmentation truthiness:

```python
if bbox is not None and not seg_masks and not seg_rois:
```

This makes a degenerate ring fall back to the bbox while preserving existing behavior for valid polygons/RLE (geometry suppresses the fallback) and for empty/absent segmentation.

## Tests

Added two regression tests in `tests/io/test_coco.py` (class `TestCOCOROIMaskIO`):

- `test_coco_detection_degenerate_segmentation_fallback_to_bbox` — degenerate ring + valid bbox now yields exactly one `UserBoundingBox` (no mask/roi). Verified this FAILS without the fix and PASSES with it.
- `test_coco_detection_valid_polygon_no_spurious_bbox` — a valid polygon still yields a mask and does NOT also emit a bbox (control; passes both before and after).

Full module green: `uv run pytest tests/io/test_coco.py` → 92 passed. `ruff format`/`ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV