### PR TITLE
feat(cli): accept remote URLs as input to read commands

### DIFF
--- a/docs/remote.md
+++ b/docs/remote.md
@@ -54,6 +54,12 @@ sio convert s3://bucket/labels.slp -o labels.nwb
 sio filenames -i https://example.com/labels.slp
 ```
 
+Commands that write a result require a local output path when the input is a
+URL. `render` and `fix` derive a default output next to the input for local
+files, but a URL has no local location to write to, so they require an explicit
+local `-o/--output` (for `fix`, `--dry-run` works on a URL without `-o`). The
+`embed` and `unembed` commands already require `-o`, which must be local.
+
 Output paths and commands that re-encode video locally (`trim`, `reencode`,
 `transform`, `apply-crops`) require local filesystem paths.
 

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -36,6 +36,27 @@ so the same call works for local and remote files.
     JABS, DLC, CSV, TrackMate, LEAP, GeoJSON, Ultralytics) raises
     `NotImplementedError` over a URL — download the file locally first.
 
+### Command-line interface
+
+The `sio` read commands accept a URL anywhere they accept a local input file —
+the input is streamed over the network just like the Python loaders. This works
+for `show`, `filenames`, `convert`, `split`, `render`, `export`, `fix`, `embed`,
+and `unembed`:
+
+```bash
+# Inspect a remote labels file
+sio show https://example.com/labels.slp
+
+# Convert a remote file to a local output (output paths stay local)
+sio convert s3://bucket/labels.slp -o labels.nwb
+
+# The -i/--input option accepts URLs too
+sio filenames -i https://example.com/labels.slp
+```
+
+Output paths and commands that re-encode video locally (`trim`, `reencode`,
+`transform`, `apply-crops`) require local filesystem paths.
+
 ---
 
 ## Supported schemes & install matrix

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -29,7 +29,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from sleap_io.io import main as io_main
-from sleap_io.io._remote import _is_url
+from sleap_io.io._remote import _is_url, _redact_url
 from sleap_io.io.video_reading import HDF5Video
 from sleap_io.model.instance import PredictedInstance
 from sleap_io.model.labels import Labels
@@ -3888,6 +3888,14 @@ def render(
     # Resolve input path from positional arg or -i option
     input_path = _resolve_input(input_arg, input_opt, "input file")
 
+    # A remote URL input has no usable local directory to derive a default output
+    # from (deriving one would crash on URL path semantics), so require an explicit
+    # local -o for URL inputs. Check up front so it fails fast before any fetch.
+    if output_path is None and _is_url(str(input_path)):
+        raise click.ClickException(
+            "An output path (-o/--output) is required when the input is a URL."
+        )
+
     # Load labels
     try:
         labels = io_main.load_file(str(input_path), open_videos=True)
@@ -3932,7 +3940,7 @@ def render(
     if lf_ind is not None and frame_idx is not None:
         raise click.ClickException("Cannot use both --lf and --frame. Choose one.")
 
-    # Determine output path
+    # Determine output path (URL inputs without -o were rejected up front).
     if output_path is None:
         input_stem = input_path.stem
         if single_image_mode:
@@ -4421,16 +4429,26 @@ def fix(
     """
     # Resolve input
     input_path = _resolve_input(input_arg, input_opt, "input labels file")
+    input_is_url = _is_url(str(input_path))
 
     # Determine default output path
     if output_path is None:
-        output_path = _get_default_output_path(input_path)
+        # A remote URL input has no usable local output to derive a default from
+        # (and writing back to a URL is unsupported), so require an explicit local
+        # -o when the command would actually write. --dry-run never writes.
+        if input_is_url and not dry_run:
+            raise click.ClickException(
+                "An output path (-o/--output) is required when the input is a URL."
+            )
+        if not input_is_url:
+            output_path = _get_default_output_path(input_path)
 
     # Check for filename options
     has_filename_opts = len(prefix_map) > 0 or len(filename_map) > 0
 
-    # Load the input file
-    console.print(f"[bold]Loading:[/] {input_path}")
+    # Load the input file (redact credentials from URLs before display)
+    display_input = _redact_url(str(input_path)) if input_is_url else input_path
+    console.print(f"[bold]Loading:[/] {display_input}")
     try:
         labels = io_main.load_file(str(input_path), open_videos=False)
     except Exception as e:
@@ -4928,8 +4946,8 @@ def embed(
     # Resolve input from positional arg or -i option
     input_path = _resolve_input(input_arg, input_opt, "input file")
 
-    # Validate input is SLP format
-    if not str(input_path).lower().endswith(".slp"):
+    # Validate input is SLP format (``.suffix`` ignores any URL query string).
+    if input_path.suffix.lower() != ".slp":
         raise click.ClickException("Input file must be a .slp file.")
 
     # Load the input file with video access for embedding
@@ -5040,8 +5058,8 @@ def unembed(
     # Resolve input from positional arg or -i option
     input_path = _resolve_input(input_arg, input_opt, "input file")
 
-    # Validate input is SLP format
-    if not str(input_path).lower().endswith(".slp"):
+    # Validate input is SLP format (``.suffix`` ignores any URL query string).
+    if input_path.suffix.lower() != ".slp":
         raise click.ClickException("Input file must be a .slp file.")
 
     # Load the input file

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -8,9 +8,11 @@ in minimal environments and CI.
 
 from __future__ import annotations
 
+import posixpath
 import re
 import subprocess
 import sys
+import urllib.parse
 from dataclasses import dataclass
 from importlib.metadata import version as pkg_version
 from pathlib import Path
@@ -27,6 +29,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from sleap_io.io import main as io_main
+from sleap_io.io._remote import _is_url
 from sleap_io.io.video_reading import HDF5Video
 from sleap_io.model.instance import PredictedInstance
 from sleap_io.model.labels import Labels
@@ -169,6 +172,113 @@ OUTPUT_EXTENSION_TO_FORMAT = {
     ".h5": "analysis_h5",  # Default .h5 output to analysis HDF5
     ".hdf5": "analysis_h5",
 }
+
+
+class _RemoteInputPath(str):
+    """A remote URL that quacks like :class:`pathlib.Path` for read inputs.
+
+    Read-input arguments accept either a local filesystem path (validated by
+    click and handed to the command as a :class:`~pathlib.Path`) or a remote
+    URL (``http(s)://``, ``s3://``, ``gs://``, ...). The downstream command code
+    treats the resolved input as a ``Path`` (calls ``.suffix`` for format
+    inference, ``.name`` for messages, etc.) and passes ``str(path)`` to the
+    loaders. A real ``Path`` cannot hold a URL: ``str(Path("https://h/f.slp"))``
+    collapses ``//`` to ``/`` (losing the authority) and, on Windows, parses the
+    scheme as a drive so ``.suffix``/``.name`` come back empty.
+
+    This ``str`` subclass holds the URL *verbatim* (so ``str(...)`` and
+    ``os.fspath(...)`` round-trip unchanged to the loaders) while deriving the
+    handful of ``Path``-like read attributes the CLI uses from URL semantics
+    (the path component, ignoring the query/fragment). Filesystem predicates
+    (:meth:`exists`, :meth:`is_dir`, :meth:`is_file`) report ``False`` because a
+    URL is not a local file; callers already guard size/stat lookups on these.
+
+    Attributes:
+        name: The final path segment of the URL (e.g. ``file.slp``).
+        suffix: The file extension of :attr:`name` (e.g. ``.slp``).
+        stem: :attr:`name` without its suffix.
+        parent: The URL with its final path segment removed, as a
+            ``_RemoteInputPath``.
+    """
+
+    @property
+    def _path(self) -> str:
+        """Return the URL's path component (no scheme/host/query/fragment)."""
+        return urllib.parse.urlparse(self).path
+
+    @property
+    def name(self) -> str:
+        """Return the final segment of the URL path."""
+        return posixpath.basename(self._path)
+
+    @property
+    def suffix(self) -> str:
+        """Return the file extension of :attr:`name` (including the dot)."""
+        return posixpath.splitext(self.name)[1]
+
+    @property
+    def stem(self) -> str:
+        """Return :attr:`name` without its suffix."""
+        return posixpath.splitext(self.name)[0]
+
+    @property
+    def parent(self) -> "_RemoteInputPath":
+        """Return the URL with its final path segment removed."""
+        parsed = urllib.parse.urlparse(self)
+        new_path = posixpath.dirname(parsed.path)
+        return _RemoteInputPath(parsed._replace(path=new_path).geturl())
+
+    def with_suffix(self, suffix: str) -> "_RemoteInputPath":
+        """Return the URL with :attr:`suffix` replaced by ``suffix``."""
+        parsed = urllib.parse.urlparse(self)
+        new_name = posixpath.splitext(self.name)[0] + suffix
+        new_path = posixpath.join(posixpath.dirname(parsed.path), new_name)
+        return _RemoteInputPath(parsed._replace(path=new_path).geturl())
+
+    def __truediv__(self, other: str) -> "_RemoteInputPath":
+        """Join ``other`` onto the URL path (mirrors ``Path / "child"``)."""
+        parsed = urllib.parse.urlparse(self)
+        new_path = posixpath.join(parsed.path, str(other))
+        return _RemoteInputPath(parsed._replace(path=new_path).geturl())
+
+    def resolve(self) -> "_RemoteInputPath":
+        """Return self (a URL is already absolute; nothing to resolve)."""
+        return self
+
+    def exists(self) -> bool:
+        """Return False (a URL is not a local filesystem path)."""
+        return False
+
+    def is_dir(self) -> bool:
+        """Return False (a URL is not a local directory)."""
+        return False
+
+    def is_file(self) -> bool:
+        """Return False (a URL is not a local file)."""
+        return False
+
+
+class RemoteOrLocalPath(click.Path):
+    """A click path type that accepts remote URLs as well as local paths.
+
+    For URL-shaped values (per :func:`sleap_io.io._remote._is_url`) the value is
+    passed through verbatim as a :class:`_RemoteInputPath` with no ``Path``
+    conversion and no existence check, so the URL reaches the loaders unmangled.
+    All other values are validated exactly like the wrapped :class:`click.Path`
+    (typically ``exists=True, path_type=Path``), preserving the existing
+    local-file error messages.
+    """
+
+    def convert(self, value, param, ctx):
+        """Pass URLs through verbatim; validate local paths as usual."""
+        if _is_url(value):
+            return _RemoteInputPath(value)
+        return super().convert(value, param, ctx)
+
+
+#: Reusable instance for read-input arguments that may be a local file or a
+#: remote URL. Local values are validated like ``click.Path(exists=True)``.
+REMOTE_OR_LOCAL_PATH = RemoteOrLocalPath(exists=True, path_type=Path)
 
 
 def _resolve_input(
@@ -1670,14 +1780,14 @@ def _print_provenance(labels: Labels, compact: bool = False) -> None:
     "path_arg",
     required=False,
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
 )
 @click.option(
     "-i",
     "--input",
     "path_opt",
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
     help="Input file (.slp, .nwb, video). Can also be passed as positional argument.",
 )
 @click.option(
@@ -1927,14 +2037,14 @@ def _infer_output_format(path: Path) -> str | None:
     "input_arg",
     required=False,
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
 )
 @click.option(
     "-i",
     "--input",
     "input_opt",
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
     help="Input file path. Can also be passed as positional argument.",
 )
 @click.option(
@@ -2176,14 +2286,14 @@ def convert(
     "input_arg",
     required=False,
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
 )
 @click.option(
     "-i",
     "--input",
     "input_opt",
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
     help="Input file path. Can also be passed as positional argument.",
 )
 @click.option(
@@ -2417,14 +2527,14 @@ def export(
     "input_arg",
     required=False,
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
 )
 @click.option(
     "-i",
     "--input",
     "input_opt",
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
     help="Input labels file. Can also be passed as positional argument.",
 )
 @click.option(
@@ -3058,14 +3168,14 @@ def merge(
     "input_arg",
     required=False,
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
 )
 @click.option(
     "-i",
     "--input",
     "input_opt",
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
     help="Input labels file. Can also be passed as positional argument.",
 )
 @click.option(
@@ -3291,14 +3401,14 @@ def filenames(
     "input_arg",
     required=False,
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
 )
 @click.option(
     "-i",
     "--input",
     "input_opt",
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
     help="Input labels file (.slp, .nwb, etc.). Can also be passed as positional arg.",
 )
 @click.option(
@@ -4139,14 +4249,14 @@ def _analyze_video_colors(labels: Labels) -> list[dict]:
     "input_arg",
     required=False,
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
 )
 @click.option(
     "-i",
     "--input",
     "input_opt",
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
     help="Input labels file. Can also be passed as positional argument.",
 )
 @click.option(
@@ -4751,14 +4861,14 @@ def fix(
     "input_arg",
     required=False,
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
 )
 @click.option(
     "-i",
     "--input",
     "input_opt",
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
     help="Input SLP file path. Can also be passed as positional argument.",
 )
 @click.option(
@@ -4889,14 +4999,14 @@ def embed(
     "input_arg",
     required=False,
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
 )
 @click.option(
     "-i",
     "--input",
     "input_opt",
     default=None,
-    type=click.Path(exists=True, path_type=Path),
+    type=REMOTE_OR_LOCAL_PATH,
     help="Input .pkg.slp file path. Can also be passed as positional argument.",
 )
 @click.option(

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -22,6 +22,7 @@ from click.testing import CliRunner
 
 from sleap_io import load_slp, save_slp, save_video
 from sleap_io.io.cli import (
+    REMOTE_OR_LOCAL_PATH,
     _ensure_utf8_streams,
     _get_ffmpeg_version,
     _infer_input_format,
@@ -29,6 +30,7 @@ from sleap_io.io.cli import (
     _load_images,
     _load_overlay,
     _parse_overlay_outline_color,
+    _RemoteInputPath,
     _run_subprocess_with_progress,
     cli,
 )
@@ -154,6 +156,107 @@ def test_show_file_not_found():
     assert result.exit_code != 0
     # Click validates file existence before our code runs
     assert "not exist" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Remote URL inputs for read commands (RemoteOrLocalPath param type)
+# ---------------------------------------------------------------------------
+
+
+def test_remote_or_local_path_does_not_mangle_url():
+    """The remote-or-local path type passes URLs through verbatim.
+
+    A plain ``click.Path``/``pathlib.Path`` would collapse ``https://`` to
+    ``https:/`` (losing the authority). The custom type must round-trip the URL
+    unchanged so it reaches the loaders intact.
+    """
+    url = "https://example.com/dir/file.slp"
+    value = REMOTE_OR_LOCAL_PATH.convert(url, None, None)
+    assert isinstance(value, _RemoteInputPath)
+    assert str(value) == url
+    assert "https://" in str(value)
+    # Cloud schemes round-trip too.
+    s3_url = "s3://bucket/key/data.nwb"
+    assert str(REMOTE_OR_LOCAL_PATH.convert(s3_url, None, None)) == s3_url
+
+
+def test_remote_input_path_pathlike_attrs():
+    """`_RemoteInputPath` derives Path-like read attrs from URL semantics."""
+    p = _RemoteInputPath("https://host/a/b/data.pkg.slp?token=secret")
+    assert p.name == "data.pkg.slp"
+    assert p.suffix == ".slp"
+    assert p.stem == "data.pkg"
+    assert str(p.parent) == "https://host/a/b?token=secret"
+    # Mirrors Path.with_suffix: only the final extension is replaced.
+    assert str(p.with_suffix(".nwb")) == "https://host/a/b/data.pkg.nwb?token=secret"
+    assert str(p / "child") == "https://host/a/b/data.pkg.slp/child?token=secret"
+    assert p.resolve() is p
+    # A URL is not a local filesystem entry.
+    assert p.exists() is False
+    assert p.is_dir() is False
+    assert p.is_file() is False
+
+
+def test_show_url_input_passes_arg_parsing():
+    """`sio show <url>` reaches the loader instead of failing at parse.
+
+    With ``click.Path(exists=True)`` this exited 2 with a BadParameter
+    "does not exist" before any loading. The URL now passes parsing and the
+    error is a load/remote failure, not a parameter-validation error.
+    """
+    runner = CliRunner()
+    # Unresolvable host: fails during the fetch, not during arg parsing.
+    result = runner.invoke(cli, ["show", "https://invalid.invalid.invalid/x.slp"])
+    assert result.exit_code != 0
+    # Not a click BadParameter "does not exist" parse error.
+    assert "does not exist" not in result.output
+    assert "Invalid value" not in result.output
+
+
+def test_convert_url_input_passes_arg_parsing(tmp_path):
+    """`sio convert <url> -o out` reaches the loader instead of failing at parse."""
+    runner = CliRunner()
+    out = tmp_path / "out.nwb"
+    result = runner.invoke(
+        cli,
+        ["convert", "https://invalid.invalid.invalid/x.slp", "-o", str(out)],
+    )
+    assert result.exit_code != 0
+    assert "does not exist" not in result.output
+    assert "Invalid value" not in result.output
+    # Our command-level load handler ran (proving parsing succeeded).
+    assert "Failed to load input file" in result.output
+
+
+def test_convert_url_via_input_option_passes_arg_parsing(tmp_path):
+    """The -i/--input option also accepts URLs without a parse error."""
+    runner = CliRunner()
+    out = tmp_path / "out.nwb"
+    result = runner.invoke(
+        cli,
+        ["convert", "-i", "https://invalid.invalid.invalid/x.slp", "-o", str(out)],
+    )
+    assert result.exit_code != 0
+    assert "does not exist" not in result.output
+    assert "Invalid value" not in result.output
+
+
+def test_convert_nonexistent_local_path_still_errors():
+    """A nonexistent local input still fails at parse with a BadParameter error.
+
+    rich-click wraps the message in a box, so the literal "does not exist" may be
+    line-wrapped; the stable marker is the "Invalid value" BadParameter header.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["convert", "/nonexistent/path/file.slp", "-o", "out.nwb"],
+    )
+    assert result.exit_code == 2
+    output = _strip_ansi(result.output)
+    assert "Invalid value" in output
+    # "exist" survives the box wrapping even if "does not" is on a prior line.
+    assert "exist" in output
 
 
 def test_show_skeleton_no_edges(tmp_path):

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -259,6 +259,122 @@ def test_convert_nonexistent_local_path_still_errors():
     assert "exist" in output
 
 
+def test_render_url_input_requires_output():
+    """`sio render <url>` with no -o errors cleanly (no AttributeError traceback).
+
+    Deriving a default output from a URL would crash on URL path semantics
+    (``with_name``/``parent.mkdir``). The command must guard with a clean
+    ClickException before any default-output derivation.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["render", "https://invalid.invalid.invalid/x.slp"])
+    assert result.exit_code != 0
+    # rich-click boxes/wraps the message; collapse whitespace before matching.
+    out = " ".join(_strip_ansi(result.output).split())
+    assert "An output path (-o/--output) is required when the input is a URL." in out
+    # Crucially: no raw traceback leaked to the user.
+    assert "AttributeError" not in out
+    assert "Traceback" not in out
+
+
+def test_render_url_input_single_image_requires_output():
+    """`sio render <url> --lf 0` with no -o also errors cleanly (image path)."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["render", "https://invalid.invalid.invalid/x.slp", "--lf", "0"]
+    )
+    assert result.exit_code != 0
+    out = " ".join(_strip_ansi(result.output).split())
+    assert "An output path (-o/--output) is required when the input is a URL." in out
+    assert "AttributeError" not in out
+    assert "Traceback" not in out
+
+
+def test_fix_url_input_requires_output():
+    """`sio fix <url>` (non-dry-run) with no -o errors cleanly, not at save.
+
+    Without the upfront guard the command would derive a remote default output
+    and fail late at save time. The guard must raise a clean ClickException.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["fix", "https://invalid.invalid.invalid/x.slp"])
+    assert result.exit_code != 0
+    out = " ".join(_strip_ansi(result.output).split())
+    assert "An output path (-o/--output) is required when the input is a URL." in out
+    assert "AttributeError" not in out
+    assert "Traceback" not in out
+    # It failed at the upfront guard, not late at the save step.
+    assert "Failed to save output file" not in out
+
+
+def test_fix_url_input_dry_run_redacts_credentials():
+    """`sio fix <url> --dry-run` works without -o and redacts URL credentials."""
+    runner = CliRunner()
+    url = "https://invalid.invalid.invalid/x.slp?token=supersecret"
+    result = runner.invoke(cli, ["fix", url, "--dry-run"])
+    out = _strip_ansi(result.output)
+    # The secret token value must never be echoed in the Loading: line.
+    assert "supersecret" not in out
+    assert "AttributeError" not in out
+    assert "Traceback" not in out
+
+
+def test_embed_url_input_passes_suffix_gate(tmp_path):
+    """`sio embed <url-with-query>` passes the .slp suffix gate and reaches load.
+
+    A credential-bearing URL ends with ``?token=...``, so the old
+    ``str(...).endswith('.slp')`` gate rejected it as "not a .slp file". Using
+    ``.suffix`` (which ignores the query) must let it through to the loader.
+    """
+    runner = CliRunner()
+    out = tmp_path / "out.pkg.slp"
+    url = "https://invalid.invalid.invalid/x.slp?token=t"
+    result = runner.invoke(cli, ["embed", url, "-o", str(out)])
+    assert result.exit_code != 0
+    err = _strip_ansi(result.output)
+    # It must NOT be rejected at the suffix gate; it reached the loader/fetch.
+    assert "must be a .slp file" not in err
+
+
+def test_unembed_url_input_passes_suffix_gate(tmp_path):
+    """`sio unembed <url-with-query>` passes the .slp suffix gate and reaches load."""
+    runner = CliRunner()
+    out = tmp_path / "out.slp"
+    url = "https://invalid.invalid.invalid/x.slp?token=t"
+    result = runner.invoke(cli, ["unembed", url, "-o", str(out)])
+    assert result.exit_code != 0
+    err = _strip_ansi(result.output)
+    assert "must be a .slp file" not in err
+
+
+def test_remote_input_path_degenerate_urls():
+    """`_RemoteInputPath` handles degenerate URLs without raising on read attrs."""
+    # Trailing slash (directory-like): name empty, suffix empty.
+    trailing = _RemoteInputPath("https://h/dir/")
+    assert str(trailing) == "https://h/dir/"
+    assert trailing.name == ""
+    assert trailing.suffix == ""
+
+    # Host-only URL: no path component.
+    host_only = _RemoteInputPath("https://h")
+    assert str(host_only) == "https://h"
+    assert host_only.name == ""
+    assert host_only.suffix == ""
+
+    # No file extension.
+    no_ext = _RemoteInputPath("https://h/file")
+    assert str(no_ext) == "https://h/file"
+    assert no_ext.name == "file"
+    assert no_ext.suffix == ""
+
+    # Percent-encoded segment round-trips verbatim.
+    encoded = _RemoteInputPath("https://h/a%20b/data%2Efile.slp")
+    assert str(encoded) == "https://h/a%20b/data%2Efile.slp"
+    # name/suffix must not raise (exact decoding is not asserted here).
+    _ = encoded.name
+    _ = encoded.suffix
+
+
 def test_show_skeleton_no_edges(tmp_path):
     """Test skeleton display when skeleton has no edges."""
     from sleap_io import save_file


### PR DESCRIPTION
## Problem

The read-input arguments of the `sio` inspection/conversion/render/export/filenames commands all used `click.Path(exists=True, path_type=Path)`. As a result, commands like `sio show <url>`, `sio convert <url>`, and `sio render s3://...` failed at **argument parsing** (exit 2, "Path does not exist") even though the Python loaders (`load_file` → `_remote.open_url`; schemes `http`/`https`/`s3`/`gs`/`gcs`/`az`/`abfs`) already support those URLs.

