### PR TITLE
fix(cli): clean error for non-integer transform index prefix (L14)

### DIFF
--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -7004,7 +7004,14 @@ def _parse_transform_param(
     """
     if ":" in value:
         idx_str, param = value.split(":", 1)
-        return int(idx_str), param
+        try:
+            return int(idx_str), param
+        except ValueError:
+            raise click.ClickException(
+                f"Invalid transform parameter {value!r}: the part before ':' must be "
+                "an integer video index. Expected '[idx:]value' "
+                "(e.g. '100,100,200,200' or '0:100,100,200,200')."
+            )
     return None, value
 
 

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -10595,6 +10595,25 @@ def test_transform_parse_fill_value_invalid():
         _parse_fill_value("abc")
 
 
+def test_parse_transform_param_with_index():
+    """_parse_transform_param parses an optional integer video-index prefix."""
+    from sleap_io.io.cli import _parse_transform_param
+
+    assert _parse_transform_param("100,100,200,200") == (None, "100,100,200,200")
+    assert _parse_transform_param("0:100,100,200,200") == (0, "100,100,200,200")
+    assert _parse_transform_param("12:2.0") == (12, "2.0")
+
+
+def test_parse_transform_param_invalid_index_raises_clickexception():
+    """Non-integer index prefix raises ClickException, not raw ValueError (L14)."""
+    import click
+
+    from sleap_io.io.cli import _parse_transform_param
+
+    with pytest.raises(click.ClickException, match="integer video index"):
+        _parse_transform_param("foo:1,2,3,4")
+
+
 def test_transform_fill_rgb_option(tmp_path, slp_real_data):
     """Test transform with RGB fill value."""
     runner = CliRunner()


### PR DESCRIPTION
## Summary
Fixes audit finding **L14**: `_parse_transform_param` (used by `sio transform`'s `--crop`/`--scale`/`--rotate`/`--pad`) did an unguarded `int(idx_str)` on the optional `idx:` prefix. A non-integer prefix (e.g. `--crop "foo:1,2,3,4"`) raised a bare `ValueError` — an **uncaught traceback** on the video branch and an unhelpful raw message on the SLP branch.

## Change
- Wrap the `int()` and raise a clear `click.ClickException` describing the expected `[idx:]value` form (mirrors the existing `_parse_fill_value` pattern). Since both call sites surface `ClickException` cleanly, this fixes the traceback on both branches.

## Testing
- `test_parse_transform_param_with_index`: valid no-prefix and `idx:` parsing.
- `test_parse_transform_param_invalid_index_raises_clickexception`: a non-integer prefix raises `ClickException`, not `ValueError`.

Deferred low-severity finding from the 0.8.0 preflight audit.