### PR TITLE
fix(cli): clear error for --from dlc on a DLC project (L9)

### DIFF
--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -2186,6 +2186,19 @@ def convert(
                     f"Please specify --from with one of: {', '.join(INPUT_FORMATS)}"
                 )
 
+    # An explicit `--from dlc` pointed at a DLC *project* (config.yaml or a
+    # project directory) would misroute to the single-CSV reader and fail with a
+    # confusing parse error; guide the user to dlc_project instead (L9).
+    if resolved_input_format == "dlc":
+        from sleap_io.io import dlc as _dlc
+
+        if _dlc._is_dlc_project_path(input_path):
+            raise click.ClickException(
+                f"'{input_path.name}' looks like a DeepLabCut project, not a single "
+                "DLC annotation CSV. Use --from dlc_project (or omit --from to "
+                "auto-detect)."
+            )
+
     # Resolve output format
     resolved_output_format = output_format
     if resolved_output_format is None:

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -2245,6 +2245,25 @@ def test_infer_input_format_non_dlc_config_file(tmp_path):
     assert _infer_input_format(cfg) is None
 
 
+def test_convert_from_dlc_on_project_guides_to_dlc_project(tmp_path):
+    """`--from dlc` on a DLC project errors clearly, pointing to dlc_project (L9)."""
+    project = _make_dlc_project(tmp_path / "proj")
+    output = tmp_path / "out.slp"
+    runner = CliRunner()
+
+    # Both the project directory and its config.yaml, given explicitly as
+    # `--from dlc`, must fail with a clear pointer to dlc_project rather than
+    # misrouting to the single-CSV reader.
+    for inp in (str(project), str(project / "config.yaml")):
+        result = runner.invoke(
+            cli, ["convert", inp, "-o", str(output), "--from", "dlc"]
+        )
+        assert result.exit_code != 0, result.output
+        out = " ".join(_strip_ansi(result.output).split())
+        assert "dlc_project" in out
+        assert "DeepLabCut project" in out
+
+
 def test_convert_dlc_project_directory(tmp_path):
     """`sio convert <dlcproject>` auto-detects dlc_project and writes frames."""
     project = _make_dlc_project(tmp_path / "proj")


### PR DESCRIPTION
## Summary
Fixes audit finding **L9** (residual after #496): `sio convert <project> --from dlc` (directory or `config.yaml`) skipped the dlc_project auto-detection and routed a DLC **project** to the single-CSV `load_dlc` reader, failing with a confusing `Failed to load input file: Error tokenizing data...` (CSV parse error).

## Change
- In `convert`, after format resolution, if `--from dlc` is set but the input is actually a DLC project (`dlc._is_dlc_project_path(input_path)`), raise a clear `click.ClickException` directing the user to `--from dlc_project` (or to omit `--from` for auto-detection). Does not override the (correct) single-CSV `--from dlc` case.

## Testing
- `test_convert_from_dlc_on_project_guides_to_dlc_project`: both the project directory and its `config.yaml`, given as `--from dlc`, fail with a message naming `dlc_project`.

Deferred low-severity finding from the 0.8.0 preflight audit.