### PR TITLE
fix(render): stop double-scaling centroid markers by scale

### DIFF
--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -1327,11 +1327,15 @@ def render_image(
                     c_colors.append(centroid_pal[tidx % len(centroid_pal)])
                 else:
                     c_colors.append(centroid_pal[0] if centroid_pal else (0, 255, 0))
+            # centroid_marker_size is NOT pre-scaled: the centroids are drawn
+            # here, then the whole image is upscaled once by `scale` inside
+            # render_frame, so the final radius matches pose nodes
+            # (marker_size * scale).
             render_image_data = _draw_centroids(
                 render_image_data,
                 frame_centroids,
                 colors=c_colors,
-                marker_size=centroid_marker_size * scale,
+                marker_size=centroid_marker_size,
                 offset=crop_offset,
             )
 
@@ -1966,11 +1970,14 @@ def render_video(
                     _centroid_palette[0] if _centroid_palette else (0, 255, 0)
                 )
 
+        # centroid_marker_size is NOT pre-scaled: the centroids are drawn here,
+        # then the whole image is upscaled once by `scale` inside render_frame,
+        # so the final radius matches pose nodes (marker_size * scale).
         draw_centroids(
             image,
             frame_centroids,
             colors=centroid_colors,
-            marker_size=centroid_marker_size * scale,
+            marker_size=centroid_marker_size,
             offset=crop_off,
         )
         return image

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -4510,6 +4510,87 @@ def test_render_video_centroids_no_track():
     assert len(frames) == 1
 
 
+def test_render_image_centroid_marker_scales_linearly():
+    """Centroid marker area scales linearly (not quadratically) with ``scale``.
+
+    Regression test: the centroid marker used to be pre-scaled by ``scale``
+    before render_frame upscaled the whole canvas by ``scale`` again, so its
+    radius grew by ``scale**2`` (painted area by ``scale**4``). Mirroring how
+    pose nodes/edges and trails are handled, the marker must be passed
+    un-prescaled so the single canvas upscale produces a linear relationship:
+    doubling ``scale`` should roughly quadruple the painted area (~4x), not
+    grow it ~16x.
+    """
+    from sleap_io.model.centroid import UserCentroid
+
+    track = Track(name="t1")
+    video = sio.Video(filename="dummy.mp4", open_backend=False)
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    lf.centroids.append(UserCentroid(x=50.0, y=50.0, track=track))
+    labels = sio.Labels(
+        labeled_frames=[lf],
+        skeletons=[sio.Skeleton(["A"])],
+        tracks=[track],
+    )
+
+    def painted(scale: float) -> int:
+        img = np.zeros((100, 100, 3), dtype=np.uint8)
+        rendered = render_image(
+            labels,
+            frame_idx=0,
+            video=video,
+            image=img,
+            show_centroids=True,
+            centroid_marker_size=5,
+            scale=scale,
+            show_nodes=False,
+            show_edges=False,
+        )
+        return int(np.any(rendered != 0, axis=-1).sum())
+
+    ratio = painted(2.0) / painted(1.0)
+    # Linear scaling => area ratio ~4x (allow margin for anti-aliasing). The
+    # quadratic bug produced ~16x, far outside this band.
+    assert 2.5 < ratio < 8.0
+
+
+def test_render_video_centroid_marker_scales_linearly():
+    """render_video centroid marker area scales linearly with ``scale``.
+
+    Same regression as render_image but exercising the render_video
+    ``_draw_frame_centroids`` call site.
+    """
+    from sleap_io.model.centroid import UserCentroid
+
+    track = Track(name="t1")
+    video = sio.Video(filename="test.mp4", open_backend=False)
+    video.backend_metadata["shape"] = (3, 100, 100, 3)
+    lf = sio.LabeledFrame(video=video, frame_idx=0)
+    lf.centroids.append(UserCentroid(x=50.0, y=50.0, track=track))
+    labels = sio.Labels(
+        labeled_frames=[lf],
+        skeletons=[sio.Skeleton(["A"])],
+        tracks=[track],
+    )
+
+    def painted(scale: float) -> int:
+        frames = render_video(
+            labels,
+            background="black",
+            show_progress=False,
+            frame_inds=[0],
+            show_centroids=True,
+            centroid_marker_size=5,
+            scale=scale,
+            show_nodes=False,
+            show_edges=False,
+        )
+        return int(np.any(frames[0] != 0, axis=-1).sum())
+
+    ratio = painted(2.0) / painted(1.0)
+    assert 2.5 < ratio < 8.0
+
+
 # ============================================================================
 # Motion trail tests
 # ============================================================================


### PR DESCRIPTION
## Problem

Centroid markers were scaled twice by `scale`, so their radius grew quadratically (painted area by `scale**4`). At large scales markers ballooned; under preview/draft (downscale) presets they shrank toward invisibility.

The two call sites passed `marker_size=centroid_marker_size * scale` while drawing onto the **pre-scale** canvas:
- `sleap_io/rendering/core.py` `render_image` (centroid block)
- `sleap_io/rendering/core.py` `render_video` `_draw_frame_centroids`

`render_frame` then upscales the whole canvas by `scale` once more (`_scale_frame` at line 644), so the centroid radius ended up scaled by `scale**2`. Pose nodes/edges are drawn *inside* `render_frame` on the already-upscaled canvas and multiply by `scale` exactly once there; `trail_width` is deliberately passed **un-prescaled** (see the existing comment at the trail call sites) for the same reason.

Repro (one node `marker_size=5`, one centroid `centroid_marker_size=5`, black bg): non-black pixel count from `scale=1`→`scale=2` was ~3.77x for the node (linear, correct) but ~16.4x for the centroid (quadratic, bug).

## Fix

Drop the `* scale` at both call sites so `centroid_marker_size` is passed un-prescaled, letting `render_frame`'s single canvas upscale do the one scaling. This mirrors `trail_width` and matches pose nodes (`marker_size * scale` applied once on the upscaled canvas). Default sizes are unchanged. Added an explanatory comment at each site matching the existing trail comments.

## Tests

`tests/rendering/test_rendering.py` (skia-gated via `importorskip`):
- `test_render_image_centroid_marker_scales_linearly`
- `test_render_video_centroid_marker_scales_linearly`

Each asserts the centroid painted area scales **linearly** with `scale` (area ratio `2.5 < r < 8.0` when doubling scale; observed ~4.9x with the fix). Verified both FAIL without the fix (ratio ~16.76, outside the band) and PASS with it. Full rendering module: 266 passed.

Addresses the MEDIUM rendering finding for the 0.8.0 release (centroid double-scaling).