### PR TITLE
ci: faster coverage core (sysmon) on py3.13 + raise test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
   tests:
     needs: changes
     if: needs.changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
-    timeout-minutes: 30  # Allow buffer for Windows (video encoding tests skipped)
+    timeout-minutes: 60  # Buffer for GitHub windows-runner variance (suite is ~4-6 min real)
     strategy:
       fail-fast: false
       matrix:
@@ -109,6 +109,11 @@ jobs:
           sudo apt-get update && sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1 libglx-mesa0
 
       - name: Test with pytest (with coverage)
+        env:
+          # Use coverage's fast PEP 669 sys.monitoring core on Python 3.12+
+          # (much lower overhead than the settrace-based C tracer). Empty on
+          # 3.10 -> coverage's default core.
+          COVERAGE_CORE: ${{ matrix.python == '3.13' && 'sysmon' || '' }}
         run: |
           uv run pytest --cov=sleap_io --cov-report=xml --durations=-1 tests/
 


### PR DESCRIPTION
## Summary

The `tests` job in `.github/workflows/ci.yml` had `timeout-minutes: 30`. The full suite is genuinely fast (~4-6 min locally on py3.13-windows with coverage), but GitHub's windows-py3.13 runner intermittently runs the same suite in ~29 min due to runner variance, tipping over the 30-min timeout and cancelling the job. A cancelled `tests` job fails the required `CI` check and blocks all PR merges.

## Diagnosis

- Suite runs in ~4-6 min locally (py3.13-windows, with coverage).
- CI's windows-py3.13 job intermittently hit the old 30-min timeout purely from runner variance, not from a real slowdown in the tests.
- The cancellation cascaded into the required `CI` aggregate check, blocking merges.

## Key Changes

- **Raise `timeout-minutes` 30 -> 60** on the `tests` job to absorb runner variance.
- **Set `COVERAGE_CORE=sysmon` on Python 3.13** so coverage uses the fast PEP 669 `sys.monitoring` core (much lower overhead than the settrace-based C tracer). This is available on Python 3.12+. On 3.10 the var is empty, so coverage uses its default core.

## Testing

- Verified locally: `COVERAGE_CORE=sysmon` works on 3.13; empty `COVERAGE_CORE` on 3.10 falls back to coverage's default core (both confirmed OK).
- YAML validated with `yaml.safe_load`.

## Notes

This PR only changes `.github/workflows/ci.yml`, which is in the `code` path filter, so the test matrix should run and validate the timeout/sysmon change end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6ZBs7Yww49sCmFF6XSSHs