### PR TITLE
fix(render): handle grayscale input in draw_masks/draw_rois/draw_bboxes/draw_label_image

### DIFF
--- a/sleap_io/rendering/overlays.py
+++ b/sleap_io/rendering/overlays.py
@@ -34,8 +34,9 @@ def draw_rois(
     ``MultiLineString``, and ``GeometryCollection`` geometries.
 
     Args:
-        image: Image array of shape (H, W, 3) uint8. Modified in-place and
-            returned.
+        image: Image array of shape (H, W, 3) uint8. A 2-D grayscale
+            ``(H, W)`` (or ``(H, W, 1)``) image is accepted and promoted to
+            RGB. Modified in-place and returned.
         rois: List of ROI objects to draw.
         color: RGB color tuple for the ROI outlines. Used when ``colors`` is
             ``None``.
@@ -52,6 +53,12 @@ def draw_rois(
         return image
 
     import skia
+
+    # Ensure RGB before padding to RGBA.
+    if image.ndim == 2:
+        image = np.stack([image] * 3, axis=-1)
+    elif image.ndim == 3 and image.shape[2] == 1:
+        image = np.concatenate([image] * 3, axis=-1)
 
     # Pad to RGBA for skia surface
     frame_rgba = np.dstack([image, np.full(image.shape[:2], 255, dtype=np.uint8)])
@@ -122,8 +129,9 @@ def draw_masks(
     """Draw segmentation masks as colored overlays on an image.
 
     Args:
-        image: Image array of shape (H, W, 3) uint8. Modified in-place and
-            returned.
+        image: Image array of shape (H, W, 3) uint8. A 2-D grayscale
+            ``(H, W)`` (or ``(H, W, 1)``) image is accepted and promoted to
+            RGB. Modified in-place and returned.
         masks: List of SegmentationMask objects to draw.
         color: RGB color tuple for the mask overlay. Used when ``colors`` is
             ``None``.
@@ -134,6 +142,12 @@ def draw_masks(
     Returns:
         The modified image array.
     """
+    # Ensure RGB so grayscale images can be blended with colored overlays.
+    if image.ndim == 2:
+        image = np.stack([image] * 3, axis=-1)
+    elif image.ndim == 3 and image.shape[2] == 1:
+        image = np.concatenate([image] * 3, axis=-1)
+
     for i, mask in enumerate(masks):
         mask_color = colors[i] if colors is not None else color
         mask_data = mask.data
@@ -194,8 +208,9 @@ def draw_label_image(
     each pixel value represents a different object ID (0 = background).
 
     Args:
-        image: Image array of shape ``(H, W, 3)`` uint8. Modified in-place and
-            returned.
+        image: Image array of shape ``(H, W, 3)`` uint8. A 2-D grayscale
+            ``(H, W)`` (or ``(H, W, 1)``) image is accepted and promoted to
+            RGB. Modified in-place and returned.
         labels: Integer label array of shape ``(H, W)`` where 0 is background
             and positive values are object IDs.
         alpha: Opacity of the mask overlay (0.0 to 1.0).
@@ -214,6 +229,12 @@ def draw_label_image(
         The modified image array.
     """
     from sleap_io.rendering.colors import get_palette
+
+    # Ensure RGB so grayscale images can be blended with colored overlays.
+    if image.ndim == 2:
+        image = np.stack([image] * 3, axis=-1)
+    elif image.ndim == 3 and image.shape[2] == 1:
+        image = np.concatenate([image] * 3, axis=-1)
 
     # Get unique non-background labels
     unique_ids = np.unique(labels)
@@ -377,8 +398,9 @@ def draw_bboxes(
     near the top-left corner.
 
     Args:
-        image: Image array of shape (H, W, 3) uint8. Modified in-place and
-            returned.
+        image: Image array of shape (H, W, 3) uint8. A 2-D grayscale
+            ``(H, W)`` (or ``(H, W, 1)``) image is accepted and promoted to
+            RGB. Modified in-place and returned.
         bboxes: List of BoundingBox objects to draw.
         color: RGB color tuple for the bounding box outlines. Used when
             ``colors`` is ``None``.
@@ -399,6 +421,12 @@ def draw_bboxes(
     import skia
 
     from sleap_io.model.bbox import PredictedBoundingBox
+
+    # Ensure RGB before padding to RGBA.
+    if image.ndim == 2:
+        image = np.stack([image] * 3, axis=-1)
+    elif image.ndim == 3 and image.shape[2] == 1:
+        image = np.concatenate([image] * 3, axis=-1)
 
     # Pad to RGBA for skia surface
     frame_rgba = np.dstack([image, np.full(image.shape[:2], 255, dtype=np.uint8)])

--- a/sleap_io/rendering/overlays.py
+++ b/sleap_io/rendering/overlays.py
@@ -19,6 +19,24 @@ if TYPE_CHECKING:
     from sleap_io.model.roi import ROI
 
 
+def _ensure_rgb(image: np.ndarray) -> np.ndarray:
+    """Promote a grayscale image to 3-channel RGB.
+
+    Args:
+        image: Image array of shape ``(H, W)``, ``(H, W, 1)``, or ``(H, W, 3)``.
+
+    Returns:
+        The image as ``(H, W, 3)`` uint8. A ``(H, W, 3)`` input is returned
+        unchanged (same array, preserving in-place semantics); a ``(H, W)`` or
+        ``(H, W, 1)`` grayscale input is promoted to a new RGB array.
+    """
+    if image.ndim == 2:
+        return np.stack([image] * 3, axis=-1)
+    if image.shape[-1] == 1:
+        return np.concatenate([image] * 3, axis=-1)
+    return image
+
+
 def draw_rois(
     image: np.ndarray,
     rois: list["ROI"],
@@ -55,10 +73,7 @@ def draw_rois(
     import skia
 
     # Ensure RGB before padding to RGBA.
-    if image.ndim == 2:
-        image = np.stack([image] * 3, axis=-1)
-    elif image.ndim == 3 and image.shape[2] == 1:
-        image = np.concatenate([image] * 3, axis=-1)
+    image = _ensure_rgb(image)
 
     # Pad to RGBA for skia surface
     frame_rgba = np.dstack([image, np.full(image.shape[:2], 255, dtype=np.uint8)])
@@ -143,10 +158,7 @@ def draw_masks(
         The modified image array.
     """
     # Ensure RGB so grayscale images can be blended with colored overlays.
-    if image.ndim == 2:
-        image = np.stack([image] * 3, axis=-1)
-    elif image.ndim == 3 and image.shape[2] == 1:
-        image = np.concatenate([image] * 3, axis=-1)
+    image = _ensure_rgb(image)
 
     for i, mask in enumerate(masks):
         mask_color = colors[i] if colors is not None else color
@@ -231,10 +243,7 @@ def draw_label_image(
     from sleap_io.rendering.colors import get_palette
 
     # Ensure RGB so grayscale images can be blended with colored overlays.
-    if image.ndim == 2:
-        image = np.stack([image] * 3, axis=-1)
-    elif image.ndim == 3 and image.shape[2] == 1:
-        image = np.concatenate([image] * 3, axis=-1)
+    image = _ensure_rgb(image)
 
     # Get unique non-background labels
     unique_ids = np.unique(labels)
@@ -423,10 +432,7 @@ def draw_bboxes(
     from sleap_io.model.bbox import PredictedBoundingBox
 
     # Ensure RGB before padding to RGBA.
-    if image.ndim == 2:
-        image = np.stack([image] * 3, axis=-1)
-    elif image.ndim == 3 and image.shape[2] == 1:
-        image = np.concatenate([image] * 3, axis=-1)
+    image = _ensure_rgb(image)
 
     # Pad to RGBA for skia surface
     frame_rgba = np.dstack([image, np.full(image.shape[:2], 255, dtype=np.uint8)])
@@ -705,10 +711,7 @@ def draw_centroids(
     ox, oy = offset
 
     # Ensure RGB before padding to RGBA.
-    if image.ndim == 2:
-        image = np.stack([image] * 3, axis=-1)
-    elif image.ndim == 3 and image.shape[2] == 1:
-        image = np.concatenate([image] * 3, axis=-1)
+    image = _ensure_rgb(image)
 
     # Pad to RGBA for skia surface.
     frame_rgba = np.dstack([image, np.full(image.shape[:2], 255, dtype=np.uint8)])
@@ -793,10 +796,7 @@ def draw_trails(
     ox, oy = offset
 
     # Ensure RGB so trail pixels can be composited back.
-    if image.ndim == 2:
-        image = np.stack([image] * 3, axis=-1)
-    elif image.ndim == 3 and image.shape[2] == 1:
-        image = np.concatenate([image] * 3, axis=-1)
+    image = _ensure_rgb(image)
 
     # Rasterize the trails into a separate transparent RGBA buffer. Drawing into
     # a dedicated buffer (rather than the frame) lets the kSrc blend mode below

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -2809,6 +2809,77 @@ def test_draw_label_image_with_offset():
 
 
 # ============================================================================
+# Grayscale input tests for overlay helpers
+# ============================================================================
+
+
+def test_draw_rois_grayscale():
+    """draw_rois should accept a 2-D grayscale image and promote it to RGB."""
+    img = np.zeros((100, 100), dtype=np.uint8)
+    roi = UserROI.from_bbox(10, 10, 30, 30)
+
+    result = draw_rois(img, [roi], color=(0, 255, 0), line_width=1)
+
+    # Promoted to RGB without raising.
+    assert result.shape == (100, 100, 3)
+    # The outline should be drawn in the requested color.
+    assert result[10, 10].tolist() == [0, 255, 0]
+    # Outside the ROI stays black.
+    assert result[50, 50].tolist() == [0, 0, 0]
+
+
+def test_draw_masks_grayscale():
+    """draw_masks should accept a 2-D grayscale image and promote it to RGB."""
+    img = np.ones((50, 50), dtype=np.uint8) * 100
+    mask_data = np.zeros((50, 50), dtype=bool)
+    mask_data[10:30, 10:30] = True
+    mask = UserSegmentationMask.from_numpy(mask_data)
+
+    result = draw_masks(img, [mask], color=(255, 0, 0), alpha=0.5)
+
+    # Promoted to RGB without raising.
+    assert result.shape == (50, 50, 3)
+    # Masked region should be blended toward red.
+    assert result[20, 20, 0] > 100
+    # Non-masked region keeps the grayscale value across all channels.
+    assert result[5, 5].tolist() == [100, 100, 100]
+
+
+def test_draw_label_image_grayscale():
+    """draw_label_image should accept a 2-D grayscale image and promote to RGB."""
+    img = np.ones((50, 50), dtype=np.uint8) * 128
+    labels = np.zeros((50, 50), dtype=np.int32)
+    labels[10:20, 10:20] = 1
+    labels[30:40, 30:40] = 2
+
+    result = draw_label_image(img, labels, alpha=0.5, palette="distinct")
+
+    # Promoted to RGB without raising.
+    assert result.shape == (50, 50, 3)
+    # Labeled regions differ from the original gray.
+    assert not np.array_equal(result[15, 15], [128, 128, 128])
+    assert not np.array_equal(result[35, 35], [128, 128, 128])
+    # Background keeps the grayscale value across all channels.
+    np.testing.assert_array_equal(result[0, 0], [128, 128, 128])
+
+
+def test_draw_bboxes_grayscale():
+    """draw_bboxes should accept a 2-D grayscale image and promote it to RGB."""
+    img = np.zeros((100, 100), dtype=np.uint8)
+    bbox = UserBoundingBox.from_xyxy(10, 10, 50, 50)
+
+    result = draw_bboxes(img, [bbox], color=(0, 255, 0), line_width=1)
+
+    # Promoted to RGB without raising.
+    assert result.shape == (100, 100, 3)
+    # The outline should be drawn in the requested color.
+    assert result[10, 10].tolist() == [0, 255, 0]
+    assert result[50, 50].tolist() == [0, 255, 0]
+    # Outside the box stays black.
+    assert result[80, 80].tolist() == [0, 0, 0]
+
+
+# ============================================================================
 # render_image overlay integration tests
 # ============================================================================
 

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -20,6 +20,7 @@ from sleap_io.rendering import render_video
 from sleap_io.rendering.colors import get_palette
 from sleap_io.rendering.core import render_image
 from sleap_io.rendering.overlays import (
+    _ensure_rgb,
     draw_bboxes,
     draw_label_image,
     draw_masks,
@@ -2877,6 +2878,25 @@ def test_draw_bboxes_grayscale():
     assert result[50, 50].tolist() == [0, 255, 0]
     # Outside the box stays black.
     assert result[80, 80].tolist() == [0, 0, 0]
+
+
+def test_ensure_rgb_shapes():
+    """_ensure_rgb promotes (H, W) and (H, W, 1) to RGB and passes (H, W, 3)."""
+    gray_2d = np.arange(12, dtype=np.uint8).reshape(3, 4)
+    out_2d = _ensure_rgb(gray_2d)
+    assert out_2d.shape == (3, 4, 3)
+    # Every channel equals the original grayscale plane.
+    np.testing.assert_array_equal(out_2d[..., 0], gray_2d)
+    np.testing.assert_array_equal(out_2d[..., 2], gray_2d)
+
+    gray_1ch = np.arange(12, dtype=np.uint8).reshape(3, 4, 1)
+    out_1ch = _ensure_rgb(gray_1ch)
+    assert out_1ch.shape == (3, 4, 3)
+    np.testing.assert_array_equal(out_1ch[..., 1], gray_1ch[..., 0])
+
+    rgb = np.zeros((3, 4, 3), dtype=np.uint8)
+    # A 3-channel image is returned unchanged (same array, in-place preserved).
+    assert _ensure_rgb(rgb) is rgb
 
 
 # ============================================================================


### PR DESCRIPTION
## Problem (finding L23)

The standalone overlay helpers `draw_rois`, `draw_masks`, `draw_label_image`, and `draw_bboxes` document and assume `(H, W, 3)` RGB input and crash on a 2-D grayscale `(H, W)` image:

- `draw_rois`/`draw_bboxes` do `np.dstack([image, np.full(image.shape[:2], 255)])` to pad to RGBA. For a 2-D input this yields `(H, W, 2)` instead of RGBA, so `skia.Surface(...)` raises `ValueError: Incorrect number of color channels (expected 4 bytes per pixel, given 2 bytes per pixel)`.
- `draw_masks`/`draw_label_image` blend a colored `(R, G, B)` overlay into the image, which fails on a single-channel array.

By contrast, `draw_centroids` (and `draw_trails`) already handle grayscale via an `if image.ndim == 2: ... ensure RGB` guard.

## Fix

Mirror the existing `draw_centroids` grayscale->RGB guard at the top of `draw_rois`, `draw_masks`, `draw_label_image`, and `draw_bboxes` so a 2-D `(H, W)` (or `(H, W, 1)`) uint8 image is promoted to `(H, W, 3)` before processing:

```python
if image.ndim == 2:
    image = np.stack([image] * 3, axis=-1)
elif image.ndim == 3 and image.shape[2] == 1:
    image = np.concatenate([image] * 3, axis=-1)
```

- Behavior is identical for `(H, W, 3)` input (neither branch fires; the existing `result is img` invariant still holds).
- `draw_masks`/`draw_label_image` take a separate mask/label array argument; only the **image** argument is promoted.
- Each docstring now notes that grayscale input is accepted.

## Testing

Added four skia-gated regression tests in `tests/rendering/test_rendering.py` (`test_draw_rois_grayscale`, `test_draw_masks_grayscale`, `test_draw_label_image_grayscale`, `test_draw_bboxes_grayscale`) that pass a 2-D grayscale uint8 image to each helper and assert it does not raise and produces an `(H, W, 3)` result with the overlay drawn. Verified each test fails without the guard (the `(H, W, 2)` skia error reproduced) and passes with it.

```
uv run --extra all --group dev pytest tests/rendering/test_rendering.py -p no:cacheprovider -q -k "grayscale or draw_"
# 68 passed, 200 deselected

uv run --extra all --group dev pytest tests/rendering/test_rendering.py -p no:cacheprovider -q
# 268 passed
```

`ruff format` / `ruff check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV