### PR TITLE
feat: per-instance + Identity categories via CategoriesMixin (1/2)

### DIFF
--- a/docs/model/3d.md
+++ b/docs/model/3d.md
@@ -187,6 +187,7 @@ Key properties:
 - `color` — optional hex color string for visualization.
 - `metadata` — arbitrary metadata dictionary (e.g. `species`/`sex`/`genotype`).
 - `embeddings` — optional re-ID prototype / gallery [`Embedding`](embedding.md) vectors keyed by space name.
+- `categories` — optional [entity-level categorical labels](categories.md) keyed by dimension name (e.g. `{"sex": "M", "strain": "C57BL/6"}`).
 
 Identities attach at three levels:
 
@@ -299,6 +300,7 @@ classDiagram
         +Identity identity
         +float identity_score
         +dict~str,Embedding~ embeddings
+        +dict~str,object~ categories
     }
     class Identity:::threed {
         +str name

--- a/docs/model/categories.md
+++ b/docs/model/categories.md
@@ -1,0 +1,70 @@
+# Categories
+
+A **category** is a named categorical label attached to a detection (or to an
+[`Identity`](3d.md#identity)) along some dimension — for example `"sex"`, `"strain"`, or
+`"behavior"`. Categories are how you tag instances with discrete attributes for grouping,
+filtering, and balanced sampling.
+
+Categories are stored in a `categories: dict` mapping keyed by **dimension name**. Values are
+typically plain strings, but may be any JSON-serializable value (e.g. a list encoding a one-hot
+or class-probability distribution):
+
+| Dimension | Example value |
+| --- | --- |
+| `"sex"` | `"M"` |
+| `"strain"` | `"C57BL/6"` |
+| `"behavior"` | `"grooming"` |
+| `"sex_probs"` | `[0.2, 0.8]` |
+
+!!! note "Plural `categories` vs. scalar `category`"
+    This plural `categories` mapping is **distinct** from the singular scalar `category` attribute
+    on the geometry primitives ([`Centroid`](centroids.md), [`BoundingBox`](boxes.md),
+    [`SegmentationMask`](segmentation.md), [`ROI`](rois.md)), which names the *detector class* of a
+    single shape. The two never collide — categories are addressed through the `cat` alias, not
+    `category`.
+
+## Accessing categories
+
+[`Instance`](poses.md), [`PredictedInstance`](poses.md), and [`Identity`](3d.md#identity) carry a
+`categories` mapping plus a convenience `cat` alias and `set_category()` / `set_categories()`
+helpers (mirroring the [`embeddings`](embedding.md) accessor pattern):
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "tail"])
+>>> inst = sio.Instance.from_numpy(np.array([[0, 1], [2, 3]]), skeleton=skeleton)
+>>> inst.set_category("sex", "M")                       # single dimension
+>>> inst.set_categories({"strain": "C57BL/6", "age": "adult"})  # merge several
+>>> inst.cat["behavior"] = "grooming"                   # `cat` is the live mapping
+>>> sorted(inst.categories)
+['age', 'behavior', 'sex', 'strain']
+```
+
+The `cat` property is a short alias for the live `categories` dict, so you can read or assign
+entries in place. Assigning to `cat` directly replaces the whole mapping.
+
+## Identity categories
+
+An [`Identity`](3d.md#identity) carries categories at the **entity level** — attributes of the
+animal itself rather than of one detection (e.g. the known sex or strain of `"mouse_A"`):
+
+```pycon
+>>> import sleap_io as sio
+>>> identity = sio.Identity(name="mouse_A")
+>>> identity.set_categories({"species": "mouse", "sex": "M"})
+>>> identity.categories
+{'species': 'mouse', 'sex': 'M'}
+```
+
+## Scope
+
+In this iteration, categories are attached to **instances and `Identity`** only. The geometry
+primitives keep their singular scalar `category` and do not yet carry the plural mapping; this can
+be extended later, exactly like the [embeddings](embedding.md) rollout.
+
+---
+
+## API reference
+
+::: sleap_io.model.categories.CategoriesMixin

--- a/docs/model/poses.md
+++ b/docs/model/poses.md
@@ -17,7 +17,7 @@ The pose data model is built around four key types:
 - **[`Track`][sleap_io.Track]** is the **video-local identity**: links the same animal across frames of one recording.
 - **[`Identity`](3d.md#identity)** is the **global identity**: a persistent, cross-session animal label assigned via `Instance.identity` (with `identity_score`), distinct from the ephemeral `Track`.
 
-A `Skeleton` is shared across all instances in a dataset. Each `Instance` references a `Skeleton` to know which landmarks it contains, optionally a `Track` (and a global `Identity`) to indicate which animal it belongs to, and optionally re-ID [`embeddings`](embedding.md) describing its appearance.
+A `Skeleton` is shared across all instances in a dataset. Each `Instance` references a `Skeleton` to know which landmarks it contains, optionally a `Track` (and a global `Identity`) to indicate which animal it belongs to, optionally re-ID [`embeddings`](embedding.md) describing its appearance, and optionally [`categories`](categories.md) tagging it with discrete attributes (e.g. `sex`, `strain`).
 
 ---
 
@@ -335,6 +335,7 @@ classDiagram
         +Identity identity
         +float identity_score
         +dict~str,Embedding~ embeddings
+        +dict~str,object~ categories
         +numpy() ndarray
         +n_visible: int
         +is_empty: bool

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
       - ROIs: model/rois.md
       - Segmentation: model/segmentation.md
       - Embeddings: model/embedding.md
+      - Categories: model/categories.md
     - Formats:
       - formats/index.md
       - SLP Format: formats/slp.md

--- a/sleap_io/model/categories.py
+++ b/sleap_io/model/categories.py
@@ -1,0 +1,68 @@
+"""Categorical-label storage for per-detection and per-identity attributes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class CategoriesMixin:
+    """Mixin adding per-detection categorical-label storage helpers.
+
+    A *category* is a named categorical label describing a detection (or an
+    `Identity`) along some dimension, e.g. ``{"sex": "M", "strain": "C57BL/6"}``.
+    Categories are stored in a ``categories`` mapping keyed by dimension name.
+    Values are typically plain strings but may be any JSON-serializable value
+    (e.g. a list encoding a one-hot / class-probability distribution), so they
+    round-trip through the SLP ``/instance_categories`` side-table.
+
+    Classes using this mixin must declare a ``categories: dict`` attrs field. The
+    mixin adds a convenience ``cat`` alias for that mapping plus ``set_category``
+    / ``set_categories`` helpers without storing any state of its own
+    (``__slots__`` is empty so slotted attrs subclasses keep their slots).
+
+    Note:
+        This plural ``categories`` mapping is distinct from the singular scalar
+        ``category`` attribute on the geometry primitives (`Centroid`,
+        `BoundingBox`, `SegmentationMask`, `ROI`), which names the detector class
+        of a single shape. The ``cat`` alias deliberately avoids that name.
+    """
+
+    __slots__ = ()
+
+    @property
+    def cat(self) -> dict[str, Any]:
+        """Alias for the ``categories`` mapping.
+
+        Returns the live ``categories`` dict, so entries can be read or assigned
+        in place, e.g. ``instance.cat["sex"] = "M"``.
+        """
+        return self.categories
+
+    @cat.setter
+    def cat(self, value: dict[str, Any]) -> None:
+        self.categories = value
+
+    def set_category(self, dim: str, value: Any) -> None:
+        """Set a single category dimension.
+
+        This is an in-place mutator (like ``dict.__setitem__``) and returns
+        ``None``; equivalent to ``self.cat[dim] = value``.
+
+        Args:
+            dim: Category dimension name (e.g. ``"sex"``).
+            value: Category value (typically a string, but any JSON-serializable
+                value is allowed).
+        """
+        self.categories[dim] = value
+
+    def set_categories(self, categories: dict[str, Any]) -> None:
+        """Merge multiple category dimensions into the mapping.
+
+        This is an in-place mutator (like ``dict.update``) and returns ``None``.
+
+        Args:
+            categories: A mapping of dimension names to values. Merged into the
+                existing ``categories`` mapping; keys already present are
+                overwritten.
+        """
+        self.categories.update(categories)

--- a/sleap_io/model/identity.py
+++ b/sleap_io/model/identity.py
@@ -6,6 +6,7 @@ import attrs
 from attrs import define, field
 from attrs.validators import instance_of
 
+from sleap_io.model.categories import CategoriesMixin
 from sleap_io.model.embedding import Embedding, EmbeddingMixin
 
 
@@ -15,7 +16,7 @@ def _generate_uuid() -> str:
 
 
 @define(eq=False)
-class Identity(EmbeddingMixin):
+class Identity(EmbeddingMixin, CategoriesMixin):
     """Ground-truth animal identity, persistent across sessions and videos.
 
     Unlike `Track` (an ephemeral temporal trajectory within a single video),
@@ -40,6 +41,10 @@ class Identity(EmbeddingMixin):
             `Embedding` prototype / gallery vector representing this identity in
             that space (e.g. the cluster centroid of its member instances). Empty
             by default.
+        categories: A mapping from category dimension name (e.g. ``"sex"``) to a
+            categorical label (typically a string) describing this identity at
+            the entity level. Empty by default. Use the `cat` alias /
+            `set_category` helper for read/write access.
 
     Notes:
         `Identity` objects use object-identity equality (`eq=False`), matching
@@ -52,6 +57,7 @@ class Identity(EmbeddingMixin):
     color: str | None = field(default=None, converter=attrs.converters.optional(str))
     metadata: dict = field(factory=dict, validator=instance_of(dict))
     embeddings: dict[str, Embedding] = field(factory=dict, repr=False)
+    categories: dict = field(factory=dict, repr=False)
 
     def matches(self, other: "Identity", method: str = "uuid") -> bool:
         """Check if this identity matches another identity.

--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import attrs
 import numpy as np
 
+from sleap_io.model.categories import CategoriesMixin
 from sleap_io.model.embedding import Embedding, EmbeddingMixin
 from sleap_io.model.identity import Identity
 from sleap_io.model.skeleton import Node, Skeleton
@@ -386,7 +387,7 @@ class Track:
 
 
 @attrs.define(auto_attribs=True, slots=True, eq=False)
-class Instance(EmbeddingMixin):
+class Instance(EmbeddingMixin, CategoriesMixin):
     """This class represents a ground truth instance such as an animal.
 
     An `Instance` has a set of landmarks (points) that correspond to a `Skeleton`. Each
@@ -422,6 +423,10 @@ class Instance(EmbeddingMixin):
             `Embedding` describing this instance's appearance for re-identification.
             Empty by default. Use the `embedding` accessor / `set_embedding` helper
             for the common single-vector case.
+        categories: A mapping from category dimension name (e.g. ``"sex"``) to a
+            categorical label (typically a string). Empty by default. Use the
+            `cat` alias / `set_category` helper for read/write access. Distinct
+            from the singular scalar ``category`` on geometry primitives.
     """
 
     points: PointsArray = attrs.field(eq=attrs.cmp_using(eq=np.array_equal))
@@ -432,6 +437,7 @@ class Instance(EmbeddingMixin):
     identity_score: float | None = None
     from_predicted: "PredictedInstance | None" = None
     embeddings: dict[str, Embedding] = attrs.field(factory=dict, repr=False)
+    categories: dict = attrs.field(factory=dict, repr=False)
 
     @classmethod
     def empty(
@@ -903,6 +909,8 @@ class PredictedInstance(Instance):
             `Instance.identity_score`).
         embeddings: A mapping from embedding-space name to an `Embedding` (see
             `Instance.embeddings`).
+        categories: A mapping from category dimension name to a categorical label
+            (see `Instance.categories`).
     """
 
     points: PredictedPointsArray = attrs.field(eq=attrs.cmp_using(eq=np.array_equal))
@@ -914,6 +922,7 @@ class PredictedInstance(Instance):
     identity_score: float | None = None
     from_predicted: "PredictedInstance | None" = None
     embeddings: dict[str, Embedding] = attrs.field(factory=dict, repr=False)
+    categories: dict = attrs.field(factory=dict, repr=False)
 
     def __repr__(self) -> str:
         """Return a readable representation of the instance."""

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -4076,7 +4076,8 @@ class Labels:
                 (deduped) `Identity` in the merged catalog. When provided, the
                 instance's identity is resolved through this map so that the same
                 animal across files points at a single catalog object. The
-                instance's ``identity_score`` and ``embeddings`` are always copied.
+                instance's ``identity_score``, ``embeddings``, and ``categories``
+                are always copied.
             memo: Optional mapping from the id of the source instance to the new
                 instance, mutated in place. Used to repair ``from_predicted``
                 links so a remapped user instance references the remapped source
@@ -4133,6 +4134,7 @@ class Labels:
                 identity=mapped_identity,
                 identity_score=instance.identity_score,
                 embeddings=dict(instance.embeddings),
+                categories=dict(instance.categories),
             )
         else:
             new_instance = Instance(
@@ -4144,6 +4146,7 @@ class Labels:
                 identity=mapped_identity,
                 identity_score=instance.identity_score,
                 embeddings=dict(instance.embeddings),
+                categories=dict(instance.categories),
             )
         if memo is not None:
             memo[id(instance)] = new_instance

--- a/tests/model/test_categories.py
+++ b/tests/model/test_categories.py
@@ -1,0 +1,146 @@
+"""Tests for the CategoriesMixin and per-instance / per-identity categories."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+
+from sleap_io.model.categories import CategoriesMixin
+from sleap_io.model.centroid import UserCentroid
+from sleap_io.model.identity import Identity
+from sleap_io.model.instance import Instance, PredictedInstance
+from sleap_io.model.skeleton import Skeleton
+
+
+def test_categories_default_empty():
+    """Test that categories defaults to an empty dict surfaced via `cat`."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    assert inst.categories == {}
+    assert inst.cat == {}
+    assert isinstance(inst, CategoriesMixin)
+
+
+def test_cat_is_live_categories_dict():
+    """Test the `cat` alias returns the live mapping (in-place assignment)."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+
+    # `cat` is the same object as `categories`.
+    assert inst.cat is inst.categories
+
+    # Index-assigning through `cat` mutates `categories` in place.
+    inst.cat["sex"] = "M"
+    assert inst.categories == {"sex": "M"}
+
+
+def test_set_category_is_void_mutator():
+    """Test set_category stores under the dimension and returns None."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+
+    assert inst.set_category("sex", "M") is None  # in-place mutator
+    inst.set_category("strain", "C57BL/6")
+    assert inst.categories == {"sex": "M", "strain": "C57BL/6"}
+
+
+def test_set_categories_merges_and_overwrites():
+    """Test set_categories merges, overwrites existing keys, and returns None."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    inst.set_category("sex", "M")
+
+    assert inst.set_categories({"sex": "F", "age": "adult"}) is None
+    assert inst.categories == {"sex": "F", "age": "adult"}
+
+
+def test_cat_setter_replaces_mapping():
+    """Test assigning to `cat` replaces the whole mapping."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    inst.set_category("sex", "M")
+
+    inst.cat = {"reset": True}
+    assert inst.categories == {"reset": True}
+
+
+def test_categories_non_string_values():
+    """Test categories accept JSON-serializable non-string values (e.g. lists)."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    inst.set_category("sex_probs", [0.2, 0.8])
+    assert inst.categories["sex_probs"] == [0.2, 0.8]
+
+
+def test_categories_constructor_kwarg():
+    """Test categories can be supplied directly to the constructor."""
+    skel = Skeleton(["A", "B"])
+    points = Instance._convert_points(np.array([[0, 1], [2, 3]]), skel)
+    inst = Instance(points=points, skeleton=skel, categories={"sex": "M"})
+    assert inst.categories == {"sex": "M"}
+
+
+def test_categories_on_predicted_instance():
+    """Test categories work on PredictedInstance and keep slots intact."""
+    skel = Skeleton(["A", "B"])
+    pred = PredictedInstance.from_numpy(np.array([[0, 1], [2, 3]]), skel, score=0.5)
+    assert isinstance(pred, CategoriesMixin)
+    pred.cat["view"] = "top"
+    pred.set_category("sex", "F")
+    assert pred.categories == {"view": "top", "sex": "F"}
+    assert not hasattr(pred, "__dict__")
+
+
+def test_categories_on_identity():
+    """Test Identity carries entity-level categories."""
+    identity = Identity(name="mouse_A")
+    assert isinstance(identity, CategoriesMixin)
+    assert identity.categories == {}
+    identity.set_category("species", "mouse")
+    identity.set_categories({"sex": "M", "strain": "C57BL/6"})
+    assert identity.categories == {"species": "mouse", "sex": "M", "strain": "C57BL/6"}
+
+
+def test_categories_slotted_no_dict():
+    """Test the categories slot does not add a __dict__ to slotted instances."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    inst.set_category("sex", "M")
+    assert not hasattr(inst, "__dict__")
+
+
+def test_categories_preserved_on_copy():
+    """Test categories survive a deep copy of the owning instance."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    inst.set_categories({"sex": "M", "age": "adult"})
+    copied = deepcopy(inst)
+    assert copied.categories == {"sex": "M", "age": "adult"}
+    # The copy is independent of the original.
+    copied.set_category("sex", "F")
+    assert inst.categories["sex"] == "M"
+
+
+def test_categories_not_in_repr():
+    """Test the categories field is excluded from the repr (repr=False)."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    inst.set_category("sex", "M")
+    assert "categories" not in repr(inst)
+
+
+def test_plural_categories_distinct_from_scalar_category():
+    """Test the plural `categories` mapping is scoped to instances + Identity.
+
+    Geometry primitives (e.g. `Centroid`) keep their singular scalar `category`
+    field and do not gain the plural `categories` mapping in this iteration.
+    """
+    skel = Skeleton(["A", "B"])
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    assert hasattr(inst, "categories")
+    assert not hasattr(inst, "category")  # no singular scalar on instances
+
+    centroid = UserCentroid(x=1.0, y=2.0)
+    assert hasattr(centroid, "category")  # singular scalar retained
+    assert not hasattr(centroid, "categories")  # no plural mapping (scope)

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -4333,6 +4333,35 @@ def test_labels_merge_predicted_instance_mapping():
     assert np.array_equal(mapped_inst.numpy(), inst.numpy())
 
 
+def test_labels_merge_map_instance_preserves_categories():
+    """Test _map_instance copies per-instance categories (independent dict).
+
+    Regression: the merge rebuild copied identity/embeddings but dropped
+    `Instance.categories`, silently losing category labels on a merge.
+    """
+    skel1 = Skeleton(nodes=["head", "tail"])
+    skel2 = Skeleton(nodes=["head", "tail"])
+    labels = Labels()
+    labels.skeletons.append(skel1)
+    skeleton_map = {skel2: skel1}
+
+    inst = Instance.from_numpy(np.array([[10, 10], [20, 20]]), skeleton=skel2)
+    inst.set_categories({"sex": "M", "probs": [0.2, 0.8]})
+    mapped = labels._map_instance(inst, skeleton_map, {})
+    assert mapped.categories == {"sex": "M", "probs": [0.2, 0.8]}
+    # The mapped dict is independent of the source (shallow-copied).
+    mapped.categories["sex"] = "F"
+    assert inst.categories["sex"] == "M"
+
+    pred = PredictedInstance.from_numpy(
+        np.array([[1, 1], [2, 2]]), skeleton=skel2, score=0.9
+    )
+    pred.set_category("view", "top")
+    mapped_pred = labels._map_instance(pred, skeleton_map, {})
+    assert isinstance(mapped_pred, PredictedInstance)
+    assert mapped_pred.categories == {"view": "top"}
+
+
 def test_labels_merge_dedupes_same_uuid_identity():
     """Merge dedupes same-uuid identities and preserves score/embeddings.
 


### PR DESCRIPTION
## Summary

Adds a flexible per-instance and per-`Identity` **`categories`** mapping — categorical labels (e.g. `{"sex": "M", "strain": "C57BL/6"}`) for grouping, filtering, and balanced sampling — mirroring the `EmbeddingMixin` pattern. This is the model layer; SLP persistence (format 2.7) and DataFrame export columns follow in the stacked PR.

> Stacked on #515 (`feat/embeddings`). Review/merge after the embeddings stack lands.

## Key Changes

- **`CategoriesMixin`** (`sleap_io/model/categories.py`): empty `__slots__`, a `cat` alias for the live `categories` dict, and `set_category`/`set_categories` **in-place mutators** (return `None`, like `dict.__setitem__`/`dict.update`). Values are typically strings but may be any JSON-serializable value (e.g. a one-hot list).
- Wires the mixin + a `categories: dict` field (`factory=dict, repr=False`) into `Instance`, `PredictedInstance`, and `Identity`.
- **Merge preservation**: `Labels._map_instance` now copies `categories` (alongside `identity_score`/`embeddings`) so a merge does not silently drop category labels.

## Example Usage

```python
inst.set_category("sex", "M")
inst.set_categories({"strain": "C57BL/6", "age": "adult"})
inst.cat["behavior"] = "grooming"   # `cat` is the live mapping
sorted(inst.categories)             # ['age', 'behavior', 'sex', 'strain']

identity.set_categories({"species": "mouse", "sex": "M"})  # entity-level
```

## API Changes

- New `sleap_io.model.categories.CategoriesMixin`.
- New `categories: dict` attribute + `cat` property + `set_category`/`set_categories` on `Instance`, `PredictedInstance`, `Identity`.
- Distinct from the existing singular scalar `category` on geometry primitives (`Centroid`/`BoundingBox`/`SegmentationMask`/`ROI`), which is unchanged.

## Testing

- `tests/model/test_categories.py` (100% coverage of the new module): accessor/alias semantics, void-mutator helpers, non-string values, constructor kwarg, predicted-instance + identity carriers, slotted no-`__dict__`, deepcopy survival, repr exclusion, scalar-vs-plural distinction.
- `tests/model/test_labels.py`: `_map_instance` category preservation on merge.

## Design Decisions

- **Scope: instances + `Identity` only** to start (geometry primitives keep their scalar `category`), mirroring the embeddings deferral pattern; extendable later.
- **`set_category`/`set_categories` return `None`** — they are in-place mutators; returning the value (as `set_embedding` does for a *constructed* object) added no value and forced awkward `_ =` in examples.
- `.cat` is a thin alias for the live `categories` dict (so `inst.cat["sex"] = "M"` works), not a primary-entry accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbXnTzogXjYJ6fiVzq2TN1
