### PR TITLE
fix(cli): fix reencode deadlock at 0 frames; default .mp4 output + --replace

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2239,7 +2239,22 @@ sio reencode video.mp4 -o output.mp4 --dry-run
 
 # Force Python path (for HDF5-embedded sources or when ffmpeg unavailable)
 sio reencode video.mp4 -o output.mp4 --no-ffmpeg
+
+# Default output (no -o) is always {stem}.reencoded.mp4
+sio reencode video.mov            # -> video.reencoded.mp4
+
+# Reencode in place: replace the input with {stem}.mp4 and delete the original
+sio reencode video.mov --replace  # -> video.mp4 (deletes video.mov)
 ```
+
+!!! note "Output is always MP4"
+    Reencoding always produces an H.264/MP4 file. The default output therefore
+    uses a `.mp4` extension regardless of the input container, and the
+    `.reencoded` infix keeps it distinct from the source (even for `.mp4`
+    inputs). `--replace` drops the infix and writes `{stem}.mp4` in place,
+    deleting the original when the extension changes (e.g. `.mov` → `.mp4`).
+    `--replace` cannot be combined with `-o/--output` and is not supported for
+    SLP inputs.
 
 ### SLP Batch Processing
 
@@ -2282,7 +2297,8 @@ This is particularly useful for:
 | Option | Default | Description |
 |--------|---------|-------------|
 | `-i, --input` | (required) | Input video or SLP file (can also pass as positional argument) |
-| `-o, --output` | `{input}.reencoded.mp4` or `.slp` | Output video/SLP path |
+| `-o, --output` | `{input}.reencoded.mp4` or `.slp` | Output video/SLP path (always `.mp4` for the video default) |
+| `--replace` | False | Reencode in place: replace the input with `{stem}.mp4` and delete the original. Mutually exclusive with `-o/--output`; not supported for SLP inputs |
 | `--overwrite` | False | Overwrite existing output file |
 | `--dry-run` | False | Show ffmpeg command without executing |
 

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -5519,7 +5519,7 @@ def _run_ffmpeg_with_progress(
     total_frames: int,
     description: str = "Reencoding",
 ) -> None:
-    """Run ffmpeg command with progress bar.
+    """Run an ffmpeg command with a progress bar.
 
     Args:
         cmd: FFmpeg command as list of arguments.
@@ -5529,8 +5529,49 @@ def _run_ffmpeg_with_progress(
     Raises:
         click.ClickException: If ffmpeg fails.
     """
+    # Add progress flags to ffmpeg so it emits machine-readable progress on
+    # stdout. Insert right after the ffmpeg executable path.
+    # Note: -stats_period not supported in ffmpeg 4.x, use -progress alone.
+    cmd_with_progress = cmd.copy()
+    cmd_with_progress[1:1] = ["-progress", "pipe:1"]
+
+    _run_subprocess_with_progress(cmd_with_progress, total_frames, description)
+
+
+def _run_subprocess_with_progress(
+    cmd: list[str],
+    total_frames: int,
+    description: str = "Reencoding",
+) -> None:
+    """Run a subprocess that streams ``frame=N`` progress on stdout.
+
+    The command is expected to write machine-readable progress (lines containing
+    ``frame=<n>``) to stdout. stderr is drained concurrently on a background
+    thread and only surfaced if the process fails.
+
+    .. note::
+
+        Draining stderr concurrently is required for correctness, not just
+        tidiness. ffmpeg writes its banner, stream info, and periodic stats to
+        stderr even with ``-progress pipe:1``. If only stdout is read, the
+        stderr pipe buffer fills (~4 KB on Windows, ~64 KB on Linux), ffmpeg
+        blocks on the stderr write, stops emitting stdout progress, and the
+        ``readline()`` below parks forever -- the progress bar freezes (often at
+        frame 0) while the rich spinner, which animates on its own thread, keeps
+        spinning. Reading stderr on a separate thread keeps the child unblocked.
+
+    Args:
+        cmd: Full command to run, including any progress flags.
+        total_frames: Total number of frames for progress tracking.
+        description: Description for the progress bar.
+
+    Raises:
+        click.ClickException: If the subprocess exits with a non-zero code.
+        click.Abort: If interrupted by the user (Ctrl+C).
+    """
     import re
     import subprocess
+    import threading
 
     from rich.progress import (
         BarColumn,
@@ -5542,52 +5583,69 @@ def _run_ffmpeg_with_progress(
         TimeRemainingColumn,
     )
 
-    # Add progress flag to ffmpeg
-    cmd_with_progress = cmd.copy()
-    # Insert progress flags after the ffmpeg executable path
-    # Note: -stats_period not supported in ffmpeg 4.x, use -progress alone
-    progress_flags = ["-progress", "pipe:1"]
-    cmd_with_progress[1:1] = progress_flags
-
     process = subprocess.Popen(
-        cmd_with_progress,
+        cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
         bufsize=1,
     )
 
-    # Progress bar
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(),
-        MofNCompleteColumn(),
-        TimeElapsedColumn(),
-        TimeRemainingColumn(),
-        console=console,
-    ) as progress:
-        task = progress.add_task(description, total=total_frames)
+    # Drain stderr on a background thread to avoid a pipe-buffer deadlock (see
+    # the note in this function's docstring).
+    stderr_lines: list[str] = []
 
-        # Parse ffmpeg progress output
-        frame_pattern = re.compile(r"frame=(\d+)")
+    def _drain_stderr() -> None:
+        # process.stderr is always a pipe here (we passed stderr=PIPE).
+        for line in process.stderr:  # type: ignore[union-attr]
+            stderr_lines.append(line)
 
-        while True:
-            line = process.stdout.readline()
-            if not line and process.poll() is not None:
-                break
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
 
-            match = frame_pattern.search(line)
-            if match:
-                current_frame = int(match.group(1))
-                progress.update(task, completed=current_frame)
+    # Parse progress output (e.g. ffmpeg's `frame=<n>`).
+    frame_pattern = re.compile(r"frame=(\d+)")
 
-        progress.update(task, completed=total_frames)
+    try:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            TimeRemainingColumn(),
+            console=console,
+        ) as progress:
+            task = progress.add_task(description, total=total_frames)
+
+            while True:
+                line = process.stdout.readline()  # type: ignore[union-attr]
+                if not line and process.poll() is not None:
+                    break
+
+                match = frame_pattern.search(line)
+                if match:
+                    current_frame = int(match.group(1))
+                    progress.update(task, completed=current_frame)
+
+            progress.update(task, completed=total_frames)
+    except KeyboardInterrupt:
+        # Don't leave the child running after a Ctrl+C; tear it down and abort.
+        process.kill()
+        process.wait()
+        stderr_thread.join(timeout=5)
+        raise click.Abort()
+    finally:
+        # Safety net: never leave a child process behind.
+        if process.poll() is None:
+            process.kill()
+            process.wait()
 
     # Check for errors
     returncode = process.wait()
+    stderr_thread.join(timeout=5)
     if returncode != 0:
-        stderr = process.stderr.read()
+        stderr = "".join(stderr_lines)
         raise click.ClickException(f"ffmpeg failed (exit code {returncode}):\n{stderr}")
 
 

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -6194,6 +6194,13 @@ def _reencode_slp(
     default=False,
     help="Overwrite existing output file.",
 )
+@click.option(
+    "--replace",
+    is_flag=True,
+    default=False,
+    help="Reencode in place: replace the input with {stem}.mp4 and delete the "
+    "original. Mutually exclusive with -o/--output.",
+)
 def reencode(
     input_arg: Path | None,
     input_opt: Path | None,
@@ -6207,6 +6214,7 @@ def reencode(
     use_ffmpeg: bool | None,
     dry_run: bool,
     overwrite: bool,
+    replace: bool,
 ) -> None:
     """Reencode video for improved seekability.
 
@@ -6246,6 +6254,10 @@ def reencode(
 
         $ sio reencode recording.seq -o recording.mp4
 
+        $ sio reencode video.mp4                 # -> video.reencoded.mp4
+
+        $ sio reencode video.mov --replace       # -> video.mp4 (deletes video.mov)
+
     [dim]SLP batch examples:[/]
 
         $ sio reencode project.slp -o project.reencoded.slp
@@ -6256,6 +6268,19 @@ def reencode(
     """
     # Resolve input path
     input_path = _resolve_input(input_arg, input_opt, "input file")
+
+    # --replace is an in-place destructive reencode of a single video; it is
+    # incompatible with -o/--output and with SLP batch mode.
+    if replace and output_path is not None:
+        raise click.ClickException(
+            "Cannot use --replace together with -o/--output. "
+            "--replace reencodes the input file in place."
+        )
+    if replace and input_path.suffix.lower() == ".slp":
+        raise click.ClickException(
+            "--replace is not supported for SLP files. "
+            "Use the SLP batch mode with an explicit -o/--output path."
+        )
 
     # Check if input is an SLP file - route to batch processing
     if input_path.suffix.lower() == ".slp":
@@ -6307,24 +6332,40 @@ def reencode(
         )
         return
 
-    # Resolve output path for video files
-    if output_path is None:
-        output_path = input_path.with_stem(f"{input_path.stem}.reencoded")
-        if output_path.suffix.lower() not in {".mp4", ".mkv", ".avi", ".mov"}:
-            output_path = output_path.with_suffix(".mp4")
+    # Resolve the final output path. Reencoding always produces an H.264/MP4
+    # file, so the default output uses a .mp4 extension regardless of the input
+    # container; the `.reencoded` infix keeps it distinct from the source (even
+    # for .mp4 inputs).
+    if replace:
+        final_path = input_path.with_name(f"{input_path.stem}.mp4")
+    elif output_path is None:
+        final_path = input_path.with_name(f"{input_path.stem}.reencoded.mp4")
+    else:
+        final_path = output_path
 
-    # Check for same file
-    if output_path.resolve() == input_path.resolve():
-        raise click.ClickException(
-            f"Output path cannot be the same as input: {input_path}\n"
-            "Use a different output path or rename the output file."
-        )
+    same_as_input = final_path.resolve() == input_path.resolve()
 
-    # Check output exists
-    if output_path.exists() and not overwrite:
-        raise click.ClickException(
-            f"Output file already exists: {output_path}\nUse --overwrite to replace it."
-        )
+    if replace:
+        # Guard against silently clobbering a *different* existing file at the
+        # target name (e.g. foo.mov -> foo.mp4 where an unrelated foo.mp4 exists).
+        if not same_as_input and final_path.exists() and not overwrite:
+            raise click.ClickException(
+                f"Target already exists: {final_path}\n"
+                "Use --overwrite to replace it (or drop --replace)."
+            )
+    else:
+        # Check for same file
+        if same_as_input:
+            raise click.ClickException(
+                f"Output path cannot be the same as input: {input_path}\n"
+                "Use --replace to reencode in place, or choose another output."
+            )
+        # Check output exists
+        if final_path.exists() and not overwrite:
+            raise click.ClickException(
+                f"Output file already exists: {final_path}\n"
+                "Use --overwrite to replace it."
+            )
 
     # Resolve quality/CRF
     if crf is not None and quality is not None:
@@ -6364,87 +6405,132 @@ def reencode(
         else (ffmpeg_available if use_ffmpeg is None else use_ffmpeg)
     )
 
-    if use_ffmpeg_path:
-        # FFmpeg fast path
-        try:
-            metadata = _get_video_metadata(input_path)
-            input_fps = metadata["fps"]
-            total_frames = metadata["num_frames"]
+    # Capture the original size now, before a (possibly destructive) --replace.
+    original_input_size = input_path.stat().st_size
 
-            # Resolve keyframe interval / GOP
-            if gop is not None:
-                # Convert GOP to interval for display
-                effective_fps = output_fps if output_fps is not None else input_fps
-                resolved_keyframe_interval = gop / effective_fps
-            else:
-                resolved_keyframe_interval = keyframe_interval
+    # Decide where the encoder actually writes. For --replace we encode to a temp
+    # file in the destination directory and atomically move it over the input
+    # afterwards; ffmpeg cannot read and write the same file in one pass.
+    import os
+    import tempfile
 
-            # Build command
-            cmd = _build_ffmpeg_reencode_command(
+    if replace:
+        if dry_run:
+            console.print("[bold]Dry run - would reencode in place:[/]")
+            console.print(f"  Input:  {input_path}")
+            console.print(f"  Output: {final_path}")
+            if not same_as_input:
+                console.print(f"  Then delete original: {input_path}")
+            return
+
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{final_path.stem}_reencode_",
+            suffix=".mp4",
+            dir=str(final_path.parent),
+        )
+        os.close(fd)
+        encode_path = Path(tmp_name)
+        encode_overwrite = True  # temp file already exists (0 bytes from mkstemp)
+    else:
+        encode_path = final_path
+        encode_overwrite = overwrite
+
+    try:
+        if use_ffmpeg_path:
+            # FFmpeg fast path
+            try:
+                metadata = _get_video_metadata(input_path)
+                input_fps = metadata["fps"]
+                total_frames = metadata["num_frames"]
+
+                # Resolve keyframe interval / GOP
+                if gop is not None:
+                    # Convert GOP to interval for display
+                    effective_fps = output_fps if output_fps is not None else input_fps
+                    resolved_keyframe_interval = gop / effective_fps
+                else:
+                    resolved_keyframe_interval = keyframe_interval
+
+                # Build command
+                cmd = _build_ffmpeg_reencode_command(
+                    input_path=input_path,
+                    output_path=encode_path,
+                    fps=input_fps,
+                    output_fps=output_fps,
+                    crf=resolved_crf,
+                    preset=preset,
+                    keyframe_interval=resolved_keyframe_interval,
+                    overwrite=encode_overwrite,
+                )
+
+                if dry_run:
+                    console.print("[bold]Dry run - ffmpeg command:[/]")
+                    console.print(" ".join(cmd))
+                    return
+
+                # Print info
+                console.print(f"[bold]Reencoding:[/] {input_path}")
+                console.print(f"[dim]  Output: {final_path}[/]")
+                console.print(
+                    f"[dim]  Quality: CRF {resolved_crf}, "
+                    f"Preset: {preset}, "
+                    f"Keyframes: {resolved_keyframe_interval}s[/]"
+                )
+                if output_fps is not None:
+                    console.print(f"[dim]  FPS: {input_fps} -> {output_fps}[/]")
+
+                # Run ffmpeg with progress
+                _run_ffmpeg_with_progress(cmd, total_frames)
+
+            except click.ClickException:
+                raise
+            except Exception as e:
+                raise click.ClickException(f"ffmpeg reencoding failed: {e}")
+
+        else:
+            # Python fallback path
+            if dry_run:
+                console.print("[bold]Dry run - would use Python path[/]")
+                console.print(f"  Input: {input_path}")
+                console.print(f"  Output: {final_path}")
+                console.print(f"  CRF: {resolved_crf}, Preset: {preset}")
+                return
+
+            console.print(f"[bold]Reencoding (Python path):[/] {input_path}")
+            console.print(f"[dim]  Output: {final_path}[/]")
+
+            _reencode_python_path(
                 input_path=input_path,
-                output_path=output_path,
-                fps=input_fps,
+                output_path=encode_path,
                 output_fps=output_fps,
                 crf=resolved_crf,
                 preset=preset,
-                keyframe_interval=resolved_keyframe_interval,
-                overwrite=overwrite,
+                keyframe_interval=keyframe_interval,
             )
 
-            if dry_run:
-                console.print("[bold]Dry run - ffmpeg command:[/]")
-                console.print(" ".join(cmd))
-                return
+        # For --replace, move the freshly encoded temp file over the final path
+        # and remove the original source if the extension/name changed.
+        if replace:
+            os.replace(encode_path, final_path)
+            if not same_as_input:
+                input_path.unlink()
+    except BaseException:
+        # Clean up the temp file on any failure or interruption.
+        if replace and encode_path != final_path and encode_path.exists():
+            try:
+                encode_path.unlink()
+            except OSError:
+                pass
+        raise
 
-            # Print info
-            console.print(f"[bold]Reencoding:[/] {input_path}")
-            console.print(f"[dim]  Output: {output_path}[/]")
-            console.print(
-                f"[dim]  Quality: CRF {resolved_crf}, "
-                f"Preset: {preset}, "
-                f"Keyframes: {resolved_keyframe_interval}s[/]"
-            )
-            if output_fps is not None:
-                console.print(f"[dim]  FPS: {input_fps} -> {output_fps}[/]")
-
-            # Run ffmpeg with progress
-            _run_ffmpeg_with_progress(cmd, total_frames)
-
-        except click.ClickException:
-            raise
-        except Exception as e:
-            raise click.ClickException(f"ffmpeg reencoding failed: {e}")
-
-    else:
-        # Python fallback path
-        if dry_run:
-            console.print("[bold]Dry run - would use Python path[/]")
-            console.print(f"  Input: {input_path}")
-            console.print(f"  Output: {output_path}")
-            console.print(f"  CRF: {resolved_crf}, Preset: {preset}")
-            return
-
-        console.print(f"[bold]Reencoding (Python path):[/] {input_path}")
-        console.print(f"[dim]  Output: {output_path}[/]")
-
-        _reencode_python_path(
-            input_path=input_path,
-            output_path=output_path,
-            output_fps=output_fps,
-            crf=resolved_crf,
-            preset=preset,
-            keyframe_interval=keyframe_interval,
-        )
-
-    console.print(f"[bold green]Saved:[/] {output_path}")
+    console.print(f"[bold green]Saved:[/] {final_path}")
 
     # Show file size comparison
-    input_size = input_path.stat().st_size
-    output_size = output_path.stat().st_size
-    size_change = (output_size - input_size) / input_size * 100
+    output_size = final_path.stat().st_size
+    size_change = (output_size - original_input_size) / original_input_size * 100
 
     console.print(
-        f"[dim]  Size: {_format_file_size(input_size)} -> "
+        f"[dim]  Size: {_format_file_size(original_input_size)} -> "
         f"{_format_file_size(output_size)} "
         f"({size_change:+.1f}%)[/]"
     )

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -8440,6 +8440,149 @@ def test_run_subprocess_with_progress_reports_stderr_on_failure():
     assert "BOOM_MARKER" in str(error)
 
 
+def test_reencode_default_output_forces_mp4(tmp_path, centered_pair_low_quality_path):
+    """Default output is always .mp4, even for a non-mp4 input container."""
+    import shutil
+
+    clip = tmp_path / "clip.mov"
+    shutil.copy(centered_pair_low_quality_path, clip)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["reencode", str(clip), "--dry-run"])
+    assert result.exit_code == 0, _strip_ansi(result.output)
+    output = _strip_ansi(result.output)
+
+    assert "clip.reencoded.mp4" in output
+    assert "clip.reencoded.mov" not in output
+
+
+def test_reencode_replace_dry_run_in_place(tmp_path, centered_pair_low_quality_path):
+    """--replace --dry-run on a .mp4 reports in-place replacement, no deletion."""
+    import shutil
+
+    clip = tmp_path / "clip.mp4"
+    shutil.copy(centered_pair_low_quality_path, clip)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["reencode", str(clip), "--replace", "--dry-run"])
+    assert result.exit_code == 0, _strip_ansi(result.output)
+    output = _strip_ansi(result.output)
+
+    assert "reencode in place" in output.lower()
+    assert "clip.mp4" in output
+    # Same path in and out -> nothing to delete.
+    assert "delete original" not in output.lower()
+    # Dry run must not touch anything.
+    assert clip.exists()
+    assert not list(tmp_path.glob(".*reencode*"))
+
+
+def test_reencode_replace_dry_run_changes_extension(
+    tmp_path, centered_pair_low_quality_path
+):
+    """--replace --dry-run on a .mov targets {stem}.mp4 and deletes the original."""
+    import shutil
+
+    clip = tmp_path / "clip.mov"
+    shutil.copy(centered_pair_low_quality_path, clip)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["reencode", str(clip), "--replace", "--dry-run"])
+    assert result.exit_code == 0, _strip_ansi(result.output)
+    output = _strip_ansi(result.output)
+
+    assert "clip.mp4" in output
+    assert "delete original" in output.lower()
+    assert "clip.mov" in output
+    assert clip.exists()  # dry run keeps the original
+
+
+def test_reencode_replace_conflicts_with_output(
+    tmp_path, centered_pair_low_quality_path
+):
+    """--replace and -o/--output are mutually exclusive."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "reencode",
+            centered_pair_low_quality_path,
+            "--replace",
+            "-o",
+            str(tmp_path / "out.mp4"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "Cannot use --replace together with -o" in _strip_ansi(result.output)
+
+
+def test_reencode_replace_slp_error(tmp_path, slp_real_data):
+    """--replace is rejected for SLP inputs."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["reencode", slp_real_data, "--replace"])
+    assert result.exit_code != 0
+    assert "not supported for SLP" in _strip_ansi(result.output)
+
+
+def test_reencode_replace_existing_target_requires_overwrite(
+    tmp_path, centered_pair_low_quality_path
+):
+    """--replace won't clobber a *different* existing {stem}.mp4 without --overwrite."""
+    import shutil
+
+    clip = tmp_path / "clip.mov"
+    shutil.copy(centered_pair_low_quality_path, clip)
+    # An unrelated file already occupies the target name.
+    (tmp_path / "clip.mp4").write_text("do not clobber me")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["reencode", str(clip), "--replace"])
+    assert result.exit_code != 0
+    assert "Target already exists" in _strip_ansi(result.output)
+    # Original and existing target both untouched.
+    assert clip.exists()
+    assert (tmp_path / "clip.mp4").read_text() == "do not clobber me"
+
+
+@skip_slow_video_on_windows
+def test_reencode_replace_in_place_mp4(tmp_path, centered_pair_low_quality_path):
+    """--replace reencodes a .mp4 in place (same filename), no temp/extra files."""
+    import shutil
+
+    clip = tmp_path / "clip.mp4"
+    shutil.copy(centered_pair_low_quality_path, clip)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["reencode", str(clip), "--replace"])
+    assert result.exit_code == 0, _strip_ansi(result.output)
+
+    assert clip.exists()
+    assert clip.stat().st_size > 0
+    # No side-car output and no leftover temp file.
+    assert not (tmp_path / "clip.reencoded.mp4").exists()
+    assert not list(tmp_path.glob(".*reencode*"))
+
+
+@skip_slow_video_on_windows
+def test_reencode_replace_deletes_original_on_extension_change(
+    tmp_path, centered_pair_low_quality_path
+):
+    """--replace on a .mov produces {stem}.mp4 and deletes the original .mov."""
+    import shutil
+
+    clip = tmp_path / "clip.mov"
+    shutil.copy(centered_pair_low_quality_path, clip)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["reencode", str(clip), "--replace"])
+    assert result.exit_code == 0, _strip_ansi(result.output)
+
+    assert (tmp_path / "clip.mp4").exists()
+    assert (tmp_path / "clip.mp4").stat().st_size > 0
+    assert not clip.exists()  # original .mov removed
+    assert not list(tmp_path.glob(".*reencode*"))
+
+
 @skip_slow_video_on_windows
 def test_reencode_with_quality(tmp_path, centered_pair_low_quality_path):
     """Test reencoding with quality option."""

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 
 import re
 import sys
+import threading
 from pathlib import Path
 
+import click
 import h5py
 import numpy as np
 import pytest
@@ -21,6 +23,7 @@ from sleap_io.io.cli import (
     _load_images,
     _load_overlay,
     _parse_overlay_outline_color,
+    _run_subprocess_with_progress,
     cli,
 )
 from sleap_io.model.instance import Instance, PredictedInstance
@@ -8361,6 +8364,80 @@ def test_reencode_basic(tmp_path, centered_pair_low_quality_path):
     assert "Saved:" in output
     assert output_path.exists()
     assert output_path.stat().st_size > 0
+
+
+# Build a stand-in for ffmpeg: a child that writes far more to stderr than any OS
+# pipe buffer (~4 KB Windows / ~64 KB Linux) while emitting `frame=N` progress on
+# stdout. Under the old undrained-stderr code the child blocks on the stderr write
+# and the progress reader deadlocks; with concurrent stderr draining it completes.
+_FAKE_FFMPEG_OK = (
+    "import sys\n"
+    "chunk = 'e' * 4000\n"  # ~4 KB of stderr per frame -> ~320 KB total
+    "for i in range(1, 81):\n"
+    "    sys.stderr.write(chunk + '\\n'); sys.stderr.flush()\n"
+    "    sys.stdout.write('frame=%d\\n' % i); sys.stdout.flush()\n"
+    "sys.exit(0)\n"
+)
+
+_FAKE_FFMPEG_FAIL = (
+    "import sys\n"
+    "chunk = 'x' * 4000\n"
+    "for i in range(1, 51):\n"
+    "    sys.stderr.write(chunk + '\\n'); sys.stderr.flush()\n"
+    "    sys.stdout.write('frame=%d\\n' % i); sys.stdout.flush()\n"
+    "sys.stderr.write('BOOM_MARKER\\n'); sys.stderr.flush()\n"
+    "sys.exit(3)\n"
+)
+
+
+def _run_in_guard_thread(fn, timeout: float = 60.0):
+    """Run ``fn`` in a daemon thread so a deadlock fails the test, not hangs it.
+
+    Returns a tuple ``(finished, error)`` where ``finished`` is False if the call
+    did not return within ``timeout`` (i.e. it deadlocked) and ``error`` is any
+    exception raised by ``fn`` (or None).
+    """
+    done = threading.Event()
+    box: list[BaseException] = []
+
+    def runner() -> None:
+        try:
+            fn()
+        except BaseException as e:  # noqa: BLE001 - surface any failure to caller
+            box.append(e)
+        finally:
+            done.set()
+
+    threading.Thread(target=runner, daemon=True).start()
+    finished = done.wait(timeout=timeout)
+    return finished, (box[0] if box else None)
+
+
+def test_run_subprocess_with_progress_drains_stderr_no_deadlock():
+    """Regression: large stderr must not deadlock the progress reader.
+
+    Reproduces the `sio reencode` hang where the progress bar froze at frame 0
+    (spinner still animating) because stderr was never drained while ffmpeg
+    filled the OS pipe buffer.
+    """
+    cmd = [sys.executable, "-c", _FAKE_FFMPEG_OK]
+    finished, error = _run_in_guard_thread(
+        lambda: _run_subprocess_with_progress(cmd, total_frames=80, description="t")
+    )
+    assert finished, "deadlocked: stderr was not drained concurrently"
+    assert error is None, f"unexpected error: {error!r}"
+
+
+def test_run_subprocess_with_progress_reports_stderr_on_failure():
+    """A non-zero exit raises ClickException with the (drained) stderr, no hang."""
+    cmd = [sys.executable, "-c", _FAKE_FFMPEG_FAIL]
+    finished, error = _run_in_guard_thread(
+        lambda: _run_subprocess_with_progress(cmd, total_frames=50, description="t")
+    )
+    assert finished, "deadlocked on the failure path"
+    assert isinstance(error, click.ClickException)
+    assert "exit code 3" in str(error)
+    assert "BOOM_MARKER" in str(error)
 
 
 @skip_slow_video_on_windows


### PR DESCRIPTION
## Summary

Fixes a hard hang in `sio reencode` and adds two requested UX enhancements. Three logical changes (separate commits):

1. **fix:** `sio reencode` (ffmpeg path) could hang **forever at `0/X frames`** — spinner still animating, **Ctrl+C unresponsive**.
2. **feat:** default output is now always `{stem}.reencoded.mp4` (no longer keeps `.mov`/`.mkv`/`.avi`).
3. **feat:** new `--replace` flag for destructive in-place reencode.

---

## 1. The deadlock (root cause)

`_run_ffmpeg_with_progress` ran ffmpeg with `stderr=subprocess.PIPE` but, during the encode, only read **stdout** (`-progress pipe:1`); stderr was read **only after** the process exited. ffmpeg still writes its banner, stream info, and periodic `frame= fps=` stats to **stderr** even with `-progress pipe:1`. Once the stderr pipe buffer fills, ffmpeg blocks on the stderr write → it stops emitting stdout progress → `stdout.readline()` blocks forever. The **spinner keeps spinning because rich animates on a separate thread**, masking the dead main thread; Ctrl+C can't be delivered while the main thread is parked in a blocking pipe read.

### Measured (real `drone-clip.mov`, HEVC 1080p60, 11.46s)

| Probe | Value |
|---|---|
| Windows anonymous-pipe buffer | **4096 bytes** |
| ffmpeg startup stderr (banner + input info) | **2443 bytes** |
| total stderr for the full encode | **5838 bytes** (> 4096 → blocks before first progress flush → stuck at frame 0) |
| Old code on the real file (watchdog) | **DEADLOCK at frame 0** |
| Fixed code | ✅ 688 frames in ~2.7s |

Hit on essentially any real-length video; worse on Windows (4 KB pipe buffer vs Linux's 64 KB), which is why short CI fixtures never tripped it.

### Fix
- Split out **`_run_subprocess_with_progress`** (testable core) from `_run_ffmpeg_with_progress` (which just inserts the progress flags and delegates).
- **Drain stderr concurrently** on a background thread (kept for error reporting) so ffmpeg never blocks.
- **Tear down the child on `KeyboardInterrupt`** (+ `finally` safety net) so Ctrl+C aborts cleanly instead of orphaning ffmpeg.

## 2. Default output is always `.mp4`

Reencoding always produces H.264/MP4, so keeping the source container extension on the output was misleading. The default is now `{stem}.reencoded.mp4` regardless of input (the `.reencoded` infix keeps it distinct even for `.mp4` inputs). Explicit `-o` is still honored as-is.

## 3. `--replace` (destructive in-place reencode)

```
sio reencode foo.mov --replace   -> foo.mp4   (deletes foo.mov)
sio reencode foo.mp4 --replace   -> foo.mp4   (replaced in place)
```

Encodes to a temp file in the destination directory, then **atomically** `os.replace`s it over `{stem}.mp4`, deleting the original when the extension changes (ffmpeg can't read+write the same file in one pass). The temp file is cleaned up on failure/interrupt. `--replace` is **mutually exclusive with `-o/--output`** and **unsupported for SLP** inputs; clobbering an *unrelated* existing `{stem}.mp4` still requires `--overwrite`.

## Testing

- **Deadlock regression** (`test_run_subprocess_with_progress_*`): feed a stand-in child emitting more stderr than any OS pipe buffer while streaming `frame=N`, run in a guard thread so a regression *fails* (not hangs) the test. Verified these **deadlock under the old code** and pass under the fix.
- **`--replace` / `.mp4` default**: dry-run path/messaging, `-o` conflict, SLP rejection, existing-target `--overwrite` guard, plus real in-place (`.mp4`) and extension-change (`.mov`→`.mp4`, original deleted) encodes (the two real encodes are `skipif win32` like the other slow video tests, but were verified manually on Windows here).
- Full `reencode` suite green; lint clean. (One unrelated CSV-export test fails locally on a terminal-width rich-panel quirk — pre-existing on `main`.)
- End-to-end re-verified on the real `drone-clip.mov`: 688/688 frames in ~3s.

## Design decisions

- **Drain (not suppress) stderr:** keeps ffmpeg's error text available on failure; we just read it concurrently. `-nostats`/`-loglevel error` would only reduce, not eliminate, the deadlock risk.
- **Refactor for testability:** the helper takes an already-built command so tests inject a fake `frame=`-emitting child without ffmpeg-specific flag insertion poisoning the command — no mocking/monkeypatching.
- **Separate `--replace` (not overloading `--overwrite`):** `--overwrite` keeps its existing "clobber an existing output" meaning; `--replace` is the distinct in-place operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)