### PR TITLE
docs: COCO 0.8.0 breaking-change callout, honest render --crop docs, repair dead anchors

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -140,7 +140,7 @@ sio render predictions.slp                                 # -> predictions.viz.
 sio render predictions.slp --preset preview                # Fast 0.25x preview
 sio render predictions.slp --start 100 --end 200
 sio render predictions.slp --lf 0                          # Single frame -> PNG
-sio render predictions.slp --lf 0 --crop auto              # Auto-fit to instances
+sio render predictions.slp --lf 0 --crop 100,100,300,300  # Crop to region
 sio render predictions.slp --color-by track --marker-shape diamond
 sio render predictions.slp --trails --trail-length 10           # Motion trails
 
@@ -1896,8 +1896,7 @@ temporal context).
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--crop` | none | Crop region: `auto` or `x1,y1,x2,y2` (pixels or normalized 0.0-1.0) |
-| `--crop-padding` | 0.2 | Padding for auto-crop as fraction of bounding box |
+| `--crop` | none | Crop region: `x1,y1,x2,y2` (pixels or normalized 0.0-1.0) |
 
 ### Single Image Rendering
 
@@ -1922,15 +1921,9 @@ sio render predictions.slp --lf 5 -o frame.png
 
 ### Cropping (Single Image Only)
 
-Crop the output image to focus on specific regions or automatically fit around detected instances:
+Crop the output image to focus on specific regions:
 
 ```bash
-# Auto-fit: crop to bounding box of all instances with 20% padding (default)
-sio render predictions.slp --lf 0 --crop auto
-
-# Auto-fit with custom padding (30% of bounding box)
-sio render predictions.slp --lf 0 --crop auto --crop-padding 0.3
-
 # Pixel coordinates (x1, y1, x2, y2)
 sio render predictions.slp --lf 0 --crop 100,100,300,300
 
@@ -1940,7 +1933,6 @@ sio render predictions.slp --lf 0 --crop 0.25,0.25,0.75,0.75
 
 The crop modes:
 
-- **`auto`**: Automatically fit to the bounding box of all instances, with padding. Best for focusing on animals.
 - **Pixel coordinates**: `x1,y1,x2,y2` as integers. Use for precise cropping when you know exact pixel locations.
 - **Normalized coordinates**: `x1,y1,x2,y2` as floats between 0.0-1.0. Use for relative cropping that works across different video resolutions.
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -545,8 +545,8 @@ nwb_labels.save("converted.slp")
 
 !!! note "See also"
     - [NWB Format Documentation](formats/nwb.md): Complete NWB format reference
-    - [`load_nwb`](formats/nwb.md#sleap_io.load_nwb): NWB loading function
-    - [`save_nwb`](formats/nwb.md#sleap_io.save_nwb): NWB saving function with format options
+    - [`load_nwb`](formats/nwb.md#sleap_io.io.main.load_nwb): NWB loading function
+    - [`save_nwb`](formats/nwb.md#sleap_io.io.main.save_nwb): NWB saving function with format options
 
 ### Convert to Ultralytics YOLO format
 
@@ -622,8 +622,8 @@ sio.save_coco(
     - Integration with COCO-compatible evaluation tools
 
 !!! note "See also"
-    - [`save_coco`](formats/coco.md#sleap_io.save_coco): Full COCO export documentation
-    - [`load_coco`](formats/coco.md#sleap_io.load_coco): COCO import documentation
+    - [`save_coco`](formats/coco.md#sleap_io.io.main.save_coco): Full COCO export documentation
+    - [`load_coco`](formats/coco.md#sleap_io.io.main.load_coco): COCO import documentation
     - [COCO Format](formats/coco.md): COCO format details
 
 ## Loading from URLs
@@ -1201,8 +1201,8 @@ labels.save("segmentation.slp")
 
 !!! note "See also"
     - [Regions: Label images](model/segmentation.md#label-images): Full label image data model documentation
-    - [`PredictedLabelImage.from_stack`](model/segmentation.md#sleap_io.PredictedLabelImage.from_stack): Stack conversion API
-    - [`PredictedLabelImage.from_numpy`](model/segmentation.md#sleap_io.PredictedLabelImage.from_numpy): Per-frame conversion API
+    - [`PredictedLabelImage.from_stack`](model/segmentation.md#sleap_io.LabelImage.from_stack): Stack conversion API
+    - [`PredictedLabelImage.from_numpy`](model/segmentation.md#sleap_io.LabelImage.from_numpy): Per-frame conversion API
 
 ### Import per-object binary masks to SLP
 
@@ -1243,7 +1243,7 @@ labels.save("sam_output.slp")
 
 !!! note "See also"
     - [Regions: From binary masks](model/segmentation.md#from-binary-masks): Full `from_binary_masks` documentation
-    - [`PredictedLabelImage.from_binary_masks`](model/segmentation.md#sleap_io.PredictedLabelImage.from_binary_masks): API reference
+    - [`PredictedLabelImage.from_binary_masks`](model/segmentation.md#sleap_io.LabelImage.from_binary_masks): API reference
 
 ### Stream large segmentation results to SLP
 

--- a/docs/formats/coco.md
+++ b/docs/formats/coco.md
@@ -35,6 +35,14 @@ the `segmentation_format` argument of `load_coco` / `coco.read_labels`:
 - `"roi"`: keep the native vector geometry as [`ROI`][sleap_io.ROI] objects (one
   per ring), without rasterizing.
 
+!!! warning "Breaking change in 0.8.0"
+    The default polygon segmentation handling changed in v0.8.0. In v0.7.1,
+    polygon segmentation was read as vector [`ROI`][sleap_io.ROI] objects (one per
+    ring). The new default (`segmentation_format="mask"`) rasterizes each
+    annotation's polygon(s) into a single [`SegmentationMask`][sleap_io.SegmentationMask].
+    **To restore the pre-0.8.0 vector-ROI behavior, pass
+    `segmentation_format="roi"`.**
+
 ```python
 import sleap_io as sio
 

--- a/docs/merging.md
+++ b/docs/merging.md
@@ -740,6 +740,12 @@ Key behavior:
     options:
         heading_level: 4
 
+### Labels.match
+
+::: sleap_io.model.labels.Labels.match
+    options:
+        heading_level: 4
+
 ### Labels.add_video
 
 ::: sleap_io.model.labels.Labels.add_video
@@ -785,5 +791,11 @@ Key behavior:
 ### MergeResult
 
 ::: sleap_io.model.matching.MergeResult
+    options:
+        heading_level: 4
+
+### MatchResult
+
+::: sleap_io.model.matching.MatchResult
     options:
         heading_level: 4


### PR DESCRIPTION
## Summary

Three documentation-only corrections confirmed by the 0.8.0 release audit. All are docs-only; no library code changes.

### Finding 1 — COCO breaking-change doc gap
`docs/formats/coco.md` documented the new polygon→mask default but had no migration callout. In v0.7.1 polygon segmentation produced vector `ROI`s; the HEAD default (`segmentation_format="mask"`) rasterizes to a single `SegmentationMask`.

**Fix:** added a prominent `!!! warning "Breaking change in 0.8.0"` callout (matching the style already used in `docs/merging.md` and `docs/cli.md`) stating the new default and that `segmentation_format="roi"` restores the v0.7.1 vector-ROI behavior.

### Finding 2 — render `--crop` doc errors
`docs/cli.md` documented `sio render --crop auto` and `--crop-padding`, but neither exists: `_parse_crop_string` (`sleap_io/io/cli.py:309`) only accepts `x1,y1,x2,y2`, and the `--crop` option (`sleap_io/io/cli.py:3424`) is the only crop flag — there is no `--crop-padding`.

**Fix:** removed the `auto` mode and `--crop-padding` references from the quick-example block, the Crop Options table, and the Cropping section. Docs now describe only the supported `--crop x1,y1,x2,y2` (pixel and normalized) form. Auto-crop was **not** implemented (out of scope) — the docs are simply made honest.

### Finding 3 — dead in-page anchors
- `docs/examples.md` linked to `#sleap_io.{save,load}_{coco,nwb}` (actual rendered ids are `#sleap_io.io.main.*`) and `#sleap_io.PredictedLabelImage.from_{stack,numpy,binary_masks}` (actual ids are `#sleap_io.LabelImage.*`, since those factory methods are defined on `LabelImage`).
- `docs/merging.md` linked to `#sleap_io.model.labels.Labels.match` (line 54) and `#sleap_io.model.matching.MatchResult` (line 85), neither of which was rendered on that page.

**Fix:** repointed the seven `examples.md` anchors to their real target ids, and added `::: sleap_io.model.labels.Labels.match` and `::: sleap_io.model.matching.MatchResult` blocks to the `merging.md` Reference section (same pattern as the existing `::: ` blocks there) so both in-page links resolve.

## Testing

Docs-only change. Verified with `EAGER_IMPORT=1 uv run mkdocs build`:
- COCO callout renders ("Breaking change in 0.8.0" + `segmentation_format="roi"` restore guidance present in built HTML).
- No `--crop auto` / `--crop-padding` strings remain in the rendered cli page; the valid `--crop 100,100,300,300` and normalized forms still render.
- All seven `examples.md` anchors and both `merging.md` anchors now resolve to real `id="..."` elements in their target pages (verified by grepping the built HTML).

The build introduces benign "Multiple primary URLs" autoref warnings for `Labels.match` / `MatchResult` — the same class of warning already emitted for every other `::: ` block in `merging.md` (the guide page duplicates the auto-generated `reference/` API). The build is not aborted and the same-page fragment links resolve regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV