### PR TITLE
feat: re-ID Embedding data model + persistence (3/3)

### DIFF
--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -108,6 +108,13 @@ file.slp
 │
 ├── /video_crops                 # Dataset: JSON, virtual on-read crops (Format 2.3+, optional)
 │
+├── /embeddings/                 # Group: re-ID embeddings, one subgroup per space (Format 2.6+)
+│   └── <space>/                 # e.g. "reid", "jabs"
+│       ├── vectors              # Dataset: float (n, D), gzip-compressed (dtype preserved)
+│       ├── owner_type           # Dataset: uint8 (0=instance, 1=identity)
+│       ├── owner_id             # Dataset: int64 owner index (global instance_id / identity index)
+│       └── meta_json            # Dataset: per-row JSON (normalized, source, centroid_xy, metadata)
+│
 └── /video{N}/                   # Group: Per-video embedded data (one per video)
     ├── /video                   # Dataset: Embedded image data
     │   ├── @format              # Attribute: "png", "jpg", or "hdf5"
@@ -148,6 +155,7 @@ file.slp
 | `sessions_json` | `bytes[]` | JSON array of recording sessions (optional) |
 | `identities_json` | `bytes[]` | JSON array of identity definitions, incl. stable `uuid` (optional) |
 | `instance_identities` | structured | Per-instance global identity links: `instance_id`, `identity_idx`, `identity_score` (Format 2.5+, optional) |
+| `embeddings/<space>` | group | re-ID embedding vectors + `owner_type`/`owner_id` join columns + `meta_json` (Format 2.6+, optional) |
 | `provenance_json` | `bytes` | JSON object of provenance metadata (optional) |
 
 ### Provenance storage and the 64 KB metadata limit
@@ -569,7 +577,7 @@ Per-instance global identity assignments are stored in the optional `/instance_i
 | `identity_idx` | `int32` | Index into `/identities_json` |
 | `identity_score` | `float32` | Identity-assignment score (NaN if unrecorded) |
 
-This is additive: old readers ignore the dataset, and instances without a global identity simply have no row.
+This is additive: old readers ignore the dataset, and instances without a global identity simply have no row. Per-identity prototype embeddings and per-instance re-ID embeddings live in the `/embeddings` group — see [Embeddings](../model/embedding.md).
 
 ### Instance Group Linking
 

--- a/docs/model/3d.md
+++ b/docs/model/3d.md
@@ -186,6 +186,7 @@ Key properties:
 - `uuid` — a stable 32-character hex key, auto-generated per identity. This is the canonical cross-file matching key: it survives serialization and merges, where Python object identity (used by `Track`) and positional indices both fail.
 - `color` — optional hex color string for visualization.
 - `metadata` — arbitrary metadata dictionary (e.g. `species`/`sex`/`genotype`).
+- `embeddings` — optional re-ID prototype / gallery [`Embedding`](embedding.md) vectors keyed by space name.
 
 Identities attach at three levels:
 
@@ -215,7 +216,7 @@ Compare identities with `matches()` (default `method="uuid"`), or configure an [
 ```
 
 !!! note "SLP persistence"
-    The identity catalog (with `uuid`) persists in SLP format v1.9+. Per-instance identity links (`Instance.identity`/`identity_score`) persist in **format 2.5+** via the additive `/instance_identities` dataset. These are additive, so older readers ignore them and older files round-trip unchanged. See [Formats → SLP](../formats/slp.md).
+    The identity catalog (with `uuid`) persists in SLP format v1.9+. Per-instance identity links (`Instance.identity`/`identity_score`) persist in **format 2.5+** via the additive `/instance_identities` dataset; re-ID embeddings persist in **format 2.6+**. All are additive, so older readers ignore them and older files round-trip unchanged. See [Embeddings](embedding.md) and [Formats → SLP](../formats/slp.md).
 
 ---
 
@@ -297,6 +298,7 @@ classDiagram
         +Skeleton skeleton
         +Identity identity
         +float identity_score
+        +dict~str,Embedding~ embeddings
     }
     class Identity:::threed {
         +str name

--- a/docs/model/embedding.md
+++ b/docs/model/embedding.md
@@ -1,0 +1,77 @@
+# Embeddings
+
+An [`Embedding`][sleap_io.Embedding] is a per-detection appearance / re-identification feature
+vector. It is the bridge for **multi-object tracking** and **re-ID** workflows: a model
+produces one vector per detection crop, and those vectors are compared (typically by cosine
+similarity) to link detections to a global [`Identity`](3d.md#identity).
+
+`Embedding` is a small value object — the vector is the only heavy part:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `vector` | `np.ndarray` `(D,)` | The feature vector. Floating dtype is preserved (e.g. `float32` from a network, `float64` from JABS prototypes); non-floating input is cast to `float32`. |
+| `name` | `str` | Embedding-space name (e.g. `"reid"`, `"jabs"`). Multiple spaces may coexist on one detection. |
+| `normalized` | `bool` | Whether the vector is L2-normalized (cosine geometry). Defaults to `True`. |
+| `source` | `str \| None` | Optional provenance / model identifier. |
+| `centroid_xy` | `np.ndarray` `(2,)` `\| None` | Optional source location the crop was sampled at. |
+| `metadata` | `dict` | Arbitrary metadata. |
+
+## Per-modality slots
+
+Every detection modality — [`Instance`](poses.md), [`Centroid`](centroids.md),
+[`SegmentationMask`](segmentation.md), [`BoundingBox`](boxes.md), [`ROI`](rois.md) — as well as
+[`Identity`](3d.md#identity) carries an `embeddings: dict[str, Embedding]` mapping keyed by space
+name, plus a convenience `embedding` accessor and a `set_embedding()` helper:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "tail"])
+>>> inst = sio.Instance.from_numpy(np.array([[0, 1], [2, 3]]), skeleton=skeleton)
+>>> _ = inst.set_embedding(np.ones(128, dtype="float32"), name="reid", source="reid_v1")
+>>> print(inst.embedding.dim)
+
+```
+
+The `embedding` accessor returns the `"reid"` space if present, otherwise the sole space if there
+is exactly one, otherwise `None`. A second named space coexists without conflict:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "tail"])
+>>> inst = sio.Instance.from_numpy(np.array([[0, 1], [2, 3]]), skeleton=skeleton)
+>>> _ = inst.set_embedding(np.ones(128, dtype="float32"))           # -> "reid"
+>>> _ = inst.set_embedding(np.ones(64, dtype="float64"), name="jabs")
+>>> print(sorted(inst.embeddings))
+
+```
+
+## Identity prototypes
+
+An [`Identity`](3d.md#identity) carries gallery / prototype embeddings (e.g. the cluster centroid
+of its member instances) in the same `embeddings` mapping. A detection is resolved to a global
+identity by comparing its `embedding` against the identity prototypes by cosine similarity.
+
+## SLP persistence
+
+Embeddings persist to SLP in **format 2.6+** via the additive `/embeddings` group, with one
+subgroup per named space holding the stacked `vectors` `(n, D)` (dtype preserved per space), the
+`owner_type`/`owner_id` join columns, and a per-row `meta_json`. The large float vectors live in
+their own gzipped numeric datasets — never in any JSON blob and never in the fixed instance row
+layout — so the format stays additive: older readers ignore the group and embedding-free files
+round-trip unchanged. Per-instance embeddings are loaded lazily alongside the rest of the lazy
+store.
+
+!!! note "Persistence scope"
+    Instance and Identity embeddings are written today. Embeddings attached to centroid / mask /
+    bounding-box / ROI detections are not yet persisted; saving emits a warning so they are not
+    silently dropped.
+
+---
+
+## API reference
+
+::: sleap_io.Embedding
+
+::: sleap_io.model.embedding.EmbeddingMixin

--- a/docs/model/index.md
+++ b/docs/model/index.md
@@ -78,6 +78,7 @@ classDiagram
         +Track track
         +Identity identity
         +float identity_score
+        +dict~str,Embedding~ embeddings
     }
     class PredictedInstance:::poses {
         +float score

--- a/docs/model/labels.md
+++ b/docs/model/labels.md
@@ -440,6 +440,7 @@ classDiagram
         +PointsArray points
         +Identity identity
         +float identity_score
+        +dict~str,Embedding~ embeddings
     }
 
     class Video {

--- a/docs/model/poses.md
+++ b/docs/model/poses.md
@@ -17,7 +17,7 @@ The pose data model is built around four key types:
 - **[`Track`][sleap_io.Track]** is the **video-local identity**: links the same animal across frames of one recording.
 - **[`Identity`](3d.md#identity)** is the **global identity**: a persistent, cross-session animal label assigned via `Instance.identity` (with `identity_score`), distinct from the ephemeral `Track`.
 
-A `Skeleton` is shared across all instances in a dataset. Each `Instance` references a `Skeleton` to know which landmarks it contains, and optionally a `Track` (and a global `Identity`) to indicate which animal it belongs to.
+A `Skeleton` is shared across all instances in a dataset. Each `Instance` references a `Skeleton` to know which landmarks it contains, optionally a `Track` (and a global `Identity`) to indicate which animal it belongs to, and optionally re-ID [`embeddings`](embedding.md) describing its appearance.
 
 ---
 
@@ -334,6 +334,7 @@ classDiagram
         +Track track
         +Identity identity
         +float identity_score
+        +dict~str,Embedding~ embeddings
         +numpy() ndarray
         +n_visible: int
         +is_empty: bool

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,6 +173,7 @@ nav:
       - Boxes: model/boxes.md
       - ROIs: model/rois.md
       - Segmentation: model/segmentation.md
+      - Embeddings: model/embedding.md
     - Formats:
       - formats/index.md
       - SLP Format: formats/slp.md

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -89,6 +89,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             "InstanceGroup",
             "RecordingSession",
         ],
+        "model.embedding": ["Embedding"],
         "model.identity": ["Identity"],
         "model.instance": [
             "Instance",

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -1646,6 +1646,35 @@ def _print_tracks_summary(labels: Labels) -> None:
     console.print(f"  {track_names}")
 
 
+def _print_embeddings_summary(labels: Labels) -> None:
+    """Print a per-instance embedding summary (inline).
+
+    Reports the number of instances carrying embeddings and the set of embedding
+    space names. Skipped for lazy labels, since scanning instances would force a
+    full materialization.
+    """
+    # Iterating instances on lazy labels would force materialization; only
+    # summarize embeddings when the labeled frames are readily available.
+    if labels.is_lazy:
+        return
+
+    n_with_embeddings = 0
+    space_names: set[str] = set()
+    for lf in labels.labeled_frames:
+        for inst in lf.instances:
+            if inst.embeddings:
+                n_with_embeddings += 1
+                space_names.update(inst.embeddings.keys())
+
+    if n_with_embeddings == 0:
+        return
+
+    console.print()
+    console.print(f"[bold]Embeddings[/] ({n_with_embeddings} instances)")
+    spaces = ", ".join(sorted(space_names))
+    console.print(f"  [dim]Spaces:[/] {spaces}")
+
+
 def _print_tracks_details(labels: Labels) -> None:
     """Print detailed track information."""
     if not labels.tracks:
@@ -1933,6 +1962,7 @@ def show(
             _print_skeleton_summary(obj)
             _print_video_summary(obj)
             _print_tracks_summary(obj)
+            _print_embeddings_summary(obj)
         else:
             # Detailed views
             if skeleton:

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -22,6 +22,9 @@ Format version history:
     - 2.5: Added per-instance global identity links (/instance_identities dataset:
             instance_id, identity_idx, identity_score) joining instances to the
             identity catalog; additive, read with try/except on dataset presence
+    - 2.6: Added appearance / re-ID embeddings (/embeddings group, one subgroup
+            per named space: vectors (n, D) float + owner_type/owner_id join
+            columns + per-row meta_json); additive, read on group presence
 """
 
 from __future__ import annotations
@@ -1812,6 +1815,282 @@ def _instance_identity_rows_from_store(
     return rows
 
 
+# Owner-type codes for the /embeddings owner_type join column.
+#
+# Only instance and identity owners are written today. Codes 2-7 are reserved
+# (not yet implemented) so per-modality embedding persistence can be completed
+# later without renumbering or breaking existing files:
+#   2 = centroid
+#   3 = mask
+#   4 = bbox
+#   5 = roi
+#   6 = frame
+#   7 = track
+# When adding a new owner type, define its named constant here and extend both
+# the builders feeding `_write_embedding_groups` and the `read_embeddings`
+# dispatch on `owner_type`.
+EMBEDDING_OWNER_INSTANCE = 0
+EMBEDDING_OWNER_IDENTITY = 1
+# Reserved for future use (see note above); not yet written or read.
+EMBEDDING_OWNER_CENTROID = 2
+EMBEDDING_OWNER_MASK = 3
+EMBEDDING_OWNER_BBOX = 4
+EMBEDDING_OWNER_ROI = 5
+EMBEDDING_OWNER_FRAME = 6
+EMBEDDING_OWNER_TRACK = 7
+
+
+def read_embeddings(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> tuple[dict[int, dict], dict[int, dict]]:
+    """Read appearance / re-ID embeddings from a SLEAP labels file.
+
+    Embeddings are stored in the optional ``/embeddings`` group (SLP format 2.6+),
+    one subgroup per named embedding space. Each subgroup holds the stacked
+    ``vectors`` ``(n, D)`` (dtype preserved), the ``owner_type`` / ``owner_id``
+    join columns, and a per-row ``meta_json`` carrying the remaining `Embedding`
+    attributes (``normalized``, ``source``, ``centroid_xy``, ``metadata``).
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from.
+
+    Returns:
+        A 2-tuple ``(instance_embeddings, identity_embeddings)`` where each maps
+        the owner index (global ``instance_id`` / index into the identity catalog)
+        to a ``{space_name: Embedding}`` dict. Both are empty for older files.
+    """
+    from sleap_io.model.embedding import Embedding
+
+    instance_embeddings: dict[int, dict] = {}
+    identity_embeddings: dict[int, dict] = {}
+
+    cm = (
+        nullcontext(_hdf5_file)
+        if _hdf5_file is not None
+        else h5py.File(labels_path, "r")
+    )
+    with cm as f:
+        if "embeddings" not in f:
+            return instance_embeddings, identity_embeddings
+
+        group = f["embeddings"]
+        for space in group:
+            sub = group[space]
+            vectors = sub["vectors"][:]
+            owner_type = sub["owner_type"][:]
+            owner_id = sub["owner_id"][:]
+            meta_json = sub["meta_json"][:]
+            for i in range(len(vectors)):
+                meta = json.loads(meta_json[i])
+                emb = Embedding(
+                    vector=vectors[i],
+                    name=space,
+                    normalized=meta.get("normalized", True),
+                    source=meta.get("source"),
+                    centroid_xy=meta.get("centroid_xy"),
+                    metadata=meta.get("metadata", {}),
+                )
+                oid = int(owner_id[i])
+                if int(owner_type[i]) == EMBEDDING_OWNER_IDENTITY:
+                    identity_embeddings.setdefault(oid, {})[space] = emb
+                else:
+                    instance_embeddings.setdefault(oid, {})[space] = emb
+
+    return instance_embeddings, identity_embeddings
+
+
+def write_embeddings(labels_path: str, labels: Labels) -> None:
+    """Write appearance / re-ID embeddings to a SLEAP labels file.
+
+    Creates the ``/embeddings`` group (SLP format 2.6+) with one subgroup per
+    named embedding space. Per-instance embeddings join on the global
+    ``instance_id`` (enumeration order over frames then instances, matching
+    `write_lfs`); per-identity prototype embeddings join on the identity catalog
+    index. Large float vectors live in their own gzipped numeric datasets,
+    keeping them out of any JSON blob and out of the fixed instance row layout
+    (purely additive: old readers ignore the group).
+
+    Embeddings attached to non-instance detection modalities (centroids, masks,
+    bounding boxes, ROIs) are not yet persisted; a warning is emitted if any are
+    present so they are not silently dropped.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        labels: A `Labels` object to store the embeddings for.
+
+    Raises:
+        ValueError: If a single embedding space contains vectors of differing
+            dimensionality.
+    """
+    # space name -> list of (owner_type, owner_id, Embedding)
+    by_space = _embedding_groups_from_labels(labels)
+
+    # Warn about embeddings on modalities whose persistence is not yet supported.
+    unpersisted = sum(
+        1
+        for attr in ("centroids", "bboxes", "masks", "rois")
+        for ann in getattr(labels, attr, [])
+        if getattr(ann, "embeddings", None)
+    )
+    if unpersisted:
+        warnings.warn(
+            f"{unpersisted} embedding(s) on centroid/mask/bbox/ROI detections are "
+            "not yet persisted to SLP and will be dropped on save. Only "
+            "Instance and Identity embeddings are currently written.",
+            stacklevel=2,
+        )
+
+    _write_embedding_groups(labels_path, by_space)
+
+
+def _embedding_groups_from_labels(labels: Labels) -> dict[str, list]:
+    """Build embedding groups by iterating a `Labels` (eager path).
+
+    Args:
+        labels: A `Labels` object to collect instance and identity embeddings
+            from.
+
+    Returns:
+        A mapping ``{space_name: [(owner_type, owner_id, Embedding), ...]}`` where
+        per-instance embeddings join on the global ``instance_id`` (enumeration
+        order over frames then instances, matching `write_lfs`) and per-identity
+        prototype embeddings join on the identity catalog index.
+    """
+    by_space: dict[str, list] = {}
+
+    instance_id = 0
+    for lf in labels:
+        for inst in lf:
+            for name, emb in getattr(inst, "embeddings", {}).items():
+                by_space.setdefault(name, []).append(
+                    (EMBEDDING_OWNER_INSTANCE, instance_id, emb)
+                )
+            instance_id += 1
+
+    for idx, identity in enumerate(labels.identities):
+        for name, emb in identity.embeddings.items():
+            by_space.setdefault(name, []).append((EMBEDDING_OWNER_IDENTITY, idx, emb))
+
+    return by_space
+
+
+def _embedding_groups_from_store(
+    store: "LazyDataStore", identities: list[Identity]
+) -> dict[str, list]:
+    """Build embedding groups from a lazy store without materializing instances.
+
+    The lazy store holds per-instance embeddings keyed by the global
+    ``instance_id`` (the same id space written by the fast path), so they can be
+    emitted directly without rebuilding `Instance` objects. Identity prototype
+    embeddings are read from the shared identity catalog. Per-instance entries are
+    sorted by ``instance_id`` for deterministic output.
+
+    Args:
+        store: The `LazyDataStore` backing a lazy `Labels`.
+        identities: The identity catalog (``store.identities``), whose prototype
+            embeddings are emitted with owner index = catalog position.
+
+    Returns:
+        A mapping ``{space_name: [(owner_type, owner_id, Embedding), ...]}`` in the
+        format expected by `_write_embedding_groups`.
+    """
+    by_space: dict[str, list] = {}
+
+    for instance_id in sorted(store._instance_embeddings):
+        for name, emb in store._instance_embeddings[instance_id].items():
+            by_space.setdefault(name, []).append(
+                (EMBEDDING_OWNER_INSTANCE, int(instance_id), emb)
+            )
+
+    for idx, identity in enumerate(identities):
+        for name, emb in identity.embeddings.items():
+            by_space.setdefault(name, []).append((EMBEDDING_OWNER_IDENTITY, idx, emb))
+
+    return by_space
+
+
+def _write_embedding_groups(labels_path: str, by_space: dict[str, list]) -> None:
+    """Write embedding spaces to the ``/embeddings`` group of a SLP file.
+
+    Shared dataset-writing core for both the eager (`Labels`-driven) and lazy
+    (store-driven) paths. The large float ``vectors`` and the highly redundant
+    auxiliary join columns (``meta_json``, ``owner_id``, ``owner_type``) are all
+    gzipped, keeping the group out of the fixed instance row layout (purely
+    additive: old readers ignore it).
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        by_space: A mapping ``{space_name: [(owner_type, owner_id, Embedding),
+            ...]}`` as produced by `_embedding_groups_from_labels` or
+            `_embedding_groups_from_store`. An empty mapping is a no-op.
+
+    Raises:
+        ValueError: If a single embedding space contains vectors of differing
+            dimensionality.
+    """
+    if not by_space:
+        return
+
+    with h5py.File(labels_path, "a") as f:
+        group = f.require_group("embeddings")
+        for space, entries in by_space.items():
+            dims = {emb.dim for _, _, emb in entries}
+            if len(dims) > 1:
+                raise ValueError(
+                    f"Embedding space '{space}' has inconsistent dimensions "
+                    f"{sorted(dims)}; all vectors in a space must share D."
+                )
+            vectors = np.stack([emb.vector for _, _, emb in entries])
+            owner_type = np.array([otype for otype, _, _ in entries], dtype="u1")
+            owner_id = np.array([oid for _, oid, _ in entries], dtype="i8")
+            meta_json = np.array(
+                [
+                    np.bytes_(
+                        json.dumps(
+                            {
+                                "normalized": emb.normalized,
+                                "source": emb.source,
+                                "centroid_xy": (
+                                    None
+                                    if emb.centroid_xy is None
+                                    else emb.centroid_xy.tolist()
+                                ),
+                                "metadata": emb.metadata,
+                            },
+                            separators=(",", ":"),
+                        )
+                    )
+                    for _, _, emb in entries
+                ]
+            )
+            sub = group.require_group(space)
+            sub.create_dataset(
+                "vectors",
+                data=vectors,
+                maxshape=(None, vectors.shape[1]),
+                compression="gzip",
+            )
+            sub.create_dataset(
+                "owner_type",
+                data=owner_type,
+                maxshape=(None,),
+                compression="gzip",
+            )
+            sub.create_dataset(
+                "owner_id",
+                data=owner_id,
+                maxshape=(None,),
+                compression="gzip",
+            )
+            sub.create_dataset(
+                "meta_json",
+                data=meta_json,
+                maxshape=(None,),
+                compression="gzip",
+            )
+
+
 def read_suggestions(
     labels_path: str,
     videos: list[Video],
@@ -2288,20 +2567,29 @@ def write_metadata(labels_path: str, labels: Labels):
     if has_mask_from_predicted:
         format_id = max(format_id, 2.4)
 
-    # Bump for per-instance identity links (new in 2.5). Purely additive (a
-    # separate dataset read with try/except on presence), so it is only set when
-    # an instance actually carries an identity. For lazy `Labels` the presence
-    # check reads the lazy store dict directly, mirroring what the fast-path
-    # writer persists without materializing any frames.
+    # Bump for per-instance identity links (new in 2.5) and appearance / re-ID
+    # embeddings (new in 2.6). Both are purely additive (each is a separate
+    # dataset/group read with try/except on presence), so they are only set when
+    # an instance/identity actually carries the corresponding data. For lazy
+    # `Labels` the presence checks read the lazy store dicts directly, mirroring
+    # what the fast-path writer persists without materializing any frames.
     if labels.is_lazy:
         store = labels._lazy_store
         has_instance_identities = bool(store._instance_identities)
+        has_embeddings = bool(store._instance_embeddings) or any(
+            identity.embeddings for identity in labels.identities
+        )
     else:
         has_instance_identities = any(
             getattr(inst, "identity", None) is not None for lf in labels for inst in lf
         )
+        has_embeddings = any(
+            getattr(inst, "embeddings", None) for lf in labels for inst in lf
+        ) or any(identity.embeddings for identity in labels.identities)
     if has_instance_identities:
         format_id = max(format_id, 2.5)
+    if has_embeddings:
+        format_id = max(format_id, 2.6)
 
     with h5py.File(labels_path, "a") as f:
         # Bump for chunked label image format (new in 2.2)
@@ -3424,6 +3712,14 @@ def _read_labels_lazy_from_open_file(
     tracks = read_tracks(labels_path, _hdf5_file=f)
     identities = read_identities(labels_path, _hdf5_file=f)
     instance_identities = read_instance_identities(labels_path, _hdf5_file=f)
+    # Embeddings: identity prototypes attach to the eager catalog now; per-instance
+    # embeddings ride on the lazy store and attach at materialization time.
+    instance_embeddings, identity_embeddings = read_embeddings(
+        labels_path, _hdf5_file=f
+    )
+    for identity_idx, emb_map in identity_embeddings.items():
+        if 0 <= identity_idx < len(identities):
+            identities[identity_idx].embeddings.update(emb_map)
     suggestions = read_suggestions(labels_path, videos, _hdf5_file=f)
     metadata = read_metadata(labels_path, _hdf5_file=f)
     provenance = read_provenance(labels_path, metadata, _hdf5_file=f)
@@ -3450,6 +3746,7 @@ def _read_labels_lazy_from_open_file(
         negative_frames=negative_frames,
         identities=identities,
         instance_identities=instance_identities,
+        instance_embeddings=instance_embeddings,
     )
 
     # Create LazyFrameList
@@ -6244,6 +6541,16 @@ def _read_labels_from_open_file(
             instances[inst_id].identity = identities[identity_idx]
             instances[inst_id].identity_score = identity_score
 
+    # Attach appearance / re-ID embeddings (SLP format 2.6+). Additive: absent
+    # /embeddings group -> empty mappings and a no-op.
+    inst_embeddings, ident_embeddings = read_embeddings(labels_path, _hdf5_file=f)
+    for inst_id, emb_map in inst_embeddings.items():
+        if 0 <= inst_id < len(instances):
+            instances[inst_id].embeddings.update(emb_map)
+    for identity_idx, emb_map in ident_embeddings.items():
+        if 0 <= identity_idx < len(identities):
+            identities[identity_idx].embeddings.update(emb_map)
+
     sessions = read_sessions(
         labels_path, videos, labeled_frames, identities=identities, _hdf5_file=f
     )
@@ -6425,6 +6732,7 @@ _KNOWN_TOPLEVEL_HDF5_NAMES = frozenset(
         "sessions_json",
         "identities_json",
         "instance_identities",
+        "embeddings",
         "provenance_json",
         "frames",
         "instances",
@@ -6605,15 +6913,19 @@ def _write_labels_lazy(
 
     # Write other metadata
     write_tracks(labels_path, labels.tracks)
-    # Persist identities + per-instance identity links directly from the lazy
-    # store, mirroring the eager writer (write_identities /
-    # write_instance_identities) but driven by the store dicts so no
-    # LabeledFrame/Instance is materialized. The store keys ARE the global
+    # Persist identities + per-instance identity links + embeddings directly from
+    # the lazy store, mirroring the eager writer (write_identities /
+    # write_instance_identities / write_embeddings) but driven by the store dicts
+    # so no LabeledFrame/Instance is materialized. The store keys ARE the global
     # instance_ids written above, so the join stays consistent with the raw
     # instances emitted by the fast path.
     write_identities(labels_path, lazy_store.identities)
     _write_instance_identity_rows(
         labels_path, _instance_identity_rows_from_store(lazy_store)
+    )
+    _write_embedding_groups(
+        labels_path,
+        _embedding_groups_from_store(lazy_store, lazy_store.identities),
     )
     write_suggestions(labels_path, labels.suggestions, labels.videos)
     # For sessions, pass empty list since we don't have materialized frames
@@ -6879,6 +7191,7 @@ def write_labels(
     write_tracks(labels_path, labels.tracks)
     write_identities(labels_path, labels.identities)
     write_instance_identities(labels_path, labels)
+    write_embeddings(labels_path, labels)
     write_suggestions(labels_path, labels.suggestions, labels.videos)
     write_sessions(
         labels_path,

--- a/sleap_io/io/slp_lazy.py
+++ b/sleap_io/io/slp_lazy.py
@@ -90,6 +90,10 @@ class LazyDataStore:
     _instance_identities: dict = attrs.field(
         factory=dict, repr=False, alias="instance_identities"
     )
+    # Per-instance embeddings (format 2.6+): instance_id -> {space: Embedding}.
+    _instance_embeddings: dict = attrs.field(
+        factory=dict, repr=False, alias="instance_embeddings"
+    )
 
     def __attrs_post_init__(self) -> None:
         """Validate index bounds on construction."""
@@ -168,6 +172,9 @@ class LazyDataStore:
             tracks=self.tracks,  # Share references (canonical objects)
             identities=self.identities,  # Share references (canonical objects)
             instance_identities=dict(self._instance_identities),
+            instance_embeddings={
+                k: dict(v) for k, v in self._instance_embeddings.items()
+            },
             format_id=self.format_id,
             source_path=self._source_path,
             negative_frames=self._negative_frames.copy(),
@@ -312,6 +319,14 @@ class LazyDataStore:
                     identity = self.identities[identity_idx]
                     identity_score = id_score
 
+        # Resolve optional per-instance embeddings (format 2.6+). A fresh dict per
+        # instance so mutations don't leak back into the shared lazy store.
+        embeddings = (
+            dict(self._instance_embeddings.get(instance_id, {}))
+            if self._instance_embeddings
+            else {}
+        )
+
         if instance_type == InstanceType.USER:
             pts_data = self.points_data[point_id_start:point_id_end]
             points_array = self._make_points_array(pts_data, skeleton)
@@ -325,6 +340,7 @@ class LazyDataStore:
                 tracking_score=float(tracking_score),
                 identity=identity,
                 identity_score=identity_score,
+                embeddings=embeddings,
             )
         else:  # PREDICTED
             pts_data = self.pred_points_data[point_id_start:point_id_end]
@@ -340,6 +356,7 @@ class LazyDataStore:
                 tracking_score=float(tracking_score),
                 identity=identity,
                 identity_score=identity_score,
+                embeddings=embeddings,
             )
 
     def _make_points_array(

--- a/sleap_io/model/bbox.py
+++ b/sleap_io/model/bbox.py
@@ -18,14 +18,17 @@ from typing import TYPE_CHECKING
 import attrs
 import numpy as np
 
+from sleap_io.model.embedding import EmbeddingMixin
+
 if TYPE_CHECKING:
+    from sleap_io.model.embedding import Embedding
     from sleap_io.model.instance import Instance, Track
     from sleap_io.model.mask import SegmentationMask
     from sleap_io.model.roi import ROI
 
 
 @attrs.define(eq=False)
-class BoundingBox:
+class BoundingBox(EmbeddingMixin):
     """A bounding box annotation.
 
     Supports axis-aligned and oriented (rotated) bounding boxes with optional
@@ -44,6 +47,8 @@ class BoundingBox:
         category: Class label (e.g., "mouse", "fly").
         name: Human-readable name.
         source: Annotation source identifier.
+        embeddings: Mapping from embedding-space name to an `Embedding` describing
+            this detection's appearance for re-identification. Empty by default.
 
     Notes:
         Bounding boxes use identity-based equality (two BoundingBox objects are
@@ -64,6 +69,7 @@ class BoundingBox:
     category: str = attrs.field(default="")
     name: str = attrs.field(default="")
     source: str = attrs.field(default="")
+    embeddings: dict[str, Embedding] = attrs.field(factory=dict, repr=False)
 
     # Private: deferred instance index for lazy loading.
     _instance_idx: int = attrs.field(default=-1, repr=False, eq=False, init=False)

--- a/sleap_io/model/centroid.py
+++ b/sleap_io/model/centroid.py
@@ -20,7 +20,10 @@ from typing import TYPE_CHECKING
 import attrs
 import numpy as np
 
+from sleap_io.model.embedding import EmbeddingMixin
+
 if TYPE_CHECKING:
+    from sleap_io.model.embedding import Embedding
     from sleap_io.model.instance import Instance, PredictedInstance, Track
     from sleap_io.model.skeleton import Skeleton
 
@@ -60,7 +63,7 @@ def __getattr__(name):
 
 
 @attrs.define(eq=False)
-class Centroid:
+class Centroid(EmbeddingMixin):
     """A point representing the center of an object.
 
     Supports optional 3D coordinates, track/instance metadata,
@@ -78,6 +81,8 @@ class Centroid:
         name: Human-readable name (e.g., ``"ID43008"``).
         source: How the centroid was computed (e.g., ``"center_of_mass"``,
             ``"trackmate"``).
+        embeddings: Mapping from embedding-space name to an `Embedding` describing
+            this detection's appearance for re-identification. Empty by default.
 
     Notes:
         Centroids use identity-based equality (two Centroid objects are only
@@ -96,6 +101,7 @@ class Centroid:
     category: str = attrs.field(default="")
     name: str = attrs.field(default="")
     source: str = attrs.field(default="")
+    embeddings: dict[str, Embedding] = attrs.field(factory=dict, repr=False)
 
     # Private: deferred instance index for lazy loading.
     _instance_idx: int = attrs.field(default=-1, repr=False, eq=False, init=False)

--- a/sleap_io/model/embedding.py
+++ b/sleap_io/model/embedding.py
@@ -1,0 +1,153 @@
+"""Embedding data structure for per-detection appearance / re-ID vectors."""
+
+from __future__ import annotations
+
+import attrs
+import numpy as np
+from attrs import define, field
+
+
+def _as_vector(value) -> np.ndarray:
+    """Coerce an input to a 1-D embedding vector, preserving floating dtype.
+
+    Floating inputs (e.g. float32 from a neural network, float64 from JABS
+    prototypes) keep their dtype; non-floating inputs are cast to float32.
+    """
+    arr = np.asarray(value)
+    if not np.issubdtype(arr.dtype, np.floating):
+        arr = arr.astype(np.float32)
+    if arr.ndim != 1:
+        raise ValueError(
+            f"Embedding vector must be 1-dimensional, got shape {arr.shape}."
+        )
+    return arr
+
+
+def _as_optional_xy(value) -> np.ndarray | None:
+    """Coerce an optional source location to a ``(2,)`` float32 array or None."""
+    if value is None:
+        return None
+    arr = np.asarray(value, dtype=np.float32).reshape(-1)
+    if arr.shape != (2,):
+        raise ValueError(f"centroid_xy must have shape (2,), got {arr.shape}.")
+    return arr
+
+
+@define(eq=False)
+class Embedding:
+    """A per-detection appearance / re-identification embedding vector.
+
+    An `Embedding` wraps a single feature vector describing the visual appearance
+    of one detection (e.g. the crop around an `Instance`, `Centroid`,
+    `SegmentationMask`, or `BoundingBox`). Embeddings attach to any detection
+    modality via its ``embeddings`` mapping (keyed by space name) and to
+    `Identity` as a gallery / prototype vector. They are compared by cosine
+    similarity for re-identification; when produced by a normalized model the
+    vector lies on the unit hypersphere, so cosine similarity reduces to a dot
+    product.
+
+    Attributes:
+        vector: 1-D feature vector of shape ``(D,)``. The dtype is preserved from
+            the input when floating (e.g. float32 from a neural network, float64
+            from JABS prototypes); non-floating inputs are cast to float32.
+        name: Embedding-space name (e.g. ``"reid"``, ``"jabs"``). Multiple spaces
+            may coexist on a single detection.
+        normalized: Whether ``vector`` is L2-normalized (cosine geometry). Defaults
+            to True to match typical re-ID model outputs.
+        source: Optional provenance / model identifier that produced this vector.
+        centroid_xy: Optional ``(2,)`` source location (e.g. the centroid the crop
+            was sampled at, as recorded by centroid-driven embedding inference).
+        metadata: Arbitrary metadata dictionary.
+    """
+
+    vector: np.ndarray = field(
+        converter=_as_vector,
+        eq=attrs.cmp_using(eq=np.array_equal),
+    )
+    name: str = "reid"
+    normalized: bool = True
+    source: str | None = None
+    centroid_xy: np.ndarray | None = field(default=None, converter=_as_optional_xy)
+    metadata: dict = field(factory=dict)
+
+    @property
+    def dim(self) -> int:
+        """Dimensionality ``D`` of the embedding vector."""
+        return int(self.vector.shape[0])
+
+    @property
+    def dtype(self) -> np.dtype:
+        """The numpy dtype of the stored vector."""
+        return self.vector.dtype
+
+    def __repr__(self) -> str:
+        """Return a readable string representation."""
+        parts = [f'Embedding(name="{self.name}", dim={self.dim}']
+        parts.append(f", normalized={self.normalized}")
+        if self.source is not None:
+            parts.append(f', source="{self.source}"')
+        parts.append(")")
+        return "".join(parts)
+
+
+class EmbeddingMixin:
+    """Mixin adding per-detection embedding storage helpers.
+
+    Classes using this mixin must declare an ``embeddings: dict[str, Embedding]``
+    attrs field. The mixin adds a convenience ``embedding`` accessor and a
+    ``set_embedding`` helper without storing any state of its own (``__slots__``
+    is empty so slotted attrs subclasses keep their slots).
+    """
+
+    __slots__ = ()
+
+    @property
+    def embedding(self) -> Embedding | None:
+        """The primary embedding, or None.
+
+        Returns the ``"reid"`` embedding if present; otherwise the sole embedding
+        if exactly one exists; otherwise None.
+        """
+        embeddings = self.embeddings
+        if "reid" in embeddings:
+            return embeddings["reid"]
+        if len(embeddings) == 1:
+            return next(iter(embeddings.values()))
+        return None
+
+    @embedding.setter
+    def embedding(self, value: Embedding | None) -> None:
+        if value is None:
+            self.embeddings.pop("reid", None)
+        else:
+            self.embeddings[value.name] = value
+
+    def set_embedding(
+        self,
+        vector,
+        name: str = "reid",
+        normalized: bool = True,
+        source: str | None = None,
+        centroid_xy=None,
+    ) -> Embedding:
+        """Create and attach an `Embedding` to this detection.
+
+        Args:
+            vector: 1-D feature vector of shape ``(D,)``.
+            name: Embedding-space name to store under. Defaults to ``"reid"``.
+            normalized: Whether the vector is L2-normalized.
+            source: Optional model/provenance identifier.
+            centroid_xy: Optional ``(2,)`` source location.
+
+        Returns:
+            The created `Embedding`.
+        """
+        emb = Embedding(
+            vector=vector,
+            name=name,
+            normalized=normalized,
+            source=source,
+            centroid_xy=centroid_xy,
+        )
+        self.embeddings[name] = emb
+        return emb

--- a/sleap_io/model/identity.py
+++ b/sleap_io/model/identity.py
@@ -6,6 +6,8 @@ import attrs
 from attrs import define, field
 from attrs.validators import instance_of
 
+from sleap_io.model.embedding import Embedding, EmbeddingMixin
+
 
 def _generate_uuid() -> str:
     """Generate a new random UUID hex string for an `Identity`."""
@@ -13,7 +15,7 @@ def _generate_uuid() -> str:
 
 
 @define(eq=False)
-class Identity:
+class Identity(EmbeddingMixin):
     """Ground-truth animal identity, persistent across sessions and videos.
 
     Unlike `Track` (an ephemeral temporal trajectory within a single video),
@@ -34,6 +36,10 @@ class Identity:
             cross-file matching key.
         color: Optional hex color string for visualization (e.g., "#e6194b").
         metadata: Arbitrary metadata dictionary.
+        embeddings: A mapping from embedding-space name (e.g. ``"reid"``) to an
+            `Embedding` prototype / gallery vector representing this identity in
+            that space (e.g. the cluster centroid of its member instances). Empty
+            by default.
 
     Notes:
         `Identity` objects use object-identity equality (`eq=False`), matching
@@ -45,6 +51,7 @@ class Identity:
     uuid: str = field(factory=_generate_uuid, validator=instance_of(str))
     color: str | None = field(default=None, converter=attrs.converters.optional(str))
     metadata: dict = field(factory=dict, validator=instance_of(dict))
+    embeddings: dict[str, Embedding] = field(factory=dict, repr=False)
 
     def matches(self, other: "Identity", method: str = "uuid") -> bool:
         """Check if this identity matches another identity.

--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import attrs
 import numpy as np
 
+from sleap_io.model.embedding import Embedding, EmbeddingMixin
 from sleap_io.model.identity import Identity
 from sleap_io.model.skeleton import Node, Skeleton
 
@@ -385,7 +386,7 @@ class Track:
 
 
 @attrs.define(auto_attribs=True, slots=True, eq=False)
-class Instance:
+class Instance(EmbeddingMixin):
     """This class represents a ground truth instance such as an animal.
 
     An `Instance` has a set of landmarks (points) that correspond to a `Skeleton`. Each
@@ -417,6 +418,10 @@ class Instance:
             separate from `tracking_score` (short-term tracklet vs long-term identity).
         from_predicted: The `PredictedInstance` (if any) that this instance was
             initialized from. This is used with human-in-the-loop workflows.
+        embeddings: A mapping from embedding-space name (e.g. ``"reid"``) to an
+            `Embedding` describing this instance's appearance for re-identification.
+            Empty by default. Use the `embedding` accessor / `set_embedding` helper
+            for the common single-vector case.
     """
 
     points: PointsArray = attrs.field(eq=attrs.cmp_using(eq=np.array_equal))
@@ -426,6 +431,7 @@ class Instance:
     identity: Identity | None = None
     identity_score: float | None = None
     from_predicted: "PredictedInstance | None" = None
+    embeddings: dict[str, Embedding] = attrs.field(factory=dict, repr=False)
 
     @classmethod
     def empty(
@@ -895,6 +901,8 @@ class PredictedInstance(Instance):
         identity: An optional global `Identity` (see `Instance.identity`).
         identity_score: The score associated with the `identity` assignment (see
             `Instance.identity_score`).
+        embeddings: A mapping from embedding-space name to an `Embedding` (see
+            `Instance.embeddings`).
     """
 
     points: PredictedPointsArray = attrs.field(eq=attrs.cmp_using(eq=np.array_equal))
@@ -905,6 +913,7 @@ class PredictedInstance(Instance):
     identity: Identity | None = None
     identity_score: float | None = None
     from_predicted: "PredictedInstance | None" = None
+    embeddings: dict[str, Embedding] = attrs.field(factory=dict, repr=False)
 
     def __repr__(self) -> str:
         """Return a readable representation of the instance."""

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -841,7 +841,7 @@ class Labels:
             new_tracks = [deepcopy(t) for t in self.tracks]
             # Identities are index-referenced by the store's per-instance maps, so
             # deep-copying preserves index alignment while keeping the catalog
-            # independent.
+            # (and its prototype embeddings) independent.
             new_identities = [deepcopy(i) for i in self.identities]
 
             # Update store references
@@ -4076,7 +4076,7 @@ class Labels:
                 (deduped) `Identity` in the merged catalog. When provided, the
                 instance's identity is resolved through this map so that the same
                 animal across files points at a single catalog object. The
-                instance's ``identity_score`` is always copied.
+                instance's ``identity_score`` and ``embeddings`` are always copied.
             memo: Optional mapping from the id of the source instance to the new
                 instance, mutated in place. Used to repair ``from_predicted``
                 links so a remapped user instance references the remapped source
@@ -4132,6 +4132,7 @@ class Labels:
                 from_predicted=instance.from_predicted,
                 identity=mapped_identity,
                 identity_score=instance.identity_score,
+                embeddings=dict(instance.embeddings),
             )
         else:
             new_instance = Instance(
@@ -4142,6 +4143,7 @@ class Labels:
                 from_predicted=instance.from_predicted,
                 identity=mapped_identity,
                 identity_score=instance.identity_score,
+                embeddings=dict(instance.embeddings),
             )
         if memo is not None:
             memo[id(instance)] = new_instance

--- a/sleap_io/model/mask.py
+++ b/sleap_io/model/mask.py
@@ -30,6 +30,8 @@ from typing import TYPE_CHECKING
 import attrs
 import numpy as np
 
+from sleap_io.model.embedding import EmbeddingMixin
+
 if TYPE_CHECKING:
     if sys.version_info >= (3, 11):
         from typing import Self
@@ -37,6 +39,7 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
     from sleap_io.model.bbox import BoundingBox
+    from sleap_io.model.embedding import Embedding
     from sleap_io.model.instance import Instance, Track
     from sleap_io.model.roi import ROI
 
@@ -113,7 +116,7 @@ def _resize_nearest(array: np.ndarray, target_h: int, target_w: int) -> np.ndarr
 
 
 @attrs.define(eq=False)
-class SegmentationMask:
+class SegmentationMask(EmbeddingMixin):
     """A segmentation mask stored as run-length encoded (RLE) data.
 
     Attributes:
@@ -134,6 +137,8 @@ class SegmentationMask:
             covers 2x2 image pixels). Coordinate mapping:
             ``image_coord = mask_coord / scale + offset``.
         offset: Origin ``(x, y)`` of the mask in image pixel coordinates.
+        embeddings: Mapping from embedding-space name to an `Embedding` describing
+            this detection's appearance for re-identification. Empty by default.
 
     Notes:
         Masks use identity-based equality (two mask objects are only equal if they
@@ -155,6 +160,7 @@ class SegmentationMask:
     _instance_idx: int = attrs.field(default=-1, repr=False, eq=False, init=False)
     scale: tuple[float, float] = attrs.field(default=(1.0, 1.0))
     offset: tuple[float, float] = attrs.field(default=(0.0, 0.0))
+    embeddings: dict[str, Embedding] = attrs.field(factory=dict, repr=False)
 
     def __attrs_post_init__(self):
         """Validate that this class is not instantiated directly."""

--- a/sleap_io/model/roi.py
+++ b/sleap_io/model/roi.py
@@ -15,10 +15,13 @@ from typing import TYPE_CHECKING
 import attrs
 import numpy as np
 
+from sleap_io.model.embedding import EmbeddingMixin
+
 if TYPE_CHECKING:
     from shapely.geometry import Polygon
     from shapely.geometry.base import BaseGeometry
 
+    from sleap_io.model.embedding import Embedding
     from sleap_io.model.instance import Instance, Track
     from sleap_io.model.mask import SegmentationMask
     from sleap_io.model.video import Video
@@ -43,7 +46,7 @@ class AnnotationType(IntEnum):
 
 
 @attrs.define(eq=False)
-class ROI:
+class ROI(EmbeddingMixin):
     """A region of interest defined by vector geometry.
 
     ROIs store Shapely geometry objects and optional metadata for associating
@@ -61,6 +64,8 @@ class ROI:
             if unassigned or manually assigned.
         instance: Optional `Instance` this ROI is associated with. Persisted in
             SLP format (v1.6+) via instance index.
+        embeddings: Mapping from embedding-space name to an `Embedding` describing
+            this detection's appearance for re-identification. Empty by default.
 
     Notes:
         ROIs use identity-based equality (two ROI objects are only equal if they
@@ -87,6 +92,7 @@ class ROI:
     track: "Track | None" = attrs.field(default=None)
     tracking_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
+    embeddings: dict[str, Embedding] = attrs.field(factory=dict, repr=False)
 
     # Private: deferred instance index for lazy loading. When ROIs are read
     # from a file without materialized instances (e.g., lazy mode), this stores

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -62,11 +62,14 @@ def _data_path(rel: str) -> Path:
     return root / rel
 
 
-def _make_identity_slp(path: Path, *, color: str | None = "#ff0000") -> Labels:
+def _make_identity_slp(
+    path: Path, *, with_embeddings: bool = False, color: str | None = "#ff0000"
+) -> Labels:
     """Write a minimal 2-instance .slp carrying global identities.
 
     Builds one labeled frame with two instances assigned to two `Identity`
-    objects (the first optionally colored).
+    objects (the first optionally colored). When ``with_embeddings`` is set, the
+    first instance also carries a per-instance ``"reid"`` embedding.
     """
     skeleton = Skeleton(["head", "tail"])
     id_a = Identity(name="mouse_A", color=color)
@@ -78,6 +81,8 @@ def _make_identity_slp(path: Path, *, color: str | None = "#ff0000") -> Labels:
     inst_b = Instance.from_numpy(
         np.array([[30, 30], [40, 40]]), skeleton=skeleton, identity=id_b
     )
+    if with_embeddings:
+        inst_a.set_embedding(np.ones(8, dtype="float32"), name="reid")
     lf = LabeledFrame(video=video, frame_idx=0, instances=[inst_a, inst_b])
     labels = Labels(
         labeled_frames=[lf],
@@ -178,6 +183,36 @@ def test_show_reports_identities(tmp_path):
     assert result.exit_code == 0, result.output
     out = _strip_ansi(result.output)
     assert "2 identities" in out
+
+
+def test_show_reports_embeddings(tmp_path):
+    """`sio show --no-lazy` summarizes per-instance embedding spaces."""
+    slp_path = tmp_path / "ids_emb.slp"
+    _make_identity_slp(slp_path, with_embeddings=True)
+
+    runner = CliRunner()
+    # Embedding scan is skipped for lazy labels, so request eager loading.
+    result = runner.invoke(
+        cli, ["show", str(slp_path), "--no-lazy", "--no-open-videos"]
+    )
+    assert result.exit_code == 0, result.output
+    out = _strip_ansi(result.output)
+    assert "Embeddings (1 instances)" in out
+    assert "reid" in out
+
+
+def test_show_embeddings_skipped_when_absent(tmp_path):
+    """The embedding summary is omitted when no instance carries embeddings."""
+    slp_path = tmp_path / "ids_noemb.slp"
+    _make_identity_slp(slp_path, with_embeddings=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["show", str(slp_path), "--no-lazy", "--no-open-videos"]
+    )
+    assert result.exit_code == 0, result.output
+    out = _strip_ansi(result.output)
+    assert "Embeddings" not in out
 
 
 def test_show_lf_zero_details():

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -1189,6 +1189,97 @@ def test_no_identity_keeps_low_format_and_no_dataset(tmp_path):
     assert list(loaded[0].instances)[0].identity is None
 
 
+def test_embeddings_round_trip(tmp_path):
+    """Test instance + identity embeddings round-trip through SLP (format 2.6)."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    identity = Identity(name="mouse_A")
+    identity.set_embedding(np.ones(128, dtype=np.float32), source="gallery")
+
+    i0 = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel, identity=identity)
+    i0.set_embedding(np.arange(128, dtype=np.float32), source="reid_v1")
+    i0.set_embedding(np.ones(4, dtype=np.float64), name="jabs")  # 2nd space, f64
+    i1 = PredictedInstance.from_numpy(np.array([[4, 5], [6, 7]]), skel, score=0.8)
+    i1.set_embedding(np.full(128, 2.0, dtype=np.float32), centroid_xy=[10, 20])
+    i2 = Instance.from_numpy(np.array([[8, 9], [0, 1]]), skel)  # no embedding
+
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[i0, i1, i2])])
+    labels.update()
+
+    path = str(tmp_path / "embeddings.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] >= 2.6
+        assert set(f["embeddings"].keys()) == {"reid", "jabs"}
+        assert f["embeddings/reid/vectors"].dtype == np.float32
+        assert f["embeddings/jabs/vectors"].dtype == np.float64  # dtype preserved
+
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)
+    # Multiple named spaces on one instance.
+    assert li[0].embeddings["reid"].dim == 128
+    assert li[0].embeddings["reid"].source == "reid_v1"
+    np.testing.assert_array_equal(li[0].embeddings["reid"].vector, np.arange(128))
+    assert li[0].embeddings["jabs"].dtype == np.float64
+    # centroid_xy round-trips.
+    np.testing.assert_array_equal(li[1].embedding.centroid_xy, [10.0, 20.0])
+    # Sparse: instances without embeddings stay empty.
+    assert li[2].embeddings == {}
+    # Identity prototype embedding round-trips.
+    assert loaded.identities[0].embedding.dim == 128
+    assert loaded.identities[0].embedding.source == "gallery"
+
+
+def test_no_embeddings_keeps_low_format_and_no_group(tmp_path):
+    """Test embedding-free labels stay additive (no group, no 2.6 bump)."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    labels = Labels(
+        [
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)],
+            )
+        ]
+    )
+    path = str(tmp_path / "no_embeddings.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] < 2.6
+        assert "embeddings" not in f
+
+
+def test_embeddings_inconsistent_dim_raises(tmp_path):
+    """Test that mismatched vector dims within one space raise on save."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    i0 = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    i0.set_embedding(np.ones(128))
+    i1 = Instance.from_numpy(np.array([[4, 5], [6, 7]]), skel)
+    i1.set_embedding(np.ones(64))  # same "reid" space, different D
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[i0, i1])])
+
+    with pytest.raises(ValueError, match="inconsistent dimensions"):
+        save_slp(labels, str(tmp_path / "bad.slp"))
+
+
+def test_modality_embeddings_warn_on_save(tmp_path):
+    """Test a warning fires for not-yet-persisted modality embeddings."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    centroid = UserCentroid(x=1.0, y=2.0)
+    centroid.set_embedding(np.ones(8))  # not yet persisted
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst], centroids=[centroid])
+    labels = Labels([lf])
+
+    with pytest.warns(UserWarning, match="not yet persisted"):
+        save_slp(labels, str(tmp_path / "modality.slp"))
+
+
 def test_make_frame_group_and_frame_group_to_dict(
     frame_group_345: FrameGroup, camera_group_345: CameraGroup
 ):

--- a/tests/io/test_slp_lazy.py
+++ b/tests/io/test_slp_lazy.py
@@ -1701,22 +1701,68 @@ def test_lazy_per_instance_identity_round_trip(tmp_path):
     assert copied.identities[0] is not lazy.identities[0]  # independent copy
 
 
-def test_lazy_save_persists_identities(tmp_path):
-    """Lazy save must persist identities + per-instance links.
+def test_lazy_embeddings_round_trip(tmp_path):
+    """Test instance + identity embeddings materialize via the lazy loader."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    identity = sio.Identity(name="mouse_A")
+    identity.set_embedding(np.ones(128, dtype=np.float32), source="gallery")
+
+    i0 = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel, identity=identity)
+    i0.set_embedding(np.arange(128, dtype=np.float32))
+    i0.set_embedding(np.ones(4, dtype=np.float64), name="jabs")
+    i1 = PredictedInstance.from_numpy(np.array([[4, 5], [6, 7]]), skel, score=0.8)
+    i1.set_embedding(np.full(128, 2.0, dtype=np.float32), centroid_xy=[10, 20])
+    i2 = Instance.from_numpy(np.array([[8, 9], [0, 1]]), skel)  # no embedding
+
+    labels = sio.Labels(
+        [LabeledFrame(video=video, frame_idx=0, instances=[i0, i1, i2])]
+    )
+    labels.update()
+
+    path = str(tmp_path / "lazy_embeddings.slp")
+    sio.save_slp(labels, path)
+
+    lazy = sio.load_slp(path, lazy=True)
+    assert lazy.is_lazy
+    li = list(lazy[0].instances)
+    np.testing.assert_array_equal(li[0].embeddings["reid"].vector, np.arange(128))
+    assert li[0].embeddings["jabs"].dtype == np.float64
+    np.testing.assert_array_equal(li[1].embedding.centroid_xy, [10.0, 20.0])
+    assert li[2].embeddings == {}
+    # Identity prototype attaches to the eager catalog.
+    assert lazy.identities[0].embedding.dim == 128
+
+    # Mutating a materialized instance's embeddings must not leak into the store.
+    li[0].embeddings["reid"] = sio.Embedding(np.zeros(128))
+    li_again = list(lazy[0].instances)
+    np.testing.assert_array_equal(li_again[0].embeddings["reid"].vector, np.arange(128))
+
+    # Lazy store copy preserves embeddings.
+    cli = list(lazy.copy()[0].instances)
+    assert cli[0].embeddings["reid"].dim == 128
+
+
+def test_lazy_save_persists_identities_and_embeddings(tmp_path):
+    """Lazy save must persist identities + per-instance links + embeddings.
 
     Regression test for the silent-data-loss bug where the lazy fast-path writer
-    copied raw points/instances/tracks but skipped identities, so
-    ``load_slp(p, lazy=True).save(p2)`` dropped them. Saving the lazy labels
+    copied raw points/instances/tracks but skipped identities and embeddings, so
+    ``load_slp(p, lazy=True).save(p2)`` dropped them all. Saving the lazy labels
     must round-trip identical to saving the eager labels.
     """
     skel = Skeleton(["A", "B"])
     video = Video(filename="test.mp4")
     id_a = sio.Identity(name="mouse_A", metadata={"sex": "F"})
     id_b = sio.Identity(name="mouse_B")
+    # Identity prototype (gallery) embedding -> owner_type=identity.
+    id_a.set_embedding(np.ones(128, dtype=np.float32), source="gallery")
 
     i0 = Instance.from_numpy(
         np.array([[0, 1], [2, 3]]), skel, identity=id_a, identity_score=0.95
     )
+    i0.set_embedding(np.arange(128, dtype=np.float32))  # reID, float32
+    i0.set_embedding(np.ones(4, dtype=np.float64), name="jabs")  # dtype preserved
     i1 = PredictedInstance.from_numpy(
         np.array([[4, 5], [6, 7]]), skel, score=0.8, identity=id_b
     )
@@ -1740,11 +1786,16 @@ def test_lazy_save_persists_identities(tmp_path):
     # The fast path must not have materialized: lazy labels stay lazy after save.
     assert lazy.is_lazy
 
-    # Format must reflect per-instance identity links (>= 2.5).
+    # Format must reflect embeddings (>= 2.6 implies >= 2.5 for identities too).
     with h5py.File(b, "r") as f:
-        assert f["metadata"].attrs["format_id"] >= 2.5
+        assert f["metadata"].attrs["format_id"] >= 2.6
         assert "identities_json" in f
         assert "instance_identities" in f
+        assert "embeddings" in f
+        # Aux join columns are gzip-compressed (compression fix).
+        sub = f["embeddings/reid"]
+        for ds in ("vectors", "owner_type", "owner_id", "meta_json"):
+            assert sub[ds].compression == "gzip"
 
     reb = sio.load_slp(b)
 
@@ -1765,3 +1816,19 @@ def test_lazy_save_persists_identities(tmp_path):
     assert ri[1].identity.name == "mouse_B"
     assert ri[1].identity_score is None
     assert ri[2].identity is None
+
+    # Per-instance embeddings survived (vectors, dtype, space names).
+    assert set(ri[0].embeddings) == {"reid", "jabs"}
+    np.testing.assert_array_equal(
+        ri[0].embeddings["reid"].vector, np.arange(128, dtype=np.float32)
+    )
+    assert ri[0].embeddings["reid"].vector.dtype == np.float32
+    assert ri[0].embeddings["jabs"].vector.dtype == np.float64
+    assert ri[2].embeddings == {}
+
+    # Identity prototype embedding survived (owner_type=identity).
+    assert by_name["mouse_A"].embedding.dim == 128
+    assert by_name["mouse_A"].embedding.source == "gallery"
+    np.testing.assert_array_equal(
+        by_name["mouse_A"].embedding.vector, np.ones(128, dtype=np.float32)
+    )

--- a/tests/model/test_embedding.py
+++ b/tests/model/test_embedding.py
@@ -1,0 +1,161 @@
+"""Tests for the Embedding data structure and per-modality embedding slots."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from shapely.geometry import box
+
+from sleap_io.model.bbox import PredictedBoundingBox
+from sleap_io.model.centroid import UserCentroid
+from sleap_io.model.embedding import Embedding, EmbeddingMixin
+from sleap_io.model.identity import Identity
+from sleap_io.model.instance import Instance, PredictedInstance
+from sleap_io.model.roi import PredictedROI
+from sleap_io.model.skeleton import Skeleton
+
+
+def test_embedding_basic():
+    """Test Embedding construction, dim, dtype, and defaults."""
+    emb = Embedding(np.ones(128, dtype=np.float32))
+    assert emb.vector.shape == (128,)
+    assert emb.dim == 128
+    assert emb.dtype == np.float32
+    assert emb.name == "reid"
+    assert emb.normalized is True
+    assert emb.source is None
+    assert emb.centroid_xy is None
+    assert emb.metadata == {}
+
+
+def test_embedding_dtype_preserved():
+    """Test that floating dtype is preserved (e.g. JABS float64 prototypes)."""
+    f64 = Embedding(np.ones(4, dtype=np.float64))
+    assert f64.dtype == np.float64
+
+    # Non-floating input is cast to float32.
+    from_list = Embedding([1, 2, 3])
+    assert from_list.dtype == np.float32
+    np.testing.assert_array_equal(from_list.vector, [1.0, 2.0, 3.0])
+
+
+def test_embedding_rejects_non_1d():
+    """Test that a non-1-D vector raises rather than silently flattening."""
+    with pytest.raises(ValueError, match="must be 1-dimensional"):
+        Embedding(np.ones((2, 3)))
+
+
+def test_embedding_centroid_xy():
+    """Test centroid_xy coercion and shape validation."""
+    emb = Embedding(np.ones(8), centroid_xy=[5, 6])
+    assert emb.centroid_xy.shape == (2,)
+    assert emb.centroid_xy.dtype == np.float32
+    np.testing.assert_array_equal(emb.centroid_xy, [5.0, 6.0])
+
+    with pytest.raises(ValueError, match=r"shape \(2,\)"):
+        Embedding(np.ones(8), centroid_xy=[1, 2, 3])
+
+
+def test_embedding_eq_false():
+    """Test that Embedding uses object-identity equality."""
+    e1 = Embedding(np.ones(4))
+    e2 = Embedding(np.ones(4))
+    assert e1 is not e2
+    assert e1 != e2
+
+
+def test_embedding_repr():
+    """Test the Embedding repr."""
+    assert (
+        repr(Embedding(np.ones(3))) == 'Embedding(name="reid", dim=3, normalized=True)'
+    )
+    emb = Embedding(np.ones(3), name="jabs", normalized=False, source="model_v1")
+    assert (
+        repr(emb)
+        == 'Embedding(name="jabs", dim=3, normalized=False, source="model_v1")'
+    )
+
+
+def test_embedding_accessor_on_instance():
+    """Test the embedding accessor / set_embedding on an Instance."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+
+    # No embeddings -> None.
+    assert inst.embeddings == {}
+    assert inst.embedding is None
+
+    # set_embedding stores under name and returns the Embedding.
+    emb = inst.set_embedding(np.arange(128, dtype=np.float32))
+    assert isinstance(emb, Embedding)
+    assert inst.embedding is emb
+    assert list(inst.embeddings) == ["reid"]
+
+    # A second named space coexists; the accessor still prefers "reid".
+    inst.set_embedding(np.zeros(64), name="jabs")
+    assert set(inst.embeddings) == {"reid", "jabs"}
+    assert inst.embedding.name == "reid"
+
+
+def test_embedding_accessor_sole_and_setter():
+    """Test the accessor falls back to the sole space, and the setter."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+
+    # Sole non-reid space -> returned by accessor.
+    inst.set_embedding(np.ones(32), name="jabs")
+    assert inst.embedding.name == "jabs"
+
+    # Setter stores under the embedding's own name.
+    inst.embedding = Embedding(np.ones(16), name="reid")
+    assert inst.embeddings["reid"].dim == 16
+
+    # Setting None removes the "reid" entry.
+    inst.embedding = None
+    assert "reid" not in inst.embeddings
+
+
+def test_embedding_on_predicted_instance():
+    """Test embeddings work on PredictedInstance."""
+    skel = Skeleton(["A", "B"])
+    pred = PredictedInstance.from_numpy(np.array([[0, 1], [2, 3]]), skel, score=0.5)
+    pred.set_embedding(np.ones(128))
+    assert pred.embedding.dim == 128
+
+
+def test_embedding_on_identity():
+    """Test Identity carries a prototype/gallery embedding."""
+    identity = Identity(name="mouse_A")
+    assert identity.embeddings == {}
+    identity.set_embedding(np.ones(128), source="gallery")
+    assert identity.embedding.dim == 128
+    assert identity.embedding.source == "gallery"
+
+
+def test_embedding_on_all_modalities():
+    """Test the embedding slot exists and works on every detection modality."""
+    detections = [
+        UserCentroid(x=1.0, y=2.0),
+        PredictedBoundingBox(x1=0, y1=0, x2=10, y2=10, score=0.5),
+        PredictedROI(geometry=box(0, 0, 10, 10), score=0.5),
+    ]
+    for det in detections:
+        assert isinstance(det, EmbeddingMixin)
+        assert det.embeddings == {}
+        det.set_embedding(np.ones(64))
+        assert det.embedding.dim == 64
+        # Slotted classes must not gain a __dict__.
+        assert not hasattr(det, "__dict__")
+
+
+def test_embedding_preserved_on_copy():
+    """Test embeddings survive a deep copy of the owning instance."""
+    from copy import deepcopy
+
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    inst.set_embedding(np.arange(8, dtype=np.float32))
+    copied = deepcopy(inst)
+    assert copied.embedding is not None
+    assert copied.embedding.dim == 8
+    np.testing.assert_array_equal(copied.embedding.vector, np.arange(8))

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -12,6 +12,7 @@ from shapely.geometry import box
 
 import sleap_io
 from sleap_io import (
+    Embedding,
     FrameGroup,
     Identity,
     Instance,
@@ -4333,12 +4334,12 @@ def test_labels_merge_predicted_instance_mapping():
 
 
 def test_labels_merge_dedupes_same_uuid_identity():
-    """Merge dedupes same-uuid identities and preserves identity_score.
+    """Merge dedupes same-uuid identities and preserves score/embeddings.
 
     The same animal (shared ``uuid``) referenced by two separately-built files
     must collapse to a single canonical catalog `Identity` after merge, with both
-    instances pointing at it. Per-instance ``identity_score`` must survive the
-    rebuild in ``_map_instance``.
+    instances pointing at it. Per-instance ``identity_score`` and ``embeddings``
+    must survive the rebuild in ``_map_instance``.
     """
     skel1 = Skeleton(nodes=["head", "tail"])
     skel2 = Skeleton(nodes=["head", "tail"])  # Same structure -> matched.
@@ -4355,12 +4356,14 @@ def test_labels_merge_dedupes_same_uuid_identity():
     )
     labels1 = Labels([LabeledFrame(video=video1, frame_idx=0, instances=[inst1])])
 
+    emb = Embedding(vector=[1.0, 0.0, 0.0], name="reid")
     inst2 = Instance.from_numpy(
         np.array([[30, 30], [40, 40]]),
         skeleton=skel2,
         identity=id2,
         identity_score=0.87,
     )
+    inst2.embeddings["reid"] = emb
     labels2 = Labels([LabeledFrame(video=video2, frame_idx=0, instances=[inst2])])
 
     # Each file independently collected its own identity object.
@@ -4380,11 +4383,13 @@ def test_labels_merge_dedupes_same_uuid_identity():
     assert len(merged_instances) == 2
     assert all(inst.identity is canonical for inst in merged_instances)
 
-    # identity_score survived the merge for the incoming instance.
+    # identity_score and embeddings survived the merge for the incoming instance.
     incoming = [i for i in merged_instances if i.identity_score == 0.87]
     assert len(incoming) == 1
     inc = incoming[0]
     assert inc is not inst2  # Rebuilt by _map_instance.
+    assert inc.embeddings["reid"] is emb  # Dict shallow-copied; Embedding shared.
+    assert np.array_equal(inc.embeddings["reid"].vector, [1.0, 0.0, 0.0])
 
 
 def test_labels_merge_keeps_distinct_uuid_identities():


### PR DESCRIPTION
## Summary

**PR 3 of 3** (stacked on `feat/instance-identity`). Adds a flexible **re-ID Embedding** data model so sleap-nn can attach appearance vectors to detections and stop using its side-channel `.h5`.

## Key changes
- **Model:** `Embedding` value object — a 1-D feature vector (dtype-preserving: float32 from nets, float64 from JABS prototypes) plus `name`/`normalized`/`source`/`centroid_xy`/`metadata`. Attaches to **all five detection modalities** (`Instance`, `Centroid`, `SegmentationMask`, `BoundingBox`, `ROI`) **and `Identity`** via an `embeddings: dict[str, Embedding]` slot (named spaces) + `.embedding` accessor / `set_embedding()`, through a shared `EmbeddingMixin` (slots preserved).
- **Persistence (SLP format 2.6):** additive `/embeddings/<space>` group — gzipped `vectors (n, D)` (dtype preserved per space) + `owner_type`/`owner_id` join + per-row `meta_json`. Eager and **lazy fast-path** save; merge preserves per-instance embeddings. Heavy vectors stay out of JSON and out of the fixed instance row layout.
- **CLI:** `sio show` reports per-instance embedding spaces/counts.

## Review items addressed
- Compression was backwards — aux datasets (`meta_json`/`owner_id`/`owner_type`) now gzipped.
- `owner_type` codes reserved (2=centroid … 7=track) so completing per-modality persistence later is non-breaking.
- Scope documented: only `Instance` + `Identity` embeddings persist today; centroid/mask/bbox/ROI embeddings **warn** on save (no silent drop).

## Deferred follow-ups (tracked, not blockers)
Streaming embedding writer + slice-on-demand reader; bulk `(N, D)` accessor for training export; columnar metadata; save opt-out; **stable per-instance `uuid` join key** (today the join is positional); embedding multiplicity (multi-crop/temporal); persist non-instance-modality embeddings; the re-ID **resolve loop** (`cosine_similarity`, gallery prototypes, `Labels.resolve_identities`, `IdentityMatchMethod.EMBEDDING`); `dict[uuid->Identity]` index; identity hierarchy; the sleap-nn-side wiring.

## Testing
Full suite green (3856 passed, 1 skipped), incl. eager+lazy embedding round-trips, multiple named spaces, dtype preservation, sparse, identity prototypes, lazy-save round-trip, and inconsistent-dim guard.

## Stack
Base: `feat/instance-identity` (PR2). Final PR in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbXnTzogXjYJ6fiVzq2TN1
