### PR TITLE
fix(io): preserve isolated-node order in standalone skeleton JSON (L3)

### DIFF
--- a/sleap_io/io/skeleton.py
+++ b/sleap_io/io/skeleton.py
@@ -236,29 +236,38 @@ class SkeletonDecoder:
                     symmetries.append(Symmetry([source_node, target_node]))
                     seen_symmetries.add(sym_key)
 
-        # Build nodes list from the nodes section
-        nodes = []
-        nodes_from_refs = []
+        # Build nodes list in the order declared by the nodes section. Map decoded
+        # Node objects by name so each nodes-array entry resolves back to the SAME
+        # object the edges reference — whether it is a ``py/id`` back-reference
+        # (link-connected node) or an inline ``py/object`` (an isolated/edge-less
+        # node, which was otherwise missed here and appended to the tail, dropping
+        # its declared position; see #438).
+        all_nodes = [obj for obj in self.decoded_objects if isinstance(obj, Node)]
+        node_by_name = {n.name: n for n in all_nodes}
 
-        # First collect nodes based on the nodes array
+        nodes_from_refs = []
         for node_ref in nodes_data:
-            if isinstance(node_ref["id"], dict) and "py/id" in node_ref["id"]:
-                py_id = node_ref["id"]["py/id"]
-                # Get node from decoded objects (py/id is 1-indexed)
+            ref_id = node_ref.get("id")
+            if not isinstance(ref_id, dict):
+                continue
+            if "py/id" in ref_id:
+                py_id = ref_id["py/id"]
+                # py/id is 1-indexed into the decoded objects.
                 if py_id <= len(self.decoded_objects):
                     obj = self.decoded_objects[py_id - 1]
                     if isinstance(obj, Node):
                         nodes_from_refs.append(obj)
-
-        # If we're missing nodes (due to malformed JSON), collect all Node objects
-        all_nodes = [obj for obj in self.decoded_objects if isinstance(obj, Node)]
+            elif "py/object" in ref_id:
+                # Isolated node declared inline; resolve to its canonical object.
+                name = self._decode_node(ref_id).name
+                if name in node_by_name:
+                    nodes_from_refs.append(node_by_name[name])
 
         if len(nodes_from_refs) < len(all_nodes):
-            # The nodes array is incomplete or includes non-nodes
-            # Use all nodes in their natural order
+            # Incomplete/malformed nodes array: fall back to natural order.
             nodes = all_nodes
         else:
-            # Use the order from the nodes array
+            # Use the declared nodes-array order (isolated nodes kept in slot).
             nodes = nodes_from_refs
 
         # Get skeleton name

--- a/tests/io/test_skeleton_io.py
+++ b/tests/io/test_skeleton_io.py
@@ -330,6 +330,34 @@ def test_round_trip_isolated_node():
     assert len(skeleton2.edges) == 1
 
 
+def test_round_trip_isolated_node_order():
+    """Isolated (edge-less) nodes keep their declared position on round-trip (L3)."""
+    # Isolated node first.
+    a, b, iso = sio.Node("a"), sio.Node("b"), sio.Node("iso")
+    skel = sio.Skeleton(nodes=[iso, a, b], edges=[sio.Edge(a, b)], name="iso_first")
+    decoded = decode_skeleton(encode_skeleton(skel))
+    assert [n.name for n in decoded.nodes] == ["iso", "a", "b"]
+
+    # Isolated node in the middle.
+    a2, b2, iso2 = sio.Node("a"), sio.Node("b"), sio.Node("iso")
+    skel2 = sio.Skeleton(nodes=[a2, iso2, b2], edges=[sio.Edge(a2, b2)], name="iso_mid")
+    decoded2 = decode_skeleton(encode_skeleton(skel2))
+    assert [n.name for n in decoded2.nodes] == ["a", "iso", "b"]
+
+
+def test_round_trip_isolated_node_order_with_symmetry():
+    """Isolated node keeps its declared slot alongside a symmetry edge (L3)."""
+    iso, left, right = sio.Node("iso"), sio.Node("L"), sio.Node("R")
+    skel = sio.Skeleton(
+        nodes=[iso, left, right],
+        symmetries=[sio.Symmetry([left, right])],
+        name="iso_sym",
+    )
+    decoded = decode_skeleton(encode_skeleton(skel))
+    assert [n.name for n in decoded.nodes] == ["iso", "L", "R"]
+    assert len(decoded.symmetries) == 1
+
+
 # File I/O tests using fixtures
 def test_load_minimal_skeleton_fixture(skeleton_json_minimal):
     """Test loading the minimal skeleton fixture."""


### PR DESCRIPTION
## Summary
Fixes audit finding **L3**: `save_skeleton`/`load_skeleton` (standalone jsonpickle JSON) moved isolated (edge-less) nodes to the end of the node list — e.g. `Skeleton([iso, a, b], edges=[a-b])` round-tripped to `[a, b, iso]`. The `.slp` path was unaffected, and #438 had already stopped the earlier node-*dropping*; this is the residual ordering bug.

## Root cause
The decoder's 'build nodes list' step resolved only `py/id` back-references from the nodes section. Isolated nodes are serialized inline as full `py/object` entries (not refs), so they were skipped, leaving `nodes_from_refs` short → the `all_nodes` natural-order fallback appended them last.

## Change
- Resolve **both** `py/id` references **and** inline `py/object` nodes (matched by name to the canonical decoded object the edges already reference), so the declared nodes-section order is preserved with isolated nodes kept in slot. The malformed-JSON natural-order fallback is retained.

## Testing
- New `test_round_trip_isolated_node_order`: iso-first `[iso, a, b]` and iso-middle `[a, iso, b]` both preserve order.
- Full `tests/io/test_skeleton_io.py` (59 tests) passes — no regression.

Deferred low-severity finding from the 0.8.0 preflight audit.