### PR TITLE
fix(io): spill oversized source_video metadata to a dataset (#516)

### DIFF
--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -117,8 +117,15 @@ file.slp
     │   └── @fps                 # Attribute: Frames per second (optional)
     ├── /frame_numbers           # Dataset: Embedded frame indices (int array)
     └── /source_video/           # Group: Source video metadata
-        └── @json                # Attribute: JSON with source video info
+        ├── @json                # Attribute: JSON with source video info (≤64 KB)
+        └── /json                # Dataset: JSON fallback when info exceeds 64 KB (optional)
 ```
+
+!!! note "Source video metadata over 64 KB"
+    Source video metadata is normally stored in the `source_video/@json`
+    attribute. If it would exceed HDF5's 64 KB attribute limit (e.g. a very large
+    `backend_metadata`), it is written to a `source_video/json` *dataset* instead
+    and a warning is emitted; readers prefer the dataset when present.
 
 ### Core Datasets
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -188,6 +188,57 @@ def _is_embedded_video_metadata(video: Video) -> bool:
     return False
 
 
+def _write_source_video_json(source_grp: h5py.Group, source_video_dict: dict) -> None:
+    """Write a source video's metadata JSON into its ``source_video`` group.
+
+    Normally stored in the group's ``json`` *attribute*. If the serialized
+    metadata would exceed HDF5's 64 KB attribute limit (e.g. a very large
+    ``backend_metadata``), it is written to a ``json`` *dataset* in the same group
+    instead — datasets have no such limit — and a ``UserWarning`` is emitted.
+    `_read_source_video_json` reads the dataset first, falling back to the
+    attribute, so the two stay interchangeable.
+
+    Args:
+        source_grp: The ``{group}/source_video`` HDF5 group to write into.
+        source_video_dict: The source video metadata dict (from `video_to_dict`).
+    """
+    blob = json.dumps(source_video_dict, separators=(",", ":"))
+    if len(blob.encode()) <= METADATA_ATTR_SIZE_LIMIT:
+        source_grp.attrs["json"] = blob
+        return
+
+    warnings.warn(
+        f"Source video metadata ({len(blob.encode())} bytes) exceeds the "
+        f"{METADATA_ATTR_SIZE_LIMIT}-byte HDF5 attribute limit; storing it in a "
+        f"'{source_grp.name}/json' dataset instead of the attribute. Readers older "
+        "than this version will not find the source video metadata.",
+        stacklevel=2,
+    )
+    if "json" in source_grp:
+        del source_grp["json"]
+    source_grp.create_dataset("json", data=np.bytes_(blob))
+
+
+def _read_source_video_json(source_grp: h5py.Group) -> dict:
+    """Read a source video's metadata JSON from its ``source_video`` group.
+
+    Reads the ``json`` *dataset* (written by `_write_source_video_json` for
+    oversized metadata) when present, otherwise the ``json`` *attribute* (the
+    normal case and all legacy files).
+
+    Args:
+        source_grp: The ``{group}/source_video`` HDF5 group to read from.
+
+    Returns:
+        The parsed source video metadata dict.
+    """
+    # json.loads accepts the dataset's np.bytes_ scalar and the attribute's str
+    # directly, so no explicit decoding is needed.
+    if "json" in source_grp:
+        return json.loads(source_grp["json"][()])
+    return json.loads(source_grp.attrs["json"])
+
+
 def make_video(
     labels_path: str,
     video_json: dict,
@@ -260,8 +311,8 @@ def make_video(
 
             # Load source_video metadata
             if dataset in f and "source_video" in f[dataset]:
-                source_video_json = json.loads(
-                    f[f"{dataset}/source_video"].attrs["json"]
+                source_video_json = _read_source_video_json(
+                    f[f"{dataset}/source_video"]
                 )
                 source_video = make_video(
                     labels_path,
@@ -1066,9 +1117,7 @@ def process_and_embed_frames(
 
             # Store source video metadata
             grp = f.require_group(f"{group}/source_video")
-            grp.attrs["json"] = json.dumps(
-                video_to_dict(source_video, labels_path), separators=(",", ":")
-            )
+            _write_source_video_json(grp, video_to_dict(source_video, labels_path))
 
             # Store the embedded video for return
             replaced_videos[video] = embedded_video
@@ -1125,9 +1174,7 @@ def _create_empty_embedded_video(
 
         # Store source video metadata for restoration
         source_grp = f.require_group(f"{group}/source_video")
-        source_grp.attrs["json"] = json.dumps(
-            video_to_dict(source_video, labels_path), separators=(",", ":")
-        )
+        _write_source_video_json(source_grp, video_to_dict(source_video, labels_path))
 
     # Create the embedded video object using VideoBackend.from_filename
     # This ensures the HDF5Video is properly initialized with the dataset metadata
@@ -1518,9 +1565,7 @@ def write_videos(
                     source_json = video_to_dict(
                         source_to_save, labels_path, prefer_metadata=prefer_metadata
                     )
-                    source_grp.attrs["json"] = json.dumps(
-                        source_json, separators=(",", ":")
-                    )
+                    _write_source_video_json(source_grp, source_json)
 
 
 def read_tracks(

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -46,8 +46,10 @@ from sleap_io.io.slp import (
     LabelImageWriter,
     _encode_metadata_attr,
     _points_from_hdf5_data,
+    _read_source_video_json,
     _write_metadata_standalone,
     _write_provenance_dataset,
+    _write_source_video_json,
     camera_group_to_dict,
     camera_to_dict,
     can_use_fast_path,
@@ -5892,6 +5894,51 @@ def test_write_metadata_standalone_provenance_dataset(tmp_path):
         assert "provenance_json" in f
     md = read_metadata(path)
     assert read_provenance(path, md)["source"] == "x.slp"
+
+
+def test_source_video_json_small_uses_attr(tmp_path):
+    """Small source video metadata stays in the group's json attribute."""
+    path = str(tmp_path / "sv.slp")
+    payload = {"filename": "v.mp4", "backend": {"type": "MediaVideo"}}
+    with h5py.File(path, "a") as f:
+        grp = f.require_group("video0/source_video")
+        _write_source_video_json(grp, payload)
+        assert "json" not in grp  # no dataset
+        assert "json" in grp.attrs  # stored as attribute
+
+    with h5py.File(path, "r") as f:
+        assert _read_source_video_json(f["video0/source_video"]) == payload
+
+
+def test_source_video_json_large_spills_to_dataset(tmp_path):
+    """Oversized source video metadata spills to a dataset with a warning."""
+    path = str(tmp_path / "sv_big.slp")
+    payload = {"filename": "v.mp4", "backend_metadata": {"blob": "x" * 70000}}
+    with h5py.File(path, "a") as f:
+        grp = f.require_group("video0/source_video")
+        with pytest.warns(UserWarning, match="exceeds the .* HDF5 attribute limit"):
+            _write_source_video_json(grp, payload)
+        assert "json" in grp  # stored as dataset
+        assert "json" not in grp.attrs  # not in the attribute
+
+    with h5py.File(path, "r") as f:
+        assert _read_source_video_json(f["video0/source_video"]) == payload
+
+
+def test_source_video_json_spill_overwrites_dataset(tmp_path):
+    """Re-spilling overwrites an existing source_video json dataset."""
+    path = str(tmp_path / "sv_re.slp")
+    big1 = {"backend_metadata": {"blob": "x" * 70000}}
+    big2 = {"backend_metadata": {"blob": "y" * 70000}}
+    with h5py.File(path, "a") as f:
+        grp = f.require_group("video0/source_video")
+        with pytest.warns(UserWarning):
+            _write_source_video_json(grp, big1)
+        with pytest.warns(UserWarning):
+            _write_source_video_json(grp, big2)  # exercises delete-then-create
+
+    with h5py.File(path, "r") as f:
+        assert _read_source_video_json(f["video0/source_video"]) == big2
 
 
 def test_read_h5wasm_instances_float64_indices(tmp_path):


### PR DESCRIPTION
> Stacked on #517 — review/merge that first. The base of this PR is `fix/metadata-provenance-64kb`, so the diff shown here is only the source_video change.

## Summary

Companion hardening to #517. The per-video **source video** metadata is serialized into each `video{N}/source_video` group's `json` *attribute*, which is subject to the same HDF5 64 KB attribute limit. A large `backend_metadata` could overflow it and crash the save. This applies the same dataset-spill safeguard to source video metadata.

## Key Changes

- **`_write_source_video_json(source_grp, source_video_dict)`** — writes the `json` attribute as before when it fits under 64 KB; otherwise spills to a `source_video/json` *dataset* (no size limit) and emits a `UserWarning`.
- **`_read_source_video_json(source_grp)`** — reads the dataset when present, otherwise the attribute (the normal case and all legacy files).
- Routes the three source-video writers and the embedded-video reader through the helpers.

## API Changes

- New optional `video{N}/source_video/json` HDF5 *dataset* (fallback for oversized source video metadata), documented in `docs/formats/slp.md`.

## Testing

- Unit tests: small metadata → attribute (no dataset); oversized → dataset + warning; re-spill overwrites the dataset; read prefers dataset, falls back to attribute.
- All existing embed/video round-trip tests pass (they now route through the helpers for the normal attribute path). Full `tests/io/test_slp.py` (322) green; new code fully covered.

## Design Decisions

- Different shape from the metadata size-guard in #517: a source video dict can't have keys "dropped" (the reader needs all of it), so the fix is **spill-to-dataset** rather than drop-largest-key.
- `original_video` (legacy, read-only — never written by sleap-io) is left untouched; it can never overflow on write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
