### PR TITLE
feat(cli): reach DLC-project import and COCO seg/identity options from convert

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -473,10 +473,12 @@ sio convert spots.csv -o labels.slp --from trackmate
 | `--save-metadata` | Save JSON metadata file for CSV round-trip support |
 | `--h5-dim-order` | HDF5 axis ordering: `matlab` or `standard` (analysis_h5 only) |
 | `--min-occupancy` | Filter tracks below this occupancy ratio (analysis_h5 only) |
+| `--coco-category-as-track` | Treat each COCO category as a persistent identity track (coco input only) |
+| `--coco-segmentation` | COCO polygon handling: `mask` (rasterize) or `roi` (keep as vector ROIs); default `mask` (coco input only) |
 
 ### Supported Formats
 
-**Input formats:** `slp`, `nwb`, `coco`, `labelstudio`, `alphatracker`, `jabs`, `dlc`, `csv`, `trackmate`, `ultralytics`, `leap`
+**Input formats:** `slp`, `nwb`, `coco`, `labelstudio`, `alphatracker`, `jabs`, `dlc`, `dlc_project`, `csv`, `trackmate`, `ultralytics`, `leap`
 
 **Output formats:** `slp`, `nwb`, `coco`, `labelstudio`, `jabs`, `ultralytics`, `csv`, `analysis_h5`
 
@@ -492,8 +494,25 @@ The CLI automatically detects formats from file extensions:
 | `.csv` | TrackMate or DeepLabCut (auto-detected from headers) | CSV |
 | `.h5` / `.hdf5` | (ambiguous) | Analysis HDF5 |
 | Directory with `data.yaml` | Ultralytics | Ultralytics |
+| Directory with `config.yaml` + `labeled-data/` (or a project `config.yaml`) | DeepLabCut project | - |
 
 For `.csv` inputs, the CLI first sniffs the file header: TrackMate spots exports are detected via their `LABEL,ID,TRACK_ID,...` schema, otherwise DeepLabCut multi-index headers are matched, and everything else falls back to the generic `csv` reader. Pass `--from trackmate` or `--from dlc` to bypass sniffing.
+
+A whole DeepLabCut project is auto-detected as `dlc_project` and merged into a single `Labels` (use `--from dlc_project` to be explicit). This differs from `--from dlc`, which reads a single DLC annotation CSV:
+
+```bash
+# Import an entire DeepLabCut project (config.yaml + labeled-data/)
+sio convert my_dlc_project/ -o labels.slp
+sio convert my_dlc_project/config.yaml -o labels.slp --from dlc_project
+```
+
+For COCO instance-segmentation datasets, `--coco-category-as-track` turns each category into a persistent identity track and `--coco-segmentation roi` preserves polygons as vector ROIs instead of rasterizing them into masks:
+
+```bash
+# Identity tracks from COCO categories, polygons kept as vector ROIs
+sio convert annotations.json -o labels.slp --from coco \
+    --coco-category-as-track --coco-segmentation roi
+```
 
 **Ambiguous extensions** (`.json`, `.h5`) require explicit `--from`:
 

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -133,6 +133,7 @@ INPUT_FORMATS = [
     "alphatracker",
     "jabs",
     "dlc",
+    "dlc_project",
     "csv",
     "trackmate",
     "ultralytics",
@@ -1841,10 +1842,24 @@ def _infer_input_format(path: Path) -> str | None:
     """
     suffix = path.suffix.lower()
 
-    # Check for ultralytics (directory with data.yaml)
+    # Check for ultralytics (directory with data.yaml) or DLC project directory
+    # (config.yaml + labeled-data/).
     if path.is_dir():
         if (path / "data.yaml").exists():
             return "ultralytics"
+
+        from sleap_io.io import dlc
+
+        if dlc._is_dlc_project_path(path):
+            return "dlc_project"
+        return None
+
+    # A standalone DLC project config.yaml (validated by content).
+    if path.name == "config.yaml":
+        from sleap_io.io import dlc
+
+        if dlc._is_dlc_project_path(path):
+            return "dlc_project"
         return None
 
     # CSV requires content-based detection (trackmate vs dlc vs generic)
@@ -1961,6 +1976,23 @@ def _infer_output_format(path: Path) -> str | None:
     default=0.0,
     help="Filter tracks with occupancy below this ratio (0-1). analysis_h5 only.",
 )
+@click.option(
+    "--coco-category-as-track",
+    "coco_category_as_track",
+    is_flag=True,
+    default=False,
+    help="Treat each COCO category as a persistent identity track. coco input only.",
+)
+@click.option(
+    "--coco-segmentation",
+    "coco_segmentation",
+    type=click.Choice(["mask", "roi"]),
+    default="mask",
+    help=(
+        "How to represent COCO polygon segmentation: mask (rasterize) or roi "
+        "(keep as vector ROIs). coco input only. Default: mask."
+    ),
+)
 def convert(
     input_arg: Path | None,
     input_opt: Path | None,
@@ -1973,6 +2005,8 @@ def convert(
     save_metadata: bool,
     h5_dim_order: str,
     min_occupancy: float,
+    coco_category_as_track: bool,
+    coco_segmentation: str,
 ):
     """Convert between pose data formats.
 
@@ -1981,17 +2015,24 @@ def convert(
     but can be explicitly specified using --from and --to.
 
     [bold]Supported input formats:[/]
-    slp, nwb, coco, labelstudio, alphatracker, jabs, dlc, csv,
-    trackmate, ultralytics, leap
+    slp, nwb, coco, labelstudio, alphatracker, jabs, dlc, dlc_project,
+    csv, trackmate, ultralytics, leap
 
     [bold]Supported output formats:[/]
     slp, nwb, coco, labelstudio, jabs, ultralytics, csv, analysis_h5
+
+    A DeepLabCut project (a directory with config.yaml + labeled-data/, or its
+    config.yaml directly) is auto-detected as dlc_project. For COCO input,
+    --coco-category-as-track and --coco-segmentation control identity tracks and
+    polygon handling.
 
     [dim]Examples:[/]
 
         $ sio convert labels.slp -o labels.nwb
         $ sio convert -i labels.slp -o labels.nwb
         $ sio convert annotations.json -o labels.slp --from coco
+        $ sio convert dlc_project/ -o labels.slp
+        $ sio convert seg.json -o labels.slp --from coco --coco-category-as-track
         $ sio convert labels.slp -o labels.pkg.slp --embed user
         $ sio convert labels.slp -o dataset/ --to ultralytics
         $ sio convert labels.slp -o analysis.h5 --to analysis_h5
@@ -2044,9 +2085,12 @@ def convert(
     # Load the input file
     # Note: open_videos is only valid for SLP format
     try:
-        load_kwargs = {"format": resolved_input_format}
+        load_kwargs: dict = {"format": resolved_input_format}
         if resolved_input_format == "slp":
             load_kwargs["open_videos"] = needs_video
+        elif resolved_input_format == "coco":
+            load_kwargs["category_as_track"] = coco_category_as_track
+            load_kwargs["segmentation_format"] = coco_segmentation
         labels = io_main.load_file(str(input_path), **load_kwargs)
     except Exception as e:
         raise click.ClickException(f"Failed to load input file: {e}")

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -5,8 +5,10 @@ Covers summary output, labeled frame details, skeleton printing, and format conv
 
 from __future__ import annotations
 
+import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import threading
@@ -22,6 +24,7 @@ from sleap_io import load_slp, save_slp, save_video
 from sleap_io.io.cli import (
     _ensure_utf8_streams,
     _get_ffmpeg_version,
+    _infer_input_format,
     _is_ffmpeg_available,
     _load_images,
     _load_overlay,
@@ -1860,6 +1863,172 @@ def test_convert_trackmate_explicit_from(tmp_path):
     )
     assert result.exit_code == 0, result.output
     assert output.exists()
+
+
+def _make_dlc_project(dest: Path) -> Path:
+    """Build a DLC project directory from the test fixtures under ``dest``.
+
+    Copies ``tests/data/dlc/labeled-data`` and the multi-animal config into
+    ``dest`` as a self-contained DLC project (config.yaml + labeled-data/).
+
+    Args:
+        dest: Directory to populate as the project root.
+
+    Returns:
+        The project root path (``dest``).
+    """
+    shutil.copytree(_data_path("dlc/labeled-data"), dest / "labeled-data")
+    shutil.copy(_data_path("dlc/madlc_230_config.yaml"), dest / "config.yaml")
+    return dest
+
+
+def test_infer_input_format_dlc_project_directory(tmp_path):
+    """A directory with config.yaml + labeled-data/ is detected as dlc_project."""
+    project = _make_dlc_project(tmp_path / "proj")
+    assert _infer_input_format(project) == "dlc_project"
+
+
+def test_infer_input_format_dlc_project_config_file(tmp_path):
+    """A standalone DLC project config.yaml is detected as dlc_project."""
+    project = _make_dlc_project(tmp_path / "proj")
+    assert _infer_input_format(project / "config.yaml") == "dlc_project"
+
+
+def test_infer_input_format_non_dlc_config_file(tmp_path):
+    """A config.yaml that is not a DLC project config is not misclassified."""
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("foo: bar\nbaz: 1\n")
+    assert _infer_input_format(cfg) is None
+
+
+def test_convert_dlc_project_directory(tmp_path):
+    """`sio convert <dlcproject>` auto-detects dlc_project and writes frames."""
+    project = _make_dlc_project(tmp_path / "proj")
+    output = tmp_path / "out.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["convert", str(project), "-o", str(output)])
+    assert result.exit_code == 0, result.output
+    assert "dlc_project -> slp" in result.output
+    assert output.exists()
+
+    labels = load_slp(str(output))
+    assert len(labels.labeled_frames) > 0
+
+
+def test_convert_dlc_project_explicit_from(tmp_path):
+    """`sio convert --from dlc_project` loads a project config.yaml directly."""
+    project = _make_dlc_project(tmp_path / "proj")
+    output = tmp_path / "out.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "convert",
+            str(project / "config.yaml"),
+            "-o",
+            str(output),
+            "--from",
+            "dlc_project",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+    assert len(load_slp(str(output)).labeled_frames) > 0
+
+
+def _write_identity_coco(dest: Path) -> Path:
+    """Write a small two-category, polygon-segmentation COCO dataset.
+
+    Args:
+        dest: Directory to place the image files and JSON into.
+
+    Returns:
+        Path to the written COCO JSON file.
+    """
+    (dest / "img1.png").touch()
+    (dest / "img2.png").touch()
+    data = {
+        "images": [
+            {"id": 1, "file_name": "img1.png", "height": 40, "width": 40},
+            {"id": 2, "file_name": "img2.png", "height": 40, "width": 40},
+        ],
+        "annotations": [
+            {
+                "id": 1,
+                "image_id": 1,
+                "category_id": 1,
+                "segmentation": [[1.0, 1.0, 10.0, 1.0, 10.0, 10.0, 1.0, 10.0]],
+            },
+            {
+                "id": 2,
+                "image_id": 1,
+                "category_id": 2,
+                "segmentation": [[20.0, 20.0, 30.0, 20.0, 30.0, 30.0, 20.0, 30.0]],
+            },
+            {
+                "id": 3,
+                "image_id": 2,
+                "category_id": 1,
+                "segmentation": [[2.0, 2.0, 12.0, 2.0, 12.0, 12.0, 2.0, 12.0]],
+            },
+        ],
+        "categories": [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}],
+    }
+    json_path = dest / "seg.json"
+    json_path.write_text(json.dumps(data))
+    return json_path
+
+
+def test_convert_coco_category_as_track_and_roi(tmp_path):
+    """COCO convert with --coco-category-as-track --coco-segmentation roi."""
+    json_path = _write_identity_coco(tmp_path)
+    output = tmp_path / "out.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "convert",
+            str(json_path),
+            "-o",
+            str(output),
+            "--from",
+            "coco",
+            "--coco-category-as-track",
+            "--coco-segmentation",
+            "roi",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert output.exists()
+
+    labels = load_slp(str(output))
+    # roi mode keeps polygons as vector ROIs (no rasterized masks).
+    assert len(labels.rois) == 3
+    assert len(labels.masks) == 0
+    # category_as_track creates one identity track per category.
+    assert {t.name for t in labels.tracks} == {"a", "b"}
+
+
+def test_convert_coco_defaults_no_track_mask(tmp_path):
+    """COCO convert defaults: rasterized masks and no identity tracks."""
+    json_path = _write_identity_coco(tmp_path)
+    output = tmp_path / "out.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["convert", str(json_path), "-o", str(output), "--from", "coco"],
+    )
+    assert result.exit_code == 0, result.output
+
+    labels = load_slp(str(output))
+    # Default mask mode rasterizes the polygons; no ROIs, no identity tracks.
+    assert len(labels.masks) == 3
+    assert len(labels.rois) == 0
+    assert len(labels.tracks) == 0
 
 
 def test_infer_output_format_directory(tmp_path):


### PR DESCRIPTION
## Summary

Closes two related medium CLI-gap findings by extending `sio convert` (and CLI format inference) to reach two 0.8.0 readers that were previously Python-only.

## Finding A: DLC project import unreachable from the CLI

`_infer_input_format` returned `None` for a DeepLabCut project directory and `config.yaml`, so `sio convert <dir>` failed with "Cannot infer input format", and `--from dlc` on a `config.yaml` misrouted to the single-CSV DLC reader.

**Fix:**
- `_infer_input_format` now detects a DLC project — a directory containing both `config.yaml` and `labeled-data/`, or a standalone `config.yaml` that validates as a DLC project config (via the existing `dlc._is_dlc_project_path`) — and returns a new `dlc_project` format.
- `dlc_project` added to `INPUT_FORMATS` so `--from dlc_project` is accepted.
- A plain DLC CSV is still detected as `dlc`; an unrelated `config.yaml` is not misclassified.

`sio convert <dlcproject>` works end to end via `load_file` (convert does not pass `open_videos` for non-slp inputs).

## Finding B: COCO category_as_track / segmentation_format not reachable from convert

The #479 identity-track feature and ROI mode were Python-only because `convert` built `load_kwargs` with only `format` (+`open_videos` for slp).

**Fix:** `convert` gains `--coco-category-as-track` (flag) and `--coco-segmentation [mask|roi]`, forwarded into the COCO loader when the input format is `coco`. Defaults match the Python API (`category_as_track=False`, `segmentation_format="mask"`).

## Testing

`tests/io/test_cli.py`:
- DLC project detection: directory, standalone `config.yaml`, and a non-DLC `config.yaml` (returns `None`).
- `sio convert <dlcproject>` auto-detected, and explicit `--from dlc_project` on a `config.yaml`; both write frames.
- COCO convert with `--coco-category-as-track --coco-segmentation roi` (identity tracks + vector ROIs) vs defaults (rasterized masks, no tracks).

Each new-feature test fails on `main` and passes with the fix (verified by stashing `cli.py`). Lint clean (`ruff format` + `ruff check`); docs rebuilt with `mkdocs build`.

## Notes

- `sio show <dlcproject>` additionally requires the separate open PR #488 (`fix/dlc-loader-kwargs`, adds `**kwargs` to `dlc.load_dlc_project` so show's `open_videos`/`lazy` kwargs are tolerated). That fix is not on `main`, so this PR intentionally does not test `sio show <dlcproject>`.
- `cli.py` is also edited by sibling CLI PRs; edits here are localized to `_infer_input_format`, `INPUT_FORMATS`, and the `convert` command to minimize merge conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV