### PR TITLE
fix(render): accept a single SegmentationMask/ROI/BoundingBox as render_image overlay=

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -719,10 +719,13 @@ img = sio.render_image(
     overlay_outline=True,
 )
 
-# SegmentationMask, ROI, or BoundingBox objects
+# SegmentationMask, ROI, or BoundingBox objects (a list, or a single object)
 img = sio.render_image(image=frame, overlay=masks, overlay_alpha=0.3)
 img = sio.render_image(image=frame, overlay=rois, overlay_alpha=0.3)
 img = sio.render_image(image=frame, overlay=bboxes, overlay_alpha=0.3)
+
+# A single annotation object also works (treated like a one-element list)
+img = sio.render_image(image=frame, overlay=masks[0], overlay_alpha=0.3)
 
 # Overlay on a labeled frame (poses render on top)
 img = sio.render_image(lf, overlay=label_mask, overlay_alpha=0.4)

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -474,6 +474,7 @@ def _apply_overlay(
     image: np.ndarray,
     overlay: (
         "np.ndarray | LabelImage"
+        " | SegmentationMask | ROI | BoundingBox"
         " | list[SegmentationMask] | list[ROI] | list[BoundingBox]"
     ),
     alpha: float = 0.3,
@@ -495,6 +496,8 @@ def _apply_overlay(
 
             - ``np.ndarray``: Integer label image ``(H, W)`` with 0 =
               background and positive values as object IDs.
+            - ``SegmentationMask``, ``ROI``, or ``BoundingBox``: A single
+              annotation object (normalized to a one-element list).
             - ``list[SegmentationMask]``: Binary segmentation masks.
             - ``list[ROI]``: Vector geometries (polygons, points, etc.).
             - ``list[BoundingBox]``: Axis-aligned or rotated bounding boxes.
@@ -511,12 +514,21 @@ def _apply_overlay(
     Returns:
         The modified image array.
     """
+    from sleap_io.model.bbox import BoundingBox
+    from sleap_io.model.mask import SegmentationMask
+    from sleap_io.model.roi import ROI
     from sleap_io.rendering.overlays import (
         draw_bboxes,
         draw_label_image,
         draw_masks,
         draw_rois,
     )
+
+    # Normalize a single annotation object to a one-element list so a bare
+    # ``SegmentationMask``/``ROI``/``BoundingBox`` (or a User/Predicted subclass)
+    # "just works" like a one-element list. ndarray/LabelImage are handled below.
+    if isinstance(overlay, (SegmentationMask, ROI, BoundingBox)):
+        overlay = [overlay]
 
     if isinstance(overlay, np.ndarray):
         draw_label_image(
@@ -541,10 +553,6 @@ def _apply_overlay(
             offset=overlay.offset,
         )
     elif isinstance(overlay, list) and overlay:
-        from sleap_io.model.bbox import BoundingBox
-        from sleap_io.model.mask import SegmentationMask
-        from sleap_io.model.roi import ROI
-
         first = overlay[0]
 
         if _is_label_image(first):
@@ -808,6 +816,7 @@ def render_image(
     # Annotation overlay
     overlay: (
         "np.ndarray | LabelImage"
+        " | SegmentationMask | ROI | BoundingBox"
         " | list[SegmentationMask] | list[ROI] | list[BoundingBox]"
         " | None"
     ) = None,
@@ -861,6 +870,8 @@ def render_image(
 
             - ``np.ndarray``: Integer label image ``(H, W)`` where 0 is
               background and positive values are object IDs.
+            - ``SegmentationMask``, ``ROI``, or ``BoundingBox``: A single
+              annotation object (treated like a one-element list).
             - ``list[SegmentationMask]``: Binary segmentation masks.
             - ``list[ROI]``: Vector geometries (polygons, points, etc.).
             - ``list[BoundingBox]``: Bounding boxes.

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -2955,6 +2955,53 @@ def test_render_image_overlay_bboxes():
     assert result[50, 50].any()
 
 
+def test_render_image_overlay_single_mask_matches_list():
+    """A bare SegmentationMask overlay paints the same as a one-element list.
+
+    Regression (L18): ``_apply_overlay`` previously dispatched only on
+    ndarray/LabelImage/non-empty-list, so a bare mask silently no-op'd.
+    """
+    base = np.ones((50, 50, 3), dtype=np.uint8) * 128
+    mask_data = np.zeros((50, 50), dtype=bool)
+    mask_data[10:30, 10:30] = True
+    mask = UserSegmentationMask.from_numpy(mask_data)
+
+    single = render_image(image=base.copy(), overlay=mask, overlay_alpha=1.0)
+    listed = render_image(image=base.copy(), overlay=[mask], overlay_alpha=1.0)
+
+    # The bare object must actually paint pixels (not no-op).
+    n_painted = int(np.any(single != base, axis=-1).sum())
+    assert n_painted > 0
+    # And paint exactly the same pixels as the one-element list.
+    assert np.array_equal(single, listed)
+
+
+def test_render_image_overlay_single_roi_matches_list():
+    """A bare ROI overlay paints the same as a one-element list (L18)."""
+    base = np.zeros((100, 100, 3), dtype=np.uint8)
+    roi = UserROI(geometry=box(20, 20, 60, 60))
+
+    single = render_image(image=base.copy(), overlay=roi, overlay_alpha=1.0)
+    listed = render_image(image=base.copy(), overlay=[roi], overlay_alpha=1.0)
+
+    n_painted = int(np.any(single != base, axis=-1).sum())
+    assert n_painted > 0
+    assert np.array_equal(single, listed)
+
+
+def test_render_image_overlay_single_bbox_matches_list():
+    """A bare BoundingBox overlay paints the same as a one-element list (L18)."""
+    base = np.zeros((100, 100, 3), dtype=np.uint8)
+    bbox = UserBoundingBox(x1=30, y1=30, x2=70, y2=70)
+
+    single = render_image(image=base.copy(), overlay=bbox, overlay_alpha=1.0)
+    listed = render_image(image=base.copy(), overlay=[bbox], overlay_alpha=1.0)
+
+    n_painted = int(np.any(single != base, axis=-1).sum())
+    assert n_painted > 0
+    assert np.array_equal(single, listed)
+
+
 def test_render_image_overlay_with_scale():
     """render_image with overlay and scale should scale the output."""
     img = np.ones((100, 100, 3), dtype=np.uint8) * 128


### PR DESCRIPTION
## Problem (finding L18)

`render_image(..., overlay=<single object>)` silently no-op'd for a bare `SegmentationMask`/`ROI`/`BoundingBox`. The dispatcher `_apply_overlay` (`sleap_io/rendering/core.py`) only handled `np.ndarray`, `LabelImage`, or a non-empty `list`; a single annotation object fell through every branch and returned the image untouched. This was surprising because a single `LabelImage`/`ndarray` already works, and both the docstrings (`render_image` / `_apply_overlay`) and `docs/rendering.md` prose already advertised those objects as accepted.

## Fix

In `_apply_overlay`, normalize a single supported annotation object to a one-element list before the list-handling branch:

```python
if isinstance(overlay, (SegmentationMask, ROI, BoundingBox)):
    overlay = [overlay]
```

This covers the `User*`/`Predicted*` subclasses too (they inherit from the base classes). `ndarray` and `LabelImage` handling is unchanged. The `SegmentationMask`/`ROI`/`BoundingBox` imports moved to the top of the function (they were previously imported inside the list branch). Type hints, docstrings, and `docs/rendering.md` prose were tightened to reflect single-object support.

A single object skips the (`isinstance(..., list)`-gated) track-coloring block in `render_image` and is colored positionally by `_apply_overlay` — no crash, consistent with passing a one-element list without tracks.

## Testing

Added 3 skia-gated regression tests in `tests/rendering/test_rendering.py`:

- `test_render_image_overlay_single_mask_matches_list`
- `test_render_image_overlay_single_roi_matches_list`
- `test_render_image_overlay_single_bbox_matches_list`

Each asserts the bare object paints a non-zero pixel count and produces pixels exactly equal to `overlay=[obj]`. Verified the tests fail without the production change (bare object paints 0 pixels) and pass with it.

```
uv run --extra all --group dev pytest tests/rendering/test_rendering.py -p no:cacheprovider -q -k "overlay"
# 34 passed, 233 deselected
```

Docs build (`EAGER_IMPORT=1 uv run mkdocs build`) succeeds and the new prose renders in the built HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV