### PR TITLE
feat: per-instance Identity — persistence, merge, CLI (2/3)

### DIFF
--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -41,6 +41,8 @@ file.slp
 ├── /points                      # Dataset: User-labeled points (structured array)
 ├── /pred_points                 # Dataset: Predicted points (structured array)
 ├── /negative_frames             # Dataset: Negative frame markers (optional)
+├── /instance_identities         # Dataset: Per-instance global identity links (Format 2.5+)
+│                                 #   structured: instance_id, identity_idx, identity_score
 │
 ├── /bboxes/                     # Group: Columnar bounding box storage (Format 2.0+)
 │   ├── x1                       # Dataset: float64 top-left x
@@ -144,7 +146,8 @@ file.slp
 | `tracks_json` | `bytes[]` | JSON array of track definitions |
 | `suggestions_json` | `bytes[]` | JSON array of suggested frames (optional) |
 | `sessions_json` | `bytes[]` | JSON array of recording sessions (optional) |
-| `identities_json` | `bytes[]` | JSON array of identity definitions (optional) |
+| `identities_json` | `bytes[]` | JSON array of identity definitions, incl. stable `uuid` (optional) |
+| `instance_identities` | structured | Per-instance global identity links: `instance_id`, `identity_idx`, `identity_score` (Format 2.5+, optional) |
 | `provenance_json` | `bytes` | JSON object of provenance metadata (optional) |
 
 ### Provenance storage and the 64 KB metadata limit
@@ -544,15 +547,29 @@ Each identity is stored as a JSON object:
 ```json
 {
     "name": "mouse_A",
+    "uuid": "3f2a9c1e4b7d4e8a9c0d1e2f3a4b5c6d",
     "color": "#e6194b"
 }
 ```
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | `string` | Human-readable identity name |
+| `name` | `string` | Human-readable identity name (not required to be unique) |
+| `uuid` | `string` | Stable 32-char hex key — the canonical cross-file/merge matching key. Legacy files written before format 2.5 omit it; a fresh one is synthesized on load |
 | `color` | `string` | Optional hex color for visualization (omitted if null) |
 | *custom* | `any` | Additional metadata fields |
+
+### Per-Instance Linking
+
+Per-instance global identity assignments are stored in the optional `/instance_identities` structured dataset (Format 2.5+), joined to instances by the global `instance_id`:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `instance_id` | `int64` | Global instance id (enumeration order over frames then instances) |
+| `identity_idx` | `int32` | Index into `/identities_json` |
+| `identity_score` | `float32` | Identity-assignment score (NaN if unrecorded) |
+
+This is additive: old readers ignore the dataset, and instances without a global identity simply have no row.
 
 ### Instance Group Linking
 

--- a/docs/model/3d.md
+++ b/docs/model/3d.md
@@ -178,17 +178,20 @@ Key properties:
 
 ## Identity
 
-An `Identity` represents a ground-truth animal that can be recognized across videos, sessions, and experiments. Unlike [`Track`](poses.md) (an ephemeral temporal trajectory within a single video), `Identity` is persistent and can be shared across multiple recording sessions.
-
-In multi-view setups, multiple per-camera Tracks may map to a single Identity. The mapping is stored in `RecordingSession.metadata`.
+An `Identity` represents a ground-truth animal that can be recognized across videos, sessions, and experiments. Unlike [`Track`](poses.md) (an ephemeral, video-local temporal trajectory), `Identity` is the **global** re-identification key, persistent across recordings, sessions, and multi-view setups.
 
 Key properties:
 
-- `name` — human-readable name (e.g., `"mouse_A"`).
+- `name` — human-readable name (e.g., `"mouse_A"`). Not required to be unique.
+- `uuid` — a stable 32-character hex key, auto-generated per identity. This is the canonical cross-file matching key: it survives serialization and merges, where Python object identity (used by `Track`) and positional indices both fail.
 - `color` — optional hex color string for visualization.
-- `metadata` — arbitrary metadata dictionary.
+- `metadata` — arbitrary metadata dictionary (e.g. `species`/`sex`/`genotype`).
 
-Identities are stored at the top level on [`Labels.identities`](labels.md) and referenced by `InstanceGroup.identity`.
+Identities attach at three levels:
+
+- **Per instance** — [`Instance.identity`](poses.md) + `Instance.identity_score` assign a global identity to a detection (distinct from the short-term `track`/`tracking_score`).
+- **Per multi-view group** — `InstanceGroup.identity` binds the triangulated detections of one animal across cameras; the many per-camera `Track`s of an animal map to a single `Identity`.
+- **Top-level catalog** — [`Labels.identities`](labels.md) holds the canonical identity objects, auto-collected from instances.
 
 ```pycon
 >>> import sleap_io as sio
@@ -199,8 +202,20 @@ Identities are stored at the top level on [`Labels.identities`](labels.md) and r
 
 ```
 
+### Matching identities
+
+Compare identities with `matches()` (default `method="uuid"`), or configure an [`IdentityMatcher`](../merging.md) for merges. The `uuid` key dedupes correctly across reloaded files, where two `Identity` objects with the same name are otherwise distinct:
+
+```pycon
+>>> import sleap_io as sio
+>>> a1 = sio.Identity(name="mouse_A", uuid="shared")
+>>> a2 = sio.Identity(name="renamed", uuid="shared")
+>>> print(a1.matches(a2))  # same uuid -> same animal
+
+```
+
 !!! note "SLP persistence"
-    `Identity` and [`Instance3D`](#instance3d) persist into SLP format v1.9+, so round-tripping between sleap-io and sleap-io.js / luc3d is lossless.
+    The identity catalog (with `uuid`) persists in SLP format v1.9+. Per-instance identity links (`Instance.identity`/`identity_score`) persist in **format 2.5+** via the additive `/instance_identities` dataset. These are additive, so older readers ignore them and older files round-trip unchanged. See [Formats → SLP](../formats/slp.md).
 
 ---
 
@@ -280,6 +295,8 @@ classDiagram
     class Instance:::core {
         +PointsArray points
         +Skeleton skeleton
+        +Identity identity
+        +float identity_score
     }
     class Identity:::threed {
         +str name

--- a/docs/model/index.md
+++ b/docs/model/index.md
@@ -76,6 +76,8 @@ classDiagram
         +PointsArray points
         +Skeleton skeleton
         +Track track
+        +Identity identity
+        +float identity_score
     }
     class PredictedInstance:::poses {
         +float score

--- a/docs/model/labels.md
+++ b/docs/model/labels.md
@@ -438,6 +438,8 @@ classDiagram
         +Skeleton skeleton
         +Track track
         +PointsArray points
+        +Identity identity
+        +float identity_score
     }
 
     class Video {

--- a/docs/model/poses.md
+++ b/docs/model/poses.md
@@ -14,9 +14,10 @@ The pose data model is built around four key types:
 - **[`Skeleton`][sleap_io.Skeleton]** is the **template**: defines what landmarks exist, how they connect, and which are symmetric.
 - **[`Instance`][sleap_io.Instance]** is the **data**: stores actual (x, y) coordinates for one animal in one frame.
 - **[`PredictedInstance`][sleap_io.PredictedInstance]** is like `Instance` but includes per-point and instance-level confidence scores from a model.
-- **[`Track`][sleap_io.Track]** is the **identity**: links the same animal across frames.
+- **[`Track`][sleap_io.Track]** is the **video-local identity**: links the same animal across frames of one recording.
+- **[`Identity`](3d.md#identity)** is the **global identity**: a persistent, cross-session animal label assigned via `Instance.identity` (with `identity_score`), distinct from the ephemeral `Track`.
 
-A `Skeleton` is shared across all instances in a dataset. Each `Instance` references a `Skeleton` to know which landmarks it contains, and optionally a `Track` to indicate which animal it belongs to.
+A `Skeleton` is shared across all instances in a dataset. Each `Instance` references a `Skeleton` to know which landmarks it contains, and optionally a `Track` (and a global `Identity`) to indicate which animal it belongs to.
 
 ---
 
@@ -331,6 +332,8 @@ classDiagram
         +PointsArray points
         +Skeleton skeleton
         +Track track
+        +Identity identity
+        +float identity_score
         +numpy() ndarray
         +n_visible: int
         +is_empty: bool

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -914,6 +914,13 @@ def _print_header(path: Path, labels: Labels) -> None:
             f"track{'s' if len(labels.tracks) != 1 else ''}"
         )
 
+    # Global identities - only shown when present (pose-only files have none).
+    n_identities = len(labels.identities)
+    if n_identities > 0:
+        stats_parts.append(
+            f"[bold]{n_identities}[/] identit{'ies' if n_identities != 1 else 'y'}"
+        )
+
     # Segmentation masks and ROIs - only shown when present to avoid cluttering
     # pose-only files.
     n_masks = len(labels.masks)
@@ -2972,6 +2979,13 @@ def unsplit(
     help="Track matching method.",
 )
 @click.option(
+    "--identity",
+    type=click.Choice(["uuid", "name"]),
+    default="uuid",
+    show_default=True,
+    help="Identity matching method for deduping the identity catalog.",
+)
+@click.option(
     "--frame",
     type=click.Choice(
         [
@@ -3011,6 +3025,7 @@ def merge(
     skeleton: str,
     video: str,
     track: str,
+    identity: str,
     frame: str,
     instance: str,
     embed: str | None,
@@ -3059,6 +3074,10 @@ def merge(
       • identity: Match by track identity
       • iou: Match by bounding box overlap
 
+    [dim]Identity:[/] How to dedupe the global identity catalog
+      • uuid: Match identities by stable UUID key [default]
+      • name: Match identities by name
+
     [dim]Examples:[/]
 
         $ sio merge project.slp predictions.slp -o merged.slp
@@ -3104,6 +3123,10 @@ def merge(
 
     click.echo(f"  {initial_frames} frames, {initial_videos} videos")
 
+    # Select how the global identity catalog is deduped during merge ("uuid" or
+    # "name"), forwarded to Labels.merge() as the identity matcher method.
+    merge_identity_kwargs: dict = {"identity": identity}
+
     # Merge remaining files
     for input_file in expanded_files[1:]:
         click.echo(f"Merging: {input_file.name}")
@@ -3128,6 +3151,7 @@ def merge(
             track=track,
             frame=frame,
             instance=instance,
+            **merge_identity_kwargs,
         )
 
         frames_added = len(labels) - frames_before
@@ -3523,10 +3547,10 @@ def filenames(
 # Appearance options
 @click.option(
     "--color-by",
-    type=click.Choice(["auto", "track", "instance", "node"]),
+    type=click.Choice(["auto", "track", "instance", "node", "identity"]),
     default="auto",
     show_default=True,
-    help="Color scheme: auto (smart default), track, instance, or node.",
+    help="Color scheme: auto (smart default), track, instance, node, or identity.",
 )
 @click.option(
     "--palette",

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -19,6 +19,9 @@ Format version history:
     - 2.3: Virtual on-read video crops (/video_crops dataset)
     - 2.4: Persisted mask from_predicted provenance (from_predicted column in
             mask_dtype storing the source prediction's index in the mask list)
+    - 2.5: Added per-instance global identity links (/instance_identities dataset:
+            instance_id, identity_idx, identity_score) joining instances to the
+            identity catalog; additive, read with try/except on dataset presence
 """
 
 from __future__ import annotations
@@ -83,6 +86,7 @@ from sleap_io.model.suggestions import SuggestionFrame
 from sleap_io.model.video import Video
 
 if TYPE_CHECKING:
+    from sleap_io.io.slp_lazy import LazyDataStore
     from sleap_io.model.centroid import Centroid
     from sleap_io.model.instance import PointsArray, PredictedPointsArray
     from sleap_io.model.labels_set import LabelsSet
@@ -1671,6 +1675,143 @@ def write_identities(labels_path: str, identities: list[Identity]):
         f.create_dataset("identities_json", data=identities_json, maxshape=(None,))
 
 
+def read_instance_identities(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> dict[int, tuple[int, float | None]]:
+    """Read per-instance identity links from a SLEAP labels file.
+
+    Links are stored in the optional ``instance_identities`` dataset (SLP format
+    2.5+), a structured array of ``(instance_id, identity_idx, identity_score)``
+    rows joining the global instance id to an index into the file's identity
+    catalog. The dataset is absent in older files, in which case an empty mapping
+    is returned (purely additive; reads are gated on dataset presence).
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally.
+
+    Returns:
+        A dict mapping the global ``instance_id`` to a
+        ``(identity_idx, identity_score)`` tuple. ``identity_score`` is ``None``
+        when it was not recorded (stored as NaN).
+    """
+    try:
+        data = read_hdf5_dataset(
+            labels_path, "instance_identities", _hdf5_file=_hdf5_file
+        )
+    except KeyError:
+        return {}
+    result: dict[int, tuple[int, float | None]] = {}
+    for row in data:
+        score = float(row["identity_score"])
+        result[int(row["instance_id"])] = (
+            int(row["identity_idx"]),
+            None if np.isnan(score) else score,
+        )
+    return result
+
+
+def _write_instance_identity_rows(
+    labels_path: str, rows: list[tuple[int, int, float]]
+) -> None:
+    """Write ``(instance_id, identity_idx, identity_score)`` rows to a SLP file.
+
+    Shared dataset-writing core for the per-instance identity link. The rows can
+    be built either by iterating a `Labels` (the eager path, see
+    `write_instance_identities`) or from a lazy store dict (the lazy save path),
+    keeping the on-disk ``instance_identities`` layout identical for both.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        rows: A list of ``(instance_id, identity_idx, identity_score)`` tuples.
+            ``identity_score`` is a float (NaN encodes an unrecorded score). An
+            empty list is a no-op (no dataset is created).
+    """
+    if not rows:
+        return
+
+    instance_identity_dtype = np.dtype(
+        [
+            ("instance_id", "i8"),
+            ("identity_idx", "i4"),
+            ("identity_score", "f4"),
+        ]
+    )
+    arr = np.array(rows, dtype=instance_identity_dtype)
+    with h5py.File(labels_path, "a") as f:
+        f.create_dataset("instance_identities", data=arr, maxshape=(None,))
+
+
+def write_instance_identities(labels_path: str, labels: Labels) -> None:
+    """Write per-instance identity links to a SLEAP labels file.
+
+    Creates the ``instance_identities`` dataset (SLP format 2.5+) as a structured
+    array of ``(instance_id, identity_idx, identity_score)`` rows for every
+    instance carrying an `Identity` that is registered in ``labels.identities``.
+    The ``instance_id`` matches the global id assigned by `write_lfs` (enumeration
+    order over frames then instances), so the link is resolved by joining on that
+    id at read time. This keeps identity out of the fixed-layout ``instances``
+    dataset, making it purely additive: old readers simply ignore the dataset.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        labels: A `Labels` object to store the identity links for.
+    """
+    if not labels.identities:
+        return
+
+    rows = []
+    instance_id = 0
+    for lf in labels:
+        for inst in lf:
+            identity = getattr(inst, "identity", None)
+            if identity is not None and identity in labels.identities:
+                identity_idx = labels.identities.index(identity)
+                score = inst.identity_score
+                rows.append(
+                    (
+                        instance_id,
+                        identity_idx,
+                        float("nan") if score is None else float(score),
+                    )
+                )
+            instance_id += 1
+
+    _write_instance_identity_rows(labels_path, rows)
+
+
+def _instance_identity_rows_from_store(
+    store: "LazyDataStore",
+) -> list[tuple[int, int, float]]:
+    """Build ``instance_identities`` rows from a lazy store without materializing.
+
+    The lazy store already holds the per-instance identity links keyed by the
+    global ``instance_id`` (the same id space written by the fast path), so the
+    rows can be emitted directly without rebuilding `Instance` objects. Rows are
+    sorted by ``instance_id`` for deterministic output.
+
+    Args:
+        store: The `LazyDataStore` backing a lazy `Labels`.
+
+    Returns:
+        A list of ``(instance_id, identity_idx, identity_score)`` tuples matching
+        the format expected by `_write_instance_identity_rows`.
+    """
+    rows = []
+    for instance_id in sorted(store._instance_identities):
+        identity_idx, score = store._instance_identities[instance_id]
+        rows.append(
+            (
+                int(instance_id),
+                int(identity_idx),
+                float("nan") if score is None else float(score),
+            )
+        )
+    return rows
+
+
 def read_suggestions(
     labels_path: str,
     videos: list[Video],
@@ -2146,6 +2287,21 @@ def write_metadata(labels_path: str, labels: Labels):
     )
     if has_mask_from_predicted:
         format_id = max(format_id, 2.4)
+
+    # Bump for per-instance identity links (new in 2.5). Purely additive (a
+    # separate dataset read with try/except on presence), so it is only set when
+    # an instance actually carries an identity. For lazy `Labels` the presence
+    # check reads the lazy store dict directly, mirroring what the fast-path
+    # writer persists without materializing any frames.
+    if labels.is_lazy:
+        store = labels._lazy_store
+        has_instance_identities = bool(store._instance_identities)
+    else:
+        has_instance_identities = any(
+            getattr(inst, "identity", None) is not None for lf in labels for inst in lf
+        )
+    if has_instance_identities:
+        format_id = max(format_id, 2.5)
 
     with h5py.File(labels_path, "a") as f:
         # Bump for chunked label image format (new in 2.2)
@@ -3266,6 +3422,8 @@ def _read_labels_lazy_from_open_file(
     )
     skeletons = read_skeletons(labels_path, _hdf5_file=f)
     tracks = read_tracks(labels_path, _hdf5_file=f)
+    identities = read_identities(labels_path, _hdf5_file=f)
+    instance_identities = read_instance_identities(labels_path, _hdf5_file=f)
     suggestions = read_suggestions(labels_path, videos, _hdf5_file=f)
     metadata = read_metadata(labels_path, _hdf5_file=f)
     provenance = read_provenance(labels_path, metadata, _hdf5_file=f)
@@ -3274,7 +3432,9 @@ def _read_labels_lazy_from_open_file(
     # Read sessions (small, no need for lazy loading)
     # Note: sessions require labeled_frames for full linking, but for lazy loading
     # we pass an empty list since we don't have materialized frames yet
-    sessions = read_sessions(labels_path, videos, [], _hdf5_file=f)
+    sessions = read_sessions(
+        labels_path, videos, [], identities=identities, _hdf5_file=f
+    )
 
     # Create LazyDataStore
     lazy_store = LazyDataStore(
@@ -3288,6 +3448,8 @@ def _read_labels_lazy_from_open_file(
         format_id=format_id,
         source_path=str(labels_path),
         negative_frames=negative_frames,
+        identities=identities,
+        instance_identities=instance_identities,
     )
 
     # Create LazyFrameList
@@ -3378,6 +3540,7 @@ def _read_labels_lazy_from_open_file(
         videos=videos,
         skeletons=skeletons,
         tracks=tracks,
+        identities=identities,
         suggestions=suggestions,
         sessions=sessions,
         provenance=provenance,
@@ -6072,6 +6235,15 @@ def _read_labels_from_open_file(
         )
 
     identities = read_identities(labels_path, _hdf5_file=f)
+    # Attach per-instance identity links (SLP format 2.5+). Additive: when the
+    # dataset is absent (older files) this is an empty mapping and a no-op. The
+    # global instances list is ordered by instance_id, so it indexes directly.
+    instance_identity_map = read_instance_identities(labels_path, _hdf5_file=f)
+    for inst_id, (identity_idx, identity_score) in instance_identity_map.items():
+        if 0 <= inst_id < len(instances) and 0 <= identity_idx < len(identities):
+            instances[inst_id].identity = identities[identity_idx]
+            instances[inst_id].identity_score = identity_score
+
     sessions = read_sessions(
         labels_path, videos, labeled_frames, identities=identities, _hdf5_file=f
     )
@@ -6252,6 +6424,7 @@ _KNOWN_TOPLEVEL_HDF5_NAMES = frozenset(
         "suggestions_json",
         "sessions_json",
         "identities_json",
+        "instance_identities",
         "provenance_json",
         "frames",
         "instances",
@@ -6432,6 +6605,16 @@ def _write_labels_lazy(
 
     # Write other metadata
     write_tracks(labels_path, labels.tracks)
+    # Persist identities + per-instance identity links directly from the lazy
+    # store, mirroring the eager writer (write_identities /
+    # write_instance_identities) but driven by the store dicts so no
+    # LabeledFrame/Instance is materialized. The store keys ARE the global
+    # instance_ids written above, so the join stays consistent with the raw
+    # instances emitted by the fast path.
+    write_identities(labels_path, lazy_store.identities)
+    _write_instance_identity_rows(
+        labels_path, _instance_identity_rows_from_store(lazy_store)
+    )
     write_suggestions(labels_path, labels.suggestions, labels.videos)
     # For sessions, pass empty list since we don't have materialized frames
     # (consistent with lazy load behavior)
@@ -6695,6 +6878,7 @@ def write_labels(
     write_video_crops(labels_path, labels)
     write_tracks(labels_path, labels.tracks)
     write_identities(labels_path, labels.identities)
+    write_instance_identities(labels_path, labels)
     write_suggestions(labels_path, labels.suggestions, labels.videos)
     write_sessions(
         labels_path,

--- a/sleap_io/io/slp_lazy.py
+++ b/sleap_io/io/slp_lazy.py
@@ -15,6 +15,7 @@ import attrs
 import numpy as np
 
 if TYPE_CHECKING:
+    from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, PredictedInstance, Track
     from sleap_io.model.labeled_frame import LabeledFrame
     from sleap_io.model.skeleton import Skeleton
@@ -81,6 +82,14 @@ class LazyDataStore:
     _undistributed_bboxes: list = attrs.field(factory=list, repr=False)
     _undistributed_centroids: list = attrs.field(factory=list, repr=False)
     _undistributed_label_images: list = attrs.field(factory=list, repr=False)
+
+    # Global identity catalog and per-instance identity links (format 2.5+).
+    # ``identities`` are canonical objects shared with Labels.identities;
+    # ``_instance_identities`` maps global instance_id -> (identity_idx, score).
+    identities: list["Identity"] = attrs.field(factory=list, repr=False)
+    _instance_identities: dict = attrs.field(
+        factory=dict, repr=False, alias="instance_identities"
+    )
 
     def __attrs_post_init__(self) -> None:
         """Validate index bounds on construction."""
@@ -157,6 +166,8 @@ class LazyDataStore:
             videos=self.videos,  # Share references (canonical objects)
             skeletons=self.skeletons,  # Share references (canonical objects)
             tracks=self.tracks,  # Share references (canonical objects)
+            identities=self.identities,  # Share references (canonical objects)
+            instance_identities=dict(self._instance_identities),
             format_id=self.format_id,
             source_path=self._source_path,
             negative_frames=self._negative_frames.copy(),
@@ -289,6 +300,18 @@ class LazyDataStore:
         skeleton = self.skeletons[skeleton_id]
         track = self.tracks[track_id] if track_id >= 0 else None
 
+        # Resolve optional per-instance global identity (format 2.5+). Joined on
+        # the global instance_id; absent for older files (empty mapping -> None).
+        identity = None
+        identity_score = None
+        if self._instance_identities:
+            entry = self._instance_identities.get(instance_id)
+            if entry is not None:
+                identity_idx, id_score = entry
+                if 0 <= identity_idx < len(self.identities):
+                    identity = self.identities[identity_idx]
+                    identity_score = id_score
+
         if instance_type == InstanceType.USER:
             pts_data = self.points_data[point_id_start:point_id_end]
             points_array = self._make_points_array(pts_data, skeleton)
@@ -300,6 +323,8 @@ class LazyDataStore:
                 skeleton=skeleton,
                 track=track,
                 tracking_score=float(tracking_score),
+                identity=identity,
+                identity_score=identity_score,
             )
         else:  # PREDICTED
             pts_data = self.pred_points_data[point_id_start:point_id_end]
@@ -313,6 +338,8 @@ class LazyDataStore:
                 track=track,
                 score=float(instance_score),
                 tracking_score=float(tracking_score),
+                identity=identity,
+                identity_score=identity_score,
             )
 
     def _make_points_array(

--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import attrs
 import numpy as np
 
+from sleap_io.model.identity import Identity
 from sleap_io.model.skeleton import Node, Skeleton
 
 
@@ -406,6 +407,14 @@ class Instance:
             typically the value from the score matrix used in an identity assignment.
             This is `None` if the instance is not associated with a track or if the
             track was assigned manually.
+        identity: An optional `Identity` representing the global, ground-truth animal
+            this instance belongs to (persistent across videos/sessions). Unlike
+            `track` (an ephemeral, video-local tracklet), `Identity` is the cross-file
+            re-identification key. `None` if no global identity is assigned.
+        identity_score: The score associated with the `identity` assignment (e.g. the
+            cosine similarity to a re-ID gallery prototype). This is `None` if the
+            instance has no identity or the identity was assigned manually. Kept
+            separate from `tracking_score` (short-term tracklet vs long-term identity).
         from_predicted: The `PredictedInstance` (if any) that this instance was
             initialized from. This is used with human-in-the-loop workflows.
     """
@@ -414,6 +423,8 @@ class Instance:
     skeleton: Skeleton
     track: Track | None = None
     tracking_score: float | None = None
+    identity: Identity | None = None
+    identity_score: float | None = None
     from_predicted: "PredictedInstance | None" = None
 
     @classmethod
@@ -422,6 +433,8 @@ class Instance:
         skeleton: Skeleton,
         track: Track | None = None,
         tracking_score: float | None = None,
+        identity: Identity | None = None,
+        identity_score: float | None = None,
         from_predicted: "PredictedInstance | None" = None,
     ) -> "Instance":
         """Create an empty instance with no points.
@@ -434,6 +447,8 @@ class Instance:
                 typically the value from the score matrix used in an identity
                 assignment. This is `None` if the instance is not associated with a
                 track or if the track was assigned manually.
+            identity: An optional global `Identity` for this instance.
+            identity_score: The score associated with the `identity` assignment.
             from_predicted: The `PredictedInstance` (if any) that this instance was
                 initialized from. This is used with human-in-the-loop workflows.
 
@@ -448,6 +463,8 @@ class Instance:
             skeleton=skeleton,
             track=track,
             tracking_score=tracking_score,
+            identity=identity,
+            identity_score=identity_score,
             from_predicted=from_predicted,
         )
 
@@ -475,6 +492,8 @@ class Instance:
         skeleton: Skeleton,
         track: Track | None = None,
         tracking_score: float | None = None,
+        identity: Identity | None = None,
+        identity_score: float | None = None,
         from_predicted: "PredictedInstance | None" = None,
     ) -> "Instance":
         """Create an instance object from a numpy array.
@@ -500,6 +519,8 @@ class Instance:
                 typically the value from the score matrix used in an identity
                 assignment. This is `None` if the instance is not associated with a
                 track or if the track was assigned manually.
+            identity: An optional global `Identity` for this instance.
+            identity_score: The score associated with the `identity` assignment.
             from_predicted: The `PredictedInstance` (if any) that this instance was
                 initialized from. This is used with human-in-the-loop workflows.
 
@@ -511,6 +532,8 @@ class Instance:
             skeleton=skeleton,
             track=track,
             tracking_score=tracking_score,
+            identity=identity,
+            identity_score=identity_score,
             from_predicted=from_predicted,
         )
 
@@ -753,18 +776,23 @@ class Instance:
             return np.all(distances <= tolerance)
 
     def same_identity_as(self, other: "Instance") -> bool:
-        """Check if this instance has the same identity (track) as another instance.
+        """Check if this instance has the same identity as another instance.
 
         Args:
             other: Another instance to compare with.
 
         Returns:
-            True if both instances have the same track identity, False otherwise.
+            True if both instances share the same identity, False otherwise.
 
         Notes:
-            Instances have the same identity if they share the same Track object
-            (by identity, not just by name).
+            Global `Identity` takes precedence: if both instances carry an
+            `Identity`, they match when their `uuid`s match (which survives
+            serialization and cross-file merges). Otherwise this falls back to
+            the ephemeral `Track`, where instances match only when they share the
+            same `Track` object (by object identity, not just by name).
         """
+        if self.identity is not None and other.identity is not None:
+            return self.identity.matches(other.identity, method="uuid")
         if self.track is None or other.track is None:
             return False
         return self.track is other.track
@@ -864,6 +892,9 @@ class PredictedInstance(Instance):
             predicted. This may not always be applicable depending on the model type.
         tracking_score: The score associated with the `Track` assignment. This is
             typically the value from the score matrix used in an identity assignment.
+        identity: An optional global `Identity` (see `Instance.identity`).
+        identity_score: The score associated with the `identity` assignment (see
+            `Instance.identity_score`).
     """
 
     points: PredictedPointsArray = attrs.field(eq=attrs.cmp_using(eq=np.array_equal))
@@ -871,6 +902,8 @@ class PredictedInstance(Instance):
     score: float = 0.0
     track: Track | None = None
     tracking_score: float | None = 0
+    identity: Identity | None = None
+    identity_score: float | None = None
     from_predicted: "PredictedInstance | None" = None
 
     def __repr__(self) -> str:
@@ -896,6 +929,8 @@ class PredictedInstance(Instance):
         score: float = 0.0,
         track: Track | None = None,
         tracking_score: float | None = None,
+        identity: Identity | None = None,
+        identity_score: float | None = None,
         from_predicted: "PredictedInstance | None" = None,
     ) -> "PredictedInstance":
         """Create an empty instance with no points."""
@@ -908,6 +943,8 @@ class PredictedInstance(Instance):
             score=score,
             track=track,
             tracking_score=tracking_score,
+            identity=identity,
+            identity_score=identity_score,
             from_predicted=from_predicted,
         )
 
@@ -937,6 +974,8 @@ class PredictedInstance(Instance):
         score: float = 0.0,
         track: Track | None = None,
         tracking_score: float | None = None,
+        identity: Identity | None = None,
+        identity_score: float | None = None,
         from_predicted: "PredictedInstance | None" = None,
     ) -> "PredictedInstance":
         """Create a predicted instance object from a numpy array."""
@@ -950,6 +989,8 @@ class PredictedInstance(Instance):
             score=score,
             track=track,
             tracking_score=tracking_score,
+            identity=identity,
+            identity_score=identity_score,
             from_predicted=from_predicted,
         )
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from sleap_io.model.labels_set import LabelsSet
     from sleap_io.model.mask import SegmentationMask
     from sleap_io.model.matching import (
+        IdentityMatcher,
         InstanceMatcher,
         MatchResult,
         MergeResult,
@@ -495,8 +496,8 @@ class Labels:
     def update(self):
         """Update data structures based on contents.
 
-        This function will update the list of skeletons, videos and tracks from the
-        labeled frames, instances, annotations, and suggestions.
+        This function will update the list of skeletons, videos, tracks and
+        identities from the labeled frames, instances, annotations, and suggestions.
         """
         for lf in self.labeled_frames:
             if lf.video not in self.videos:
@@ -508,8 +509,14 @@ class Labels:
                 if inst.track is not None and inst.track not in self.tracks:
                     self.tracks.append(inst.track)
 
+                if inst.identity is not None and inst.identity not in self.identities:
+                    self.identities.append(inst.identity)
+
             # Collect tracks from nested annotations
             self._collect_annotation_tracks(lf)
+
+        # Collect multi-view identities bound only on InstanceGroups (sessions).
+        self._collect_session_identities()
 
         for sf in self.suggestions:
             if sf.video not in self.videos:
@@ -832,11 +839,16 @@ class Labels:
             new_videos = [deepcopy(v) for v in self.videos]
             new_skeletons = [deepcopy(s) for s in self.skeletons]
             new_tracks = [deepcopy(t) for t in self.tracks]
+            # Identities are index-referenced by the store's per-instance maps, so
+            # deep-copying preserves index alignment while keeping the catalog
+            # independent.
+            new_identities = [deepcopy(i) for i in self.identities]
 
             # Update store references
             new_store.videos = new_videos
             new_store.skeletons = new_skeletons
             new_store.tracks = new_tracks
+            new_store.identities = new_identities
 
             # Annotations are stored on the lazy store's per-frame dicts
             # and will be attached to frames when they are materialized.
@@ -854,6 +866,7 @@ class Labels:
                 videos=new_videos,
                 skeletons=new_skeletons,
                 tracks=new_tracks,
+                identities=new_identities,
                 suggestions=[deepcopy(s) for s in self.suggestions],
                 sessions=[deepcopy(s) for s in self.sessions],
                 provenance=dict(self.provenance),
@@ -890,6 +903,24 @@ class Labels:
                 if info.track is not None and info.track not in self.tracks:
                     self.tracks.append(info.track)
 
+    def _collect_session_identities(self):
+        """Collect multi-view identities bound only on `InstanceGroup`s.
+
+        A multi-view animal identity may be attached to an `InstanceGroup`
+        (``session.frame_groups[*].instance_groups[*].identity``) without ever
+        appearing on a per-instance ``Instance.identity``. Those identities would
+        otherwise be dropped on save, so collect them into ``self.identities``.
+
+        Deduped by object identity (``not in``), mirroring instance-identity
+        collection. Cheap no-op for labels without sessions.
+        """
+        for session in self.sessions:
+            for frame_group in session.frame_groups.values():
+                for instance_group in frame_group.instance_groups:
+                    identity = instance_group.identity
+                    if identity is not None and identity not in self.identities:
+                        self.identities.append(identity)
+
     def append(self, lf: LabeledFrame, update: bool = True):
         """Append a labeled frame to the labels.
 
@@ -915,7 +946,11 @@ class Labels:
                 if inst.track is not None and inst.track not in self.tracks:
                     self.tracks.append(inst.track)
 
+                if inst.identity is not None and inst.identity not in self.identities:
+                    self.identities.append(inst.identity)
+
             self._collect_annotation_tracks(lf)
+            self._collect_session_identities()
 
     def extend(self, lfs: list[LabeledFrame], update: bool = True):
         """Append labeled frames to the labels.
@@ -943,7 +978,15 @@ class Labels:
                     if inst.track is not None and inst.track not in self.tracks:
                         self.tracks.append(inst.track)
 
+                    if (
+                        inst.identity is not None
+                        and inst.identity not in self.identities
+                    ):
+                        self.identities.append(inst.identity)
+
                 self._collect_annotation_tracks(lf)
+
+            self._collect_session_identities()
 
     def numpy(
         self,
@@ -3336,6 +3379,7 @@ class Labels:
         skeleton: "str | SkeletonMatcher | None" = None,
         video: "str | VideoMatcher | None" = None,
         track: "str | TrackMatcher | None" = None,
+        identity: "str | IdentityMatcher | None" = None,
         frame: str = "auto",
         instance: "str | InstanceMatcher | None" = None,
         validate: bool = True,
@@ -3362,6 +3406,12 @@ class Labels:
                 attribute instead, for cases where track names are semantically
                 meaningful (e.g. user-assigned identities or identity-classification
                 model outputs).
+            identity: Global `Identity` catalog matching method. Can be a string
+                ("uuid", "name") or an IdentityMatcher object. Default is "uuid",
+                which dedupes the identity catalog by the stable cross-file `uuid`
+                key so the same animal across files collapses to one canonical
+                `Identity`. Pass "name" to dedupe by name instead. Per-instance
+                identity links always join by `uuid`.
             frame: Frame merge strategy. One of "auto", "keep_original",
                 "keep_new", "keep_both", "update_tracks", "replace_predictions".
                 Default is "auto".
@@ -3409,8 +3459,10 @@ class Labels:
 
         import sleap_io
         from sleap_io.model.matching import (
+            UUID_IDENTITY_MATCHER,
             ConflictResolution,
             ErrorMode,
+            IdentityMatcher,
             InstanceMatcher,
             InstanceMatchMethod,
             MergeError,
@@ -3658,6 +3710,34 @@ class Labels:
                 other, video_map, track_map, track_matcher, instance_matcher
             )
 
+            # Step 3b: Match and merge identities (dedupe by stable uuid).
+            # Mirrors track matching above, but keyed by ``Identity.uuid`` so the
+            # same animal across files maps to a single canonical catalog object.
+            # ``identity_map`` is threaded into ``_map_instance`` so per-instance
+            # identities point at the deduped catalog entry instead of a copy.
+            # The matcher controls how catalog entries are deduped; the map is
+            # always keyed by ``Identity.uuid`` (the per-instance join key).
+            if isinstance(identity, IdentityMatcher):
+                identity_matcher = identity
+            elif isinstance(identity, str):
+                identity_matcher = IdentityMatcher(method=identity)
+            else:
+                identity_matcher = UUID_IDENTITY_MATCHER
+            identity_map: dict[str, Identity] = {}
+            for other_identity in other.identities:
+                matched_identity = None
+                for self_identity in self.identities:
+                    if identity_matcher.match(self_identity, other_identity):
+                        matched_identity = self_identity
+                        break
+
+                if matched_identity is None:
+                    # Add new identity if no uuid match.
+                    self.identities.append(other_identity)
+                    matched_identity = other_identity
+
+                identity_map[other_identity.uuid] = matched_identity
+
             # Step 4: Merge frames
             total_frames = len(other.labeled_frames)
 
@@ -3696,7 +3776,11 @@ class Labels:
                     instance_memo: dict[int, Instance | PredictedInstance] = {}
                     for inst in other_frame.instances:
                         new_inst = self._map_instance(
-                            inst, skeleton_map, track_map, memo=instance_memo
+                            inst,
+                            skeleton_map,
+                            track_map,
+                            identity_map=identity_map,
+                            memo=instance_memo,
                         )
                         new_frame.instances.append(new_inst)
                         result.instances_added += 1
@@ -3732,7 +3816,11 @@ class Labels:
                         if inst.skeleton in skeleton_map:
                             # Instance needs remapping
                             remapped_inst = self._map_instance(
-                                inst, skeleton_map, track_map, memo=instance_memo
+                                inst,
+                                skeleton_map,
+                                track_map,
+                                identity_map=identity_map,
+                                memo=instance_memo,
                             )
                             remapped_instances.append(remapped_inst)
                         else:
@@ -3975,14 +4063,20 @@ class Labels:
         instance: Instance | PredictedInstance,
         skeleton_map: dict[Skeleton, Skeleton],
         track_map: dict[Track, Track],
+        identity_map: dict[str, Identity] | None = None,
         memo: dict[int, Instance | PredictedInstance] | None = None,
     ) -> Instance | PredictedInstance:
-        """Map an instance to use mapped skeleton and track.
+        """Map an instance to use mapped skeleton, track, and identity.
 
         Args:
             instance: Instance to map.
             skeleton_map: Dictionary mapping old skeletons to new ones.
             track_map: Dictionary mapping old tracks to new ones.
+            identity_map: Optional mapping from ``Identity.uuid`` to the canonical
+                (deduped) `Identity` in the merged catalog. When provided, the
+                instance's identity is resolved through this map so that the same
+                animal across files points at a single catalog object. The
+                instance's ``identity_score`` is always copied.
             memo: Optional mapping from the id of the source instance to the new
                 instance, mutated in place. Used to repair ``from_predicted``
                 links so a remapped user instance references the remapped source
@@ -4003,6 +4097,14 @@ class Labels:
         mapped_skeleton = skeleton_map.get(instance.skeleton, instance.skeleton)
         mapped_track = (
             track_map.get(instance.track, instance.track) if instance.track else None
+        )
+        # Resolve the identity through the catalog dedup map (keyed by uuid) so the
+        # same animal across merged files maps to one canonical Identity. Falls back
+        # to the instance's own identity when no map/identity is present.
+        mapped_identity = (
+            identity_map.get(instance.identity.uuid, instance.identity)
+            if (instance.identity is not None and identity_map)
+            else instance.identity
         )
 
         # Reorder points by node name when the source order differs from the mapped
@@ -4028,6 +4130,8 @@ class Labels:
                 track=mapped_track,
                 tracking_score=instance.tracking_score,
                 from_predicted=instance.from_predicted,
+                identity=mapped_identity,
+                identity_score=instance.identity_score,
             )
         else:
             new_instance = Instance(
@@ -4036,6 +4140,8 @@ class Labels:
                 track=mapped_track,
                 tracking_score=instance.tracking_score,
                 from_predicted=instance.from_predicted,
+                identity=mapped_identity,
+                identity_score=instance.identity_score,
             )
         if memo is not None:
             memo[id(instance)] = new_instance

--- a/sleap_io/rendering/colors.py
+++ b/sleap_io/rendering/colors.py
@@ -166,7 +166,7 @@ PaletteName = Literal[
 ]
 
 # Type alias for color schemes
-ColorScheme = Literal["track", "instance", "node", "auto"]
+ColorScheme = Literal["track", "instance", "node", "identity", "auto"]
 
 
 def get_palette(name: PaletteName | str, n_colors: int) -> list[tuple[int, int, int]]:
@@ -414,6 +414,9 @@ def build_color_map(
     n_tracks: int,
     track_indices: list[int] | None = None,
     palette: PaletteName | str = "standard",
+    identity_indices: list[int] | None = None,
+    n_identities: int = 0,
+    identity_colors: list[tuple[int, int, int] | None] | None = None,
 ) -> dict[str, list[tuple[int, int, int]]]:
     """Build color mapping based on scheme.
 
@@ -424,6 +427,12 @@ def build_color_map(
         n_tracks: Total number of tracks (for track coloring).
         track_indices: Track index for each instance (for track coloring).
         palette: Color palette name.
+        identity_indices: Global identity index for each instance (for identity
+            coloring).
+        n_identities: Total number of identities (for identity coloring).
+        identity_colors: Optional explicit RGB color for each instance, resolved
+            from ``Identity.color``. When an entry is not None it overrides the
+            palette color for that instance (used by identity coloring).
 
     Returns:
         Dictionary with 'instance_colors' and/or 'node_colors' lists.
@@ -439,6 +448,30 @@ def build_color_map(
             instance_colors = [
                 palette_colors[idx % len(palette_colors)] for idx in track_indices
             ]
+        else:
+            instance_colors = palette_colors[:n_instances]
+
+        colors["instance_colors"] = instance_colors
+
+    elif scheme == "identity":
+        # Colors based on global identity. Mirrors the track scheme: a palette
+        # index per identity, but an explicit ``Identity.color`` (resolved into
+        # ``identity_colors``) wins when set.
+        n = max(n_identities, n_instances) if n_identities > 0 else n_instances
+        palette_colors = get_palette(palette, max(n, 1))
+
+        if identity_indices is not None:
+            instance_colors = []
+            for i, idx in enumerate(identity_indices):
+                explicit = (
+                    identity_colors[i]
+                    if identity_colors is not None and i < len(identity_colors)
+                    else None
+                )
+                if explicit is not None:
+                    instance_colors.append(explicit)
+                else:
+                    instance_colors.append(palette_colors[idx % len(palette_colors)])
         else:
             instance_colors = palette_colors[:n_instances]
 

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -580,6 +580,45 @@ def _apply_overlay(
     return image
 
 
+def _compute_identity_coloring(
+    instances: Iterable,
+    catalog: list | None,
+) -> tuple[list[int], int, list[tuple[int, int, int] | None]]:
+    """Compute per-instance identity indices and explicit colors.
+
+    Mirrors the track-index plumbing for the ``identity`` color scheme. Each
+    instance is mapped to a stable index in the identity catalog (the
+    ``Labels.identities`` order when available, otherwise discovered from the
+    instances in encounter order). Instances without an identity map to index 0.
+    When an identity carries an explicit ``color``, it is resolved to RGB and
+    used in preference to the palette color.
+
+    Args:
+        instances: Instances to color (order matches the rendered points).
+        catalog: Optional starting identity catalog (e.g. ``labels.identities``).
+
+    Returns:
+        Tuple of ``(identity_indices, n_identities, identity_colors)``.
+    """
+    catalog = list(catalog) if catalog else []
+    idmap = {id(idn): i for i, idn in enumerate(catalog)}
+    identity_indices: list[int] = []
+    identity_colors: list[tuple[int, int, int] | None] = []
+    for inst in instances:
+        idn = getattr(inst, "identity", None)
+        if idn is None:
+            identity_indices.append(0)
+            identity_colors.append(None)
+            continue
+        if id(idn) not in idmap:
+            idmap[id(idn)] = len(catalog)
+            catalog.append(idn)
+        identity_indices.append(idmap[id(idn)])
+        color = getattr(idn, "color", None)
+        identity_colors.append(resolve_color(color) if color else None)
+    return identity_indices, len(catalog), identity_colors
+
+
 def render_frame(
     frame: np.ndarray,
     instances_points: list[np.ndarray],
@@ -599,6 +638,10 @@ def render_frame(
     # Track info for track coloring
     track_indices: list[int] | None = None,
     n_tracks: int = 0,
+    # Identity info for identity coloring
+    identity_indices: list[int] | None = None,
+    n_identities: int = 0,
+    identity_colors: list[tuple[int, int, int] | None] | None = None,
     # Callbacks
     pre_render_callback: Callable[[RenderContext], None] | None = None,
     post_render_callback: Callable[[RenderContext], None] | None = None,
@@ -619,7 +662,7 @@ def render_frame(
         instances_points: List of (n_nodes, 2) arrays of keypoint coordinates.
         edge_inds: List of (src_idx, dst_idx) tuples for skeleton edges.
         node_names: List of node name strings.
-        color_by: Color scheme - 'track', 'instance', or 'node'.
+        color_by: Color scheme - 'track', 'instance', 'node', or 'identity'.
         palette: Color palette name.
         marker_shape: Node marker shape.
         marker_size: Node marker radius in pixels.
@@ -630,6 +673,11 @@ def render_frame(
         scale: Scale factor for output.
         track_indices: Track index for each instance (for track coloring).
         n_tracks: Total number of tracks (for track coloring).
+        identity_indices: Global identity index for each instance (for identity
+            coloring).
+        n_identities: Total number of identities (for identity coloring).
+        identity_colors: Optional explicit RGB color per instance resolved from
+            ``Identity.color`` (for identity coloring).
         pre_render_callback: Called before poses are drawn.
         post_render_callback: Called after poses are drawn.
         per_instance_callback: Called after each instance is drawn.
@@ -672,6 +720,9 @@ def render_frame(
         n_tracks=n_tracks,
         track_indices=track_indices,
         palette=palette,
+        identity_indices=identity_indices,
+        n_identities=n_identities,
+        identity_colors=identity_colors,
     )
 
     # Get drawing function for marker shape
@@ -892,7 +943,8 @@ def render_image(
               ``(0.25, 0.25, 0.75, 0.75)`` crops the center 50% of the frame.
               Detection is type-based: all values must be ``float`` and in range.
             - ``None``: No cropping (default).
-        color_by: Color scheme - 'track', 'instance', 'node', or 'auto'.
+        color_by: Color scheme - 'track', 'instance', 'node', 'identity', or
+            'auto'.
         palette: Color palette name.
         marker_shape: Node marker shape.
         marker_size: Node marker radius in pixels.
@@ -1373,6 +1425,17 @@ def render_image(
             meta["confidence"] = inst.score
         instance_metadata.append(meta)
 
+    # Compute identity coloring (per-instance index + explicit colors) when the
+    # resolved scheme is "identity", mirroring the track-index plumbing.
+    identity_indices = None
+    n_identities = 0
+    identity_colors = None
+    if resolved_scheme == "identity":
+        catalog = source.identities if isinstance(source, Labels) else None
+        identity_indices, n_identities, identity_colors = _compute_identity_coloring(
+            instances, catalog
+        )
+
     # Render
     rendered = render_frame(
         frame=render_image_data,
@@ -1390,6 +1453,9 @@ def render_image(
         scale=scale,
         track_indices=track_indices,
         n_tracks=n_tracks,
+        identity_indices=identity_indices,
+        n_identities=n_identities,
+        identity_colors=identity_colors,
         pre_render_callback=pre_render_callback,
         post_render_callback=post_render_callback,
         per_instance_callback=per_instance_callback,
@@ -1503,7 +1569,8 @@ def render_video(
             - ``None``: No cropping (default).
         preset: Quality preset ('preview'=0.25x, 'draft'=0.5x, 'final'=1.0x).
         scale: Scale factor (overrides preset if both provided).
-        color_by: Color scheme - 'track', 'instance', 'node', or 'auto'.
+        color_by: Color scheme - 'track', 'instance', 'node', 'identity', or
+            'auto'.
         palette: Color palette name.
         marker_shape: Node marker shape.
         marker_size: Node marker radius in pixels.
@@ -1943,6 +2010,12 @@ def render_video(
     if labels is not None and has_tracks:
         _track_idx_map = {id(t): i for i, t in enumerate(labels.tracks)}
 
+    # Identity catalog for stable identity coloring across frames (mirrors the
+    # track index map). Only built when coloring by identity.
+    _identity_catalog: list | None = None
+    if resolved_scheme == "identity":
+        _identity_catalog = list(labels.identities) if labels is not None else []
+
     # Track-keyed palette for overlay (mask/ROI/bbox) coloring under
     # color_by="track", matching centroids/poses/trails (same `palette`).
     _overlay_palette_by_track: list[tuple[int, int, int]] = []
@@ -2120,6 +2193,9 @@ def render_video(
                     scale=scale,
                     track_indices=None,
                     n_tracks=n_tracks,
+                    n_identities=(
+                        len(_identity_catalog) if _identity_catalog is not None else 0
+                    ),
                     pre_render_callback=pre_render_callback,
                     post_render_callback=post_render_callback,
                     per_instance_callback=None,
@@ -2145,6 +2221,17 @@ def render_video(
                 for inst in instances:
                     tidx = _track_idx_map.get(id(inst.track)) if inst.track else None
                     track_indices.append(tidx if tidx is not None else 0)
+
+            # Get identity indices/colors when coloring by identity
+            identity_indices = None
+            n_identities = 0
+            identity_colors = None
+            if resolved_scheme == "identity":
+                (
+                    identity_indices,
+                    n_identities,
+                    identity_colors,
+                ) = _compute_identity_coloring(instances, _identity_catalog)
 
             # Build instance metadata
             instance_metadata = []
@@ -2215,6 +2302,9 @@ def render_video(
                 scale=scale,
                 track_indices=track_indices,
                 n_tracks=n_tracks,
+                identity_indices=identity_indices,
+                n_identities=n_identities,
+                identity_colors=identity_colors,
                 pre_render_callback=pre_render_callback,
                 post_render_callback=post_render_callback,
                 per_instance_callback=per_instance_callback,

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -34,6 +34,7 @@ from sleap_io.io.cli import (
     _run_subprocess_with_progress,
     cli,
 )
+from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, PredictedInstance
 from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
@@ -59,6 +60,33 @@ def _strip_ansi(text: str) -> str:
 def _data_path(rel: str) -> Path:
     root = Path(__file__).resolve().parents[2] / "tests" / "data"
     return root / rel
+
+
+def _make_identity_slp(path: Path, *, color: str | None = "#ff0000") -> Labels:
+    """Write a minimal 2-instance .slp carrying global identities.
+
+    Builds one labeled frame with two instances assigned to two `Identity`
+    objects (the first optionally colored).
+    """
+    skeleton = Skeleton(["head", "tail"])
+    id_a = Identity(name="mouse_A", color=color)
+    id_b = Identity(name="mouse_B")
+    video = Video(filename="dummy.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    inst_a = Instance.from_numpy(
+        np.array([[10, 10], [20, 20]]), skeleton=skeleton, identity=id_a
+    )
+    inst_b = Instance.from_numpy(
+        np.array([[30, 30], [40, 40]]), skeleton=skeleton, identity=id_b
+    )
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst_a, inst_b])
+    labels = Labels(
+        labeled_frames=[lf],
+        videos=[video],
+        skeletons=[skeleton],
+        identities=[id_a, id_b],
+    )
+    save_slp(labels, str(path))
+    return labels
 
 
 def test_version_shows_plugin_info():
@@ -138,6 +166,18 @@ def test_show_summary_typical_slp():
     # Skeleton summary with Python code
     assert "nodes = " in out
     assert "Skeletons" in out
+
+
+def test_show_reports_identities(tmp_path):
+    """`sio show` reports the global identity count in the header stats."""
+    slp_path = tmp_path / "ids.slp"
+    _make_identity_slp(slp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["show", str(slp_path), "--no-open-videos"])
+    assert result.exit_code == 0, result.output
+    out = _strip_ansi(result.output)
+    assert "2 identities" in out
 
 
 def test_show_lf_zero_details():
@@ -4166,6 +4206,64 @@ def test_merge_all_options(tmp_path, slp_typical):
     assert "Merged 2 files:" in output
 
 
+@pytest.mark.parametrize("method", ["uuid", "name"])
+def test_merge_identity_option_accepted(method, tmp_path):
+    """`sio merge --identity {uuid,name}` is accepted and runs."""
+    a = tmp_path / "a.slp"
+    b = tmp_path / "b.slp"
+    _make_identity_slp(a)
+    _make_identity_slp(b)
+
+    runner = CliRunner()
+    merged_path = tmp_path / "merged.slp"
+    result = runner.invoke(
+        cli,
+        [
+            "merge",
+            str(a),
+            str(b),
+            "-o",
+            str(merged_path),
+            "--identity",
+            method,
+            "--frame",
+            "keep_both",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    output = _strip_ansi(result.output)
+    assert "Merged 2 files:" in output
+    assert merged_path.exists()
+
+
+def test_merge_identity_invalid_choice(tmp_path, slp_typical):
+    """An unsupported --identity value is rejected by Click."""
+    runner = CliRunner()
+    merged_path = tmp_path / "merged.slp"
+    result = runner.invoke(
+        cli,
+        [
+            "merge",
+            slp_typical,
+            slp_typical,
+            "-o",
+            str(merged_path),
+            "--identity",
+            "bogus",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "identity" in _strip_ansi(result.output).lower()
+
+
+def test_merge_help_lists_identity():
+    """`sio merge --help` documents the --identity option."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["merge", "--help"])
+    assert result.exit_code == 0
+    assert "--identity" in _strip_ansi(result.output)
+
+
 def test_merge_frame_strategies(tmp_path, slp_typical):
     """Test different frame strategies."""
     runner = CliRunner()
@@ -4961,6 +5059,46 @@ def test_render_single_frame_masks_only_no_skeleton(specifier, tmp_path):
     assert result.exit_code == 0, result.output
     assert "Rendered:" in result.output
     assert output_path.exists()
+
+
+def test_render_color_by_identity(tmp_path):
+    """`sio render --color-by identity` is accepted and renders an image.
+
+    The first identity is colored (``#ff0000``), exercising the
+    ``Identity.color`` preference path; the second falls back to the palette.
+    """
+    slp_path = tmp_path / "ids.slp"
+    _make_identity_slp(slp_path, color="#ff0000")
+
+    output_path = tmp_path / "frame.png"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            str(slp_path),
+            "--lf",
+            "0",
+            "--background",
+            "black",
+            "--color-by",
+            "identity",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Rendered:" in result.output
+    assert output_path.exists()
+
+
+def test_render_color_by_identity_help_choice():
+    """`sio render --help` lists identity as a --color-by choice."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["render", "--help"])
+    assert result.exit_code == 0
+    assert "identity" in _strip_ansi(result.output)
 
 
 def test_render_crop_pixel(centered_pair, tmp_path):

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -1123,6 +1123,72 @@ def test_identities_legacy_without_uuid_synthesizes_one(tmp_path):
     assert "uuid" not in loaded[0].metadata
 
 
+def test_per_instance_identity_round_trip(tmp_path):
+    """Test per-instance identity links round-trip through SLP (format 2.5)."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    id_a = Identity(name="mouse_A", metadata={"sex": "F"})
+    id_b = Identity(name="mouse_B")
+    insts = [
+        Instance.from_numpy(
+            np.array([[0, 1], [2, 3]]), skel, identity=id_a, identity_score=0.95
+        ),
+        PredictedInstance.from_numpy(
+            np.array([[4, 5], [6, 7]]), skel, score=0.8, identity=id_b
+        ),
+        Instance.from_numpy(np.array([[8, 9], [10, 11]]), skel),  # no identity
+    ]
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=insts)])
+    labels.update()
+
+    path = str(tmp_path / "identities.slp")
+    save_slp(labels, path)
+
+    # Format bumped to 2.5 and the additive dataset is present.
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] >= 2.5
+        assert "instance_identities" in f
+
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)
+    assert li[0].identity is not None
+    assert li[0].identity.name == "mouse_A"
+    assert li[0].identity.uuid == id_a.uuid
+    assert li[0].identity.metadata == {"sex": "F"}
+    assert li[0].identity_score == pytest.approx(0.95)
+    assert li[1].identity is not None
+    assert li[1].identity.name == "mouse_B"
+    assert li[1].identity_score is None  # not recorded -> None
+    assert li[2].identity is None
+    # The two distinct loaded identities are shared with the catalog.
+    assert {i.name for i in loaded.identities} == {"mouse_A", "mouse_B"}
+    assert li[0].identity is loaded.identities[loaded.identities.index(li[0].identity)]
+
+
+def test_no_identity_keeps_low_format_and_no_dataset(tmp_path):
+    """Test identity-free labels stay additive (no dataset, no format bump)."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    labels = Labels(
+        [
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)],
+            )
+        ]
+    )
+    path = str(tmp_path / "no_identity.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] < 2.5
+        assert "instance_identities" not in f
+
+    loaded = load_slp(path)
+    assert list(loaded[0].instances)[0].identity is None
+
+
 def test_make_frame_group_and_frame_group_to_dict(
     frame_group_345: FrameGroup, camera_group_345: CameraGroup
 ):

--- a/tests/io/test_slp_lazy.py
+++ b/tests/io/test_slp_lazy.py
@@ -1651,3 +1651,117 @@ class TestLazyLegacyFormatWithConfidence:
         np.testing.assert_allclose(arr[0, 0, :, :2], expected_pred)
         # Confidence should be from the predicted instance point scores
         np.testing.assert_allclose(arr[0, 0, :, 2], 0.85, rtol=0.01)
+
+
+def test_lazy_per_instance_identity_round_trip(tmp_path):
+    """Test per-instance identities materialize correctly via the lazy loader."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    id_a = sio.Identity(name="mouse_A", metadata={"sex": "F"})
+    id_b = sio.Identity(name="mouse_B")
+    insts = [
+        Instance.from_numpy(
+            np.array([[0, 1], [2, 3]]), skel, identity=id_a, identity_score=0.95
+        ),
+        PredictedInstance.from_numpy(
+            np.array([[4, 5], [6, 7]]), skel, score=0.8, identity=id_b
+        ),
+        Instance.from_numpy(np.array([[8, 9], [10, 11]]), skel),  # no identity
+    ]
+    labels = sio.Labels([LabeledFrame(video=video, frame_idx=0, instances=insts)])
+    labels.update()
+
+    path = str(tmp_path / "lazy_identities.slp")
+    sio.save_slp(labels, path)
+
+    lazy = sio.load_slp(path, lazy=True)
+    assert lazy.is_lazy
+    assert {i.name for i in lazy.identities} == {"mouse_A", "mouse_B"}
+
+    li = list(lazy[0].instances)
+    assert li[0].identity is not None
+    assert li[0].identity.name == "mouse_A"
+    assert li[0].identity.uuid == id_a.uuid
+    assert li[0].identity_score == pytest.approx(0.95)
+    assert li[1].identity is not None
+    assert li[1].identity.name == "mouse_B"
+    assert li[1].identity_score is None
+    assert li[2].identity is None
+
+    # The materialized identity is the canonical catalog object.
+    assert li[0].identity in lazy.identities
+
+    # Lazy store copy preserves identity wiring, the catalog, and consistency.
+    copied = lazy.copy()
+    cli = list(copied[0].instances)
+    assert cli[0].identity is not None
+    assert cli[0].identity.name == "mouse_A"
+    assert {i.name for i in copied.identities} == {"mouse_A", "mouse_B"}
+    assert cli[0].identity in copied.identities  # materialized inst -> catalog
+    assert copied.identities[0] is not lazy.identities[0]  # independent copy
+
+
+def test_lazy_save_persists_identities(tmp_path):
+    """Lazy save must persist identities + per-instance links.
+
+    Regression test for the silent-data-loss bug where the lazy fast-path writer
+    copied raw points/instances/tracks but skipped identities, so
+    ``load_slp(p, lazy=True).save(p2)`` dropped them. Saving the lazy labels
+    must round-trip identical to saving the eager labels.
+    """
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    id_a = sio.Identity(name="mouse_A", metadata={"sex": "F"})
+    id_b = sio.Identity(name="mouse_B")
+
+    i0 = Instance.from_numpy(
+        np.array([[0, 1], [2, 3]]), skel, identity=id_a, identity_score=0.95
+    )
+    i1 = PredictedInstance.from_numpy(
+        np.array([[4, 5], [6, 7]]), skel, score=0.8, identity=id_b
+    )
+    i2 = Instance.from_numpy(np.array([[8, 9], [10, 11]]), skel)  # no identity
+
+    labels = sio.Labels(
+        [LabeledFrame(video=video, frame_idx=0, instances=[i0, i1, i2])]
+    )
+    labels.update()
+
+    # Save eagerly, then load lazily.
+    a = str(tmp_path / "a.slp")
+    sio.save_slp(labels, a)
+    lazy = sio.load_slp(a, lazy=True)
+    assert lazy.is_lazy
+
+    # Save the LAZY labels (exercises the fast-path writer) and reload eagerly.
+    b = str(tmp_path / "b.slp")
+    sio.save_slp(lazy, b)
+
+    # The fast path must not have materialized: lazy labels stay lazy after save.
+    assert lazy.is_lazy
+
+    # Format must reflect per-instance identity links (>= 2.5).
+    with h5py.File(b, "r") as f:
+        assert f["metadata"].attrs["format_id"] >= 2.5
+        assert "identities_json" in f
+        assert "instance_identities" in f
+
+    reb = sio.load_slp(b)
+
+    # Identities survived with uuids intact.
+    assert {i.name for i in reb.identities} == {"mouse_A", "mouse_B"}
+    by_name = {i.name: i for i in reb.identities}
+    assert by_name["mouse_A"].uuid == id_a.uuid
+    assert by_name["mouse_B"].uuid == id_b.uuid
+    assert by_name["mouse_A"].metadata == {"sex": "F"}
+
+    # Per-instance identity + identity_score survived.
+    ri = reb[0].instances
+    assert ri[0].identity is not None
+    assert ri[0].identity.name == "mouse_A"
+    assert ri[0].identity.uuid == id_a.uuid
+    assert ri[0].identity_score == pytest.approx(0.95)
+    assert ri[1].identity is not None
+    assert ri[1].identity.name == "mouse_B"
+    assert ri[1].identity_score is None
+    assert ri[2].identity is None

--- a/tests/model/test_instance.py
+++ b/tests/model/test_instance.py
@@ -5,6 +5,7 @@ import pytest
 from numpy.testing import assert_array_equal, assert_equal
 
 from sleap_io import Skeleton
+from sleap_io.model.identity import Identity
 from sleap_io.model.instance import (
     Instance,
     PredictedInstance,
@@ -453,6 +454,77 @@ def test_instance_same_identity_as():
     # Both without tracks
     inst5 = Instance.from_numpy(np.array([[10, 10], [20, 20]]), skeleton=skeleton)
     assert not inst4.same_identity_as(inst5)
+
+
+def test_instance_identity_fields():
+    """Test that Instance/PredictedInstance carry identity and identity_score."""
+    skeleton = Skeleton(["head", "tail"])
+    identity = Identity(name="mouse_A")
+
+    inst = Instance.from_numpy(
+        np.array([[10, 10], [20, 20]]),
+        skeleton=skeleton,
+        identity=identity,
+        identity_score=0.9,
+    )
+    assert inst.identity is identity
+    assert inst.identity_score == 0.9
+
+    pred = PredictedInstance.from_numpy(
+        np.array([[10, 10], [20, 20]]),
+        skeleton=skeleton,
+        score=0.8,
+        identity=identity,
+        identity_score=0.7,
+    )
+    assert pred.identity is identity
+    assert pred.identity_score == 0.7
+
+    # Defaults are None.
+    bare = Instance.from_numpy(np.array([[10, 10], [20, 20]]), skeleton=skeleton)
+    assert bare.identity is None
+    assert bare.identity_score is None
+
+    # empty() also threads identity.
+    empty = Instance.empty(skeleton, identity=identity, identity_score=0.5)
+    assert empty.identity is identity
+    assert empty.identity_score == 0.5
+
+
+def test_instance_same_identity_as_global_identity():
+    """Test that same_identity_as prefers global Identity (by uuid) over track."""
+    skeleton = Skeleton(["head", "tail"])
+    track1 = Track(name="t1")
+    track2 = Track(name="t2")
+
+    # Same uuid (e.g. two reloads of one animal) -> same identity even across
+    # different track objects.
+    idA1 = Identity(name="mouse_A", uuid="shared")
+    idA2 = Identity(name="mouse_A", uuid="shared")
+    inst1 = Instance.from_numpy(
+        np.array([[1, 1], [2, 2]]), skeleton=skeleton, track=track1, identity=idA1
+    )
+    inst2 = Instance.from_numpy(
+        np.array([[3, 3], [4, 4]]), skeleton=skeleton, track=track2, identity=idA2
+    )
+    assert inst1.same_identity_as(inst2)  # uuid matches despite different tracks
+
+    # Different uuid -> not the same identity even if tracks are the same object.
+    idB = Identity(name="mouse_B")
+    inst3 = Instance.from_numpy(
+        np.array([[5, 5], [6, 6]]), skeleton=skeleton, track=track1, identity=idB
+    )
+    assert not inst1.same_identity_as(inst3)
+
+    # When only one has an identity, fall back to track comparison.
+    inst4 = Instance.from_numpy(
+        np.array([[7, 7], [8, 8]]), skeleton=skeleton, track=track1
+    )
+    assert inst1.same_identity_as(inst4)  # idA1 has no identity peer -> track t1
+    inst5 = Instance.from_numpy(
+        np.array([[9, 9], [0, 0]]), skeleton=skeleton, track=track2
+    )
+    assert not inst1.same_identity_as(inst5)  # falls back to track, t1 != t2
 
 
 def test_instance_overlaps_with():

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -12,7 +12,10 @@ from shapely.geometry import box
 
 import sleap_io
 from sleap_io import (
+    FrameGroup,
+    Identity,
     Instance,
+    InstanceGroup,
     LabeledFrame,
     PredictedInstance,
     RecordingSession,
@@ -168,7 +171,53 @@ def test_append_extend():
     assert labels.tracks == [new_track, new_track2]
 
 
-def test_update_dedupes_same_order_skeletons():
+def test_identities_auto_collected():
+    """Test that Labels auto-collects per-instance Identity objects."""
+    skel = Skeleton(["A", "B"])
+    video = Video.from_filename("fake.mp4")
+    id_a = Identity(name="mouse_A")
+    id_b = Identity(name="mouse_B")
+
+    # append() collects identities from instances.
+    labels = Labels()
+    labels.append(
+        LabeledFrame(
+            video=video,
+            frame_idx=0,
+            instances=[
+                Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel, identity=id_a),
+                Instance.from_numpy(np.array([[4, 5], [6, 7]]), skel, identity=id_b),
+                Instance.from_numpy(np.array([[8, 9], [0, 1]]), skel),  # no identity
+            ],
+        ),
+        update=True,
+    )
+    assert labels.identities == [id_a, id_b]
+
+    # extend() collects new identities and dedupes existing ones.
+    id_c = Identity(name="mouse_C")
+    labels.extend(
+        [
+            LabeledFrame(
+                video=video,
+                frame_idx=1,
+                instances=[
+                    Instance.from_numpy(
+                        np.array([[0, 1], [2, 3]]), skel, identity=id_a
+                    ),
+                    Instance.from_numpy(
+                        np.array([[4, 5], [6, 7]]), skel, identity=id_c
+                    ),
+                ],
+            )
+        ],
+        update=True,
+    )
+    assert labels.identities == [id_a, id_b, id_c]
+
+    # update() rebuilds from scratch without duplicating.
+    labels.update()
+    assert labels.identities == [id_a, id_b, id_c]
     """Structurally-equal, same-order skeletons collapse to one on update."""
     skel1 = Skeleton(nodes=["A", "B", "C"], edges=[("A", "B"), ("B", "C")])
     skel2 = Skeleton(nodes=["A", "B", "C"], edges=[("A", "B"), ("B", "C")])
@@ -4281,6 +4330,136 @@ def test_labels_merge_predicted_instance_mapping():
     assert mapped_inst.track == track1
     assert mapped_inst.score == 0.95
     assert np.array_equal(mapped_inst.numpy(), inst.numpy())
+
+
+def test_labels_merge_dedupes_same_uuid_identity():
+    """Merge dedupes same-uuid identities and preserves identity_score.
+
+    The same animal (shared ``uuid``) referenced by two separately-built files
+    must collapse to a single canonical catalog `Identity` after merge, with both
+    instances pointing at it. Per-instance ``identity_score`` must survive the
+    rebuild in ``_map_instance``.
+    """
+    skel1 = Skeleton(nodes=["head", "tail"])
+    skel2 = Skeleton(nodes=["head", "tail"])  # Same structure -> matched.
+    video1 = Video(filename="video1.mp4")
+    video2 = Video(filename="video2.mp4")  # Different video -> new frame.
+
+    # Distinct Identity objects that share a stable uuid (same animal).
+    shared_uuid = "a" * 32
+    id1 = Identity(name="mouse_A", uuid=shared_uuid)
+    id2 = Identity(name="mouse_A", uuid=shared_uuid)
+
+    inst1 = Instance.from_numpy(
+        np.array([[10, 10], [20, 20]]), skeleton=skel1, identity=id1
+    )
+    labels1 = Labels([LabeledFrame(video=video1, frame_idx=0, instances=[inst1])])
+
+    inst2 = Instance.from_numpy(
+        np.array([[30, 30], [40, 40]]),
+        skeleton=skel2,
+        identity=id2,
+        identity_score=0.87,
+    )
+    labels2 = Labels([LabeledFrame(video=video2, frame_idx=0, instances=[inst2])])
+
+    # Each file independently collected its own identity object.
+    assert labels1.identities == [id1]
+    assert labels2.identities == [id2]
+
+    video_matcher = VideoMatcher(method=VideoMatchMethod.PATH, strict=True)
+    labels1.merge(labels2, video=video_matcher)
+
+    # Deduped to a single canonical catalog identity (no duplicate uuids).
+    assert len(labels1.identities) == 1
+    canonical = labels1.identities[0]
+    assert canonical is id1  # Existing self identity is canonical.
+
+    # Both merged instances point at the canonical catalog object.
+    merged_instances = [inst for lf in labels1 for inst in lf]
+    assert len(merged_instances) == 2
+    assert all(inst.identity is canonical for inst in merged_instances)
+
+    # identity_score survived the merge for the incoming instance.
+    incoming = [i for i in merged_instances if i.identity_score == 0.87]
+    assert len(incoming) == 1
+    inc = incoming[0]
+    assert inc is not inst2  # Rebuilt by _map_instance.
+
+
+def test_labels_merge_keeps_distinct_uuid_identities():
+    """Merge keeps both identities when their uuids differ."""
+    skel1 = Skeleton(nodes=["head", "tail"])
+    skel2 = Skeleton(nodes=["head", "tail"])
+    video1 = Video(filename="video1.mp4")
+    video2 = Video(filename="video2.mp4")
+
+    id1 = Identity(name="mouse_A")  # Auto-generated, distinct uuid.
+    id2 = Identity(name="mouse_B")  # Different uuid.
+
+    inst1 = Instance.from_numpy(
+        np.array([[10, 10], [20, 20]]), skeleton=skel1, identity=id1
+    )
+    labels1 = Labels([LabeledFrame(video=video1, frame_idx=0, instances=[inst1])])
+
+    inst2 = Instance.from_numpy(
+        np.array([[30, 30], [40, 40]]), skeleton=skel2, identity=id2
+    )
+    labels2 = Labels([LabeledFrame(video=video2, frame_idx=0, instances=[inst2])])
+
+    video_matcher = VideoMatcher(method=VideoMatchMethod.PATH, strict=True)
+    labels1.merge(labels2, video=video_matcher)
+
+    # Both distinct identities appear in the catalog.
+    assert len(labels1.identities) == 2
+    assert {i.uuid for i in labels1.identities} == {id1.uuid, id2.uuid}
+    assert id1 in labels1.identities
+    assert id2 in labels1.identities
+
+
+def test_labels_merge_identity_by_name():
+    """merge(identity="name") dedupes the catalog by name despite distinct uuids."""
+    skel1 = Skeleton(nodes=["head", "tail"])
+    skel2 = Skeleton(nodes=["head", "tail"])
+    video1 = Video(filename="video1.mp4")
+    video2 = Video(filename="video2.mp4")
+
+    # Same name, different (auto) uuids — the uuid default would keep both.
+    id1 = Identity(name="mouse_A")
+    id2 = Identity(name="mouse_A")
+    assert id1.uuid != id2.uuid
+
+    inst1 = Instance.from_numpy(
+        np.array([[10, 10], [20, 20]]), skeleton=skel1, identity=id1
+    )
+    labels1 = Labels([LabeledFrame(video=video1, frame_idx=0, instances=[inst1])])
+    inst2 = Instance.from_numpy(
+        np.array([[30, 30], [40, 40]]), skeleton=skel2, identity=id2
+    )
+    labels2 = Labels([LabeledFrame(video=video2, frame_idx=0, instances=[inst2])])
+
+    video_matcher = VideoMatcher(method=VideoMatchMethod.PATH, strict=True)
+    labels1.merge(labels2, video=video_matcher, identity="name")
+
+    # Name matching collapses the two into a single canonical catalog entry.
+    assert len(labels1.identities) == 1
+    assert labels1.identities[0] is id1
+
+
+def test_update_collects_instance_group_identity():
+    """update() collects multi-view identities bound only on `InstanceGroup`s."""
+    id_mv = Identity(name="multiview_mouse")
+    instance_group = InstanceGroup(identity=id_mv)
+    frame_group = FrameGroup(frame_idx=0, instance_groups=[instance_group])
+    session = RecordingSession(frame_group_by_frame_idx={0: frame_group})
+
+    # Constructor runs update(), which must collect the InstanceGroup identity.
+    labels = Labels(sessions=[session])
+    assert id_mv in labels.identities
+
+    # A repeated update() must not duplicate it (deduped by object identity).
+    labels.update()
+    assert labels.identities.count(id_mv) == 1
 
 
 def test_labels_merge_video_basename_with_fallback_dirs(tmp_path):


### PR DESCRIPTION
## Summary

**PR 2 of 3** (stacked on `feat/identity-core`). Makes `Identity` a first-class **per-instance, global** identity — the cross-session re-ID key, distinct from the ephemeral video-local `Track` — and persists/merges it correctly everywhere.

## Key changes
- **Model:** `Instance.identity` / `Instance.identity_score` on `Instance` and `PredictedInstance` (threaded through `empty`/`from_numpy`). `same_identity_as` now prefers global identity (by uuid), falling back to track. Auto-collected into `Labels.identities` from instances **and** from multi-view `InstanceGroup.identity`.
- **Persistence (SLP format 2.5):** new **additive** `/instance_identities` dataset (`instance_id`, `identity_idx`, `identity_score`) joined on the global `instance_id` — *not* new columns in the static instance dtype (that would break round-trips + upstream SLEAP). Works on both eager and the **lazy fast-path** save (driven from the lazy store, no materialization). Old readers ignore it; old files round-trip unchanged.
- **Merge:** `Labels.merge()` dedupes the identity catalog by `uuid` (new `identity` matcher param, default uuid; `"name"` supported) and preserves per-instance `identity`/`identity_score` through `_map_instance`.
- **CLI:** `sio show` reports identity counts; `sio merge --identity {uuid,name}`; `sio render --color-by identity` (prefers `Identity.color`).

## Adversarial-review blockers fixed here
- **Lazy-save dropped identities** — the lazy fast-path never wrote them; now persisted from the store.
- **`merge` dropped per-instance identity + made catalog dupes** — now threaded + uuid-deduped.
- **`InstanceGroup`-only identities dropped on save** — now auto-collected.

## Testing
Full suite green (3835 passed, 1 skipped), incl. eager+lazy round-trips, lazy-save round-trip, merge uuid/name dedup, InstanceGroup collection, format gating, and CLI tests.

## Stack
Base: `feat/identity-core` (PR1). Followed by `feat/embeddings` (PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbXnTzogXjYJ6fiVzq2TN1
