### PR TITLE
fix(model): count ROIs in LabeledFrame.is_user_labeled (L6)

### DIFF
--- a/sleap_io/model/labeled_frame.py
+++ b/sleap_io/model/labeled_frame.py
@@ -436,7 +436,7 @@ class LabeledFrame:
 
         This property indicates whether the frame represents intentional user
         annotation, either through labeled instances, user annotations
-        (centroids, bboxes, masks, label images), or explicit marking as a
+        (centroids, bboxes, ROIs, masks, label images), or explicit marking as a
         negative/background frame.
         """
         from sleap_io.model.label_image import PredictedLabelImage
@@ -447,6 +447,7 @@ class LabeledFrame:
             or self.is_negative
             or any(not c.is_predicted for c in self.centroids)
             or any(not b.is_predicted for b in self.bboxes)
+            or any(not r.is_predicted for r in self.rois)
             or any(not isinstance(m, PredictedSegmentationMask) for m in self.masks)
             or any(not isinstance(li, PredictedLabelImage) for li in self.label_images)
         )

--- a/tests/model/test_labeled_frame.py
+++ b/tests/model/test_labeled_frame.py
@@ -1289,6 +1289,23 @@ def test_labeled_frame_is_user_labeled_with_annotations():
     assert not lf2.is_user_labeled
 
 
+def test_labeled_frame_is_user_labeled_with_rois():
+    """is_user_labeled is True for a UserROI-only frame, False for predicted-only."""
+    from sleap_io.model.roi import PredictedROI, UserROI
+
+    video = Video(filename="test.mp4", open_backend=False)
+
+    # Frame with only a user ROI — is user labeled (regression for L6).
+    roi_user = UserROI.from_bbox(0, 0, 10, 10)
+    lf = LabeledFrame(video=video, frame_idx=0, rois=[roi_user])
+    assert lf.is_user_labeled
+
+    # Frame with only a predicted ROI — not user labeled.
+    roi_pred = PredictedROI.from_bbox(0, 0, 10, 10, score=0.5)
+    lf2 = LabeledFrame(video=video, frame_idx=1, rois=[roi_pred])
+    assert not lf2.is_user_labeled
+
+
 def test_labeled_frame_remove_predictions_annotations():
     """remove_predictions removes predicted annotations from frame."""
     from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox


### PR DESCRIPTION
## Summary
Fixes audit finding **L6**: `LabeledFrame.is_user_labeled` checked instances, centroids, bboxes, masks, and label images, but **omitted `rois`** — so a frame with only a `UserROI` reported `False` and was excluded from user-labeled selection (e.g. `Labels` training-data export/embedding at `labels.py`).

## Change
- `is_user_labeled` now also returns `True` when the frame has any non-predicted ROI (`any(not r.is_predicted for r in self.rois)`), mirroring the existing centroid/bbox clauses. Docstring updated to mention ROIs.

## Testing
- New focused test `test_labeled_frame_is_user_labeled_with_rois`: a `UserROI`-only frame is user-labeled; a `PredictedROI`-only frame is not.

Deferred low-severity finding from the 0.8.0 preflight audit (post-release cleanup).