There was also a latent mangling bug: a real `pathlib.Path` cannot hold a URL. `str(Path("https://h/f.slp"))` collapses `//` to `/` (losing the authority), and on Windows the scheme is parsed as a drive so `.suffix`/`.name` come back empty.

This addresses the MEDIUM finding `gap-cli`.

## Fix

- Added `RemoteOrLocalPath(click.Path)` whose `convert()` short-circuits URL-shaped values (detected via `sleap_io.io._remote._is_url`) and returns them verbatim as a `_RemoteInputPath` — **no `Path` conversion, no existence check** — so the URL reaches the loaders unmangled. All other values go through the wrapped `click.Path(exists=True, path_type=Path)` unchanged, preserving the existing local-file error messages.
- `_RemoteInputPath` is a `str` subclass that round-trips the URL verbatim through `str()`/`os.fspath()` while exposing the handful of `Path`-like read attributes the CLI uses (`.name`, `.suffix`, `.stem`, `.parent`, `.with_suffix`, `/`, `.resolve`, `.exists`/`.is_dir`/`.is_file`), derived from URL semantics (path component, ignoring query/fragment).
- Applied the new type to the genuine remote-capable read inputs of: `show`, `convert`, `export`, `split`, `filenames`, `render` (input only), `fix`, `embed`, `unembed`.
- **Left local** (unchanged): all output paths, the video-re-encoding commands (`trim`, `reencode`, `transform`, `apply-crops`), the `merge`/`unsplit` directory-glob inputs, and `render --images`/`--overlay` (local TIFF stacks/dirs).

