### PR TITLE
feat: persist categories (SLP 2.7) + DataFrame columns (2/2)

### DIFF
--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -43,6 +43,8 @@ file.slp
 ├── /negative_frames             # Dataset: Negative frame markers (optional)
 ├── /instance_identities         # Dataset: Per-instance global identity links (Format 2.5+)
 │                                 #   structured: instance_id, identity_idx, identity_score
+├── /instance_categories         # Dataset: Per-instance categorical labels (Format 2.7+)
+│                                 #   JSON rows: {instance_id, categories: {dim: value}}
 │
 ├── /bboxes/                     # Group: Columnar bounding box storage (Format 2.0+)
 │   ├── x1                       # Dataset: float64 top-left x
@@ -153,9 +155,10 @@ file.slp
 | `tracks_json` | `bytes[]` | JSON array of track definitions |
 | `suggestions_json` | `bytes[]` | JSON array of suggested frames (optional) |
 | `sessions_json` | `bytes[]` | JSON array of recording sessions (optional) |
-| `identities_json` | `bytes[]` | JSON array of identity definitions, incl. stable `uuid` (optional) |
+| `identities_json` | `bytes[]` | JSON array of identity definitions, incl. stable `uuid` and optional entity-level `categories` (optional) |
 | `instance_identities` | structured | Per-instance global identity links: `instance_id`, `identity_idx`, `identity_score` (Format 2.5+, optional) |
 | `embeddings/<space>` | group | re-ID embedding vectors + `owner_type`/`owner_id` join columns + `meta_json` (Format 2.6+, optional) |
+| `instance_categories` | `bytes[]` | Per-instance categorical labels: JSON `{instance_id, categories}` rows (Format 2.7+, optional) |
 | `provenance_json` | `bytes` | JSON object of provenance metadata (optional) |
 
 ### Provenance storage and the 64 KB metadata limit
@@ -556,7 +559,8 @@ Each identity is stored as a JSON object:
 {
     "name": "mouse_A",
     "uuid": "3f2a9c1e4b7d4e8a9c0d1e2f3a4b5c6d",
-    "color": "#e6194b"
+    "color": "#e6194b",
+    "categories": {"species": "mouse", "sex": "M"}
 }
 ```
 
@@ -565,6 +569,7 @@ Each identity is stored as a JSON object:
 | `name` | `string` | Human-readable identity name (not required to be unique) |
 | `uuid` | `string` | Stable 32-char hex key — the canonical cross-file/merge matching key. Legacy files written before format 2.5 omit it; a fresh one is synthesized on load |
 | `color` | `string` | Optional hex color for visualization (omitted if null) |
+| `categories` | `object` | Optional entity-level categorical labels keyed by dimension (Format 2.7+; omitted if empty). A reserved key — excluded from the metadata catch-all |
 | *custom* | `any` | Additional metadata fields |
 
 ### Per-Instance Linking
@@ -578,6 +583,21 @@ Per-instance global identity assignments are stored in the optional `/instance_i
 | `identity_score` | `float32` | Identity-assignment score (NaN if unrecorded) |
 
 This is additive: old readers ignore the dataset, and instances without a global identity simply have no row. Per-identity prototype embeddings and per-instance re-ID embeddings live in the `/embeddings` group — see [Embeddings](../model/embedding.md).
+
+### Per-Instance Categories
+
+Per-instance [categorical labels](../model/categories.md) are stored in the optional `/instance_categories` dataset (Format 2.7+), a 1-D array of JSON byte-strings — one row per instance that carries any categories, joined to instances by the global `instance_id`:
+
+```json
+{"instance_id": 0, "categories": {"sex": "M", "behavior": "grooming"}}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `instance_id` | `int` | Global instance id (enumeration order over frames then instances) |
+| `categories` | `object` | Mapping from dimension name to a categorical value (typically a string; any JSON-serializable value is allowed) |
+
+The mapping is variable-width, so each row is encoded as JSON (like `/identities_json`) rather than a fixed structured array. This is additive: old readers ignore the dataset, and instances with no categories simply have no row. Entity-level categories on an `Identity` ride in `/identities_json` instead (see above).
 
 ### Instance Group Linking
 
@@ -1411,7 +1431,7 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 - Triggered only when a video carries a crop; uncropped files stay byte-identical and at `format_id <= 2.2`
 - Purely additive: does not cross the only legacy threshold (`< 1.4`)
 
-### Format 2.4 (Current)
+### Format 2.4
 
 **Persisted mask `from_predicted` provenance.**
 
@@ -1419,6 +1439,32 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 - Lets [`UserSegmentationMask.from_predicted`][sleap_io.UserSegmentationMask] (set by [`PredictedSegmentationMask.to_user()`][sleap_io.PredictedSegmentationMask]) survive a save/load round-trip when the source prediction is also saved
 - Triggered automatically when any mask records a `from_predicted` link; otherwise the format stays at whatever other state drives `format_id`
 - Backward compatible: the column is always written but reads are gated on its presence, so files written before 2.4 (which lack the column) load `from_predicted` as `None`
+
+### Format 2.5
+
+**Per-instance global identity links.**
+
+- New optional `/instance_identities` structured dataset (`instance_id`, `identity_idx`, `identity_score`) joining instances to the `/identities_json` catalog (see [Per-Instance Linking](#per-instance-linking))
+- Triggered automatically when any instance carries an [`Identity`][sleap_io.Identity]; identity-free files stay at `format_id <= 2.4`
+- Backward compatible: reads are gated on dataset presence, so older readers ignore it
+
+### Format 2.6
+
+**Appearance / re-ID embeddings.**
+
+- New optional `/embeddings` group, one subgroup per named space holding stacked `vectors` `(n, D)` plus `owner_type`/`owner_id` join columns and a per-row `meta_json` (see [Embeddings](../model/embedding.md))
+- Persists per-instance and per-`Identity` (prototype/gallery) embeddings; large float vectors live in gzipped numeric datasets, never in JSON
+- Triggered automatically when any instance or identity carries an embedding; embedding-free files stay at `format_id <= 2.5`
+- Backward compatible: reads are gated on group presence
+
+### Format 2.7 (Current)
+
+**Per-instance and entity-level categories.**
+
+- New optional `/instance_categories` dataset — a 1-D array of `{instance_id, categories}` JSON rows joining instances to their [categorical labels](../model/categories.md) (see [Per-Instance Categories](#per-instance-categories))
+- Entity-level categories on an [`Identity`][sleap_io.Identity] ride under a reserved `categories` key in `/identities_json`
+- Triggered automatically when any instance or identity carries categories; category-free files stay at `format_id <= 2.6`
+- Backward compatible: reads are gated on presence, so older readers ignore both
 
 ## Browser-side compatibility (h5wasm / sleap-io.js)
 

--- a/docs/model/categories.md
+++ b/docs/model/categories.md
@@ -63,6 +63,17 @@ In this iteration, categories are attached to **instances and `Identity`** only.
 primitives keep their singular scalar `category` and do not yet carry the plural mapping; this can
 be extended later, exactly like the [embeddings](embedding.md) rollout.
 
+## SLP persistence
+
+Categories persist to SLP in **format 2.7+**. Per-instance categories live in the additive
+`/instance_categories` dataset — a 1-D array of `{"instance_id", "categories"}` JSON rows, one per
+instance carrying any categories, joined back to instances by the global `instance_id` (the same
+id space as the identity/embedding side-tables). Because the mapping is variable-width, each row
+is encoded as JSON rather than a fixed structured array. Entity-level `Identity` categories ride
+under a reserved `categories` key in `/identities_json`. Both are purely additive: older readers
+ignore them, and category-free files round-trip unchanged at `format_id <= 2.6`. Per-instance
+categories load lazily alongside the rest of the lazy store. See [Formats → SLP](../formats/slp.md#per-instance-categories).
+
 ---
 
 ## API reference

--- a/docs/model/categories.md
+++ b/docs/model/categories.md
@@ -102,6 +102,12 @@ it — so sparse categories sample cleanly:
 The DataFrame rows are flat (no live `Instance` handle survives the row), so to map sampled rows
 back to objects, key off the `video`/`frame_idx` locator columns.
 
+!!! note "Dimension naming"
+    Because export flattens each dimension to a `cat.<dim>` column (and vectors to
+    `cat.<dim>.<i>`), keep dimension names simple. A name containing `.` or one that collides with a
+    skeleton node name can produce overlapping columns. The SLP side-table itself preserves any
+    keys faithfully — this only affects the flattened DataFrame view.
+
 ---
 
 ## API reference

--- a/docs/model/categories.md
+++ b/docs/model/categories.md
@@ -74,6 +74,34 @@ under a reserved `categories` key in `/identities_json`. Both are purely additiv
 ignore them, and category-free files round-trip unchanged at `format_id <= 2.6`. Per-instance
 categories load lazily alongside the rest of the lazy store. See [Formats → SLP](../formats/slp.md#per-instance-categories).
 
+## Sampling via DataFrames
+
+[`Labels.to_dataframe(format="instances")`](labels.md) emits one exploded `cat.<dim>` column per
+category dimension (vector-valued dims explode to `cat.<dim>.<i>`), alongside an `identity` column
+(and `identity_score`), so categories drive ordinary pandas/polars filtering and balanced
+sampling. Columns are uniform across all rows — a dimension is `NaN`/`null` on instances that lack
+it — so sparse categories sample cleanly:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "tail"])
+>>> video = sio.Video(filename="fake.mp4")
+>>> frames = []
+>>> for i in range(4):
+...     inst = sio.Instance.from_numpy(np.zeros((2, 2)), skeleton=skeleton)
+...     inst.set_category("sex", "M" if i % 2 else "F")
+...     frames.append(sio.LabeledFrame(video=video, frame_idx=i, instances=[inst]))
+>>> labels = sio.Labels(frames)
+>>> df = labels.to_dataframe(format="instances")
+>>> males = df[df["cat.sex"] == "M"]
+>>> int((df["cat.sex"] == "M").sum())
+2
+```
+
+The DataFrame rows are flat (no live `Instance` handle survives the row), so to map sampled rows
+back to objects, key off the `video`/`frame_idx` locator columns.
+
 ---
 
 ## API reference

--- a/sleap_io/codecs/dataframe.py
+++ b/sleap_io/codecs/dataframe.py
@@ -1499,11 +1499,27 @@ def _to_instances_df_lazy(
     coord_offset = 0.5 if store.format_id < 1.1 else 0.0
 
     # Prescan for a uniform set of category columns across all emitted rows.
-    category_columns = (
-        _prescan_category_columns(store._instance_categories.values())
-        if include_metadata
-        else []
-    )
+    # Only the instances that pass the SAME type/video filters as the main loop
+    # are scanned, so the lazy schema matches the eager paths exactly (scanning
+    # the whole store would add all-None columns for filtered-out instances).
+    category_columns: list[str] = []
+    if include_metadata and store._instance_categories:
+        emitted_categories = []
+        for inst_row in store.instances_data:
+            it = int(inst_row["instance_type"])
+            if it == InstanceType.USER and not include_user_instances:
+                continue
+            if it == InstanceType.PREDICTED and not include_predicted_instances:
+                continue
+            frame_id = int(inst_row["frame_id"])
+            if frame_id not in frame_lookup:
+                continue
+            if video_filter is not None and frame_lookup[frame_id][0] != video_filter:
+                continue
+            cats = store._instance_categories.get(int(inst_row["instance_id"]))
+            if cats:
+                emitted_categories.append(cats)
+        category_columns = _prescan_category_columns(emitted_categories)
 
     # Iterate over instances
     for inst_idx, inst_row in enumerate(store.instances_data):
@@ -2547,6 +2563,12 @@ def _from_instances_df(
     node_cols = {}  # node_name -> {"x": col, "y": col, "score": col}
 
     for col in df.columns:
+        # Skip the exported category columns (cat.<dim>[.<i>]); they share the
+        # dotted flat-key style but are not node coordinates and must not be
+        # mistaken for a node named "cat" on a to_dataframe -> from_dataframe
+        # round-trip. (identity/identity_score have no dot and are ignored below.)
+        if col.startswith("cat."):
+            continue
         if "." in col:
             parts = col.rsplit(".", 1)
             if len(parts) == 2 and parts[1] in ("x", "y", "score"):

--- a/sleap_io/codecs/dataframe.py
+++ b/sleap_io/codecs/dataframe.py
@@ -73,7 +73,12 @@ def _create_dataframe_from_rows(
         return pd.DataFrame()
 
     if backend == "polars":
-        return pl.from_dicts(rows)
+        # infer_schema_length=None scans all rows when inferring the schema, so
+        # sparse columns (e.g. cat.<dim>, present on only some instances) are not
+        # dropped or mis-typed as Null when absent from the first rows. Without
+        # this, polars' bounded inference silently drops or fails on a category
+        # value that first appears beyond the default window.
+        return pl.from_dicts(rows, infer_schema_length=None)
     return pd.DataFrame(rows)
 
 
@@ -196,7 +201,9 @@ def to_dataframe(
 
         Column naming conventions:
         - Points: frame_idx, node, x, y, track, track_score, instance_score
-        - Instances: frame_idx, track, track_score, score, {node}.x/y/score
+        - Instances: frame_idx, track, track_score, score, identity,
+          identity_score, cat.<dim> (one exploded column per category dimension;
+          vector-valued dims explode to cat.<dim>.<i>), {node}.x/y/score
         - Frames: frame_idx, {inst}.track, {inst}.track_score, {inst}.score,
           {inst}.{node}.x, {inst}.{node}.y, {inst}.{node}.score
         - Multi-index: Hierarchical columns (inst, node, coord) with frame idx
@@ -662,6 +669,76 @@ def _iter_points_rows(
                 yield row
 
 
+def _category_items(categories: dict):
+    """Yield ``(column_name, value)`` pairs for a categories mapping.
+
+    Scalar values map to a single ``cat.<dim>`` column; list/tuple/array values
+    (e.g. a one-hot or class-probability distribution) are exploded to
+    ``cat.<dim>.<i>`` columns, consistent with the ``{node}.x`` flat-key style.
+
+    Args:
+        categories: A mapping of category dimension name to value.
+
+    Yields:
+        ``(column_name, value)`` tuples.
+    """
+    for dim, value in categories.items():
+        if isinstance(value, (list, tuple, np.ndarray)):
+            for i, component in enumerate(value):
+                yield f"cat.{dim}.{i}", component
+        else:
+            yield f"cat.{dim}", value
+
+
+def _prescan_category_columns(categories_iter) -> list[str]:
+    """Collect the ordered, de-duplicated set of ``cat.<dim>`` column names.
+
+    A prescan so every instance row can emit the same category columns (``None``
+    where a dimension is absent), giving a uniform schema across pandas, polars
+    (whose bounded schema inference would otherwise drop late-appearing sparse
+    columns), and streaming chunks.
+
+    Args:
+        categories_iter: An iterable of per-instance ``categories`` mappings.
+
+    Returns:
+        Ordered list of exploded category column names.
+    """
+    columns: dict[str, None] = {}
+    for categories in categories_iter:
+        for col, _ in _category_items(categories):
+            columns.setdefault(col, None)
+    return list(columns)
+
+
+def _add_instance_attr_columns(
+    row: dict,
+    *,
+    identity_name: str | None,
+    identity_score: float | None,
+    categories: dict,
+    category_columns: list[str],
+) -> None:
+    """Add the ``identity`` + uniform ``cat.<dim>`` columns to an instance row.
+
+    Args:
+        row: The row dict to populate (mutated in place).
+        identity_name: The instance's `Identity` name, or ``None``.
+        identity_score: The identity-assignment score, or ``None``.
+        categories: The instance's ``categories`` mapping (may be empty).
+        category_columns: The prescanned full set of category columns; each is
+            pre-seeded to ``None`` so every row shares the same schema.
+    """
+    row["identity"] = identity_name
+    row["identity_score"] = (
+        float(identity_score) if identity_score is not None else None
+    )
+    for col in category_columns:
+        row[col] = None
+    for col, value in _category_items(categories):
+        row[col] = value
+
+
 def _iter_instances_rows(
     labels: Labels,
     labeled_frames: list,
@@ -674,15 +751,26 @@ def _iter_instances_rows(
     video_id: str = "path",
 ) -> Generator[dict, None, None]:
     """Yield row dicts for instances format (one row per instance)."""
-    for lf in labeled_frames:
-        instances_to_process = []
 
+    def _included(lf):
+        out = []
         if include_user_instances:
-            instances_to_process.extend(lf.user_instances)
+            out.extend(lf.user_instances)
         if include_predicted_instances:
-            instances_to_process.extend(lf.predicted_instances)
+            out.extend(lf.predicted_instances)
+        return out
 
-        for instance in instances_to_process:
+    # Prescan for a uniform set of category columns across all emitted rows.
+    category_columns = (
+        _prescan_category_columns(
+            inst.categories for lf in labeled_frames for inst in _included(lf)
+        )
+        if include_metadata
+        else []
+    )
+
+    for lf in labeled_frames:
+        for instance in _included(lf):
             is_predicted = isinstance(instance, PredictedInstance)
 
             row = {"frame_idx": int(lf.frame_idx)}
@@ -711,6 +799,16 @@ def _iter_instances_rows(
                 else:
                     row["track_score"] = None
                     row["score"] = None
+
+                _add_instance_attr_columns(
+                    row,
+                    identity_name=(
+                        instance.identity.name if instance.identity else None
+                    ),
+                    identity_score=instance.identity_score,
+                    categories=instance.categories,
+                    category_columns=category_columns,
+                )
 
             # Add node coordinates
             for node_idx, node in enumerate(instance.skeleton.nodes):
@@ -1061,12 +1159,26 @@ def _to_instances_df(  # noqa: D417
     Other parameters mirror to_dataframe().
 
     Column structure:
-        frame_idx | video | track | track_score | score | {node}.x/y/score
+        frame_idx | video | track | track_score | score | identity |
+        identity_score | cat.<dim> | {node}.x/y/score
     """
     rows = []
 
     # Track which (video, frame_idx) pairs we've seen
     seen_frames = set()
+
+    # Prescan for a uniform set of category columns across all emitted rows.
+    category_columns: list[str] = []
+    if include_metadata:
+        cat_instances = []
+        for lf in labeled_frames:
+            if include_user_instances:
+                cat_instances.extend(lf.user_instances)
+            if include_predicted_instances:
+                cat_instances.extend(lf.predicted_instances)
+        category_columns = _prescan_category_columns(
+            inst.categories for inst in cat_instances
+        )
 
     for lf in labeled_frames:
         # Skip frames outside the specified range
@@ -1117,6 +1229,16 @@ def _to_instances_df(  # noqa: D417
                 else:
                     row["track_score"] = None
                     row["score"] = None
+
+                _add_instance_attr_columns(
+                    row,
+                    identity_name=(
+                        instance.identity.name if instance.identity else None
+                    ),
+                    identity_score=instance.identity_score,
+                    categories=instance.categories,
+                    category_columns=category_columns,
+                )
 
             # Add columns for each node using dot separator
             for node_idx, node in enumerate(instance.skeleton.nodes):
@@ -1181,6 +1303,13 @@ def _to_instances_df(  # noqa: D417
                         row["track"] = None
                         row["track_score"] = None
                         row["score"] = None
+                        _add_instance_attr_columns(
+                            row,
+                            identity_name=None,
+                            identity_score=None,
+                            categories={},
+                            category_columns=category_columns,
+                        )
 
                     # Add NaN columns for each node
                     if skeleton:
@@ -1369,6 +1498,13 @@ def _to_instances_df_lazy(
     # Determine coordinate adjustment for legacy format
     coord_offset = 0.5 if store.format_id < 1.1 else 0.0
 
+    # Prescan for a uniform set of category columns across all emitted rows.
+    category_columns = (
+        _prescan_category_columns(store._instance_categories.values())
+        if include_metadata
+        else []
+    )
+
     # Iterate over instances
     for inst_idx, inst_row in enumerate(store.instances_data):
         instance_type = int(inst_row["instance_type"])
@@ -1400,6 +1536,20 @@ def _to_instances_df_lazy(
         # Get tracking score
         tracking_score = float(inst_row["tracking_score"]) if is_predicted else None
 
+        # Resolve identity + categories from the store, joined on the global
+        # instance_id (the same key used by materialization), so the lazy fast
+        # path matches the eager output.
+        instance_id = int(inst_row["instance_id"])
+        identity_name = None
+        identity_score = None
+        entry = store._instance_identities.get(instance_id)
+        if entry is not None:
+            identity_idx, id_score = entry
+            if 0 <= identity_idx < len(store.identities):
+                identity_name = store.identities[identity_idx].name
+                identity_score = id_score
+        instance_categories = store._instance_categories.get(instance_id, {})
+
         # Build row
         row: dict = {"frame_idx": frame_idx}
 
@@ -1422,6 +1572,14 @@ def _to_instances_df_lazy(
             else:
                 row["track_score"] = None
                 row["score"] = None
+
+            _add_instance_attr_columns(
+                row,
+                identity_name=identity_name,
+                identity_score=identity_score,
+                categories=instance_categories,
+                category_columns=category_columns,
+            )
 
         # Get points and add node columns
         point_start = int(inst_row["point_id_start"])

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -25,6 +25,12 @@ Format version history:
     - 2.6: Added appearance / re-ID embeddings (/embeddings group, one subgroup
             per named space: vectors (n, D) float + owner_type/owner_id join
             columns + per-row meta_json); additive, read on group presence
+    - 2.7: Added per-instance and entity-level categories (categorical labels).
+            Per-instance categories live in the /instance_categories dataset (a
+            1-D array of {instance_id, categories} JSON rows joining instances to
+            their category mapping); Identity-level categories ride under a
+            reserved "categories" key in identities_json. Both additive, read on
+            presence
 """
 
 from __future__ import annotations
@@ -1648,7 +1654,12 @@ def read_identities(
         kwargs = dict(
             name=d.get("name", ""),
             color=d.get("color", None),
-            metadata={k: v for k, v in d.items() if k not in ("name", "uuid", "color")},
+            categories=d.get("categories", {}),
+            metadata={
+                k: v
+                for k, v in d.items()
+                if k not in ("name", "uuid", "color", "categories")
+            },
         )
         if "uuid" in d:
             kwargs["uuid"] = d["uuid"]
@@ -1671,6 +1682,10 @@ def write_identities(labels_path: str, identities: list[Identity]):
         d = {"name": identity.name, "uuid": identity.uuid}
         if identity.color is not None:
             d["color"] = identity.color
+        # Entity-level categories (SLP format 2.7+) ride in the identity JSON
+        # under a reserved "categories" key, distinct from the metadata catch-all.
+        if identity.categories:
+            d["categories"] = identity.categories
         d.update(identity.metadata)
         identities_json.append(np.bytes_(json.dumps(d, separators=(",", ":"))))
 
@@ -1812,6 +1827,126 @@ def _instance_identity_rows_from_store(
                 float("nan") if score is None else float(score),
             )
         )
+    return rows
+
+
+def read_instance_categories(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> dict[int, dict]:
+    """Read per-instance categories from a SLEAP labels file.
+
+    Categories are stored in the optional ``instance_categories`` dataset (SLP
+    format 2.7+), a 1-D array of JSON byte-strings, one per instance that carries
+    any categories. Each row encodes ``{"instance_id": <int>, "categories":
+    {<dim>: <value>}}``, joining the global instance id to its category mapping.
+    The dataset is absent in older files, in which case an empty mapping is
+    returned (purely additive; reads are gated on dataset presence).
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from. If provided,
+            the data is read from this handle (left open for the caller to close);
+            otherwise `labels_path` is opened and closed internally.
+
+    Returns:
+        A dict mapping the global ``instance_id`` to its ``categories`` dict.
+    """
+    try:
+        data = read_hdf5_dataset(
+            labels_path, "instance_categories", _hdf5_file=_hdf5_file
+        )
+    except KeyError:
+        return {}
+    result: dict[int, dict] = {}
+    for row in data:
+        d = json.loads(row)
+        result[int(d["instance_id"])] = d.get("categories", {})
+    return result
+
+
+def _write_instance_category_rows(
+    labels_path: str, rows: list[tuple[int, dict]]
+) -> None:
+    """Write ``(instance_id, categories)`` rows to a SLP file.
+
+    Shared dataset-writing core for the per-instance categories side-table. The
+    rows can be built either by iterating a `Labels` (the eager path, see
+    `write_instance_categories`) or from a lazy store dict (the lazy save path),
+    keeping the on-disk ``instance_categories`` layout identical for both. Each
+    row is serialized as a ``{"instance_id", "categories"}`` JSON byte-string
+    (the categories mapping is variable-width, so a fixed structured array does
+    not fit; this mirrors the ``identities_json`` encoding).
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        rows: A list of ``(instance_id, categories)`` tuples; ``categories`` is a
+            (non-empty) JSON-serializable mapping. An empty list is a no-op (no
+            dataset is created).
+    """
+    if not rows:
+        return
+
+    data = [
+        np.bytes_(
+            json.dumps(
+                {"instance_id": int(instance_id), "categories": categories},
+                separators=(",", ":"),
+            )
+        )
+        for instance_id, categories in rows
+    ]
+    with h5py.File(labels_path, "a") as f:
+        f.create_dataset("instance_categories", data=data, maxshape=(None,))
+
+
+def write_instance_categories(labels_path: str, labels: Labels) -> None:
+    """Write per-instance categories to a SLEAP labels file.
+
+    Creates the ``instance_categories`` dataset (SLP format 2.7+) for every
+    instance carrying a non-empty ``categories`` mapping. The ``instance_id``
+    matches the global id assigned by `write_lfs` (enumeration order over frames
+    then instances), so the link is resolved by joining on that id at read time.
+    This keeps categories out of the fixed-layout ``instances`` dataset, making
+    it purely additive: old readers simply ignore the dataset.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        labels: A `Labels` object to store the per-instance categories for.
+    """
+    rows = []
+    instance_id = 0
+    for lf in labels:
+        for inst in lf:
+            categories = getattr(inst, "categories", None)
+            if categories:
+                rows.append((instance_id, categories))
+            instance_id += 1
+
+    _write_instance_category_rows(labels_path, rows)
+
+
+def _instance_category_rows_from_store(
+    store: "LazyDataStore",
+) -> list[tuple[int, dict]]:
+    """Build ``instance_categories`` rows from a lazy store without materializing.
+
+    The lazy store already holds the per-instance categories keyed by the global
+    ``instance_id`` (the same id space written by the fast path), so the rows can
+    be emitted directly without rebuilding `Instance` objects. Rows are sorted by
+    ``instance_id`` for deterministic output and skip empty mappings.
+
+    Args:
+        store: The `LazyDataStore` backing a lazy `Labels`.
+
+    Returns:
+        A list of ``(instance_id, categories)`` tuples matching the format
+        expected by `_write_instance_category_rows`.
+    """
+    rows = []
+    for instance_id in sorted(store._instance_categories):
+        categories = store._instance_categories[instance_id]
+        if categories:
+            rows.append((int(instance_id), categories))
     return rows
 
 
@@ -2579,6 +2714,9 @@ def write_metadata(labels_path: str, labels: Labels):
         has_embeddings = bool(store._instance_embeddings) or any(
             identity.embeddings for identity in labels.identities
         )
+        has_categories = any(store._instance_categories.values()) or any(
+            identity.categories for identity in labels.identities
+        )
     else:
         has_instance_identities = any(
             getattr(inst, "identity", None) is not None for lf in labels for inst in lf
@@ -2586,10 +2724,19 @@ def write_metadata(labels_path: str, labels: Labels):
         has_embeddings = any(
             getattr(inst, "embeddings", None) for lf in labels for inst in lf
         ) or any(identity.embeddings for identity in labels.identities)
+        has_categories = any(
+            getattr(inst, "categories", None) for lf in labels for inst in lf
+        ) or any(identity.categories for identity in labels.identities)
     if has_instance_identities:
         format_id = max(format_id, 2.5)
     if has_embeddings:
         format_id = max(format_id, 2.6)
+    # Bump for per-instance + entity-level categories (new in 2.7). Additive:
+    # the /instance_categories side-table and the "categories" key in
+    # identities_json are read on presence, so files without categories stay
+    # <= 2.6.
+    if has_categories:
+        format_id = max(format_id, 2.7)
 
     with h5py.File(labels_path, "a") as f:
         # Bump for chunked label image format (new in 2.2)
@@ -3720,6 +3867,10 @@ def _read_labels_lazy_from_open_file(
     for identity_idx, emb_map in identity_embeddings.items():
         if 0 <= identity_idx < len(identities):
             identities[identity_idx].embeddings.update(emb_map)
+    # Categories: identity-level categories are already on the eager catalog (read
+    # in read_identities); per-instance categories ride on the lazy store and
+    # attach at materialization time.
+    instance_categories = read_instance_categories(labels_path, _hdf5_file=f)
     suggestions = read_suggestions(labels_path, videos, _hdf5_file=f)
     metadata = read_metadata(labels_path, _hdf5_file=f)
     provenance = read_provenance(labels_path, metadata, _hdf5_file=f)
@@ -3747,6 +3898,7 @@ def _read_labels_lazy_from_open_file(
         identities=identities,
         instance_identities=instance_identities,
         instance_embeddings=instance_embeddings,
+        instance_categories=instance_categories,
     )
 
     # Create LazyFrameList
@@ -6551,6 +6703,15 @@ def _read_labels_from_open_file(
         if 0 <= identity_idx < len(identities):
             identities[identity_idx].embeddings.update(emb_map)
 
+    # Attach per-instance categories (SLP format 2.7+). Additive: absent
+    # /instance_categories dataset -> empty mapping and a no-op. Identity-level
+    # categories are reconstructed inside read_identities. Indexed directly by
+    # the global instance_id ordering.
+    instance_category_map = read_instance_categories(labels_path, _hdf5_file=f)
+    for inst_id, categories in instance_category_map.items():
+        if 0 <= inst_id < len(instances):
+            instances[inst_id].categories.update(categories)
+
     sessions = read_sessions(
         labels_path, videos, labeled_frames, identities=identities, _hdf5_file=f
     )
@@ -6733,6 +6894,7 @@ _KNOWN_TOPLEVEL_HDF5_NAMES = frozenset(
         "identities_json",
         "instance_identities",
         "embeddings",
+        "instance_categories",
         "provenance_json",
         "frames",
         "instances",
@@ -6926,6 +7088,9 @@ def _write_labels_lazy(
     _write_embedding_groups(
         labels_path,
         _embedding_groups_from_store(lazy_store, lazy_store.identities),
+    )
+    _write_instance_category_rows(
+        labels_path, _instance_category_rows_from_store(lazy_store)
     )
     write_suggestions(labels_path, labels.suggestions, labels.videos)
     # For sessions, pass empty list since we don't have materialized frames
@@ -7192,6 +7357,7 @@ def write_labels(
     write_identities(labels_path, labels.identities)
     write_instance_identities(labels_path, labels)
     write_embeddings(labels_path, labels)
+    write_instance_categories(labels_path, labels)
     write_suggestions(labels_path, labels.suggestions, labels.videos)
     write_sessions(
         labels_path,

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1651,10 +1651,15 @@ def read_identities(
         # Legacy files written before format 2.5 lack a `uuid`; the Identity
         # factory synthesizes a fresh one (they never had global-identity
         # semantics, so there is nothing to match against).
+        # Guard against a malformed/non-dict "categories" value so a bad file
+        # cannot smuggle a non-mapping into Identity.categories.
+        categories = d.get("categories", {})
+        if not isinstance(categories, dict):
+            categories = {}
         kwargs = dict(
             name=d.get("name", ""),
             color=d.get("color", None),
-            categories=d.get("categories", {}),
+            categories=categories,
             metadata={
                 k: v
                 for k, v in d.items()
@@ -1679,14 +1684,21 @@ def write_identities(labels_path: str, identities: list[Identity]):
 
     identities_json = []
     for identity in identities:
-        d = {"name": identity.name, "uuid": identity.uuid}
+        # Start from metadata, then let the structured fields win: name/uuid/
+        # color and the entity-level "categories" (SLP 2.7+) are reserved keys
+        # that read_identities strips back out of the metadata catch-all, so a
+        # stray metadata key of the same name must not clobber the real field.
+        d = {
+            k: v
+            for k, v in identity.metadata.items()
+            if k not in ("name", "uuid", "color", "categories")
+        }
+        d["name"] = identity.name
+        d["uuid"] = identity.uuid
         if identity.color is not None:
             d["color"] = identity.color
-        # Entity-level categories (SLP format 2.7+) ride in the identity JSON
-        # under a reserved "categories" key, distinct from the metadata catch-all.
         if identity.categories:
             d["categories"] = identity.categories
-        d.update(identity.metadata)
         identities_json.append(np.bytes_(json.dumps(d, separators=(",", ":"))))
 
     with h5py.File(labels_path, "a") as f:

--- a/sleap_io/io/slp_lazy.py
+++ b/sleap_io/io/slp_lazy.py
@@ -94,6 +94,10 @@ class LazyDataStore:
     _instance_embeddings: dict = attrs.field(
         factory=dict, repr=False, alias="instance_embeddings"
     )
+    # Per-instance categories (format 2.7+): instance_id -> {dim: value}.
+    _instance_categories: dict = attrs.field(
+        factory=dict, repr=False, alias="instance_categories"
+    )
 
     def __attrs_post_init__(self) -> None:
         """Validate index bounds on construction."""
@@ -174,6 +178,9 @@ class LazyDataStore:
             instance_identities=dict(self._instance_identities),
             instance_embeddings={
                 k: dict(v) for k, v in self._instance_embeddings.items()
+            },
+            instance_categories={
+                k: dict(v) for k, v in self._instance_categories.items()
             },
             format_id=self.format_id,
             source_path=self._source_path,
@@ -327,6 +334,14 @@ class LazyDataStore:
             else {}
         )
 
+        # Resolve optional per-instance categories (format 2.7+). A fresh dict per
+        # instance so mutations don't leak back into the shared lazy store.
+        categories = (
+            dict(self._instance_categories.get(instance_id, {}))
+            if self._instance_categories
+            else {}
+        )
+
         if instance_type == InstanceType.USER:
             pts_data = self.points_data[point_id_start:point_id_end]
             points_array = self._make_points_array(pts_data, skeleton)
@@ -341,6 +356,7 @@ class LazyDataStore:
                 identity=identity,
                 identity_score=identity_score,
                 embeddings=embeddings,
+                categories=categories,
             )
         else:  # PREDICTED
             pts_data = self.pred_points_data[point_id_start:point_id_end]
@@ -357,6 +373,7 @@ class LazyDataStore:
                 identity=identity,
                 identity_score=identity_score,
                 embeddings=embeddings,
+                categories=categories,
             )
 
     def _make_points_array(

--- a/tests/codecs/test_dataframe.py
+++ b/tests/codecs/test_dataframe.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from sleap_io import (
+    Identity,
     Instance,
     LabeledFrame,
     Labels,
@@ -13,6 +14,7 @@ from sleap_io import (
     Track,
     Video,
     load_slp,
+    save_slp,
 )
 from sleap_io.codecs.dataframe import (
     DataFrameFormat,
@@ -152,6 +154,133 @@ def test_to_dataframe_instances_with_scores():
     # Instance-level score
     assert "score" in df.columns
     assert df.iloc[0]["score"] == 0.95
+
+
+def _categories_labels():
+    """Build labels with sparse identities + categories for codec tests."""
+    skeleton = Skeleton(["nose", "tail"])
+    video = Video(filename="test.mp4")
+    identity = Identity(name="mouse_A")
+
+    i0 = Instance.from_numpy(np.array([[0.0, 1.0], [2.0, 3.0]]), skeleton)
+    i0.identity = identity
+    i0.identity_score = 0.9
+    i0.set_categories({"sex": "M", "probs": [0.2, 0.8]})  # scalar + vector dim
+    i1 = Instance.from_numpy(np.array([[4.0, 5.0], [6.0, 7.0]]), skeleton)
+    i1.set_category("strain", "C57BL/6")  # different dim than i0
+    i2 = Instance.from_numpy(np.array([[8.0, 9.0], [0.0, 1.0]]), skeleton)  # neither
+
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[i0, i1, i2])
+    labels = Labels([lf])
+    labels.identities = [identity]
+    return labels
+
+
+def test_to_dataframe_instances_identity_columns():
+    """Test identity / identity_score columns mirror track on the instances df."""
+    labels = _categories_labels()
+    df = to_dataframe(labels, format="instances")
+
+    assert "identity" in df.columns
+    assert "identity_score" in df.columns
+    assert df.iloc[0]["identity"] == "mouse_A"
+    assert df.iloc[0]["identity_score"] == 0.9
+    # Instances without a global identity are None/NaN.
+    assert pd.isna(df.iloc[1]["identity"])
+    assert pd.isna(df.iloc[1]["identity_score"])
+
+
+def test_to_dataframe_instances_category_columns_exploded():
+    """Test categories explode to cat.<dim> (and cat.<dim>.<i> for vectors)."""
+    labels = _categories_labels()
+    df = to_dataframe(labels, format="instances")
+
+    # Scalar dims -> one column; vector dim -> exploded per component.
+    assert df.iloc[0]["cat.sex"] == "M"
+    assert df.iloc[0]["cat.probs.0"] == 0.2
+    assert df.iloc[0]["cat.probs.1"] == 0.8
+    assert df.iloc[1]["cat.strain"] == "C57BL/6"
+
+
+def test_to_dataframe_instances_categories_uniform_columns():
+    """Test sparse categories yield a uniform schema (NaN where absent)."""
+    labels = _categories_labels()
+    df = to_dataframe(labels, format="instances")
+
+    # Every cat column exists on every row, NaN where the dim is absent.
+    for col in ("cat.sex", "cat.strain", "cat.probs.0", "cat.probs.1"):
+        assert col in df.columns
+    assert pd.isna(df.iloc[1]["cat.sex"])  # i1 has no "sex"
+    assert pd.isna(df.iloc[0]["cat.strain"])  # i0 has no "strain"
+    # i2 has no categories at all.
+    assert pd.isna(df.iloc[2]["cat.sex"])
+    assert pd.isna(df.iloc[2]["cat.strain"])
+
+
+def test_to_dataframe_instances_no_metadata_omits_identity_categories():
+    """Test identity / category columns are gated by include_metadata."""
+    labels = _categories_labels()
+    df = to_dataframe(labels, format="instances", include_metadata=False)
+    assert "identity" not in df.columns
+    assert not any(c.startswith("cat.") for c in df.columns)
+
+
+def test_to_dataframe_instances_categories_polars_late_column():
+    """Test polars does not drop a category dim first appearing past row 100.
+
+    Regression: polars' bounded schema inference would silently drop (or fail
+    on) a sparse column whose first non-null value is beyond the inference
+    window; the codec forces a full schema scan.
+    """
+    pytest.importorskip("polars")
+    skeleton = Skeleton(["nose", "tail"])
+    video = Video(filename="test.mp4")
+    frames = []
+    for fi in range(130):
+        inst = Instance.from_numpy(np.array([[fi, 1.0], [2.0, 3.0]]), skeleton)
+        if fi == 125:  # first (and only) appearance, well past row 100
+            inst.set_category("late", "Z")
+        frames.append(LabeledFrame(video=video, frame_idx=fi, instances=[inst]))
+    labels = Labels(frames)
+
+    df = to_dataframe(labels, format="instances", backend="polars")
+    assert "cat.late" in df.columns
+    assert df["cat.late"][125] == "Z"
+
+
+def test_to_dataframe_iter_instances_categories_uniform():
+    """Test streaming chunks share a uniform category schema."""
+    skeleton = Skeleton(["nose", "tail"])
+    video = Video(filename="test.mp4")
+    frames = []
+    for fi in range(6):
+        inst = Instance.from_numpy(np.array([[fi, 1.0], [2.0, 3.0]]), skeleton)
+        if fi == 5:  # category only on the last (second-chunk) instance
+            inst.set_category("sex", "M")
+        frames.append(LabeledFrame(video=video, frame_idx=fi, instances=[inst]))
+    labels = Labels(frames)
+
+    chunks = list(to_dataframe_iter(labels, format="instances", chunk_size=3))
+    assert len(chunks) == 2
+    # Both chunks carry cat.sex (prescan makes the schema uniform).
+    assert all("cat.sex" in c.columns for c in chunks)
+
+
+def test_to_dataframe_instances_categories_lazy_matches_eager(tmp_path):
+    """Test the lazy fast path emits identity / category columns like eager."""
+    labels = _categories_labels()
+    path = str(tmp_path / "cats.slp")
+    save_slp(labels, path)
+
+    eager = to_dataframe(load_slp(path), format="instances")
+    lazy = to_dataframe(load_slp(path, lazy=True), format="instances")
+
+    assert list(eager["identity"]) == list(lazy["identity"])
+    for col in ("cat.sex", "cat.strain", "cat.probs.0", "cat.probs.1"):
+        assert col in lazy.columns
+    assert lazy.iloc[0]["cat.sex"] == "M"
+    assert lazy.iloc[0]["cat.probs.1"] == 0.8
+    assert lazy.iloc[1]["cat.strain"] == "C57BL/6"
 
 
 def test_to_dataframe_frames_format():

--- a/tests/codecs/test_dataframe.py
+++ b/tests/codecs/test_dataframe.py
@@ -283,6 +283,60 @@ def test_to_dataframe_instances_categories_lazy_matches_eager(tmp_path):
     assert lazy.iloc[1]["cat.strain"] == "C57BL/6"
 
 
+def test_to_dataframe_instances_lazy_categories_respect_filters(tmp_path):
+    """Test lazy category columns match eager under instance-type filters.
+
+    Regression: the lazy prescan scanned all store categories regardless of
+    include_user/predicted filters, so a filtered query produced extra all-None
+    category columns on the lazy path that the eager path did not emit.
+    """
+    skeleton = Skeleton(["a", "b"])
+    video = Video(filename="test.mp4")
+    user = Instance.from_numpy(np.array([[0.0, 1.0], [2.0, 3.0]]), skeleton)
+    user.set_category("user_only", "U")
+    pred = PredictedInstance.from_numpy(
+        np.array([[4.0, 5.0], [6.0, 7.0]]), skeleton, score=0.5
+    )
+    pred.set_category("pred_only", "P")
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[user, pred])])
+    path = str(tmp_path / "filtered.slp")
+    save_slp(labels, path)
+
+    def cat_cols(df):
+        return sorted(c for c in df.columns if c.startswith("cat."))
+
+    eager = to_dataframe(
+        load_slp(path), format="instances", include_user_instances=False
+    )
+    lazy = to_dataframe(
+        load_slp(path, lazy=True), format="instances", include_user_instances=False
+    )
+    # Predicted-only query: neither path includes the user-only category column.
+    assert cat_cols(eager) == cat_cols(lazy) == ["cat.pred_only"]
+
+
+def test_from_dataframe_ignores_category_columns(tmp_path):
+    """Test to_dataframe -> from_dataframe round-trips past cat.<dim> columns.
+
+    Regression: `cat.<dim>` columns share the dotted flat-key style, so a dim
+    named like a coordinate suffix (e.g. "x") produced a `cat.x` column the
+    instances reader mistook for a node named "cat".
+    """
+    skeleton = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    inst = Instance.from_numpy(np.array([[0.0, 1.0], [2.0, 3.0]]), skeleton)
+    inst.set_categories({"x": "weird", "sex": "M"})  # "x" collides with coord suffix
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[inst])])
+
+    df = to_dataframe(labels, format="instances")
+    assert {"cat.x", "cat.sex"}.issubset(df.columns)
+
+    rebuilt = from_dataframe(df, skeleton=skeleton, format="instances")
+    # Node detection ignores cat.* columns: skeleton is A/B, not a node "cat".
+    assert rebuilt.skeleton.node_names == ["A", "B"]
+    assert sum(len(lf.instances) for lf in rebuilt) == 1
+
+
 def test_to_dataframe_frames_format():
     """Test conversion to frames format (wide format with multiplexed instances)."""
     skeleton = Skeleton(["a", "b"])

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -1329,6 +1329,49 @@ def test_identity_categories_round_trip(tmp_path):
     assert loaded.identities[0].metadata == {"note": "keep"}
 
 
+def test_identity_reserved_keys_win_over_metadata(tmp_path):
+    """Test structured Identity fields are not clobbered by colliding metadata.
+
+    Regression: identities_json packed structured fields then `update(metadata)`,
+    so a metadata key named "name"/"uuid"/"color"/"categories" overwrote the real
+    field on write (silently losing real per-identity categories).
+    """
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    # Real categories AND a colliding metadata "categories" key + a "name" key.
+    identity = Identity(
+        name="real_name",
+        categories={"sex": "M"},
+        metadata={"categories": "clobber", "name": "evil", "keep": 1},
+    )
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel, identity=identity)
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[inst])])
+    labels.update()
+
+    path = str(tmp_path / "reserved.slp")
+    save_slp(labels, path)
+
+    reloaded = load_slp(path).identities[0]
+    assert reloaded.name == "real_name"  # not "evil"
+    assert reloaded.categories == {"sex": "M"}  # not "clobber"
+    # Reserved keys are stripped from metadata; only non-reserved keys remain.
+    assert reloaded.metadata == {"keep": 1}
+
+
+def test_read_identities_guards_non_dict_categories(tmp_path):
+    """Test a malformed non-dict "categories" value is coerced to an empty dict."""
+    path = str(tmp_path / "malformed.slp")
+    # Hand-write an identities_json with a bogus non-dict categories value.
+    with h5py.File(path, "w") as f:
+        f.create_dataset(
+            "identities_json",
+            data=[np.bytes_(json.dumps({"name": "m", "categories": "oops"}))],
+            maxshape=(None,),
+        )
+    identity = read_identities(path)[0]
+    assert identity.categories == {}  # coerced, not the bare string
+
+
 def test_no_categories_keeps_low_format_and_no_dataset(tmp_path):
     """Test category-free labels stay additive (no dataset, no 2.7 bump)."""
     skel = Skeleton(["A", "B"])

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -71,6 +71,7 @@ from sleap_io.io.slp import (
     read_bboxes,
     read_centroids,
     read_identities,
+    read_instance_categories,
     read_instances,
     read_label_images,
     read_labels,
@@ -1278,6 +1279,96 @@ def test_modality_embeddings_warn_on_save(tmp_path):
 
     with pytest.warns(UserWarning, match="not yet persisted"):
         save_slp(labels, str(tmp_path / "modality.slp"))
+
+
+def test_per_instance_categories_round_trip(tmp_path):
+    """Test per-instance categories round-trip through SLP (format 2.7)."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    i0 = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    i0.set_categories({"sex": "M", "behavior": "grooming"})
+    i1 = PredictedInstance.from_numpy(np.array([[4, 5], [6, 7]]), skel, score=0.8)
+    i1.set_category("sex_probs", [0.2, 0.8])  # non-string value
+    i2 = Instance.from_numpy(np.array([[8, 9], [10, 11]]), skel)  # no categories
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[i0, i1, i2])])
+
+    path = str(tmp_path / "categories.slp")
+    save_slp(labels, path)
+
+    # Format bumped to 2.7 and the additive dataset is present.
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] >= 2.7
+        assert "instance_categories" in f
+
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)
+    assert li[0].categories == {"sex": "M", "behavior": "grooming"}
+    assert li[1].categories == {"sex_probs": [0.2, 0.8]}  # list value preserved
+    assert li[2].categories == {}  # sparse: no categories stays empty
+
+
+def test_identity_categories_round_trip(tmp_path):
+    """Test entity-level Identity categories round-trip in identities_json."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    identity = Identity(name="mouse_A", metadata={"note": "keep"})
+    identity.set_categories({"species": "mouse", "sex": "M"})
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel, identity=identity)
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[inst])])
+    labels.update()
+
+    path = str(tmp_path / "identity_categories.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] >= 2.7
+
+    loaded = load_slp(path)
+    assert loaded.identities[0].categories == {"species": "mouse", "sex": "M"}
+    # The reserved "categories" key does not leak into the metadata catch-all.
+    assert loaded.identities[0].metadata == {"note": "keep"}
+
+
+def test_no_categories_keeps_low_format_and_no_dataset(tmp_path):
+    """Test category-free labels stay additive (no dataset, no 2.7 bump)."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    labels = Labels(
+        [
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)],
+            )
+        ]
+    )
+    path = str(tmp_path / "no_categories.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] < 2.7
+        assert "instance_categories" not in f
+
+    loaded = load_slp(path)
+    assert list(loaded[0].instances)[0].categories == {}
+
+
+def test_read_instance_categories_absent_returns_empty(tmp_path):
+    """Test read_instance_categories returns {} when the dataset is absent."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    labels = Labels(
+        [
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)],
+            )
+        ]
+    )
+    path = str(tmp_path / "absent.slp")
+    save_slp(labels, path)
+    assert read_instance_categories(path) == {}
 
 
 def test_make_frame_group_and_frame_group_to_dict(

--- a/tests/io/test_slp_lazy.py
+++ b/tests/io/test_slp_lazy.py
@@ -1832,3 +1832,72 @@ def test_lazy_save_persists_identities_and_embeddings(tmp_path):
     np.testing.assert_array_equal(
         by_name["mouse_A"].embedding.vector, np.ones(128, dtype=np.float32)
     )
+
+
+def test_lazy_categories_round_trip(tmp_path):
+    """Test per-instance categories materialize correctly via the lazy loader."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    i0 = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    i0.set_categories({"sex": "M", "behavior": "grooming"})
+    i1 = PredictedInstance.from_numpy(np.array([[4, 5], [6, 7]]), skel, score=0.8)
+    i1.set_category("sex_probs", [0.2, 0.8])
+    i2 = Instance.from_numpy(np.array([[8, 9], [10, 11]]), skel)  # no categories
+
+    labels = sio.Labels(
+        [LabeledFrame(video=video, frame_idx=0, instances=[i0, i1, i2])]
+    )
+
+    path = str(tmp_path / "lazy_categories.slp")
+    sio.save_slp(labels, path)
+
+    lazy = sio.load_slp(path, lazy=True)
+    assert lazy.is_lazy
+    li = list(lazy[0].instances)
+    assert li[0].categories == {"sex": "M", "behavior": "grooming"}
+    assert li[1].categories == {"sex_probs": [0.2, 0.8]}
+    assert li[2].categories == {}
+
+    # Mutating a materialized instance's categories must not leak into the store.
+    li[0].categories["sex"] = "F"
+    li_again = list(lazy[0].instances)
+    assert li_again[0].categories["sex"] == "M"
+
+    # Lazy store copy preserves categories.
+    cli = list(lazy.copy()[0].instances)
+    assert cli[0].categories == {"sex": "M", "behavior": "grooming"}
+
+
+def test_lazy_save_persists_categories(tmp_path):
+    """Lazy save must persist per-instance + entity-level categories (format 2.7)."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    identity = sio.Identity(name="mouse_A")
+    identity.set_categories({"species": "mouse", "sex": "M"})
+
+    i0 = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel, identity=identity)
+    i0.set_categories({"sex": "M", "behavior": "grooming"})
+    i1 = Instance.from_numpy(np.array([[8, 9], [10, 11]]), skel)  # no categories
+
+    labels = sio.Labels([LabeledFrame(video=video, frame_idx=0, instances=[i0, i1])])
+    labels.update()
+
+    a = str(tmp_path / "a.slp")
+    sio.save_slp(labels, a)
+    lazy = sio.load_slp(a, lazy=True)
+    assert lazy.is_lazy
+
+    # Save the LAZY labels (exercises the fast-path writer) and reload eagerly.
+    b = str(tmp_path / "b.slp")
+    sio.save_slp(lazy, b)
+    assert lazy.is_lazy  # fast path must not materialize
+
+    with h5py.File(b, "r") as f:
+        assert f["metadata"].attrs["format_id"] >= 2.7
+        assert "instance_categories" in f
+
+    reb = sio.load_slp(b)
+    ri = reb[0].instances
+    assert ri[0].categories == {"sex": "M", "behavior": "grooming"}
+    assert ri[1].categories == {}
+    assert reb.identities[0].categories == {"species": "mouse", "sex": "M"}


### PR DESCRIPTION
## Summary

Persists the `categories` mapping (from #519) to SLP at a new **format 2.7**, and surfaces categories + identity as columns in the `instances` DataFrame so they drive ordinary pandas/polars filtering and balanced sampling.

> Stacked on #519. Review/merge after #519.

## Key Changes

**Persistence (`sleap_io/io/slp.py`, `slp_lazy.py`) — SLP format 2.7:**
- New additive `/instance_categories` dataset: a 1-D array of `{instance_id, categories}` JSON rows (variable-width, so JSON like `identities_json`), joined to instances by the global `instance_id` — the same key as the identity/embedding side-tables.
- Identity-level categories ride under a reserved `categories` key in `identities_json`.
- Wired through eager + lazy read/write (incl. the lazy fast-path save) and the format bump. Purely additive: category-free files stay `<= 2.6`.

**DataFrame codec (`sleap_io/codecs/dataframe.py`):**
- Adds `identity` (= `Identity.name`, mirroring `track`), `identity_score`, and one exploded `cat.<dim>` column per dimension (vectors explode to `cat.<dim>.<i>`) to the `instances` format, across all three row builders (streaming / eager / lazy).
- A prescan emits a **uniform** column schema (None where a dim is absent) across pandas, polars, and streaming chunks; `pl.from_dicts(infer_schema_length=None)` prevents polars from dropping a sparse column that first appears past its inference window.

## Example Usage

```python
df = labels.to_dataframe(format="instances")
males = df[df["cat.sex"] == "M"]
balanced = df.groupby("cat.sex").sample(50)
```

## API Changes

- `Labels.to_dataframe(format="instances")` / `to_dataframe_iter` gain `identity`, `identity_score`, and `cat.<dim>` columns (additive; gated by `include_metadata`).
- New SLP **format 2.7**; new module functions `read_instance_categories` / `write_instance_categories`.

## Testing

- `tests/io/test_slp.py`, `tests/io/test_slp_lazy.py`: eager + lazy round-trips (incl. non-string list values), identity categories without metadata leak, no-categories format/dataset guard, lazy-save persistence, absent-dataset guard.
- `tests/codecs/test_dataframe.py`: identity/identity_score columns, scalar + vector explode, sparse uniform schema, `include_metadata` gating, polars late-column regression, streaming uniform schema, lazy-matches-eager.

## Design Decisions

- **Exploded `cat.<dim>` columns** (vectors → `cat.<dim>.<i>`), consistent with the existing `{node}.x` flat-key convention.
- Variable-width categories are encoded as **JSON rows** rather than a fixed structured array (like `identities_json`).
- The `instance_id` positional join is inherited from the identity/embedding side-tables (it is self-consistent for save→load; reorder-robustness is a shared follow-up).

## Adversarial review

A multi-agent review (5 lenses) found **0 issues** in the positional-join and format-compat lenses. Three confirmed issues are fixed + regression-tested in this PR (`f3ccaabf3`): Identity reserved-key vs. metadata collision, lazy-vs-eager DataFrame schema divergence under filters, and `from_dataframe` mis-parsing `cat.*` columns as nodes. Low-severity edges (dim-name `.`/node collisions; shallow-copy of mutable category values, matching `embeddings`) are documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbXnTzogXjYJ6fiVzq2TN1
