### PR TITLE
chore(cli/docs): bucket-A polish (export draw_centroids, group export cmd, __main__ guard, doc fixes)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -522,9 +522,8 @@ sio convert -i data.json -o labels.slp --from coco
 sio convert -i data.json -o labels.slp --from labelstudio
 sio convert -i data.json -o labels.slp --from alphatracker
 
-# .h5 could be JABS or DeepLabCut
+# .h5 is read as JABS
 sio convert -i data.h5 -o labels.slp --from jabs
-sio convert -i data.h5 -o labels.slp --from dlc
 ```
 
 ### Embedding Frames
@@ -1848,7 +1847,7 @@ sio render --images frames/ --overlay masks.tif -o output.mp4
 | Option | Default | Description |
 |--------|---------|-------------|
 | `--color-by` | auto | Color scheme: `auto`, `track`, `instance`, `node` |
-| `--palette` | glasbey | Color palette (glasbey, tableau10, distinct, rainbow, etc.) |
+| `--palette` | standard | Color palette (standard, tableau10, distinct, glasbey, rainbow, etc.) |
 | `--marker-shape` | circle | Node marker: `circle`, `square`, `diamond`, `triangle`, `cross` |
 | `--marker-size` | 4.0 | Node marker radius in pixels |
 | `--line-width` | 2.0 | Edge line width in pixels |
@@ -1936,8 +1935,8 @@ The crop modes:
 - **Pixel coordinates**: `x1,y1,x2,y2` as integers. Use for precise cropping when you know exact pixel locations.
 - **Normalized coordinates**: `x1,y1,x2,y2` as floats between 0.0-1.0. Use for relative cropping that works across different video resolutions.
 
-!!! note "Video mode limitation"
-    Cropping is currently only supported for single image mode (`--lf` or `--frame`). Video cropping is not yet implemented.
+!!! note "Video cropping"
+    `--crop` applies to video rendering as well as single-image mode. A static `x1,y1,x2,y2` region (pixel coordinates or normalized 0.0-1.0) is applied uniformly to every frame.
 
 ### Video Frame Ranges
 
@@ -2026,7 +2025,7 @@ sio render predictions.slp --palette glasbey  # 256 distinct colors
 sio render predictions.slp --palette glasbey_warm
 ```
 
-Available built-in palettes: `distinct`, `rainbow`, `warm`, `cool`, `pastel`, `seaborn`, `tableau10`, `viridis`
+Available built-in palettes: `standard` (default), `distinct`, `rainbow`, `warm`, `cool`, `pastel`, `seaborn`, `tableau10`, `viridis`
 
 !!! tip "Discover available options"
     Use the discovery flags to see all available colors and palettes:

--- a/docs/formats/dlc.md
+++ b/docs/formats/dlc.md
@@ -1,6 +1,6 @@
-# DeepLabCut Format (.h5, .csv)
+# DeepLabCut Format (.csv)
 
-Load annotations from [DeepLabCut](http://www.mackenziemathislab.org/deeplabcut), a popular markerless pose estimation tool.
+Load annotations from [DeepLabCut](http://www.mackenziemathislab.org/deeplabcut), a popular markerless pose estimation tool. sleap-io reads DLC annotations from the project's CSV files (optionally augmented by a `config.yaml`); it does not read DLC `.h5` outputs.
 
 `load_dlc` reads a single DLC annotation CSV. When a project `config.yaml` is
 available — either passed explicitly via `config=` or auto-discovered by walking

--- a/docs/formats/index.md
+++ b/docs/formats/index.md
@@ -215,7 +215,7 @@ with h5py.File("output.h5", "r") as f:
 
 ::: sleap_io.io.main.save_labelstudio
 
-### DeepLabCut Format (.h5, .csv)
+### DeepLabCut Format (.csv)
 
 Load annotations from [DeepLabCut](http://www.mackenziemathislab.org/deeplabcut). See the
 **[DeepLabCut Format](dlc.md)** page for single-CSV loading with `config.yaml`
@@ -407,7 +407,7 @@ Load and save skeleton definitions separately:
 sleap-io automatically detects file formats based on:
 
 1. **File extension**: `.slp`, `.nwb`, `.h5`, `.json`, `.geojson`, `.mat`, `.csv`, `.tif`, `.tiff`
-2. **File content**: For ambiguous extensions like `.h5` (JABS vs DLC) or `.json` (Label Studio vs COCO)
+2. **File content**: For ambiguous extensions like `.h5` (JABS vs Analysis HDF5) or `.json` (Label Studio vs COCO)
 3. **Explicit format**: Pass `format` parameter to override auto-detection
 
 For URLs, ambiguous extensions (`.h5`, `.json`, `.csv`) are disambiguated with a magic-byte sniff via a Range request, controllable with [`load_file`][sleap_io.load_file]'s `sniff=` argument. See [Loading from URLs](../remote.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ does *not* include labeling, training, or inference.
 
 ## Features
 
-- **Multi-format I/O** -- Read and write [SLEAP](formats/index.md#sleap-native-format-slp), [NWB](formats/index.md#nwb-format-nwb), [COCO](formats/index.md#coco-format-json), [DeepLabCut](formats/index.md#deeplabcut-format-h5-csv), [Ultralytics YOLO](formats/index.md#ultralytics-yolo-format), [JABS](formats/index.md#jabs-format-h5), [Label Studio](formats/index.md#label-studio-format-json), [CSV](formats/index.md#csv-format-csv), [Analysis HDF5](formats/index.md#sleap-analysis-hdf5-format-h5), [AlphaTracker](formats/index.md#alphatracker-format), and [LEAP](formats/index.md#leap-format-mat) formats
+- **Multi-format I/O** -- Read and write [SLEAP](formats/index.md#sleap-native-format-slp), [NWB](formats/index.md#nwb-format-nwb), [COCO](formats/index.md#coco-format-json), [DeepLabCut](formats/index.md#deeplabcut-format-csv), [Ultralytics YOLO](formats/index.md#ultralytics-yolo-format), [JABS](formats/index.md#jabs-format-h5), [Label Studio](formats/index.md#label-studio-format-json), [CSV](formats/index.md#csv-format-csv), [Analysis HDF5](formats/index.md#sleap-analysis-hdf5-format-h5), [AlphaTracker](formats/index.md#alphatracker-format), and [LEAP](formats/index.md#leap-format-mat) formats
 - **CLI tools** -- Inspect, convert, render, and transform data from the command line ([reference](cli.md))
 - **Rendering** -- Produce publication-quality videos and images with pose overlays, customizable colors, markers, motion trails, and presets ([guide](rendering.md))
 - **Transforms** -- Crop, scale, rotate, pad, and flip videos with automatic coordinate adjustment ([guide](transforms.md))

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -746,7 +746,7 @@ sio.render_video(labels, "output.mp4", overlay=masks)
 
 ### Standalone functions
 
-For direct control, use `sio.draw_label_image`, `sio.draw_masks`, `sio.draw_rois`, or `sio.draw_bboxes`:
+For direct control, use `sio.draw_label_image`, `sio.draw_masks`, `sio.draw_rois`, `sio.draw_bboxes`, or `sio.draw_centroids`:
 
 #### Label images (instance/panoptic segmentation)
 
@@ -807,6 +807,15 @@ For `BoundingBox` objects, use `sio.draw_bboxes`:
 
 ```python
 sio.draw_bboxes(image, bboxes, color=(0, 255, 0), line_width=2, fill_alpha=0.1)
+```
+
+#### Centroids
+
+For `Centroid` objects, use `sio.draw_centroids` to draw a filled marker at each
+position:
+
+```python
+sio.draw_centroids(image, centroids, color=(0, 255, 0), marker_size=5.0)
 ```
 
 ---
@@ -952,6 +961,11 @@ sio render --list-colors
       heading_level: 3
 
 ::: sleap_io.draw_bboxes
+    options:
+      show_root_heading: true
+      heading_level: 3
+
+::: sleap_io.draw_centroids
     options:
       show_root_heading: true
       heading_level: 3

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -77,6 +77,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             "draw_rois",
             "draw_masks",
             "draw_bboxes",
+            "draw_centroids",
             "draw_label_image",
             "draw_trails",
         ],

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -121,6 +121,7 @@ click.rich_click.COMMAND_GROUPS = {
                 "apply-crops",
             ],
         },
+        {"name": "Export", "commands": ["export"]},
         {"name": "Embedding", "commands": ["embed", "unembed"]},
         {"name": "Maintenance", "commands": ["fix"]},
         {"name": "Rendering", "commands": ["render"]},
@@ -8216,3 +8217,7 @@ def _transform_video_file(
         )
 
     console.print(f"[bold green]Saved:[/] {output_path}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -14,10 +14,10 @@ import sys
 import threading
 from pathlib import Path
 
-import click
 import h5py
 import numpy as np
 import pytest
+import rich_click as click
 from click.testing import CliRunner
 
 from sleap_io import load_slp, save_slp, save_video
@@ -80,6 +80,47 @@ def test_version_shows_plugin_info():
     assert "numpy:" in out
     assert "opencv:" in out
     assert "pyav:" in out
+
+
+def test_all_commands_have_help_panel():
+    """Every registered command must appear in a COMMAND_GROUPS panel.
+
+    Guards against new subcommands (or renames) silently falling into the
+    generic rich-click panel instead of an organized group.
+    """
+    grouped: set[str] = set()
+    for group in click.rich_click.COMMAND_GROUPS["sio"]:
+        grouped.update(group["commands"])
+
+    registered = set(cli.commands)
+
+    # No phantom entries: every grouped command actually exists.
+    assert grouped - registered == set()
+    # No omissions: every registered command is assigned to a panel.
+    assert registered - grouped == set()
+
+
+def test_export_command_in_command_groups():
+    """The `export` command must be assigned to a COMMAND_GROUPS panel."""
+    assert "export" in cli.commands
+    grouped = {
+        command
+        for group in click.rich_click.COMMAND_GROUPS["sio"]
+        for command in group["commands"]
+    }
+    assert "export" in grouped
+
+
+def test_module_main_runnable_via_python_m():
+    """`python -m sleap_io.io.cli` should run the CLI via the __main__ guard."""
+    result = subprocess.run(
+        [sys.executable, "-m", "sleap_io.io.cli", "--version"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() != ""
+    assert "sleap-io" in result.stdout
 
 
 def test_show_summary_typical_slp():

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -2358,6 +2358,27 @@ class TestTopLevelAPI:
 # ============================================================================
 
 
+def test_draw_centroids_exported_at_top_level():
+    """draw_centroids should be exported at sleap_io.* like the other overlays."""
+    # Listed in the public namespace alongside the other draw_* helpers.
+    assert "draw_centroids" in dir(sio)
+    for helper in (
+        "draw_rois",
+        "draw_masks",
+        "draw_bboxes",
+        "draw_centroids",
+        "draw_label_image",
+        "draw_trails",
+    ):
+        assert helper in dir(sio)
+
+    # `from sleap_io import draw_centroids` resolves to the overlay function.
+    from sleap_io import draw_centroids as exported_draw_centroids
+    from sleap_io.rendering.overlays import draw_centroids as overlay_draw_centroids
+
+    assert exported_draw_centroids is overlay_draw_centroids
+
+
 def test_draw_rois_outline():
     """draw_rois should draw ROI outlines on an image."""
     from sleap_io.rendering.overlays import draw_rois


### PR DESCRIPTION
## Summary

Bundle six small, independent low-severity polish findings for the 0.8.0 release. Three are behavioral (with regression tests); three are docs-only corrections of stale/incorrect claims.

## Changes

### Behavioral (with tests)
- **L15 (gap-api):** `draw_centroids` existed in `sleap_io/rendering/overlays.py` but was never added to the lazy-loaded public namespace, so it was missing from `sleap_io.*` while the other five overlay helpers were exported. Added it to the `rendering.overlays` entry in `sleap_io/__init__.py` and documented it in `docs/rendering.md`.
- **L13 (gap-cli):** the `export` command was absent from `COMMAND_GROUPS`, so it rendered in the generic rich-click panel. Added an `Export` panel in `sleap_io/io/cli.py`.
- **L20 (gap-cli):** `python -m sleap_io.io.cli` was a silent no-op. Added an `if __name__ == "__main__": cli()` guard (excluded from coverage by config).

### Docs-only
- **L10 (doc-error):** `--palette` default is `standard` (matches `cli.py`), not `glasbey`; added `standard` to the documented palette list (`docs/cli.md`).
- **L11 (doc-error):** removed the stale "Video cropping is not yet implemented" note; `render --crop` is wired and applies a static `x1,y1,x2,y2` region (pixel or normalized) uniformly to every frame.
- **I16 (doc-error):** removed the nonexistent DeepLabCut `.h5` reader claims from `docs/formats/dlc.md`, `docs/formats/index.md`, `docs/index.md`, and `docs/cli.md`. DLC is read from CSV / `config.yaml` only; `.h5` auto-detects JABS vs Analysis HDF5 (never DLC). Updated the section heading anchor accordingly.

## Testing
- `tests/rendering/test_rendering.py::test_draw_centroids_exported_at_top_level` — asserts `draw_centroids` is in `dir(sleap_io)` and `from sleap_io import draw_centroids` resolves to the overlay function.
- `tests/io/test_cli.py::test_all_commands_have_help_panel` — asserts the set difference between registered CLI commands and grouped commands is empty in both directions (guards future omissions and phantom entries).
- `tests/io/test_cli.py::test_export_command_in_command_groups` — asserts `export` specifically is grouped.
- `tests/io/test_cli.py::test_module_main_runnable_via_python_m` — subprocess runs `python -m sleap_io.io.cli --version`, asserts returncode 0 and non-empty output.

All four new tests verified to fail without the corresponding fix and pass with it. `ruff format`/`ruff check` clean. `EAGER_IMPORT=1 mkdocs build` succeeds and all doc edits verified in the rendered HTML.

> Note: one pre-existing test, `test_export_csv_dlc_chunked_error`, fails in this non-TTY environment due to rich console-width truncation of the error panel. Confirmed it fails identically on pristine `main` (`HEAD`) and is unrelated to these changes.

## Design notes
`cli.py` is also touched by other open CLI PRs; edits here are deliberately confined to the `COMMAND_GROUPS` dict and the trailing `__main__` guard to minimize merge conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHwWuvFdH5W539AgSjuTxV