## Example usage

```bash
sio show https://example.com/labels.slp
sio convert s3://bucket/labels.slp -o labels.nwb
sio filenames -i https://example.com/labels.slp
```

## Testing

`uv run pytest tests/io/test_cli.py -p no:cacheprovider -q -k "url or remote or path"` → 20 passed, 3 skipped.

New regression tests in `tests/io/test_cli.py`:
- `test_remote_or_local_path_does_not_mangle_url` — the param type returns the URL verbatim (no `https://` → `https:/` mangling), for both http and s3.
- `test_remote_input_path_pathlike_attrs` — `_RemoteInputPath` derives `name`/`suffix`/`stem`/`parent`/`with_suffix`/`/`/`resolve`/predicates correctly from URL semantics.
- `test_show_url_input_passes_arg_parsing` / `test_convert_url_input_passes_arg_parsing` / `test_convert_url_via_input_option_passes_arg_parsing` — a URL input passes parsing (surfacing a load/remote error, not a click "Invalid value"/"does not exist").
- `test_convert_nonexistent_local_path_still_errors` — a nonexistent local input still fails at parse (exit 2, BadParameter).

The behavioral tests were verified to FAIL without the fix (URL rejected at parse with "does not exist") and PASS with it.

Pre-existing unrelated failure: `test_export_csv_dlc_chunked_error` fails on clean `main` in this 120-col console (rich-click line-wraps "DLC format" inside the error box); not touched here.

`uv run ruff format`/`ruff check` clean on changed Python files. `EAGER_IMPORT=1 uv run mkdocs build` succeeds; the new "Command-line interface" subsection in `docs/remote.md` renders (anchor `command-line-interface`).

## Design decisions

- A `str` subclass (rather than subclassing `pathlib.Path`) was chosen because subclassing `Path` cannot reliably preserve a URL: on Windows it parses `https:` as a drive, breaking `.suffix`/`.name`. Deriving the read attributes from `urllib.parse` + `posixpath` is correct cross-platform and keeps `str(path)` byte-for-byte equal to the original URL for the loaders.
- The decorator change is deliberately mechanical (a single shared `REMOTE_OR_LOCAL_PATH` instance swapped in) to minimize conflict surface with the other CLI PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV