### PR TITLE
fix(io): store provenance in a dataset to dodge HDF5's 64KB attribute limit (#516)

### DIFF
--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -27,13 +27,14 @@ SLP files have the following hierarchical structure:
 file.slp
 ├── /metadata                    # Group: Format and skeleton metadata
 │   ├── @format_id               # Attribute: Format version (float, e.g., 1.4)
-│   └── @json                    # Attribute: JSON metadata string
+│   └── @json                    # Attribute: JSON metadata string (skeletons, nodes; ≤64 KB)
 │
 ├── /videos_json                 # Dataset: Video metadata (variable-length bytes)
 ├── /tracks_json                 # Dataset: Track metadata (variable-length bytes)
 ├── /suggestions_json            # Dataset: Suggestions (variable-length bytes, optional)
 ├── /sessions_json               # Dataset: Recording sessions (variable-length bytes, optional)
 ├── /identities_json             # Dataset: Identity metadata (variable-length bytes, optional)
+├── /provenance_json             # Dataset: Provenance metadata (JSON bytes, optional)
 │
 ├── /frames                      # Dataset: Labeled frame metadata (structured array)
 ├── /instances                   # Dataset: Instance metadata (structured array)
@@ -137,6 +138,28 @@ file.slp
 | `suggestions_json` | `bytes[]` | JSON array of suggested frames (optional) |
 | `sessions_json` | `bytes[]` | JSON array of recording sessions (optional) |
 | `identities_json` | `bytes[]` | JSON array of identity definitions (optional) |
+| `provenance_json` | `bytes` | JSON object of provenance metadata (optional) |
+
+### Provenance storage and the 64 KB metadata limit
+
+The skeletons and nodes live in the `metadata/@json` HDF5 *attribute*. HDF5 caps
+any single attribute at 64 KB (65,536 bytes), so provenance — which can grow
+without bound (e.g. `merge_history` accrues a record on every
+[`Labels`][sleap_io.Labels] `merge()`) — is stored in its own
+`/provenance_json` *dataset*, which has no such limit.
+
+Reading is backward compatible: provenance is read from `/provenance_json` when
+present, otherwise from the `provenance` key inside the `metadata/@json`
+attribute (the legacy layout). When provenance is small it is also mirrored into
+the attribute so that older readers, which only look at the attribute, still see
+it.
+
+As a final safeguard, if the `metadata/@json` blob would still exceed 64 KB
+after relocating provenance, its largest droppable top-level keys are removed
+(largest-first) until it fits and a `UserWarning` names the dropped keys. This is
+lossless — provenance is already in `/provenance_json` and the other droppable
+keys are empty placeholders whose data lives in their own datasets — so saving
+never fails on oversized metadata.
 
 ## Videos
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1808,6 +1808,46 @@ def read_metadata(labels_path: str, *, _hdf5_file: h5py.File | None = None) -> d
     return json.loads(md)
 
 
+def read_provenance(
+    labels_path: str,
+    metadata: dict,
+    *,
+    _hdf5_file: h5py.File | None = None,
+) -> dict:
+    """Read the provenance dict for a SLEAP labels file.
+
+    Provenance is stored in a dedicated top-level ``/provenance_json`` dataset so
+    it is not subject to HDF5's 64 KB per-attribute size limit. The legacy layout
+    stored provenance inside the ``metadata/json`` attribute, which an unbounded
+    ``merge_history`` (or other large provenance) could exceed, breaking saving
+    entirely. For backward compatibility with files written before this change,
+    this falls back to the ``provenance`` key inside the already-read ``metadata``
+    blob when the dataset is absent.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        metadata: The parsed ``metadata`` dict (from `read_metadata`), used as the
+            fallback source of provenance for files written in the legacy layout.
+        _hdf5_file: An already-open ``h5py.File`` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise ``labels_path`` is opened and closed internally. Private,
+            mirrors the other ``read_*`` helpers.
+
+    Returns:
+        The provenance dict. Empty if neither the dataset nor the metadata blob
+        carry provenance.
+    """
+    try:
+        raw = read_hdf5_dataset(labels_path, "provenance_json", _hdf5_file=_hdf5_file)
+    except KeyError:
+        return metadata.get("provenance", dict())
+    # The dataset is a single JSON blob, read back as np.bytes_ (or a length-1
+    # array from some writers). json.loads accepts bytes/np.bytes_/str directly.
+    if isinstance(raw, np.ndarray):
+        raw = raw.item()
+    return json.loads(raw)
+
+
 def read_skeletons(
     labels_path: str, *, _hdf5_file: h5py.File | None = None
 ) -> list[Skeleton]:
@@ -1862,10 +1902,121 @@ def serialize_skeletons(skeletons: list[Skeleton]) -> tuple[list[dict], list[dic
     return encoder.encode_skeletons(skeletons)
 
 
+# HDF5 caps any single attribute at 64 KiB (65,536 bytes). Keep the metadata JSON
+# blob comfortably under that, leaving headroom for the HDF5 object header and the
+# sibling ``format_id`` attribute. Metadata that would exceed this has its large,
+# safely-relocatable top-level keys dropped from the attribute (see
+# ``_encode_metadata_attr``); the data itself is preserved in dedicated datasets.
+METADATA_ATTR_SIZE_LIMIT = 64_000
+
+# Top-level metadata keys that must never be dropped from the ``metadata/json``
+# attribute because the reader has no other source for them. (``provenance`` is
+# stored in the ``provenance_json`` dataset, and the remaining keys are empty
+# placeholders whose real data lives in their own datasets, so all are droppable.)
+_METADATA_PROTECTED_KEYS = ("version", "skeletons", "nodes")
+
+
+def _encode_metadata_attr(md: dict) -> np.bytes_:
+    """Serialize metadata to a JSON blob that fits HDF5's 64 KB attribute limit.
+
+    Writing a single HDF5 attribute larger than 64 KB fails with a cryptic
+    ``object header message is too large`` error (and on some HDF5 builds silently
+    writes a corrupt file). To keep saving robust, if the serialized metadata
+    exceeds `METADATA_ATTR_SIZE_LIMIT` this drops droppable top-level keys
+    (everything except `_METADATA_PROTECTED_KEYS`) largest-first until it fits,
+    emitting a ``UserWarning`` naming the dropped keys.
+
+    Dropping is lossless for the file as a whole: ``provenance`` is independently
+    stored in the ``provenance_json`` dataset, and ``videos``/``tracks``/
+    ``suggestions``/``negative_anchors`` are empty placeholders in the blob whose
+    real data lives in their own datasets.
+
+    Args:
+        md: The metadata dict to serialize. Mutated in place (offending keys are
+            removed) when the blob exceeds the limit.
+
+    Returns:
+        The serialized JSON blob as ``np.bytes_``, ready to assign to an HDF5
+        attribute.
+
+    Raises:
+        ValueError: If the protected keys (``skeletons``/``nodes``) alone exceed
+            the limit and so cannot be made to fit by dropping other keys.
+    """
+
+    def _blob(d: dict) -> bytes:
+        return json.dumps(d, separators=(",", ":")).encode()
+
+    blob = _blob(md)
+    if len(blob) <= METADATA_ATTR_SIZE_LIMIT:
+        return np.bytes_(blob)
+
+    original_size = len(blob)
+    droppable = sorted(
+        (k for k in md if k not in _METADATA_PROTECTED_KEYS),
+        key=lambda k: len(_blob({k: md[k]})),
+        reverse=True,
+    )
+    dropped = []
+    for k in droppable:
+        del md[k]
+        dropped.append(k)
+        blob = _blob(md)
+        if len(blob) <= METADATA_ATTR_SIZE_LIMIT:
+            break
+
+    if len(blob) > METADATA_ATTR_SIZE_LIMIT:
+        raise ValueError(
+            "Unable to fit Labels metadata within HDF5's "
+            f"{METADATA_ATTR_SIZE_LIMIT}-byte attribute limit: the required "
+            f"skeletons/nodes metadata alone serializes to {len(blob)} bytes. "
+            "Reduce the number or size of the skeletons/nodes."
+        )
+
+    warnings.warn(
+        f"Labels metadata JSON ({original_size} bytes) exceeded the "
+        f"{METADATA_ATTR_SIZE_LIMIT}-byte HDF5 attribute limit; dropped top-level "
+        f"key(s) {dropped} from the 'metadata/json' attribute so the file could be "
+        "saved. No data was lost: provenance is stored in the 'provenance_json' "
+        "dataset and the other dropped keys are empty placeholders whose data is "
+        "stored in separate datasets.",
+        stacklevel=2,
+    )
+    return np.bytes_(blob)
+
+
+def _write_provenance_dataset(f: h5py.File, provenance: dict) -> None:
+    """Write provenance to the top-level ``provenance_json`` dataset.
+
+    Provenance is stored as a dataset rather than inside the ``metadata/json``
+    attribute so it is exempt from HDF5's 64 KB per-attribute limit (an unbounded
+    ``merge_history`` would otherwise break saving). This is a no-op for empty
+    provenance, and overwrites any existing dataset so repeated writes to the same
+    open file stay idempotent.
+
+    Args:
+        f: An open ``h5py.File`` handle (opened in a writable mode).
+        provenance: The JSON-serializable provenance dict to store.
+    """
+    if not provenance:
+        return
+    if "provenance_json" in f:
+        del f["provenance_json"]
+    f.create_dataset(
+        "provenance_json",
+        data=np.bytes_(json.dumps(provenance, separators=(",", ":"))),
+    )
+
+
 def write_metadata(labels_path: str, labels: Labels):
     """Write metadata to a SLEAP labels file.
 
     This function will write the skeletons and provenance for the labels.
+
+    Provenance is written to a dedicated top-level ``provenance_json`` dataset (not
+    subject to HDF5's 64 KB attribute limit) and, when small enough, also mirrored
+    into the ``metadata/json`` attribute for backward compatibility with older
+    readers (see `read_provenance` and `_encode_metadata_attr`).
 
     Args:
         labels_path: A string path to the SLEAP labels file.
@@ -1875,6 +2026,13 @@ def write_metadata(labels_path: str, labels: Labels):
     """
     skeletons_dicts, nodes_dicts = serialize_skeletons(labels.skeletons)
 
+    # Encode provenance into a JSON-safe dict (Path -> str). Build a copy so we
+    # never mutate the caller's ``labels.provenance``.
+    provenance = {
+        k: (v.as_posix() if isinstance(v, Path) else v)
+        for k, v in labels.provenance.items()
+    }
+
     md = {
         "version": "2.0.0",
         "skeletons": skeletons_dicts,
@@ -1883,14 +2041,8 @@ def write_metadata(labels_path: str, labels: Labels):
         "tracks": [],
         "suggestions": [],  # TODO: Handle suggestions metadata.
         "negative_anchors": {},
-        "provenance": labels.provenance,
+        "provenance": provenance,
     }
-
-    # Custom encoding.
-    for k in md["provenance"]:
-        if isinstance(md["provenance"][k], Path):
-            # Path -> str
-            md["provenance"][k] = md["provenance"][k].as_posix()
 
     # Bump format_id based on features used
     has_instance_rois = any(
@@ -1952,7 +2104,12 @@ def write_metadata(labels_path: str, labels: Labels):
 
         grp = f.require_group("metadata")
         grp.attrs["format_id"] = format_id
-        grp.attrs["json"] = np.bytes_(json.dumps(md, separators=(",", ":")))
+        # Store provenance in a dedicated dataset (no 64 KB attribute limit) so an
+        # unbounded merge_history can't break saving. A copy is also kept in the
+        # metadata/json attribute (when it fits) by `_encode_metadata_attr` for
+        # older readers.
+        _write_provenance_dataset(f, provenance)
+        grp.attrs["json"] = _encode_metadata_attr(md)
 
 
 def read_points(labels_path: str, *, _hdf5_file: h5py.File | None = None) -> np.ndarray:
@@ -3061,7 +3218,7 @@ def _read_labels_lazy_from_open_file(
     tracks = read_tracks(labels_path, _hdf5_file=f)
     suggestions = read_suggestions(labels_path, videos, _hdf5_file=f)
     metadata = read_metadata(labels_path, _hdf5_file=f)
-    provenance = metadata.get("provenance", dict())
+    provenance = read_provenance(labels_path, metadata, _hdf5_file=f)
     negative_frames = read_negative_frames(labels_path, _hdf5_file=f)
 
     # Read sessions (small, no need for lazy loading)
@@ -4907,7 +5064,10 @@ def _write_metadata_standalone(
 
         grp = f.require_group("metadata")
         grp.attrs["format_id"] = format_id
-        grp.attrs["json"] = np.bytes_(json.dumps(md, separators=(",", ":")))
+        # Mirror write_metadata: provenance goes to a dedicated dataset (no 64 KB
+        # attribute limit), kept in the metadata/json attribute too when it fits.
+        _write_provenance_dataset(f, provenance)
+        grp.attrs["json"] = _encode_metadata_attr(md)
 
         # Write empty placeholder datasets so read_labels can parse the file
         if "points" not in f:
@@ -5797,7 +5957,7 @@ def _read_labels_from_open_file(
     )
     suggestions = read_suggestions(labels_path, videos, _hdf5_file=f)
     metadata = read_metadata(labels_path, _hdf5_file=f)
-    provenance = metadata.get("provenance", dict())
+    provenance = read_provenance(labels_path, metadata, _hdf5_file=f)
 
     frames = read_hdf5_dataset(labels_path, "frames", _hdf5_file=f)
     negative_markers = read_negative_frames(labels_path, _hdf5_file=f)

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -40,11 +40,14 @@ from sleap_io import (
 )
 from sleap_io.io.slp import (
     LI_DTYPE,
+    METADATA_ATTR_SIZE_LIMIT,
     OBJ_DTYPE,
     ExportCancelled,
     LabelImageWriter,
+    _encode_metadata_attr,
     _points_from_hdf5_data,
     _write_metadata_standalone,
+    _write_provenance_dataset,
     camera_group_to_dict,
     camera_to_dict,
     can_use_fast_path,
@@ -72,6 +75,7 @@ from sleap_io.io.slp import (
     read_negative_frames,
     read_points,
     read_pred_points,
+    read_provenance,
     read_rois,
     read_sessions,
     read_skeletons,
@@ -393,6 +397,76 @@ def test_write_metadata(centered_pair, tmp_path):
         saved_skeletons[0].get_flipped_node_inds()
         == labels.skeletons[0].get_flipped_node_inds()
     )
+
+
+def test_write_metadata_provenance_dataset(centered_pair, tmp_path):
+    """Provenance is written to the dedicated ``provenance_json`` dataset."""
+    labels = read_labels(centered_pair)
+    labels.provenance["custom_key"] = "custom_value"
+    path = tmp_path / "test.slp"
+    write_metadata(path, labels)
+
+    # Provenance is stored in its own dataset (no 64 KB attribute limit) and is
+    # readable back via read_provenance.
+    with h5py.File(path, "r") as f:
+        assert "provenance_json" in f
+    md = read_metadata(path)
+    assert read_provenance(str(path), md)["custom_key"] == "custom_value"
+
+
+def test_write_metadata_does_not_mutate_provenance(tmp_path):
+    """write_metadata must not mutate the caller's ``labels.provenance``."""
+    labels = Labels(skeletons=[Skeleton(["A", "B"])])
+    labels.provenance["source"] = Path("/some/path.slp")
+    write_metadata(tmp_path / "test.slp", labels)
+
+    # The in-memory value is still a Path (serialization worked on a copy).
+    assert labels.provenance["source"] == Path("/some/path.slp")
+    assert isinstance(labels.provenance["source"], Path)
+
+
+def test_write_metadata_large_provenance_round_trips(tmp_path):
+    """Metadata over 64 KB (large merge_history) saves and round-trips."""
+    labels = Labels(skeletons=[Skeleton(["A", "B"])])
+    # Simulate ~250 merges: each record ~360 B -> well over the 64 KB attr limit.
+    labels.provenance["merge_history"] = [
+        {"i": i, "pad": "x" * 350} for i in range(250)
+    ]
+    path = tmp_path / "big.slp"
+    with pytest.warns(UserWarning, match="exceeded the .* HDF5 attribute limit"):
+        write_metadata(path, labels)
+
+    # The attr blob fits under the limit; provenance lives in the dataset.
+    with h5py.File(path, "r") as f:
+        assert len(bytes(f["metadata"].attrs["json"])) <= METADATA_ATTR_SIZE_LIMIT
+        assert "provenance_json" in f
+
+    md = read_metadata(path)
+    assert "provenance" not in md  # dropped from the oversized attr
+    prov = read_provenance(str(path), md)
+    assert len(prov["merge_history"]) == 250
+    assert prov["merge_history"][-1]["i"] == 249
+
+
+def test_save_slp_large_provenance_round_trips(tmp_path):
+    """save_slp/load_slp round-trips a Labels with >64 KB provenance."""
+    skel = Skeleton(["A", "B"])
+    lf = LabeledFrame(
+        video=Video("test.mp4"),
+        frame_idx=0,
+        instances=[Instance.from_numpy([[0, 0], [1, 1]], skeleton=skel)],
+    )
+    labels = Labels([lf])
+    labels.provenance["merge_history"] = [
+        {"i": i, "pad": "x" * 350} for i in range(250)
+    ]
+    path = tmp_path / "big.slp"
+    with pytest.warns(UserWarning, match="HDF5 attribute limit"):
+        save_slp(labels, path)
+
+    loaded = load_slp(path)
+    assert len(loaded.provenance["merge_history"]) == 250
+    assert loaded.provenance["merge_history"][-1]["i"] == 249
 
 
 def test_write_lfs(centered_pair, slp_real_data, tmp_path):
@@ -5696,6 +5770,128 @@ def test_read_metadata_malformed_json_not_remasked(tmp_path):
     with pytest.raises(ValueError) as exc_info:
         read_metadata(path)
     assert "missing its required metadata JSON blob" not in str(exc_info.value)
+
+
+def test_read_provenance_falls_back_to_attr(tmp_path):
+    """read_provenance falls back to the metadata attr for legacy files."""
+    # Legacy layout: provenance only inside the metadata/json attribute.
+    path = str(tmp_path / "legacy.slp")
+    metadata = {"version": "2.0.0", "provenance": {"sleap_version": "1.2.7"}}
+    with h5py.File(path, "w") as f:
+        grp = f.require_group("metadata")
+        grp.attrs["json"] = np.bytes_(json.dumps(metadata))
+
+    md = read_metadata(path)
+    assert read_provenance(path, md) == {"sleap_version": "1.2.7"}
+    with h5py.File(path, "r") as f:
+        assert "provenance_json" not in f
+
+
+def test_read_provenance_prefers_dataset(tmp_path):
+    """read_provenance prefers the dataset over the attr when both exist."""
+    path = str(tmp_path / "both.slp")
+    with h5py.File(path, "w") as f:
+        grp = f.require_group("metadata")
+        grp.attrs["json"] = np.bytes_(json.dumps({"provenance": {"src": "from_attr"}}))
+        f.create_dataset(
+            "provenance_json", data=np.bytes_(json.dumps({"src": "from_dataset"}))
+        )
+
+    md = read_metadata(path)
+    assert read_provenance(path, md)["src"] == "from_dataset"
+
+
+def test_read_provenance_ndarray_dataset(tmp_path):
+    """read_provenance decodes a provenance_json stored as a (non-scalar) array."""
+    path = str(tmp_path / "arr.slp")
+    payload = np.bytes_(json.dumps({"k": "v"}))
+    with h5py.File(path, "w") as f:
+        f.create_dataset("provenance_json", data=np.array([payload]))
+
+    assert read_provenance(path, {}) == {"k": "v"}
+
+
+def test_write_provenance_dataset_overwrites(tmp_path):
+    """_write_provenance_dataset overwrites an existing provenance_json dataset."""
+    path = str(tmp_path / "p.slp")
+    with h5py.File(path, "a") as f:
+        _write_provenance_dataset(f, {"a": 1})
+        _write_provenance_dataset(f, {"a": 2})  # exercises the delete-then-create path
+
+    assert read_provenance(path, {}) == {"a": 2}
+
+
+def test_encode_metadata_attr_under_limit_unchanged():
+    """Small metadata is serialized as-is with no keys dropped."""
+    md = {"version": "2.0.0", "skeletons": [], "nodes": [], "provenance": {"a": 1}}
+    blob = _encode_metadata_attr(md)
+    assert json.loads(bytes(blob)) == md
+    assert "provenance" in md  # input not mutated when under the limit
+
+
+def test_encode_metadata_attr_drops_largest_droppable_key():
+    """Oversized metadata drops droppable keys largest-first with a warning."""
+    md = {
+        "version": "2.0.0",
+        "skeletons": [],
+        "nodes": [],
+        "provenance": {"blob": "x" * (METADATA_ATTR_SIZE_LIMIT + 1000)},
+        "tracks": [{"small": "y"}],
+    }
+    with pytest.warns(
+        UserWarning, match=r"dropped top-level key\(s\) \['provenance'\]"
+    ):
+        blob = _encode_metadata_attr(md)
+
+    decoded = json.loads(bytes(blob))
+    assert "provenance" not in decoded  # largest droppable key removed
+    assert decoded["tracks"] == [{"small": "y"}]  # smaller droppable key kept
+    assert decoded["skeletons"] == []  # protected key kept
+
+
+def test_encode_metadata_attr_drops_multiple_keys():
+    """Multiple droppable keys are removed when dropping one is not enough."""
+    big = "x" * 50000
+    md = {
+        "version": "2.0.0",
+        "skeletons": [],
+        "nodes": [],
+        "provenance": {"b": big},
+        "tracks": [big],
+        "videos": [big],
+    }
+    # 3 * ~50 KB > limit, and dropping a single key still leaves it over -> loops.
+    with pytest.warns(UserWarning, match="HDF5 attribute limit"):
+        blob = _encode_metadata_attr(md)
+
+    decoded = json.loads(bytes(blob))
+    assert len(bytes(blob)) <= METADATA_ATTR_SIZE_LIMIT
+    # At least two of the three large droppable keys were removed.
+    assert sum(k in decoded for k in ("provenance", "tracks", "videos")) <= 1
+
+
+def test_encode_metadata_attr_protected_overflow_raises():
+    """Protected keys (skeletons/nodes) overflowing alone raises a clear error."""
+    md = {
+        "version": "2.0.0",
+        "skeletons": [{"big": "x" * (METADATA_ATTR_SIZE_LIMIT + 1000)}],
+        "nodes": [],
+    }
+    with pytest.raises(ValueError, match="skeletons/nodes metadata alone"):
+        _encode_metadata_attr(md)
+
+
+def test_write_metadata_standalone_provenance_dataset(tmp_path):
+    """_write_metadata_standalone also writes the provenance_json dataset."""
+    path = str(tmp_path / "meta.slp")
+    with h5py.File(path, "w"):
+        pass
+    _write_metadata_standalone(path, provenance={"source": "x.slp"})
+
+    with h5py.File(path, "r") as f:
+        assert "provenance_json" in f
+    md = read_metadata(path)
+    assert read_provenance(path, md)["source"] == "x.slp"
 
 
 def test_read_h5wasm_instances_float64_indices(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #516. Saving a `.slp` failed once `Labels.provenance` serialized past HDF5's **64 KB per-attribute limit**. `provenance["merge_history"]` grows ~390 B on every `Labels.merge()` with no bound, so after ~168 merges into the same project **every save fails** — `OSError: object header message is too large`, or a silently corrupt file that reloads with `KeyError: ... can't locate attribute: 'json'`. Inference outputs derived from such a project fail to save too.

## Key Changes

- **Provenance → dedicated `/provenance_json` dataset.** Datasets have no 64 KB limit, so provenance (including an unbounded `merge_history`) can no longer break saving. New `read_provenance()` reads the dataset first and falls back to the `metadata/json` attribute for older files.
- **Backward + forward compatible.** Old attribute-form files load unchanged. New files keep a copy of provenance *inside* the `metadata/json` attribute when it fits, so older readers (SLEAP main app, older sleap-io) still see it — they just never crash. Converting the attribute itself to a dataset (which *would* crash old readers) is deliberately avoided; we only add a sibling dataset.
- **Defensive size-guard (`_encode_metadata_attr`).** If the `metadata/json` blob would still exceed 64 KB, the largest *droppable* top-level keys are removed largest-first until it fits, with a `UserWarning` naming them. `version`/`skeletons`/`nodes` are protected; if they alone overflow, a clear `ValueError` is raised instead of the cryptic h5py one. Dropping is **lossless** — provenance is in its dataset and `videos`/`tracks`/`suggestions`/`negative_anchors` are empty placeholders stored in their own datasets.
- **Latent bug fix.** `write_metadata` mutated the caller's `labels.provenance` in place when converting `Path` values; it now serializes from a copy.

Applies to both `write_metadata` and `_write_metadata_standalone`, and both the eager and lazy read paths.

## Example

```python
import sleap_io as sio

labels = sio.load_slp("project.slp")          # 174 merges -> provenance ~68 KB
sio.save_slp(labels, "project.slp")           # before: OSError / corrupt file
                                              # now: saves fine; provenance in /provenance_json
back = sio.load_slp("project.slp")
assert back.provenance["merge_history"]        # fully preserved
```

## API Changes

- New public function `sleap_io.io.slp.read_provenance(labels_path, metadata, *, _hdf5_file=None)`.
- New module constant `METADATA_ATTR_SIZE_LIMIT = 64_000` and helpers `_encode_metadata_attr`, `_write_provenance_dataset`.
- New optional top-level HDF5 dataset `/provenance_json` in the `.slp` format (documented in `docs/formats/slp.md`). No `format_id` bump (the dataset is detected by presence; this also avoids colliding with concurrent format work).

## Testing

- Round-trip of >64 KB provenance via `write_metadata` and full `save_slp`/`load_slp` (warns, no crash, all 250 synthetic merge records preserved).
- `read_provenance` dataset-first, attr-fallback for legacy files, dataset-preferred when both present, and array-encoded datasets.
- `_encode_metadata_attr`: under-limit unchanged, single- and multi-key drops, protected-key overflow raises.
- `write_metadata` does not mutate the caller's provenance; `_write_metadata_standalone` writes the dataset.
- Full `tests/io/test_slp.py` (319) and the merge/provenance model tests (89) pass. New code is fully covered.

## Design Decisions

- **Keep-in-attr-when-it-fits** (vs. always moving provenance out): maximizes backward compat — typical small-provenance files still expose provenance to old readers; only the huge-provenance bug case loses it for them (unavoidable without crashing them).
- **No `format_id` bump**: provenance-as-dataset is detected by dataset presence, not a version gate, so a bump isn't needed for correctness — and it would collide with in-flight identity/embedding format work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
