### PR TITLE
fix(coco): write track identity (attributes.object_id) for mask/ROI/bbox annotations

### DIFF
--- a/sleap_io/io/coco.py
+++ b/sleap_io/io/coco.py
@@ -601,9 +601,25 @@ def read_labels(
                     # Detection-only annotation: create ROIs/masks/bboxes. A
                     # COCO ``score`` marks a prediction, so it selects predicted
                     # mask/ROI/bbox variants (mirrors the bbox handling below).
+                    # Restore explicit track identity from attributes.object_id
+                    # (mirrors the keypoint branch above), falling back to the
+                    # category identity when requested.
+                    track = None
+                    track_id = (
+                        annotation.get("attributes", {}).get("object_id")
+                        or annotation.get("track_id")
+                        or annotation.get("instance_id")
+                    )
+                    if track_id is not None:
+                        if track_id not in track_dict:
+                            track_dict[track_id] = Track(name=f"track_{track_id}")
+                        track = track_dict[track_id]
+                    else:
+                        track = _category_track(cat_name)
+
                     roi_kwargs = dict(
                         category=cat_name,
-                        track=_category_track(cat_name),
+                        track=track,
                     )
 
                     # Handle segmentation field
@@ -990,6 +1006,10 @@ def convert_labels(
             ]
             annotation["area"] = float(roi.area)
 
+            # Preserve track identity (mirrors keypoint annotation path above).
+            if roi.track is not None:
+                annotation["attributes"] = {"object_id": track_to_id[roi.track]}
+
             coco_data["annotations"].append(annotation)
             annotation_id_counter += 1
 
@@ -1036,6 +1056,10 @@ def convert_labels(
                 "iscrowd": 1,
             }
 
+            # Preserve track identity (mirrors keypoint annotation path above).
+            if seg_mask.track is not None:
+                annotation["attributes"] = {"object_id": track_to_id[seg_mask.track]}
+
             coco_data["annotations"].append(annotation)
             annotation_id_counter += 1
 
@@ -1079,6 +1103,10 @@ def convert_labels(
 
             if isinstance(bbox_obj, PredictedBoundingBox):
                 annotation["score"] = float(bbox_obj.score)
+
+            # Preserve track identity (mirrors keypoint annotation path above).
+            if bbox_obj.track is not None:
+                annotation["attributes"] = {"object_id": track_to_id[bbox_obj.track]}
 
             coco_data["annotations"].append(annotation)
             annotation_id_counter += 1

--- a/tests/io/test_coco.py
+++ b/tests/io/test_coco.py
@@ -1775,6 +1775,91 @@ class TestCOCOROIMaskIO:
         # Resampled to image extent: 10x10
         assert ann["segmentation"]["size"] == [10, 10]
 
+    def test_coco_mask_track_identity_roundtrip(self, tmp_path):
+        """Track on a SegmentationMask is written and restored via object_id."""
+        mask_arr = np.zeros((10, 10), dtype=bool)
+        mask_arr[2:5, 3:7] = True
+
+        video = sio.Video.from_filename(["img1.png"])
+        track = Track("id_7")
+        seg_mask = UserSegmentationMask.from_numpy(
+            mask_arr, category="cell", track=track
+        )
+        lf = sio.LabeledFrame(video=video, frame_idx=0)
+        lf.masks.append(seg_mask)
+        labels = sio.Labels(labeled_frames=[lf])
+
+        json_path = tmp_path / "mask_track.json"
+        coco.write_labels(labels, json_path)
+
+        # The JSON annotation carries the track identity as attributes.object_id.
+        with open(json_path, "r") as f:
+            data = json.load(f)
+        ann = data["annotations"][0]
+        assert "attributes" in ann
+        assert "object_id" in ann["attributes"]
+
+        # Read back: the mask's track is restored and registered on the Labels.
+        for img_info in data["images"]:
+            (tmp_path / img_info["file_name"]).touch()
+        labels_rt = coco.read_labels(json_path, dataset_root=tmp_path)
+        assert len(labels_rt.masks) == 1
+        assert labels_rt.masks[0].track is not None
+        assert len(labels_rt.tracks) > 0
+
+    def test_coco_roi_track_identity_roundtrip(self, tmp_path):
+        """Track on an ROI is written and restored via object_id."""
+        from sleap_io.model.roi import UserROI
+
+        coords = [(10.0, 20.0), (50.0, 20.0), (50.0, 60.0), (10.0, 60.0)]
+        video = sio.Video.from_filename(["img1.png"])
+        track = Track("id_7")
+        roi = UserROI.from_polygon(coords, category="region", track=track, video=video)
+        lf = sio.LabeledFrame(video=video, frame_idx=0)
+        lf.rois.append(roi)
+        labels = sio.Labels(labeled_frames=[lf])
+
+        json_path = tmp_path / "roi_track.json"
+        coco.write_labels(labels, json_path)
+
+        with open(json_path, "r") as f:
+            data = json.load(f)
+        ann = data["annotations"][0]
+        assert ann["attributes"]["object_id"] is not None
+
+        for img_info in data["images"]:
+            (tmp_path / img_info["file_name"]).touch()
+        labels_rt = coco.read_labels(
+            json_path, dataset_root=tmp_path, segmentation_format="roi"
+        )
+        assert len(labels_rt.rois) == 1
+        assert labels_rt.rois[0].track is not None
+        assert len(labels_rt.tracks) > 0
+
+    def test_coco_bbox_track_identity_roundtrip(self, tmp_path):
+        """Track on a standalone BoundingBox is written and restored."""
+        video = sio.Video.from_filename(["img1.png"])
+        track = Track("id_7")
+        bbox = UserBoundingBox.from_xywh(10, 20, 50, 30, category="dog", track=track)
+        lf = sio.LabeledFrame(video=video, frame_idx=0)
+        lf.bboxes.append(bbox)
+        labels = sio.Labels(labeled_frames=[lf])
+
+        json_path = tmp_path / "bbox_track.json"
+        coco.write_labels(labels, json_path)
+
+        with open(json_path, "r") as f:
+            data = json.load(f)
+        ann = data["annotations"][0]
+        assert ann["attributes"]["object_id"] is not None
+
+        for img_info in data["images"]:
+            (tmp_path / img_info["file_name"]).touch()
+        labels_rt = coco.read_labels(json_path, dataset_root=tmp_path)
+        assert len(labels_rt.bboxes) == 1
+        assert labels_rt.bboxes[0].track is not None
+        assert len(labels_rt.tracks) > 0
+
     def test_coco_detection_only_read(self, tmp_path):
         """Test reading a detection-only COCO JSON (no keypoints)."""
         # Create image files so they can be resolved


### PR DESCRIPTION
## Problem (finding L8 — read/write asymmetry)

On COCO save, keypoint instances write their track as `attributes.object_id`, but the mask/ROI/bbox export blocks built annotation dicts **without** any track info. As a result, a `Track` on a `UserSegmentationMask`/`UserBoundingBox`/`UserROI` was silently dropped on a COCO round-trip.

While fixing the write side, the read side turned out to be asymmetric too: the detection-only annotation branch (no keypoints) only derived a track from the category name (via `category_as_track`) and never read `attributes.object_id`. So even after writing the identity, reading it back gave `track=None`.

## Fix

**Write side** (`convert_labels`): each non-instance mask/ROI/bbox annotation that has a `.track` now sets `annotation["attributes"] = {"object_id": track_to_id[track]}`, exactly mirroring the keypoint annotation path. Only added when the object actually has a track; no other fields are disturbed.

**Read side** (`read_labels`): the detection-only branch now restores explicit track identity from `attributes.object_id` (also honoring `track_id`/`instance_id` like the keypoint branch), falling back to category-derived identity (`category_as_track`) when no explicit id is present. This makes the identity round-trip.

## Tests

Added three focused round-trip regression tests in `tests/io/test_coco.py` (`TestCOCOROIMaskIO`):
- `test_coco_mask_track_identity_roundtrip`
- `test_coco_roi_track_identity_roundtrip`
- `test_coco_bbox_track_identity_roundtrip`

Each builds `Labels` with a mask/ROI/bbox carrying `track=Track("id_7")`, saves to COCO, asserts the JSON annotation has `attributes.object_id`, loads the file back, and asserts the restored object's `.track` is not `None` and `labels.tracks` is non-empty. Verified each test fails without the production change and passes with it. Full module: `93 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV