### PR TITLE
fix(model): preserve tracking_score and _instance_idx through mask/bbox/ROI conversions

### DIFF
--- a/sleap_io/model/bbox.py
+++ b/sleap_io/model/bbox.py
@@ -272,6 +272,7 @@ class BoundingBox:
             category=self.category,
             source=self.source,
             track=self.track,
+            tracking_score=self.tracking_score,
             instance=self.instance,
         )
 

--- a/sleap_io/model/label_image.py
+++ b/sleap_io/model/label_image.py
@@ -259,9 +259,17 @@ class LabelImage:
         from sleap_io.model.mask import _resize_nearest
 
         resized = _resize_nearest(self.data, target_height, target_width)
+        objects: dict[int, LabelImage.Info] = {}
+        for lid, info in self.objects.items():
+            new_info = attrs.evolve(info)
+            # Carry the deferred instance index through (init=False, so it is not
+            # reproduced by attrs.evolve and must be set after construction;
+            # mirrors how __deepcopy__ preserves the lazy association).
+            new_info._instance_idx = info._instance_idx
+            objects[lid] = new_info
         kwargs: dict = dict(
             data=resized,
-            objects={lid: attrs.evolve(info) for lid, info in self.objects.items()},
+            objects=objects,
             source=self.source,
             scale=(1.0, 1.0),
             offset=(0.0, 0.0),

--- a/sleap_io/model/mask.py
+++ b/sleap_io/model/mask.py
@@ -206,6 +206,7 @@ class SegmentationMask:
             category=self.category,
             source=self.source,
             track=self.track,
+            tracking_score=self.tracking_score,
             instance=self.instance,
             scale=(1.0, 1.0),
             offset=(0.0, 0.0),
@@ -222,7 +223,11 @@ class SegmentationMask:
                 )
             kwargs["score_map_scale"] = (1.0, 1.0)
             kwargs["score_map_offset"] = (0.0, 0.0)
-        return type(self).from_numpy(resized, **kwargs)
+        resampled = type(self).from_numpy(resized, **kwargs)
+        # Carry the deferred instance index through (init=False, so set after
+        # construction; mirrors to_user() preserving the lazy association).
+        resampled._instance_idx = self._instance_idx
+        return resampled
 
     @classmethod
     def from_numpy(
@@ -342,6 +347,7 @@ class SegmentationMask:
         cls = PredictedBoundingBox if self.is_predicted else UserBoundingBox
         kwargs: dict = dict(
             track=self.track,
+            tracking_score=self.tracking_score,
             instance=self.instance,
             category=self.category,
             name=self.name,
@@ -396,6 +402,7 @@ class SegmentationMask:
             category=self.category,
             source=self.source,
             track=self.track,
+            tracking_score=self.tracking_score,
             instance=self.instance,
         )
 

--- a/sleap_io/model/roi.py
+++ b/sleap_io/model/roi.py
@@ -310,6 +310,7 @@ class ROI:
             category=self.category,
             source=self.source,
             track=self.track,
+            tracking_score=self.tracking_score,
             instance=self.instance,
         )
         if self.is_predicted:
@@ -344,6 +345,7 @@ class ROI:
                     source=self.source,
                     video=self.video,
                     track=self.track,
+                    tracking_score=self.tracking_score,
                     instance=self.instance,
                     **extra,
                 )

--- a/tests/model/test_bbox.py
+++ b/tests/model/test_bbox.py
@@ -251,6 +251,15 @@ def test_bbox_to_roi_preserves_metadata():
     assert roi.category == "mouse"
 
 
+def test_bbox_to_roi_preserves_tracking_score():
+    """to_roi() carries tracking_score through (regression for L4)."""
+    bbox = PredictedBoundingBox(
+        x1=40, y1=45, x2=60, y2=55, score=0.9, tracking_score=0.7
+    )
+    roi = bbox.to_roi()
+    assert roi.tracking_score == pytest.approx(0.7)
+
+
 def test_bbox_to_mask():
     bbox = UserBoundingBox(x1=7, y1=8, x2=13, y2=12)
     mask = bbox.to_mask(height=20, width=20)

--- a/tests/model/test_label_image.py
+++ b/tests/model/test_label_image.py
@@ -565,6 +565,23 @@ def test_label_image_resampled():
     assert resampled.objects[1].category == "a"
 
 
+def test_label_image_resampled_preserves_instance_idx():
+    """resampled() keeps each Info's deferred _instance_idx (regression for L7)."""
+    data = np.array([[0, 1], [2, 0]], dtype=np.int32)
+    info1 = LabelImage.Info(category="a")
+    info1._instance_idx = 3
+    info2 = LabelImage.Info(category="b")
+    info2._instance_idx = 5
+    li = UserLabelImage(
+        data=data,
+        objects={1: info1, 2: info2},
+        scale=(0.5, 0.5),
+    )
+    resampled = li.resampled(4, 4)
+    assert resampled.objects[1]._instance_idx == 3
+    assert resampled.objects[2]._instance_idx == 5
+
+
 def test_predicted_label_image_resampled():
     data = np.array([[0, 1], [2, 0]], dtype=np.int32)
     score_map = np.random.rand(2, 2).astype(np.float32)

--- a/tests/model/test_mask.py
+++ b/tests/model/test_mask.py
@@ -373,6 +373,45 @@ def test_resampled_unlinked_stays_none():
     assert resampled.from_predicted is None
 
 
+def test_resampled_preserves_tracking_score():
+    """resampled() carries tracking_score through (regression for L4)."""
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 3:7] = True
+    mask = PredictedSegmentationMask.from_numpy(
+        data, score=0.9, tracking_score=0.7, scale=(0.5, 0.5)
+    )
+    resampled = mask.resampled(20, 20)
+    assert resampled.tracking_score == pytest.approx(0.7)
+
+
+def test_resampled_preserves_instance_idx():
+    """resampled() keeps the deferred _instance_idx (regression for L7)."""
+    data = np.zeros((6, 6), dtype=bool)
+    data[1:3, 1:3] = True
+    mask = UserSegmentationMask.from_numpy(data, scale=(0.5, 0.5))
+    mask._instance_idx = 3
+    resampled = mask.resampled(12, 12)
+    assert resampled._instance_idx == 3
+
+
+def test_to_bbox_preserves_tracking_score():
+    """to_bbox() carries tracking_score through (regression for L4)."""
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 3:7] = True
+    mask = PredictedSegmentationMask.from_numpy(data, score=0.9, tracking_score=0.7)
+    bb = mask.to_bbox()
+    assert bb.tracking_score == pytest.approx(0.7)
+
+
+def test_to_polygon_preserves_tracking_score():
+    """to_polygon() carries tracking_score through (regression for L4)."""
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 3:7] = True
+    mask = PredictedSegmentationMask.from_numpy(data, score=0.9, tracking_score=0.7)
+    roi = mask.to_polygon()
+    assert roi.tracking_score == pytest.approx(0.7)
+
+
 def test_predicted_segmentation_mask_score_map_spatial():
     mask = PredictedSegmentationMask.from_numpy(
         np.zeros((5, 5), dtype=bool),

--- a/tests/model/test_roi.py
+++ b/tests/model/test_roi.py
@@ -129,6 +129,13 @@ def test_predicted_roi_to_mask_is_predicted():
     assert type(user_mask) is UserSegmentationMask
 
 
+def test_roi_to_mask_preserves_tracking_score():
+    """to_mask() carries tracking_score through (regression for L4)."""
+    roi = UserROI.from_bbox(2, 3, 4, 5, tracking_score=0.7)
+    mask = roi.to_mask(height=20, width=20)
+    assert mask.tracking_score == pytest.approx(0.7)
+
+
 def test_roi_with_video():
     video = Video(filename="test.mp4")
     roi = UserROI.from_bbox(0, 0, 10, 10, video=video)
@@ -266,6 +273,19 @@ def test_roi_explode_multi_polygon():
         assert part.category == "cat"
     assert parts[0].area == pytest.approx(100.0)
     assert parts[1].area == pytest.approx(100.0)
+
+
+def test_roi_explode_preserves_tracking_score():
+    """explode() carries tracking_score onto each part (regression for L4)."""
+    polygons = [
+        [(0, 0), (10, 0), (10, 10), (0, 10)],
+        [(20, 20), (30, 20), (30, 30), (20, 30)],
+    ]
+    roi = UserROI.from_multi_polygon(polygons, tracking_score=0.7)
+    parts = roi.explode()
+    assert len(parts) == 2
+    for part in parts:
+        assert part.tracking_score == pytest.approx(0.7)
 
 
 def test_roi_explode_single_polygon():


### PR DESCRIPTION
## Summary

Two related polish findings (L4 and L7) where annotation conversions silently
dropped fields that the source object carried, unlike `Centroid.to_instance`
which preserves them.

### L4: `tracking_score` dropped

`tracking_score` is a first-class field on `SegmentationMask`, `BoundingBox`,
and `ROI`, but these conversions reconstructed the target without it (resetting
it to `None`):

- `SegmentationMask.resampled` (`sleap_io/model/mask.py`)
- `SegmentationMask.to_bbox` (`sleap_io/model/mask.py`)
- `SegmentationMask.to_polygon` (`sleap_io/model/mask.py`)
- `BoundingBox.to_roi` (`sleap_io/model/bbox.py`)
- `ROI.to_mask` (`sleap_io/model/roi.py`)
- `ROI.explode` (`sleap_io/model/roi.py`)

Each now propagates `self.tracking_score`. No other behavior changed (the
documented predicted→user downcast in `to_polygon`/`to_mask` is preserved).

### L7: `_instance_idx` dropped

The private deferred-instance index (`_instance_idx`, `init=False`) was reset to
`-1` by two `resampled()` paths, losing the lazy instance association:

- `SegmentationMask.resampled` rebuilds via `from_numpy`, which cannot set an
  `init=False` field. Now set after construction, mirroring `to_user()`.
- `LabelImage.resampled` copied each `Info` with `attrs.evolve(info)`, which does
  not reproduce the `init=False` field. Now carried through per-`Info`, mirroring
  the existing `__deepcopy__` pattern.

## Testing

Added focused regression tests asserting the corrected behavior (each was
confirmed to fail before the fix):

- `tests/model/test_mask.py`: resampled/to_bbox/to_polygon preserve
  `tracking_score`; resampled preserves `_instance_idx`.
- `tests/model/test_bbox.py`: `to_roi` preserves `tracking_score`.
- `tests/model/test_roi.py`: `to_mask` and `explode` preserve `tracking_score`.
- `tests/model/test_label_image.py`: `resampled` preserves each `Info`'s
  `_instance_idx`.

`uv run --extra all --group dev pytest tests/model/test_mask.py tests/model/test_bbox.py tests/model/test_roi.py tests/model/test_label_image.py` → 262 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV