### PR TITLE
feat(cli): surface SegmentationMask and ROI counts in 'sio show'

### DIFF
--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -803,6 +803,16 @@ def _print_header(path: Path, labels: Labels) -> None:
             f"track{'s' if len(labels.tracks) != 1 else ''}"
         )
 
+    # Segmentation masks and ROIs - only shown when present to avoid cluttering
+    # pose-only files.
+    n_masks = len(labels.masks)
+    if n_masks > 0:
+        stats_parts.append(f"[bold]{n_masks}[/] mask{'s' if n_masks != 1 else ''}")
+
+    n_rois = len(labels.rois)
+    if n_rois > 0:
+        stats_parts.append(f"[bold]{n_rois}[/] ROI{'s' if n_rois != 1 else ''}")
+
     header_lines.append("")
     header_lines.append(" | ".join(stats_parts))
 
@@ -1562,6 +1572,13 @@ def _print_labeled_frame(labels: Labels, frame_idx: int) -> None:
     console.print(f"  [dim]Video:[/]     {video_name}")
     console.print(f"  [dim]Frame:[/]     {lf.frame_idx}")
     console.print(f"  [dim]Instances:[/] {len(lf)}")
+
+    # Masks and ROIs are separate frame-level fields; only show when present so
+    # pose-only frames stay tidy.
+    if lf.masks:
+        console.print(f"  [dim]Masks:[/]     {len(lf.masks)}")
+    if lf.rois:
+        console.print(f"  [dim]ROIs:[/]      {len(lf.rois)}")
 
     # Instances as blocks
     for idx, inst in enumerate(lf.instances):

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -35,7 +35,8 @@ from sleap_io.io.cli import (
 from sleap_io.model.instance import Instance, PredictedInstance
 from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
-from sleap_io.model.mask import PredictedSegmentationMask
+from sleap_io.model.mask import PredictedSegmentationMask, UserSegmentationMask
+from sleap_io.model.roi import UserROI
 from sleap_io.model.skeleton import Skeleton
 from sleap_io.model.video import Video
 from sleap_io.version import __version__
@@ -425,6 +426,89 @@ def test_show_header_shows_instance_counts():
     # typical.slp has both user and predicted instances
     assert "user instances" in out
     assert "predicted" in out
+
+
+def _mask_only_slp(tmp_path: Path) -> Path:
+    """Write a mask-only SLP (two masks on one frame, no instances)."""
+    video = Video(filename="test.mp4")
+    mask_a = UserSegmentationMask.from_numpy(
+        np.array([[True, False], [False, True]], dtype=bool), category="cell"
+    )
+    mask_b = UserSegmentationMask.from_numpy(
+        np.array([[False, True], [True, False]], dtype=bool), category="cell"
+    )
+    lf = LabeledFrame(video=video, frame_idx=0, masks=[mask_a, mask_b])
+    labels = Labels(
+        labeled_frames=[lf], videos=[video], skeletons=[Skeleton(nodes=["A"])]
+    )
+    path = tmp_path / "masks_only.slp"
+    save_slp(labels, str(path))
+    return path
+
+
+def test_show_header_shows_mask_counts(tmp_path):
+    """Header counts segmentation masks for a mask-only file."""
+    path = _mask_only_slp(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["show", str(path), "--no-open-videos"])
+    assert result.exit_code == 0, result.output
+    out = _strip_ansi(result.output)
+    assert "2 masks" in out
+
+
+def test_show_lf_lists_mask_counts(tmp_path):
+    """Per-frame listing reports mask counts for a mask-only frame."""
+    path = _mask_only_slp(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["show", str(path), "--lf", "0", "--no-open-videos"])
+    assert result.exit_code == 0, result.output
+    out = _strip_ansi(result.output)
+    assert "Masks:" in out
+    assert "2" in out
+
+
+def _roi_slp(tmp_path: Path) -> Path:
+    """Write an SLP with a frame-bound ROI and no instances."""
+    video = Video(filename="test.mp4")
+    roi = UserROI.from_polygon([(0, 0), (10, 0), (10, 10), (0, 10)], category="arena")
+    lf = LabeledFrame(video=video, frame_idx=0, rois=[roi])
+    labels = Labels(
+        labeled_frames=[lf], videos=[video], skeletons=[Skeleton(nodes=["A"])]
+    )
+    path = tmp_path / "rois.slp"
+    save_slp(labels, str(path))
+    return path
+
+
+def test_show_header_shows_roi_counts(tmp_path):
+    """Header counts ROIs for an ROI-only file."""
+    path = _roi_slp(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["show", str(path), "--no-open-videos"])
+    assert result.exit_code == 0, result.output
+    out = _strip_ansi(result.output)
+    assert "1 ROI" in out
+
+
+def test_show_lf_lists_roi_counts(tmp_path):
+    """Per-frame listing reports ROI counts for an ROI frame."""
+    path = _roi_slp(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["show", str(path), "--lf", "0", "--no-open-videos"])
+    assert result.exit_code == 0, result.output
+    out = _strip_ansi(result.output)
+    assert "ROIs:" in out
+
+
+def test_show_pose_only_omits_mask_and_roi_lines():
+    """Pose-only files do not show mask/ROI stats (kept tidy)."""
+    runner = CliRunner()
+    path = _data_path("slp/typical.slp")
+    result = runner.invoke(cli, ["show", str(path), "--lf", "0", "--no-open-videos"])
+    assert result.exit_code == 0, result.output
+    out = _strip_ansi(result.output)
+    assert "mask" not in out.lower()
+    assert "roi" not in out.lower()
 
 
 def test_show_header_shows_user_frames_vs_total():


### PR DESCRIPTION
## Problem

Finding (MEDIUM, gap-cli): The `sio show` header stats and per-frame listing reference only instances/frames/videos/tracks. Segmentation masks and ROIs are stored in separate `LabeledFrame` fields (`.masks`, `.rois`), and `len(lf) == len(lf.instances)`, so they were never counted or listed. A mask-only SLP (e.g. one converted from a COCO instance-segmentation dataset) showed `Instances: 0` with no mask information at all — the segmentation data looked entirely absent.

## Fix

Confined to `_print_header` and `_print_labeled_frame` in `sleap_io/io/cli.py`:

- **Header**: append `N masks` and `N ROIs` to the stats row, counted via the existing `Labels.masks` / `Labels.rois` flat-view properties (which handle both eager and lazy loading). Lines are only emitted when the counts are non-zero so pose-only files stay tidy.
- **Per-frame (`--lf`)**: print `Masks:` and `ROIs:` lines (with per-frame counts from `lf.masks` / `lf.rois`) right after the `Instances:` line, again only when present.

Matches the existing rich `[bold]`/`[dim]` formatting and pluralization style used by the surrounding stats.

## Testing

New regression tests in `tests/io/test_cli.py` (CliRunner, `tmp_path`, ANSI-stripped output):

- `test_show_header_shows_mask_counts` — mask-only SLP (two `UserSegmentationMask` on one frame, no instances) shows `2 masks` in the header.
- `test_show_lf_lists_mask_counts` — `--lf 0` lists `Masks:` for that frame.
- `test_show_header_shows_roi_counts` / `test_show_lf_lists_roi_counts` — `UserROI` case for the header and `--lf` listing.
- `test_show_pose_only_omits_mask_and_roi_lines` — guards that pose-only files do not gain mask/ROI lines.

The four behavioral tests fail without the source change and pass with it (verified via `git stash`). Full `tests/io/test_cli.py` is green except one pre-existing, unrelated failure (`test_export_csv_dlc_chunked_error`, a rich-Panel line-wrap assertion that also fails on a clean checkout of this branch's base).

Run: `uv run pytest tests/io/test_cli.py -p no:cacheprovider -q -k "show and (mask or roi or segmentation)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV