### PR TITLE
fix(video): reject (not silently drop) auth/stream kwargs for remote media video

### DIFF
--- a/docs/remote.md
+++ b/docs/remote.md
@@ -158,6 +158,13 @@ Cloud schemes (`s3://`, `gs://`, …) ignore `headers=` and use their own
 per-provider credential chains (environment variables, credential files,
 instance metadata).
 
+!!! note "`headers=` is for labels, not media video"
+    `headers=` (and the streaming options below) authenticate and configure
+    remote `.slp`/`.pkg.slp` **label** loading. They are **not** supported for
+    remote media video, which FFmpeg decodes from the URL directly — see
+    [Remote video](#remote-video). For an auth-gated remote video, use a
+    pre-signed URL instead.
+
 !!! warning "Headers are stripped on cross-origin redirect"
     For security, sensitive headers (`Authorization`, `Cookie`,
     `Proxy-Authorization`) are **dropped automatically** if a request is
@@ -213,6 +220,17 @@ ignored for extension detection, so pre-signed URLs like
 `https://host/video.mp4?token=...` route correctly. Remote video requires the
 `pyav` extra (auto-selected as the backend); without it, `load_video(url)`
 raises an `ImportError` with the install hint.
+
+!!! warning "Auth headers and stream modes do not apply to remote video"
+    Unlike remote `.slp`/`.pkg.slp` labels, remote media video is decoded by
+    handing the URL straight to FFmpeg (via pyav), which has no hook for custom
+    HTTP request headers or fsspec stream modes. Passing `headers=`,
+    `url_headers=`, `stream_mode=`, or `url_stream_mode=` to `load_video` (or
+    `Video.from_filename`) for an `http`/`https` media URL raises a `ValueError`
+    rather than silently returning an unauthenticated backend. To read an
+    auth-gated remote video, use a **pre-signed URL** that embeds credentials in
+    the query string (e.g. `https://host/video.mp4?X-Amz-...`), or download the
+    file locally first.
 
 !!! danger "Security: remote video hands untrusted data to FFmpeg"
     Decoding a remote video streams bytes from the URL into FFmpeg (via pyav).

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -597,6 +597,33 @@ class VideoBackend:
                         f"{_remote._redact_url(filename)}. Download the file "
                         "locally first."
                     )
+                # Remote media video is decoded by handing the raw URL to
+                # ``av.open`` (via imageio's pyav plugin), which has no hook for
+                # forwarding HTTP request headers or selecting an fsspec stream
+                # mode. Auth/streaming kwargs that work for remote .slp/.pkg.slp
+                # (HDF5Video) therefore cannot be honored here. Rather than
+                # silently drop them and return an unauthenticated backend,
+                # reject them with an actionable error. ``url_headers`` /
+                # ``url_stream_mode`` are the explicit ``from_filename``
+                # parameters; ``headers`` / ``stream_mode`` arrive via
+                # ``**kwargs`` (e.g. from ``load_video(url, headers=...)``).
+                if (
+                    url_headers is not None
+                    or url_stream_mode != "blockcache"
+                    or kwargs.get("headers") is not None
+                    or kwargs.get("stream_mode") not in (None, "auto")
+                ):
+                    raise ValueError(
+                        "Remote media video cannot be authenticated with "
+                        "'headers'/'url_headers' or configured with a stream "
+                        "mode: it is decoded by handing the URL directly to "
+                        "FFmpeg (via pyav), which does not support custom HTTP "
+                        "headers or fsspec streaming. Use a pre-signed URL that "
+                        "embeds credentials in the query string, or download "
+                        "the file locally first. (These options do work for "
+                        "remote .slp/.pkg.slp labels.) (URL: "
+                        f"{_remote._redact_url(filename)})"
+                    )
                 # Default to pyav when the caller did not request a specific
                 # plugin, and require the ``av`` package up front for a clear
                 # error.

--- a/tests/io/test_video_reading.py
+++ b/tests/io/test_video_reading.py
@@ -1646,6 +1646,66 @@ def test_from_filename_url_with_query_string_matches_extension(
     assert backend[0].shape == (384, 384, 1)
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"headers": {"Authorization": "Bearer SECRET"}},
+        {"url_headers": {"Authorization": "Bearer SECRET"}},
+        {"stream_mode": "filecache"},
+        {"url_stream_mode": "download"},
+    ],
+)
+def test_from_filename_url_media_rejects_auth_kwargs(kwargs):
+    """Auth/stream kwargs on a remote media URL raise instead of being dropped.
+
+    Regression: remote media video is decoded by handing the URL to ``av.open``,
+    which cannot forward HTTP headers or use an fsspec stream mode. Previously
+    these kwargs were silently dropped, returning an unauthenticated backend.
+    """
+    url = "https://example.com/video.mp4?token=abc"
+    with pytest.raises(ValueError, match="Remote media video cannot be"):
+        VideoBackend.from_filename(url, **kwargs)
+
+
+def test_from_filename_url_media_redacts_token_in_auth_error():
+    """The auth-kwarg rejection error redacts the URL's token query param."""
+    url = "https://example.com/video.mp4?token=supersecret"
+    with pytest.raises(ValueError) as excinfo:
+        VideoBackend.from_filename(url, headers={"Authorization": "Bearer X"})
+    assert "supersecret" not in str(excinfo.value)
+
+
+def test_load_video_url_media_rejects_headers():
+    """``load_video(url, headers=...)`` rejects rather than silently dropping.
+
+    This is the documented auth surface (docs/remote.md), so a user following
+    the docs must get a clear error rather than an unauthenticated backend.
+    """
+    url = "https://example.com/video.mp4"
+    with pytest.raises(ValueError, match="Remote media video cannot be"):
+        sio.load_video(url, headers={"Authorization": "Bearer SECRET"})
+
+
+def test_from_filename_url_media_default_stream_mode_ok(
+    httpserver, centered_pair_low_quality_path
+):
+    """Passing the default ``stream_mode='auto'`` does not trip the auth guard."""
+    url = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")
+    backend = VideoBackend.from_filename(url, stream_mode="auto")
+    assert type(backend) is MediaVideo
+
+
+def test_from_filename_local_media_ignores_auth_kwargs(centered_pair_low_quality_path):
+    """Local media files are unaffected: auth kwargs are still no-ops, no error."""
+    backend = VideoBackend.from_filename(
+        centered_pair_low_quality_path,
+        headers={"Authorization": "Bearer X"},
+        stream_mode="filecache",
+    )
+    assert type(backend) is MediaVideo
+    assert backend.filename == centered_pair_low_quality_path
+
+
 def test_load_video_url_reads_first_frame(httpserver, centered_pair_low_quality_path):
     """A frame read over http matches the frame read from the local file."""
     url = _serve_video(httpserver, centered_pair_low_quality_path, "/video.mp4")


### PR DESCRIPTION
## Problem

`sio.load_video(remote_mp4_url, headers={...})` (and the equivalent `Video.from_filename` / `VideoBackend.from_filename` calls with `headers=`/`url_headers=`/`stream_mode=`/`url_stream_mode=`) **silently dropped** those kwargs and returned an *unauthenticated* `MediaVideo`. Only the `HDF5Video` (`.slp`/`.pkg.slp`) path forwarded `url_headers`/`url_stream_mode`; for remote media video the kwargs hit `_get_valid_kwargs(MediaVideo, ...)` (which keys on field names) or the unused explicit params and disappeared with no error.

This is a footgun because `docs/remote.md` presents `headers=` as the general remote-auth mechanism. A user following the docs would get a backend that fails to fetch (or worse, fetches the wrong/anonymous content) with no indication their credentials were ignored.

Finding: MEDIUM `gap-api`, new in #442.

Repro (before this PR):
```python
sio.load_video("https://example.com/video.mp4?token=abc",
               headers={"Authorization": "Bearer SECRET"})
# -> MediaVideo with no headers applied, no error
```

## Fix

Remote media video is decoded by handing the URL directly to FFmpeg (via pyav / imageio's pyav plugin → `av.open`), which has **no hook** for custom HTTP headers or fsspec stream modes. So forwarding them (Option B) isn't cleanly available. This PR takes **Option A** (the preferred, fully-testable, lower-risk option): the remote-media branch of `VideoBackend.from_filename` now **raises a clear, actionable `ValueError`** when `headers`/`url_headers`/`stream_mode`/`url_stream_mode` are supplied for an `http`/`https` media URL, instead of silently dropping them. The message points users to a **pre-signed URL** (credentials in the query string) or a local download, and notes these options do work for remote `.slp`/`.pkg.slp` labels. The URL is redacted in the message.

- Local files and the no-kwargs remote path are unaffected (the guard lives inside the `is_url` media branch; the default `stream_mode="auto"` does not trip it).
- `docs/remote.md` gains two admonitions: one in **Authentication & security** clarifying `headers=` is for labels not media video, and one in **Remote video** documenting the new behavior and the pre-signed-URL workaround.

## Tests (`tests/io/test_video_reading.py`)

- `test_from_filename_url_media_rejects_auth_kwargs` (parametrized over `headers`/`url_headers`/`stream_mode`/`url_stream_mode`) — each raises `ValueError`.
- `test_from_filename_url_media_redacts_token_in_auth_error` — the error redacts the URL's `token` query param.
- `test_load_video_url_media_rejects_headers` — the documented `load_video(url, headers=...)` surface raises.
- `test_from_filename_url_media_default_stream_mode_ok` — `stream_mode="auto"` does **not** trip the guard.
- `test_from_filename_local_media_ignores_auth_kwargs` — local files still treat these kwargs as no-ops (control).

Verified the 4 behavioral tests FAIL on the unpatched source (`git stash` of the source only) and PASS with the fix. Full `tests/io/test_video_reading.py` + `tests/io/test_remote.py` green (287 passed, 1 env skip). `ruff format`/`ruff check` clean; `mkdocs build` succeeds and the `#remote-video` anchor resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV