### PR TITLE
feat(io): opt-in carry-over of unknown HDF5 datasets on save (#516)

### DIFF
--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -168,6 +168,29 @@ lossless — provenance is already in `/provenance_json` and the other droppable
 keys are empty placeholders whose data lives in their own datasets — so saving
 never fails on oversized metadata.
 
+### Forward compatibility: preserving unknown datasets
+
+Saving a `.slp` truncates the file and rebuilds it from the in-memory model, so
+any top-level dataset/group the writer does not recognize is dropped. This means
+an **older** sleap-io version round-tripping a file written by a **newer** version
+would silently lose the newer version's additions.
+
+To guard against this, pass `preserve_unknown=True` to
+[`save_slp()`][sleap_io.save_slp]:
+
+```python
+labels = sio.load_slp("from_newer_version.slp")
+sio.save_slp(labels, "out.slp", preserve_unknown=True)
+```
+
+Top-level members in the source file (`labels.provenance["filename"]`) that are
+not part of the known schema are copied verbatim into the saved file, after the
+known sections are written (regenerated data always wins on a name clash). It is
+**opt-in** (default `False`) and best-effort: it requires the source file to still
+exist and be readable HDF5. Per-video embedded groups (`video0`, `video1`, ...)
+and all datasets listed above are part of the known schema and are regenerated,
+not carried over.
+
 ## Videos
 
 Video metadata is stored in the `/videos_json` dataset as an array of JSON strings. Each video entry contains:

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -167,6 +167,7 @@ def save_slp(
     plugin: str | None = None,
     progress_callback: Callable[[int, int], bool] | None = None,
     prefer_metadata: bool = True,
+    preserve_unknown: bool = False,
 ):
     """Save a SLEAP dataset to a `.slp` file.
 
@@ -209,6 +210,11 @@ def save_slp(
             avoids decoding a frame (and leaving a resident decoder) just to recompute
             already-known metadata. Set to `False` to always read shape/grayscale/fps
             through the live backend.
+        preserve_unknown: If `True`, top-level HDF5 datasets/groups in the source
+            file that sleap-io does not recognize are carried over into the saved
+            file. This preserves additions from a newer sleap-io version across a
+            load/save cycle. Default `False`. Best-effort (requires the source file
+            to still exist and be readable HDF5). See `write_labels`.
     """
     from sleap_io.io import slp
 
@@ -222,6 +228,7 @@ def save_slp(
         plugin=plugin,
         progress_callback=progress_callback,
         prefer_metadata=prefer_metadata,
+        preserve_unknown=preserve_unknown,
     )
 
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -23,6 +23,7 @@ Format version history:
 
 from __future__ import annotations
 
+import io
 import sys
 import warnings
 import zlib
@@ -6230,6 +6231,122 @@ def read_labels_set(
     return LabelsSet(labels=labels_dict)
 
 
+# Top-level HDF5 names that sleap-io itself writes (regenerated from the model on
+# every save). Anything else found in a source file is treated as "unknown" and,
+# when ``preserve_unknown=True``, carried across a load/save cycle so a format
+# addition made by a newer sleap-io version is not silently dropped by an older
+# reader (which truncates and rebuilds the file from the model). Per-video embedded
+# groups (``video0``, ``video1``, ...) are also known -- see
+# ``_is_known_toplevel_name``. Forgetting to list a name here is safe: it would be
+# stashed and then skipped at restore because the known writer already produced it
+# (only marginally wasteful), so this never causes data loss or duplication.
+_KNOWN_TOPLEVEL_HDF5_NAMES = frozenset(
+    {
+        "metadata",
+        "videos_json",
+        "tracks_json",
+        "suggestions_json",
+        "sessions_json",
+        "identities_json",
+        "provenance_json",
+        "frames",
+        "instances",
+        "points",
+        "pred_points",
+        "negative_frames",
+        "video_crops",
+        "bboxes",
+        "centroids",
+        "rois",
+        "roi_wkb",
+        "roi_categories",
+        "roi_names",
+        "roi_sources",
+        "masks",
+        "mask_rle",
+        "mask_categories",
+        "mask_names",
+        "mask_sources",
+        "mask_score_map_index",
+        "mask_score_maps",
+        "label_images",
+        "label_image_objects",
+        "label_image_data",
+        "label_image_sources",
+        "label_image_obj_categories",
+        "label_image_obj_names",
+        "label_image_score_map_index",
+        "label_image_score_maps",
+    }
+)
+
+
+def _is_known_toplevel_name(name: str) -> bool:
+    """Return whether a top-level HDF5 object is one sleap-io writes itself.
+
+    Args:
+        name: A top-level member name in a ``.slp`` HDF5 file.
+
+    Returns:
+        ``True`` for names in `_KNOWN_TOPLEVEL_HDF5_NAMES` and for per-video
+        embedded groups (``video0``, ``video1``, ...); ``False`` otherwise.
+    """
+    if name in _KNOWN_TOPLEVEL_HDF5_NAMES:
+        return True
+    # Per-video embedded groups: video0, video1, ...
+    return name.startswith("video") and name[len("video") :].isdigit()
+
+
+def _stash_unknown_hdf5(source_path: str | None) -> bytes | None:
+    """Capture top-level HDF5 members not written by sleap-io from a source file.
+
+    Used to carry forward unrecognized datasets/groups (e.g. additions made by a
+    newer sleap-io version) across a load/save cycle, since saving truncates and
+    rebuilds the file from the in-memory model and would otherwise drop them.
+
+    Args:
+        source_path: Path to the file the labels were loaded from
+            (``labels.provenance["filename"]``), or ``None``.
+
+    Returns:
+        An in-memory HDF5 file image (bytes) holding the unknown members, or
+        ``None`` if there is no readable HDF5 source or it has no unknown members.
+    """
+    if not source_path:
+        return None
+    try:
+        if not (Path(source_path).is_file() and h5py.is_hdf5(source_path)):
+            return None
+        buffer = io.BytesIO()
+        with h5py.File(source_path, "r") as src, h5py.File(buffer, "w") as mem:
+            unknown = [k for k in src.keys() if not _is_known_toplevel_name(k)]
+            for name in unknown:
+                src.copy(name, mem)
+        return buffer.getvalue() if unknown else None
+    except (OSError, KeyError):
+        # Unreadable/locked/corrupt source: skip carry-over rather than fail the
+        # save. Preservation is best-effort.
+        return None
+
+
+def _restore_unknown_hdf5(dest_path: str, image: bytes | None) -> None:
+    """Re-emit stashed unknown HDF5 members into a freshly-written file.
+
+    Members whose names were already produced by the known writers are skipped, so
+    regenerated data always wins over the stashed copy.
+
+    Args:
+        dest_path: Path to the ``.slp`` file just written.
+        image: The in-memory HDF5 image from `_stash_unknown_hdf5`, or ``None``.
+    """
+    if not image:
+        return
+    with h5py.File(io.BytesIO(image), "r") as mem, h5py.File(dest_path, "a") as f:
+        for name in mem.keys():
+            if name not in f:
+                mem.copy(name, f)
+
+
 def _write_labels_lazy(
     labels_path: str,
     labels: Labels,
@@ -6237,6 +6354,7 @@ def _write_labels_lazy(
     restore_original_videos: bool = True,
     verbose: bool = True,
     prefer_metadata: bool = True,
+    preserve_unknown: bool = False,
 ) -> None:
     """Write lazy Labels to SLP file using fast path.
 
@@ -6264,6 +6382,9 @@ def _write_labels_lazy(
             shape/grayscale/fps from its `backend_metadata` when recorded there
             instead of querying the live backend. Set to `False` to always read
             through the live backend. See `video_to_dict`.
+        preserve_unknown: If `True`, top-level HDF5 datasets/groups in the source
+            file not recognized by sleap-io are carried over into the saved file.
+            See `write_labels`.
 
     Raises:
         ValueError: If labels is not lazy.
@@ -6272,6 +6393,14 @@ def _write_labels_lazy(
         raise ValueError("_write_labels_lazy requires lazy Labels")
 
     lazy_store = labels._lazy_store
+
+    # Capture unknown top-level members from the source file before it is
+    # truncated, to carry them across the load/save cycle (see write_labels).
+    unknown_stash = (
+        _stash_unknown_hdf5(labels.provenance.get("filename"))
+        if preserve_unknown
+        else None
+    )
 
     # Delete existing file if it exists
     if Path(labels_path).exists():
@@ -6396,6 +6525,9 @@ def _write_labels_lazy(
         contexts=li_ctxs,
     )
 
+    # Re-emit any unknown members captured from the source file.
+    _restore_unknown_hdf5(labels_path, unknown_stash)
+
 
 def write_labels(
     labels_path: str,
@@ -6408,6 +6540,7 @@ def write_labels(
     embed_all_videos: bool = True,
     progress_callback: Callable[[int, int], bool] | None = None,
     prefer_metadata: bool = True,
+    preserve_unknown: bool = False,
 ):
     """Write a SLEAP labels file.
 
@@ -6453,6 +6586,13 @@ def write_labels(
             metadata is already known (e.g. saving copies of labels loaded from a
             `.slp`). Set to `False` to always read through the live backend. See
             `video_to_dict`.
+        preserve_unknown: If `True`, top-level HDF5 datasets/groups present in the
+            source file (``labels.provenance["filename"]``) that sleap-io does not
+            recognize are copied into the saved file. This preserves additions made
+            by a newer sleap-io version across a load/save cycle with an older
+            version (which would otherwise drop them, since saving rebuilds the file
+            from the in-memory model). Default `False`. Best-effort: requires the
+            source file to still exist and be readable HDF5.
     """
     # Fast path for lazy labels (avoids materializing frames/instances)
     # Supported for simple embed modes: None, False, "source"
@@ -6482,8 +6622,18 @@ def write_labels(
                 restore_original_videos=restore_original_videos,
                 verbose=verbose,
                 prefer_metadata=prefer_metadata,
+                preserve_unknown=preserve_unknown,
             )
             return
+
+    # Capture unknown top-level members from the source file before it is
+    # truncated, so additions made by a newer sleap-io version survive a
+    # load/save cycle through this (potentially older) writer.
+    unknown_stash = (
+        _stash_unknown_hdf5(labels.provenance.get("filename"))
+        if preserve_unknown
+        else None
+    )
 
     if Path(labels_path).exists():
         Path(labels_path).unlink()
@@ -6633,3 +6783,6 @@ def write_labels(
         all_instances,
         contexts=li_contexts,
     )
+
+    # Re-emit any unknown members captured from the source file.
+    _restore_unknown_hdf5(labels_path, unknown_stash)

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -45,8 +45,11 @@ from sleap_io.io.slp import (
     ExportCancelled,
     LabelImageWriter,
     _encode_metadata_attr,
+    _is_known_toplevel_name,
     _points_from_hdf5_data,
     _read_source_video_json,
+    _restore_unknown_hdf5,
+    _stash_unknown_hdf5,
     _write_metadata_standalone,
     _write_provenance_dataset,
     _write_source_video_json,
@@ -5939,6 +5942,138 @@ def test_source_video_json_spill_overwrites_dataset(tmp_path):
 
     with h5py.File(path, "r") as f:
         assert _read_source_video_json(f["video0/source_video"]) == big2
+
+
+def _save_minimal_slp_with_unknown(path):
+    """Save a minimal .slp then inject unknown top-level members; return path."""
+    skel = Skeleton(["A", "B"])
+    lf = LabeledFrame(
+        video=Video("v.mp4"),
+        frame_idx=0,
+        instances=[Instance.from_numpy([[0, 0], [1, 1]], skeleton=skel)],
+    )
+    save_slp(Labels([lf]), path)
+    with h5py.File(path, "a") as f:
+        d = f.create_dataset("future_feature_json", data=np.bytes_(b'{"v":42}'))
+        d.attrs["k"] = "val"
+        g = f.create_group("future_group")
+        g.create_dataset("inner", data=np.arange(4))
+    return path
+
+
+def test_is_known_toplevel_name():
+    """_is_known_toplevel_name recognizes sleap-io's own top-level objects."""
+    assert _is_known_toplevel_name("metadata")
+    assert _is_known_toplevel_name("provenance_json")
+    assert _is_known_toplevel_name("video0")
+    assert _is_known_toplevel_name("video12")
+    assert not _is_known_toplevel_name("future_feature_json")
+    assert not _is_known_toplevel_name("videofoo")  # not video<digits>
+
+
+def test_stash_unknown_hdf5_none_for_no_source(tmp_path):
+    """No usable source (None, missing, or non-HDF5) yields no stash."""
+    assert _stash_unknown_hdf5(None) is None
+    assert _stash_unknown_hdf5(str(tmp_path / "missing.slp")) is None
+    txt = tmp_path / "not_hdf5.txt"
+    txt.write_text("hello")
+    assert _stash_unknown_hdf5(str(txt)) is None
+
+
+def test_stash_unknown_hdf5_none_when_no_unknown(tmp_path):
+    """A file with only known members yields no stash."""
+    path = str(tmp_path / "known.slp")
+    save_slp(Labels([LabeledFrame(video=Video("v.mp4"), frame_idx=0)]), path)
+    assert _stash_unknown_hdf5(path) is None
+
+
+def test_stash_unknown_hdf5_corrupt_source_returns_none(tmp_path):
+    """A corrupt HDF5 source is skipped rather than crashing the save."""
+    path = tmp_path / "corrupt.slp"
+    path.write_bytes(b"\x89HDF\r\n\x1a\n" + b"\x00" * 200)
+    assert h5py.is_hdf5(str(path))  # valid signature, broken structure
+    assert _stash_unknown_hdf5(str(path)) is None
+
+
+def test_restore_unknown_hdf5_none_image_noop(tmp_path):
+    """Restoring a None image is a no-op."""
+    path = str(tmp_path / "x.slp")
+    with h5py.File(path, "w") as f:
+        f.create_dataset("points", data=np.arange(3))
+    _restore_unknown_hdf5(path, None)
+    with h5py.File(path, "r") as f:
+        assert list(f.keys()) == ["points"]
+
+
+def test_restore_unknown_hdf5_skips_existing_names(tmp_path):
+    """Restore never overwrites a member already present in the destination."""
+    src = _save_minimal_slp_with_unknown(str(tmp_path / "src.slp"))
+    image = _stash_unknown_hdf5(src)
+    assert image is not None
+
+    # Destination already has a member with the same name as a stashed one.
+    dest = str(tmp_path / "dest.slp")
+    with h5py.File(dest, "w") as f:
+        f.create_dataset("future_feature_json", data=np.bytes_(b'{"keep":true}'))
+
+    _restore_unknown_hdf5(dest, image)
+    with h5py.File(dest, "r") as f:
+        # Existing member is preserved (stash does not clobber it)...
+        assert bytes(f["future_feature_json"][()]) == b'{"keep":true}'
+        # ...while the other stashed member is still added.
+        assert "future_group" in f
+
+
+def test_save_slp_drops_unknown_by_default(tmp_path):
+    """Unknown top-level members are dropped on a normal save (default)."""
+    src = _save_minimal_slp_with_unknown(str(tmp_path / "src.slp"))
+    out = str(tmp_path / "out.slp")
+    save_slp(load_slp(src), out)
+    with h5py.File(out, "r") as f:
+        assert "future_feature_json" not in f
+        assert "future_group" not in f
+
+
+def test_save_slp_preserve_unknown_carries_over(tmp_path):
+    """preserve_unknown carries unknown datasets/groups + attrs across a save."""
+    src = _save_minimal_slp_with_unknown(str(tmp_path / "src.slp"))
+    out = str(tmp_path / "out.slp")
+    save_slp(load_slp(src), out, preserve_unknown=True)
+    with h5py.File(out, "r") as f:
+        assert bytes(f["future_feature_json"][()]) == b'{"v":42}'
+        assert f["future_feature_json"].attrs["k"] == "val"
+        assert f["future_group/inner"][()].tolist() == [0, 1, 2, 3]
+    assert len(load_slp(out)) == 1  # known data still loads
+
+
+def test_save_slp_preserve_unknown_inplace(tmp_path):
+    """preserve_unknown works for an in-place save (source == destination)."""
+    src = _save_minimal_slp_with_unknown(str(tmp_path / "p.slp"))
+    save_slp(load_slp(src), src, preserve_unknown=True)
+    with h5py.File(src, "r") as f:
+        assert "future_feature_json" in f
+        assert "future_group" in f
+
+
+def test_save_slp_preserve_unknown_no_source_noop(tmp_path):
+    """preserve_unknown is a no-op for in-memory labels with no source file."""
+    labels = Labels([LabeledFrame(video=Video("v.mp4"), frame_idx=0)])
+    out = str(tmp_path / "mem.slp")
+    save_slp(labels, out, preserve_unknown=True)  # must not raise
+    with h5py.File(out, "r") as f:
+        assert "future_feature_json" not in f
+
+
+def test_save_slp_preserve_unknown_lazy(tmp_path):
+    """preserve_unknown carries unknown members through the lazy write path."""
+    src = _save_minimal_slp_with_unknown(str(tmp_path / "src.slp"))
+    out = str(tmp_path / "out.slp")
+    lazy = load_slp(src, lazy=True)
+    assert lazy.is_lazy
+    save_slp(lazy, out, preserve_unknown=True)
+    with h5py.File(out, "r") as f:
+        assert "future_feature_json" in f
+        assert "future_group" in f
 
 
 def test_read_h5wasm_instances_float64_indices(tmp_path):


### PR DESCRIPTION
_Supersedes #522 (auto-closed when the stacked base branch was deleted during the squash-merge of #517). Same change, now based directly on `main`._

> Stacked on #517 — review/merge that first. The base of this PR is `fix/metadata-provenance-64kb`, so the diff shown here is only the carry-over feature.

## Summary

Implements the forward-compatibility mechanism discussed on #516. Saving a `.slp` **truncates** the file and rebuilds it from the in-memory model, so any top-level dataset/group the writer doesn't recognize is dropped. An **older** sleap-io version round-tripping a file written by a **newer** version therefore silently loses the newer version's additions. This adds an **opt-in** flag to carry those unknown members across the save.

## Key Changes

- New `preserve_unknown=False` flag on `save_slp()` and `write_labels()`. When `True`, top-level members in the source file (`labels.provenance["filename"]`) that aren't part of the known schema are copied verbatim into the saved file, **after** the known sections are written (regenerated data wins on a name clash).
- **Save-time design — no model/state changes.** Unknown members are stashed from the source into an in-memory HDF5 image *before* truncation (`_stash_unknown_hdf5`), then re-emitted after the known writes (`_restore_unknown_hdf5`), using `h5py`'s native `.copy()` (handles nested groups + attrs).
- `_KNOWN_TOPLEVEL_HDF5_NAMES` + a `video{N}` pattern (`_is_known_toplevel_name`) define the known schema. Forgetting to list a future name is **fail-safe**: it gets stashed and then skipped at restore because the known writer already produced it.
- Covers both the eager and lazy write paths. Best-effort: a missing/corrupt/non-HDF5 source is skipped, never crashing the save.

## Example

```python
labels = sio.load_slp("written_by_newer_version.slp")  # has unknown datasets
sio.save_slp(labels, "out.slp", preserve_unknown=True)  # they survive the round-trip
```

## API Changes

- `save_slp(..., preserve_unknown: bool = False)` and `write_labels(..., preserve_unknown: bool = False)`.
- New private helpers in `sleap_io.io.slp`: `_stash_unknown_hdf5`, `_restore_unknown_hdf5`, `_is_known_toplevel_name`, and the `_KNOWN_TOPLEVEL_HDF5_NAMES` schema set.

## Testing

- Unit: known-name recognition (incl. `video{N}`); stash returns `None` for no/missing/non-HDF5/corrupt source and when there are no unknown members; restore is a no-op for a `None` image and skips names already present in the destination.
- Integration: default save drops unknowns; `preserve_unknown=True` carries datasets + nested groups + attrs across cross-path, in-place, and **lazy** saves; in-memory labels (no source) is a safe no-op.
- Full `tests/io/test_slp.py` + `test_main.py` (418) pass; new code fully covered.

## Design Decisions

- **Save-time copy-from-source** rather than load-time stash on the model: avoids polluting the `Labels` model with format-specific raw bytes and needs no changes to the (eager + lazy) read paths. The trade-off — the source file must still exist at save time — is acceptable and documented.
- **Forward-compat only:** this helps versions released from here on; it can't retroactively teach already-released versions to preserve unknowns. Opt-in so default behavior and file bytes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
