### PR TITLE
feat(io,model): identity + re-ID embedding persistence across detection modalities (#525)

### DIFF
--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -113,8 +113,8 @@ file.slp
 ├── /embeddings/                 # Group: re-ID embeddings, one subgroup per space (Format 2.6+)
 │   └── <space>/                 # e.g. "reid", "jabs"
 │       ├── vectors              # Dataset: float (n, D), gzip-compressed (dtype preserved)
-│       ├── owner_type           # Dataset: uint8 (0=instance, 1=identity, 2=centroid, 3=mask)
-│       ├── owner_id             # Dataset: int64 owner index (instance_id / identity / mask / centroid list index)
+│       ├── owner_type           # Dataset: uint8 (0=instance, 1=identity, 2=centroid, 3=mask, 4=bbox, 5=roi)
+│       ├── owner_id             # Dataset: int64 owner index (instance_id / identity / per-modality list index)
 │       └── meta_json            # Dataset: per-row JSON (normalized, source, centroid_xy, metadata)
 │
 └── /video{N}/                   # Group: Per-video embedded data (one per video)
@@ -578,8 +578,8 @@ Per-detection global identity assignments are stored in the optional `/identity_
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `owner_type` | `uint8` | Detection modality code (shared `OWNER_*` codes: `0`=instance, `1`=identity, `2`=centroid, `3`=mask, `4`=bbox, `5`=roi, `6`=frame, `7`=track). Instance (`0`), mask (`3`), and centroid (`2`) owners are written today |
-| `owner_id` | `int64` | Per-owner-type positional id: the global instance id for instance owners, or the global per-modality list index for mask / centroid owners (each enumeration order over frames then the modality, matching `write_lfs` / `write_masks` / `write_centroids`) |
+| `owner_type` | `uint8` | Detection modality code (shared `OWNER_*` codes: `0`=instance, `1`=identity, `2`=centroid, `3`=mask, `4`=bbox, `5`=roi, `6`=frame, `7`=track). Instance, centroid, mask, bbox, and ROI owners are written today |
+| `owner_id` | `int64` | Per-owner-type positional id: the global instance id for instance owners, or the global per-modality list index for centroid / mask / bbox / ROI owners (each enumeration order over frames then the modality, matching `write_lfs` / `write_masks` / `write_centroids` / `write_bboxes` / `write_rois`; static ROIs follow frame ROIs) |
 | `identity_idx` | `int32` | Index into `/identities_json` |
 | `identity_score` | `float32` | Identity-assignment score (NaN if unrecorded) |
 
@@ -1445,8 +1445,8 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 
 **Per-detection global identity links.**
 
-- New optional `/identity_links` structured dataset (`owner_type`, `owner_id`, `identity_idx`, `identity_score`) joining detections to the `/identities_json` catalog (see [Per-Detection Linking](#per-detection-linking)). The `owner_type` column reuses the shared `OWNER_*` codes (same scheme as the `/embeddings` join); instance (`0`), mask (`3`), and centroid (`2`) owners are written
-- Triggered automatically when any instance, mask, or centroid carries an [`Identity`][sleap_io.Identity]; identity-free files stay at `format_id <= 2.4`
+- New optional `/identity_links` structured dataset (`owner_type`, `owner_id`, `identity_idx`, `identity_score`) joining detections to the `/identities_json` catalog (see [Per-Detection Linking](#per-detection-linking)). The `owner_type` column reuses the shared `OWNER_*` codes (same scheme as the `/embeddings` join); instance, centroid, mask, bbox, and ROI owners are written
+- Triggered automatically when any instance, centroid, mask, bbox, or ROI carries an [`Identity`][sleap_io.Identity]; identity-free files stay at `format_id <= 2.4`
 - Backward compatible: reads are gated on dataset presence, so older readers ignore it
 
 ### Format 2.6
@@ -1454,8 +1454,8 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 **Appearance / re-ID embeddings.**
 
 - New optional `/embeddings` group, one subgroup per named space holding stacked `vectors` `(n, D)` plus `owner_type`/`owner_id` join columns and a per-row `meta_json` (see [Embeddings](../model/embedding.md))
-- Persists per-instance, per-`SegmentationMask`, per-`Centroid`, and per-`Identity` (prototype/gallery) embeddings; large float vectors live in gzipped numeric datasets, never in JSON
-- Triggered automatically when any instance, mask, centroid, or identity carries an embedding; embedding-free files stay at `format_id <= 2.5`. Pass `labels.save(..., save_embedding_vectors=False)` to persist identity *links* but skip the (large) appearance vectors
+- Persists per-instance, per-`SegmentationMask`, per-`Centroid`, per-`BoundingBox`, per-`ROI`, and per-`Identity` (prototype/gallery) embeddings; large float vectors live in gzipped numeric datasets, never in JSON
+- Triggered automatically when any instance, centroid, mask, bbox, ROI, or identity carries an embedding; embedding-free files stay at `format_id <= 2.5`. Pass `labels.save(..., save_embedding_vectors=False)` to persist identity *links* but skip the (large) appearance vectors
 - Backward compatible: reads are gated on group presence
 
 ### Format 2.7 (Current)

--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -41,8 +41,8 @@ file.slp
 ├── /points                      # Dataset: User-labeled points (structured array)
 ├── /pred_points                 # Dataset: Predicted points (structured array)
 ├── /negative_frames             # Dataset: Negative frame markers (optional)
-├── /instance_identities         # Dataset: Per-instance global identity links (Format 2.5+)
-│                                 #   structured: instance_id, identity_idx, identity_score
+├── /identity_links              # Dataset: Per-detection global identity links (Format 2.5+)
+│                                 #   structured: owner_type, owner_id, identity_idx, identity_score
 ├── /instance_categories         # Dataset: Per-instance categorical labels (Format 2.7+)
 │                                 #   JSON rows: {instance_id, categories: {dim: value}}
 │
@@ -156,7 +156,7 @@ file.slp
 | `suggestions_json` | `bytes[]` | JSON array of suggested frames (optional) |
 | `sessions_json` | `bytes[]` | JSON array of recording sessions (optional) |
 | `identities_json` | `bytes[]` | JSON array of identity definitions, incl. stable `uuid` and optional entity-level `categories` (optional) |
-| `instance_identities` | structured | Per-instance global identity links: `instance_id`, `identity_idx`, `identity_score` (Format 2.5+, optional) |
+| `identity_links` | structured | Per-detection global identity links: `owner_type`, `owner_id`, `identity_idx`, `identity_score` (Format 2.5+, optional) |
 | `embeddings/<space>` | group | re-ID embedding vectors + `owner_type`/`owner_id` join columns + `meta_json` (Format 2.6+, optional) |
 | `instance_categories` | `bytes[]` | Per-instance categorical labels: JSON `{instance_id, categories}` rows (Format 2.7+, optional) |
 | `provenance_json` | `bytes` | JSON object of provenance metadata (optional) |
@@ -572,17 +572,18 @@ Each identity is stored as a JSON object:
 | `categories` | `object` | Optional entity-level categorical labels keyed by dimension (Format 2.7+; omitted if empty). A reserved key — excluded from the metadata catch-all |
 | *custom* | `any` | Additional metadata fields |
 
-### Per-Instance Linking
+### Per-Detection Linking
 
-Per-instance global identity assignments are stored in the optional `/instance_identities` structured dataset (Format 2.5+), joined to instances by the global `instance_id`:
+Per-detection global identity assignments are stored in the optional `/identity_links` structured dataset (Format 2.5+). Each row joins a detection — identified by an `owner_type`/`owner_id` pair (the same join scheme as the `/embeddings` group) — to an entry in the identity catalog:
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `instance_id` | `int64` | Global instance id (enumeration order over frames then instances) |
+| `owner_type` | `uint8` | Detection modality code (shared `OWNER_*` codes: `0`=instance, `1`=identity, `2`=centroid, `3`=mask, `4`=bbox, `5`=roi, `6`=frame, `7`=track). Only instance owners (`0`) are written today |
+| `owner_id` | `int64` | Per-owner-type positional id. For instance owners this is the global instance id (enumeration order over frames then instances) |
 | `identity_idx` | `int32` | Index into `/identities_json` |
 | `identity_score` | `float32` | Identity-assignment score (NaN if unrecorded) |
 
-This is additive: old readers ignore the dataset, and instances without a global identity simply have no row. Per-identity prototype embeddings and per-instance re-ID embeddings live in the `/embeddings` group — see [Embeddings](../model/embedding.md).
+This is additive: old readers ignore the dataset, and detections without a global identity simply have no row. The owner-type-aware layout lets additional detection modalities be linked later without a new dataset or format bump. (Pre-rename dev files that wrote the instance-only `/instance_identities` dataset, which lacked the `owner_type` column, are still read back as instance owners.) Per-identity prototype embeddings and per-instance re-ID embeddings live in the `/embeddings` group — see [Embeddings](../model/embedding.md).
 
 ### Per-Instance Categories
 
@@ -1442,9 +1443,9 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 
 ### Format 2.5
 
-**Per-instance global identity links.**
+**Per-detection global identity links.**
 
-- New optional `/instance_identities` structured dataset (`instance_id`, `identity_idx`, `identity_score`) joining instances to the `/identities_json` catalog (see [Per-Instance Linking](#per-instance-linking))
+- New optional `/identity_links` structured dataset (`owner_type`, `owner_id`, `identity_idx`, `identity_score`) joining detections to the `/identities_json` catalog (see [Per-Detection Linking](#per-detection-linking)). The `owner_type` column reuses the shared `OWNER_*` codes (same scheme as the `/embeddings` join); only instance owners are written today
 - Triggered automatically when any instance carries an [`Identity`][sleap_io.Identity]; identity-free files stay at `format_id <= 2.4`
 - Backward compatible: reads are gated on dataset presence, so older readers ignore it
 

--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -113,8 +113,8 @@ file.slp
 ├── /embeddings/                 # Group: re-ID embeddings, one subgroup per space (Format 2.6+)
 │   └── <space>/                 # e.g. "reid", "jabs"
 │       ├── vectors              # Dataset: float (n, D), gzip-compressed (dtype preserved)
-│       ├── owner_type           # Dataset: uint8 (0=instance, 1=identity, 3=mask)
-│       ├── owner_id             # Dataset: int64 owner index (instance_id / identity index / mask index)
+│       ├── owner_type           # Dataset: uint8 (0=instance, 1=identity, 2=centroid, 3=mask)
+│       ├── owner_id             # Dataset: int64 owner index (instance_id / identity / mask / centroid list index)
 │       └── meta_json            # Dataset: per-row JSON (normalized, source, centroid_xy, metadata)
 │
 └── /video{N}/                   # Group: Per-video embedded data (one per video)
@@ -578,8 +578,8 @@ Per-detection global identity assignments are stored in the optional `/identity_
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `owner_type` | `uint8` | Detection modality code (shared `OWNER_*` codes: `0`=instance, `1`=identity, `2`=centroid, `3`=mask, `4`=bbox, `5`=roi, `6`=frame, `7`=track). Instance (`0`) and mask (`3`) owners are written today |
-| `owner_id` | `int64` | Per-owner-type positional id: the global instance id for instance owners, or the global mask-list index for mask owners (each enumeration order over frames then the modality, matching `write_lfs` / `write_masks`) |
+| `owner_type` | `uint8` | Detection modality code (shared `OWNER_*` codes: `0`=instance, `1`=identity, `2`=centroid, `3`=mask, `4`=bbox, `5`=roi, `6`=frame, `7`=track). Instance (`0`), mask (`3`), and centroid (`2`) owners are written today |
+| `owner_id` | `int64` | Per-owner-type positional id: the global instance id for instance owners, or the global per-modality list index for mask / centroid owners (each enumeration order over frames then the modality, matching `write_lfs` / `write_masks` / `write_centroids`) |
 | `identity_idx` | `int32` | Index into `/identities_json` |
 | `identity_score` | `float32` | Identity-assignment score (NaN if unrecorded) |
 
@@ -1445,8 +1445,8 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 
 **Per-detection global identity links.**
 
-- New optional `/identity_links` structured dataset (`owner_type`, `owner_id`, `identity_idx`, `identity_score`) joining detections to the `/identities_json` catalog (see [Per-Detection Linking](#per-detection-linking)). The `owner_type` column reuses the shared `OWNER_*` codes (same scheme as the `/embeddings` join); instance (`0`) and mask (`3`) owners are written
-- Triggered automatically when any instance or mask carries an [`Identity`][sleap_io.Identity]; identity-free files stay at `format_id <= 2.4`
+- New optional `/identity_links` structured dataset (`owner_type`, `owner_id`, `identity_idx`, `identity_score`) joining detections to the `/identities_json` catalog (see [Per-Detection Linking](#per-detection-linking)). The `owner_type` column reuses the shared `OWNER_*` codes (same scheme as the `/embeddings` join); instance (`0`), mask (`3`), and centroid (`2`) owners are written
+- Triggered automatically when any instance, mask, or centroid carries an [`Identity`][sleap_io.Identity]; identity-free files stay at `format_id <= 2.4`
 - Backward compatible: reads are gated on dataset presence, so older readers ignore it
 
 ### Format 2.6
@@ -1454,8 +1454,8 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 **Appearance / re-ID embeddings.**
 
 - New optional `/embeddings` group, one subgroup per named space holding stacked `vectors` `(n, D)` plus `owner_type`/`owner_id` join columns and a per-row `meta_json` (see [Embeddings](../model/embedding.md))
-- Persists per-instance, per-`SegmentationMask`, and per-`Identity` (prototype/gallery) embeddings; large float vectors live in gzipped numeric datasets, never in JSON
-- Triggered automatically when any instance, mask, or identity carries an embedding; embedding-free files stay at `format_id <= 2.5`. Pass `labels.save(..., save_embedding_vectors=False)` to persist identity *links* but skip the (large) appearance vectors
+- Persists per-instance, per-`SegmentationMask`, per-`Centroid`, and per-`Identity` (prototype/gallery) embeddings; large float vectors live in gzipped numeric datasets, never in JSON
+- Triggered automatically when any instance, mask, centroid, or identity carries an embedding; embedding-free files stay at `format_id <= 2.5`. Pass `labels.save(..., save_embedding_vectors=False)` to persist identity *links* but skip the (large) appearance vectors
 - Backward compatible: reads are gated on group presence
 
 ### Format 2.7 (Current)

--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -113,8 +113,8 @@ file.slp
 ├── /embeddings/                 # Group: re-ID embeddings, one subgroup per space (Format 2.6+)
 │   └── <space>/                 # e.g. "reid", "jabs"
 │       ├── vectors              # Dataset: float (n, D), gzip-compressed (dtype preserved)
-│       ├── owner_type           # Dataset: uint8 (0=instance, 1=identity)
-│       ├── owner_id             # Dataset: int64 owner index (global instance_id / identity index)
+│       ├── owner_type           # Dataset: uint8 (0=instance, 1=identity, 3=mask)
+│       ├── owner_id             # Dataset: int64 owner index (instance_id / identity index / mask index)
 │       └── meta_json            # Dataset: per-row JSON (normalized, source, centroid_xy, metadata)
 │
 └── /video{N}/                   # Group: Per-video embedded data (one per video)
@@ -578,12 +578,12 @@ Per-detection global identity assignments are stored in the optional `/identity_
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `owner_type` | `uint8` | Detection modality code (shared `OWNER_*` codes: `0`=instance, `1`=identity, `2`=centroid, `3`=mask, `4`=bbox, `5`=roi, `6`=frame, `7`=track). Only instance owners (`0`) are written today |
-| `owner_id` | `int64` | Per-owner-type positional id. For instance owners this is the global instance id (enumeration order over frames then instances) |
+| `owner_type` | `uint8` | Detection modality code (shared `OWNER_*` codes: `0`=instance, `1`=identity, `2`=centroid, `3`=mask, `4`=bbox, `5`=roi, `6`=frame, `7`=track). Instance (`0`) and mask (`3`) owners are written today |
+| `owner_id` | `int64` | Per-owner-type positional id: the global instance id for instance owners, or the global mask-list index for mask owners (each enumeration order over frames then the modality, matching `write_lfs` / `write_masks`) |
 | `identity_idx` | `int32` | Index into `/identities_json` |
 | `identity_score` | `float32` | Identity-assignment score (NaN if unrecorded) |
 
-This is additive: old readers ignore the dataset, and detections without a global identity simply have no row. The owner-type-aware layout lets additional detection modalities be linked later without a new dataset or format bump. (Pre-rename dev files that wrote the instance-only `/instance_identities` dataset, which lacked the `owner_type` column, are still read back as instance owners.) Per-identity prototype embeddings and per-instance re-ID embeddings live in the `/embeddings` group — see [Embeddings](../model/embedding.md).
+Identity is resolved to a catalog index by the stable `uuid`, so a producer that attaches a distinct `Identity` object sharing a uuid with a catalog entry still links correctly. This is additive: old readers ignore the dataset, and detections without a global identity simply have no row. The owner-type-aware layout lets additional detection modalities be linked without a new dataset or format bump. (Pre-rename dev files that wrote the instance-only `/instance_identities` dataset, which lacked the `owner_type` column, are still read back as instance owners.) Per-identity prototype embeddings and per-detection re-ID embeddings live in the `/embeddings` group — see [Embeddings](../model/embedding.md).
 
 ### Per-Instance Categories
 
@@ -1445,8 +1445,8 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 
 **Per-detection global identity links.**
 
-- New optional `/identity_links` structured dataset (`owner_type`, `owner_id`, `identity_idx`, `identity_score`) joining detections to the `/identities_json` catalog (see [Per-Detection Linking](#per-detection-linking)). The `owner_type` column reuses the shared `OWNER_*` codes (same scheme as the `/embeddings` join); only instance owners are written today
-- Triggered automatically when any instance carries an [`Identity`][sleap_io.Identity]; identity-free files stay at `format_id <= 2.4`
+- New optional `/identity_links` structured dataset (`owner_type`, `owner_id`, `identity_idx`, `identity_score`) joining detections to the `/identities_json` catalog (see [Per-Detection Linking](#per-detection-linking)). The `owner_type` column reuses the shared `OWNER_*` codes (same scheme as the `/embeddings` join); instance (`0`) and mask (`3`) owners are written
+- Triggered automatically when any instance or mask carries an [`Identity`][sleap_io.Identity]; identity-free files stay at `format_id <= 2.4`
 - Backward compatible: reads are gated on dataset presence, so older readers ignore it
 
 ### Format 2.6
@@ -1454,8 +1454,8 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 **Appearance / re-ID embeddings.**
 
 - New optional `/embeddings` group, one subgroup per named space holding stacked `vectors` `(n, D)` plus `owner_type`/`owner_id` join columns and a per-row `meta_json` (see [Embeddings](../model/embedding.md))
-- Persists per-instance and per-`Identity` (prototype/gallery) embeddings; large float vectors live in gzipped numeric datasets, never in JSON
-- Triggered automatically when any instance or identity carries an embedding; embedding-free files stay at `format_id <= 2.5`
+- Persists per-instance, per-`SegmentationMask`, and per-`Identity` (prototype/gallery) embeddings; large float vectors live in gzipped numeric datasets, never in JSON
+- Triggered automatically when any instance, mask, or identity carries an embedding; embedding-free files stay at `format_id <= 2.5`. Pass `labels.save(..., save_id_embeddings=False)` to persist identity *links* but skip the (large) appearance vectors
 - Backward compatible: reads are gated on group presence
 
 ### Format 2.7 (Current)

--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -1455,7 +1455,7 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 
 - New optional `/embeddings` group, one subgroup per named space holding stacked `vectors` `(n, D)` plus `owner_type`/`owner_id` join columns and a per-row `meta_json` (see [Embeddings](../model/embedding.md))
 - Persists per-instance, per-`SegmentationMask`, and per-`Identity` (prototype/gallery) embeddings; large float vectors live in gzipped numeric datasets, never in JSON
-- Triggered automatically when any instance, mask, or identity carries an embedding; embedding-free files stay at `format_id <= 2.5`. Pass `labels.save(..., save_id_embeddings=False)` to persist identity *links* but skip the (large) appearance vectors
+- Triggered automatically when any instance, mask, or identity carries an embedding; embedding-free files stay at `format_id <= 2.5`. Pass `labels.save(..., save_embedding_vectors=False)` to persist identity *links* but skip the (large) appearance vectors
 - Backward compatible: reads are gated on group presence
 
 ### Format 2.7 (Current)

--- a/docs/model/3d.md
+++ b/docs/model/3d.md
@@ -217,7 +217,7 @@ Compare identities with `matches()` (default `method="uuid"`), or configure an [
 ```
 
 !!! note "SLP persistence"
-    The identity catalog (with `uuid`) persists in SLP format v1.9+. Per-instance identity links (`Instance.identity`/`identity_score`) persist in **format 2.5+** via the additive `/instance_identities` dataset; re-ID embeddings persist in **format 2.6+**. All are additive, so older readers ignore them and older files round-trip unchanged. See [Embeddings](embedding.md) and [Formats → SLP](../formats/slp.md).
+    The identity catalog (with `uuid`) persists in SLP format v1.9+. Per-instance identity links (`Instance.identity`/`identity_score`) persist in **format 2.5+** via the additive, owner-type-aware `/identity_links` dataset; re-ID embeddings persist in **format 2.6+**. All are additive, so older readers ignore them and older files round-trip unchanged. See [Embeddings](embedding.md) and [Formats → SLP](../formats/slp.md).
 
 ---
 

--- a/docs/model/boxes.md
+++ b/docs/model/boxes.md
@@ -94,6 +94,8 @@ Every bounding box can carry optional metadata:
 | ----------- | ------------------ | -------------------------------------------- |
 | `track`     | [`Track`](poses.md) `\| None`    | Tracking identity across frames              |
 | `tracking_score` | `float \| None` | Confidence of track identity assignment    |
+| `identity`  | [`Identity`](embedding.md) `\| None` | Global cross-video re-ID identity (mirrors `Instance.identity`); persists via `/identity_links` (`owner_type=4`) |
+| `identity_score` | `float \| None` | Confidence of the `identity` assignment      |
 | `instance`  | [`Instance`](poses.md) `\| None` | Linked pose instance                         |
 | `category`  | `str`              | Class label (e.g., `"mouse"`)                |
 | `name`      | `str`              | Human-readable name                          |

--- a/docs/model/centroids.md
+++ b/docs/model/centroids.md
@@ -103,6 +103,8 @@ Every centroid can carry optional metadata:
 | ----------- | ------------------ | -------------------------------------------- |
 | `track`     | [`Track`](poses.md) `\| None`    | Tracking identity across frames              |
 | `tracking_score` | `float \| None` | Confidence of track identity assignment    |
+| `identity`  | [`Identity`](embedding.md) `\| None` | Global cross-video re-ID identity (mirrors `Instance.identity`); persists via `/identity_links` (`owner_type=2`) |
+| `identity_score` | `float \| None` | Confidence of the `identity` assignment      |
 | `instance`  | [`Instance`](poses.md) `\| None` | Linked pose instance                         |
 | `z`         | `float \| None`    | Optional Z-coordinate for 3D data            |
 | `category`  | `str`              | Class label (e.g., `"cell"`)                 |

--- a/docs/model/embedding.md
+++ b/docs/model/embedding.md
@@ -64,10 +64,10 @@ round-trip unchanged. Per-instance embeddings are loaded lazily alongside the re
 store.
 
 !!! note "Persistence scope"
-    `Instance`, `SegmentationMask`, and `Identity` embeddings are written today (mask owners join
-    on their global mask-list index, `owner_type=3`). Embeddings attached to centroid /
-    bounding-box / ROI detections are not yet persisted; saving emits a warning so they are not
-    silently dropped.
+    `Instance`, `SegmentationMask`, `Centroid`, and `Identity` embeddings are written today (mask
+    and centroid owners join on their global per-modality list index, `owner_type=3`/`2`). Embeddings
+    attached to bounding-box / ROI detections are not yet persisted; saving emits a warning so they
+    are not silently dropped.
 
 !!! tip "Skipping appearance vectors on disk"
     Appearance vectors are large. Pass `labels.save(path, save_embedding_vectors=False)` to skip the

--- a/docs/model/embedding.md
+++ b/docs/model/embedding.md
@@ -64,9 +64,16 @@ round-trip unchanged. Per-instance embeddings are loaded lazily alongside the re
 store.
 
 !!! note "Persistence scope"
-    Instance and Identity embeddings are written today. Embeddings attached to centroid / mask /
+    `Instance`, `SegmentationMask`, and `Identity` embeddings are written today (mask owners join
+    on their global mask-list index, `owner_type=3`). Embeddings attached to centroid /
     bounding-box / ROI detections are not yet persisted; saving emits a warning so they are not
     silently dropped.
+
+!!! tip "Skipping appearance vectors on disk"
+    Appearance vectors are large. Pass `labels.save(path, save_id_embeddings=False)` to skip the
+    `/embeddings` group entirely while still persisting identity *links* (`/identity_links`); the
+    vectors stay in memory (e.g. to build identity prototypes). This is distinct from `embed`,
+    which embeds *video frames*.
 
 ---
 

--- a/docs/model/embedding.md
+++ b/docs/model/embedding.md
@@ -28,7 +28,7 @@ name, plus a convenience `embedding` accessor and a `set_embedding()` helper:
 >>> import sleap_io as sio
 >>> skeleton = sio.Skeleton(["head", "tail"])
 >>> inst = sio.Instance.from_numpy(np.array([[0, 1], [2, 3]]), skeleton=skeleton)
->>> _ = inst.set_embedding(np.ones(128, dtype="float32"), name="reid", source="reid_v1")
+>>> inst.set_embedding(np.ones(128, dtype="float32"), name="reid", source="reid_v1")
 >>> print(inst.embedding.dim)
 
 ```
@@ -41,8 +41,8 @@ is exactly one, otherwise `None`. A second named space coexists without conflict
 >>> import sleap_io as sio
 >>> skeleton = sio.Skeleton(["head", "tail"])
 >>> inst = sio.Instance.from_numpy(np.array([[0, 1], [2, 3]]), skeleton=skeleton)
->>> _ = inst.set_embedding(np.ones(128, dtype="float32"))           # -> "reid"
->>> _ = inst.set_embedding(np.ones(64, dtype="float64"), name="jabs")
+>>> inst.set_embedding(np.ones(128, dtype="float32"))           # -> "reid"
+>>> inst.set_embedding(np.ones(64, dtype="float64"), name="jabs")
 >>> print(sorted(inst.embeddings))
 
 ```

--- a/docs/model/embedding.md
+++ b/docs/model/embedding.md
@@ -70,7 +70,7 @@ store.
     silently dropped.
 
 !!! tip "Skipping appearance vectors on disk"
-    Appearance vectors are large. Pass `labels.save(path, save_id_embeddings=False)` to skip the
+    Appearance vectors are large. Pass `labels.save(path, save_embedding_vectors=False)` to skip the
     `/embeddings` group entirely while still persisting identity *links* (`/identity_links`); the
     vectors stay in memory (e.g. to build identity prototypes). This is distinct from `embed`,
     which embeds *video frames*.

--- a/docs/model/embedding.md
+++ b/docs/model/embedding.md
@@ -64,10 +64,10 @@ round-trip unchanged. Per-instance embeddings are loaded lazily alongside the re
 store.
 
 !!! note "Persistence scope"
-    `Instance`, `SegmentationMask`, `Centroid`, and `Identity` embeddings are written today (mask
-    and centroid owners join on their global per-modality list index, `owner_type=3`/`2`). Embeddings
-    attached to bounding-box / ROI detections are not yet persisted; saving emits a warning so they
-    are not silently dropped.
+    Embeddings persist for every detection modality -- `Instance`, `Centroid`, `SegmentationMask`,
+    `BoundingBox`, `ROI` -- plus `Identity` (prototype/gallery). Detection owners join on their
+    global per-modality list index (`owner_type` `2`/`3`/`4`/`5`); instance owners join on the
+    global `instance_id` and identity prototypes on the catalog index.
 
 !!! tip "Skipping appearance vectors on disk"
     Appearance vectors are large. Pass `labels.save(path, save_embedding_vectors=False)` to skip the

--- a/docs/model/rois.md
+++ b/docs/model/rois.md
@@ -148,6 +148,8 @@ Every ROI can carry optional metadata:
 | `video`     | [`Video`](video.md) `\| None` | Associated video — set for static ROIs, `None` for frame-bound ROIs |
 | `track`     | [`Track`](poses.md) `\| None`    | Tracking identity across frames              |
 | `tracking_score` | `float \| None` | Confidence of track identity assignment    |
+| `identity`  | [`Identity`](embedding.md) `\| None` | Global cross-video re-ID identity (mirrors `Instance.identity`); persists via `/identity_links` (`owner_type=5`) |
+| `identity_score` | `float \| None` | Confidence of the `identity` assignment      |
 | `instance`  | [`Instance`](poses.md) `\| None` | Linked pose instance                         |
 | `category`  | `str`              | Class label (e.g., `"arena"`)                |
 | `name`      | `str`              | Human-readable name                          |

--- a/docs/model/segmentation.md
+++ b/docs/model/segmentation.md
@@ -234,6 +234,8 @@ Every segmentation mask can carry optional metadata:
 | ---------------- | ------------------ | -------------------------------------------- |
 | `track`          | [`Track`](poses.md) `\| None`    | Tracking identity across frames              |
 | `tracking_score` | `float \| None`    | Confidence of track identity assignment      |
+| `identity`       | [`Identity`](embedding.md) `\| None` | Global cross-video re-ID identity (mirrors `Instance.identity`); persists via `/identity_links` (`owner_type=3`) |
+| `identity_score` | `float \| None`    | Confidence of the `identity` assignment       |
 | `instance`       | [`Instance`](poses.md) `\| None` | Linked pose instance                         |
 | `scale`          | `tuple[float, float]` | `(sx, sy)` spatial scale (default `(1, 1)`) |
 | `offset`         | `tuple[float, float]` | `(x, y)` pixel offset (default `(0, 0)`)    |

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -168,6 +168,7 @@ def save_slp(
     progress_callback: Callable[[int, int], bool] | None = None,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
+    save_id_embeddings: bool = True,
 ):
     """Save a SLEAP dataset to a `.slp` file.
 
@@ -215,6 +216,12 @@ def save_slp(
             file. This preserves additions from a newer sleap-io version across a
             load/save cycle. Default `False`. Best-effort (requires the source file
             to still exist and be readable HDF5). See `write_labels`.
+        save_id_embeddings: If `True` (the default), write attached re-ID
+            appearance embeddings (the `/embeddings` group) to disk. If `False`,
+            skip the `/embeddings` group entirely -- appearance vectors are large
+            on disk, and a producer may want only the identity *links* persisted
+            while keeping the vectors in memory (e.g. to build identity
+            prototypes). Identity links (`/identity_links`) are written regardless.
     """
     from sleap_io.io import slp
 
@@ -229,6 +236,7 @@ def save_slp(
         progress_callback=progress_callback,
         prefer_metadata=prefer_metadata,
         preserve_unknown=preserve_unknown,
+        save_id_embeddings=save_id_embeddings,
     )
 
 

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -168,7 +168,7 @@ def save_slp(
     progress_callback: Callable[[int, int], bool] | None = None,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
-    save_id_embeddings: bool = True,
+    save_embedding_vectors: bool = True,
 ):
     """Save a SLEAP dataset to a `.slp` file.
 
@@ -216,7 +216,7 @@ def save_slp(
             file. This preserves additions from a newer sleap-io version across a
             load/save cycle. Default `False`. Best-effort (requires the source file
             to still exist and be readable HDF5). See `write_labels`.
-        save_id_embeddings: If `True` (the default), write attached re-ID
+        save_embedding_vectors: If `True` (the default), write attached re-ID
             appearance embeddings (the `/embeddings` group) to disk. If `False`,
             skip the `/embeddings` group entirely -- appearance vectors are large
             on disk, and a producer may want only the identity *links* persisted
@@ -236,7 +236,7 @@ def save_slp(
         progress_callback=progress_callback,
         prefer_metadata=prefer_metadata,
         preserve_unknown=preserve_unknown,
-        save_id_embeddings=save_id_embeddings,
+        save_embedding_vectors=save_embedding_vectors,
     )
 
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -7202,6 +7202,7 @@ def _write_labels_lazy(
     verbose: bool = True,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
+    save_id_embeddings: bool = True,
 ) -> None:
     """Write lazy Labels to SLP file using fast path.
 
@@ -7232,6 +7233,9 @@ def _write_labels_lazy(
         preserve_unknown: If `True`, top-level HDF5 datasets/groups in the source
             file not recognized by sleap-io are carried over into the saved file.
             See `write_labels`.
+        save_id_embeddings: If `True` (the default), write attached re-ID
+            appearance embeddings (the `/embeddings` group). If `False`, skip them
+            while still writing identity links. See `write_labels`.
 
     Raises:
         ValueError: If labels is not lazy.
@@ -7290,9 +7294,12 @@ def _write_labels_lazy(
     identity_rows = _identity_link_rows_from_store(lazy_store)
     identity_rows.extend(_identity_link_rows_from_masks(lazy_masks, uuid_to_idx))
     _write_identity_link_rows(labels_path, identity_rows)
-    by_space = _embedding_groups_from_store(lazy_store, lazy_store.identities)
-    _add_mask_embedding_groups(by_space, lazy_masks)
-    _write_embedding_groups(labels_path, by_space)
+    # Identity links always persist; the appearance vectors are gated by
+    # save_id_embeddings (mirrors the eager path).
+    if save_id_embeddings:
+        by_space = _embedding_groups_from_store(lazy_store, lazy_store.identities)
+        _add_mask_embedding_groups(by_space, lazy_masks)
+        _write_embedding_groups(labels_path, by_space)
     _write_instance_category_rows(
         labels_path, _instance_category_rows_from_store(lazy_store)
     )
@@ -7409,6 +7416,7 @@ def write_labels(
     progress_callback: Callable[[int, int], bool] | None = None,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
+    save_id_embeddings: bool = True,
 ):
     """Write a SLEAP labels file.
 
@@ -7461,6 +7469,11 @@ def write_labels(
             version (which would otherwise drop them, since saving rebuilds the file
             from the in-memory model). Default `False`. Best-effort: requires the
             source file to still exist and be readable HDF5.
+        save_id_embeddings: If `True` (the default), write attached re-ID appearance
+            embeddings (the `/embeddings` group). If `False`, skip them -- appearance
+            vectors are large on disk, so a producer may persist only the identity
+            *links* (`/identity_links`, always written) while keeping the vectors in
+            memory. Distinct from `embed`, which embeds *video frames*.
     """
     # Fast path for lazy labels (avoids materializing frames/instances)
     # Supported for simple embed modes: None, False, "source"
@@ -7491,6 +7504,7 @@ def write_labels(
                 verbose=verbose,
                 prefer_metadata=prefer_metadata,
                 preserve_unknown=preserve_unknown,
+                save_id_embeddings=save_id_embeddings,
             )
             return
 
@@ -7564,7 +7578,10 @@ def write_labels(
     labels._collect_identities()
     write_identities(labels_path, labels.identities)
     write_identity_links(labels_path, labels)
-    write_embeddings(labels_path, labels)
+    # Identity links always persist; the (large) appearance vectors are gated by
+    # save_id_embeddings so a producer can keep them in memory but off disk.
+    if save_id_embeddings:
+        write_embeddings(labels_path, labels)
     write_instance_categories(labels_path, labels)
     write_suggestions(labels_path, labels.suggestions, labels.videos)
     write_sessions(

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1653,7 +1653,9 @@ def read_identities(
     identity_objects = []
     for identity_data in identities:
         d = json.loads(identity_data)
-        # Legacy files written before format 2.5 lack a `uuid`; the Identity
+        # The `uuid` ships unbumped inside the format-1.9 `identities_json`
+        # catalog, so its presence is detected per-record below (independent of
+        # `format_id`). Records written before uuid existed lack it; the Identity
         # factory synthesizes a fresh one (they never had global-identity
         # semantics, so there is nothing to match against).
         # Guard against a malformed/non-dict "categories" value so a bad file

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1803,17 +1803,17 @@ def write_identity_links(labels_path: str, labels: Labels) -> None:
 
     Creates the ``identity_links`` dataset (SLP format 2.5+) as a structured array
     of ``(owner_type, owner_id, identity_idx, identity_score)`` rows for every
-    detection carrying an `Identity` registered in ``labels.identities``. Instance
-    (``OWNER_INSTANCE``), mask (``OWNER_MASK``), and centroid (``OWNER_CENTROID``)
-    owners are written; the ``owner_type`` column is owner-type-aware (same scheme
-    as the ``/embeddings`` join) so other modalities can be added without a new
-    dataset.
+    detection carrying an `Identity` registered in ``labels.identities``. Instance,
+    mask, centroid, bbox, and ROI owners are written (``OWNER_*``); the
+    ``owner_type`` column is owner-type-aware (same scheme as the ``/embeddings``
+    join) so other modalities can be added without a new dataset.
 
     The instance ``owner_id`` matches the global id assigned by `write_lfs`, and the
-    mask / centroid ``owner_id`` matches the global per-modality list index assigned
-    by `write_masks` / `write_centroids` (each enumeration order over frames then
-    the modality), so the link is resolved by joining on that id at read time.
-    Identity is resolved to a catalog index by
+    mask / centroid / bbox / ROI ``owner_id`` matches the global per-modality list
+    index assigned by `write_masks` / `write_centroids` / `write_bboxes` /
+    `write_rois` (each enumeration order over frames then the modality; ROIs append
+    static ROIs after frame ROIs), so the link is resolved by joining on that id at
+    read time. Identity is resolved to a catalog index by
     the stable ``uuid`` (not Python object identity), so a producer attaching a
     distinct `Identity` object that shares a uuid with a catalog entry still links
     correctly. This keeps identity out of the fixed-layout ``instances`` dataset,
@@ -1831,6 +1831,8 @@ def write_identity_links(labels_path: str, labels: Labels) -> None:
     instance_id = 0
     masks: list = []
     centroids: list = []
+    bboxes: list = []
+    rois: list = []
     for lf in labels:
         for inst in lf:
             identity = getattr(inst, "identity", None)
@@ -1849,9 +1851,15 @@ def write_identity_links(labels_path: str, labels: Labels) -> None:
             instance_id += 1
         masks.extend(lf.masks)
         centroids.extend(lf.centroids)
+        bboxes.extend(lf.bboxes)
+        rois.extend(lf.rois)
+    # Static ROIs are appended after frame ROIs (matching write_labels' all_rois).
+    rois.extend(labels.static_rois)
 
     rows.extend(_identity_link_rows_for_owner(masks, uuid_to_idx, OWNER_MASK))
     rows.extend(_identity_link_rows_for_owner(centroids, uuid_to_idx, OWNER_CENTROID))
+    rows.extend(_identity_link_rows_for_owner(bboxes, uuid_to_idx, OWNER_BBOX))
+    rows.extend(_identity_link_rows_for_owner(rois, uuid_to_idx, OWNER_ROI))
     _write_identity_link_rows(labels_path, rows)
 
 
@@ -2099,7 +2107,14 @@ def read_embeddings(
     """
     from sleap_io.model.embedding import Embedding
 
-    supported = (OWNER_INSTANCE, OWNER_IDENTITY, OWNER_MASK, OWNER_CENTROID)
+    supported = (
+        OWNER_INSTANCE,
+        OWNER_IDENTITY,
+        OWNER_MASK,
+        OWNER_CENTROID,
+        OWNER_BBOX,
+        OWNER_ROI,
+    )
     by_owner: dict[int, dict[int, dict]] = {}
 
     cm = (
@@ -2141,8 +2156,8 @@ def read_embeddings(
         if unknown_owner_types:
             warnings.warn(
                 "Skipped /embeddings rows with unsupported owner_type(s) "
-                f"{sorted(unknown_owner_types)}: only instance, identity, mask, and "
-                "centroid embeddings are attached on read. These vectors were "
+                f"{sorted(unknown_owner_types)}: instance, identity, mask, centroid, "
+                "bbox, and ROI embeddings are attached on read. These vectors were "
                 "written by a newer sleap-io and are ignored here.",
                 stacklevel=2,
             )
@@ -2189,15 +2204,12 @@ def write_embeddings(labels_path: str, labels: Labels) -> None:
     Creates the ``/embeddings`` group (SLP format 2.6+) with one subgroup per
     named embedding space. Per-instance embeddings join on the global
     ``instance_id`` (enumeration order over frames then instances, matching
-    `write_lfs`); per-mask and per-centroid embeddings join on the global
-    per-modality list index (same enumeration as `write_masks` / `write_centroids`);
-    per-identity prototype embeddings join on the identity catalog index. Large
-    float vectors live in their own gzipped numeric datasets, keeping them out of
-    any JSON blob and out of the fixed instance row layout (purely additive: old
-    readers ignore the group).
-
-    Embeddings attached to the bbox/ROI modalities are not yet persisted; a warning
-    is emitted if any are present so they are not silently dropped.
+    `write_lfs`); per-mask / per-centroid / per-bbox / per-ROI embeddings join on
+    the global per-modality list index (matching `write_masks` / `write_centroids`
+    / `write_bboxes` / `write_rois`); per-identity prototype embeddings join on the
+    identity catalog index. Large float vectors live in their own gzipped numeric
+    datasets, keeping them out of any JSON blob and out of the fixed instance row
+    layout (purely additive: old readers ignore the group).
 
     Args:
         labels_path: A string path to the SLEAP labels file.
@@ -2207,26 +2219,10 @@ def write_embeddings(labels_path: str, labels: Labels) -> None:
         ValueError: If a single embedding space contains vectors of differing
             dimensionality.
     """
-    # space name -> list of (owner_type, owner_id, Embedding)
+    # space name -> list of (owner_type, owner_id, Embedding). Every detection
+    # modality that carries embeddings (instance/identity/mask/centroid/bbox/ROI)
+    # is persisted, so there is nothing to warn about here.
     by_space = _embedding_groups_from_labels(labels)
-
-    # Warn about embeddings on modalities whose persistence is not yet supported
-    # (instance, identity, mask, and centroid embeddings are persisted; bbox/ROI
-    # are not).
-    unpersisted = sum(
-        1
-        for attr in ("bboxes", "rois")
-        for ann in getattr(labels, attr, [])
-        if getattr(ann, "embeddings", None)
-    )
-    if unpersisted:
-        warnings.warn(
-            f"{unpersisted} embedding(s) on bbox/ROI detections are not yet "
-            "persisted to SLP and will be dropped on save. Only Instance, Identity, "
-            "SegmentationMask, and Centroid embeddings are currently written.",
-            stacklevel=2,
-        )
-
     _write_embedding_groups(labels_path, by_space)
 
 
@@ -2240,16 +2236,19 @@ def _embedding_groups_from_labels(labels: Labels) -> dict[str, list]:
     Returns:
         A mapping ``{space_name: [(owner_type, owner_id, Embedding), ...]}`` where
         per-instance embeddings join on the global ``instance_id`` (enumeration
-        order over frames then instances, matching `write_lfs`), per-mask and
-        per-centroid embeddings join on the global per-modality list index (matching
-        `write_masks` / `write_centroids`), and per-identity prototype embeddings
-        join on the identity catalog index.
+        order over frames then instances, matching `write_lfs`), per-mask /
+        per-centroid / per-bbox / per-ROI embeddings join on the global
+        per-modality list index (matching `write_masks` / `write_centroids` /
+        `write_bboxes` / `write_rois`; static ROIs follow frame ROIs), and
+        per-identity prototype embeddings join on the identity catalog index.
     """
     by_space: dict[str, list] = {}
 
     instance_id = 0
     masks: list = []
     centroids: list = []
+    bboxes: list = []
+    rois: list = []
     for lf in labels:
         for inst in lf:
             for name, emb in getattr(inst, "embeddings", {}).items():
@@ -2257,6 +2256,11 @@ def _embedding_groups_from_labels(labels: Labels) -> dict[str, list]:
             instance_id += 1
         masks.extend(lf.masks)
         centroids.extend(lf.centroids)
+        bboxes.extend(lf.bboxes)
+        rois.extend(lf.rois)
+    # Static ROIs are appended after frame ROIs, matching `write_masks`-style
+    # enumeration in write_labels (all_rois = frame rois + static_rois).
+    rois.extend(labels.static_rois)
 
     for idx, identity in enumerate(labels.identities):
         for name, emb in identity.embeddings.items():
@@ -2264,6 +2268,8 @@ def _embedding_groups_from_labels(labels: Labels) -> dict[str, list]:
 
     _add_owner_embedding_groups(by_space, masks, OWNER_MASK)
     _add_owner_embedding_groups(by_space, centroids, OWNER_CENTROID)
+    _add_owner_embedding_groups(by_space, bboxes, OWNER_BBOX)
+    _add_owner_embedding_groups(by_space, rois, OWNER_ROI)
     return by_space
 
 
@@ -2887,11 +2893,15 @@ def write_metadata(labels_path: str, labels: Labels):
     # what the fast-path writer persists without materializing any frames.
     if labels.is_lazy:
         store = labels._lazy_store
+
+        def _store_dets(by_frame, undistributed):
+            return [d for lst in by_frame.values() for d in lst] + list(undistributed)
+
         lazy_dets = (
-            [m for lst in store._mask_by_frame.values() for m in lst]
-            + list(store._undistributed_masks)
-            + [c for lst in store._centroid_by_frame.values() for c in lst]
-            + list(store._undistributed_centroids)
+            _store_dets(store._mask_by_frame, store._undistributed_masks)
+            + _store_dets(store._centroid_by_frame, store._undistributed_centroids)
+            + _store_dets(store._bbox_by_frame, store._undistributed_bboxes)
+            + _store_dets(store._roi_by_frame, store._undistributed_rois)
         )
         has_instance_identities = bool(store._instance_identities) or any(
             getattr(d, "identity", None) is not None for d in lazy_dets
@@ -2905,7 +2915,9 @@ def write_metadata(labels_path: str, labels: Labels):
             identity.categories for identity in labels.identities
         )
     else:
-        dets = [d for lf in labels for d in (*lf.masks, *lf.centroids)]
+        dets = [
+            d for lf in labels for d in (*lf.masks, *lf.centroids, *lf.bboxes, *lf.rois)
+        ] + list(labels.static_rois)
         has_instance_identities = any(
             getattr(inst, "identity", None) is not None for lf in labels for inst in lf
         ) or any(getattr(d, "identity", None) is not None for d in dets)
@@ -4055,13 +4067,17 @@ def _read_labels_lazy_from_open_file(
     instance_identities = identity_links.get(OWNER_INSTANCE, {})
     mask_identity_map = identity_links.get(OWNER_MASK, {})
     centroid_identity_map = identity_links.get(OWNER_CENTROID, {})
+    bbox_identity_map = identity_links.get(OWNER_BBOX, {})
+    roi_identity_map = identity_links.get(OWNER_ROI, {})
     # Embeddings: identity prototypes attach to the eager catalog now; per-instance
-    # embeddings ride on the lazy store; mask/centroid embeddings attach to those
-    # (eagerly-read) annotations below.
+    # embeddings ride on the lazy store; mask/centroid/bbox/ROI embeddings attach to
+    # those (eagerly-read) annotations below.
     embeddings_by_owner = read_embeddings(labels_path, _hdf5_file=f)
     instance_embeddings = embeddings_by_owner.get(OWNER_INSTANCE, {})
     mask_embedding_map = embeddings_by_owner.get(OWNER_MASK, {})
     centroid_embedding_map = embeddings_by_owner.get(OWNER_CENTROID, {})
+    bbox_embedding_map = embeddings_by_owner.get(OWNER_BBOX, {})
+    roi_embedding_map = embeddings_by_owner.get(OWNER_ROI, {})
     for identity_idx, emb_map in embeddings_by_owner.get(OWNER_IDENTITY, {}).items():
         if 0 <= identity_idx < len(identities):
             identities[identity_idx].embeddings.update(emb_map)
@@ -4102,11 +4118,17 @@ def _read_labels_lazy_from_open_file(
     # Create LazyFrameList
     lazy_frames = LazyFrameList(lazy_store)
 
-    # Read ROIs, masks, bboxes, and label images eagerly (typically small count)
+    # Read ROIs, masks, bboxes, and label images eagerly (typically small count).
+    # Masks/centroids/bboxes/ROIs are eager even in lazy mode, so their identity +
+    # embeddings attach now by global per-modality list index.
     roi_tuples = read_rois(labels_path, videos, tracks, _hdf5_file=f)
+    _attach_identity_and_embeddings(
+        [r for r, _v, _f in roi_tuples],
+        identities,
+        roi_identity_map,
+        roi_embedding_map,
+    )
     mask_tuples = read_masks(labels_path, videos, tracks, _hdf5_file=f)
-    # Attach per-mask identity links + embeddings by global mask-list index (same
-    # id space written by write_masks). Masks/centroids are eager even in lazy mode.
     _attach_identity_and_embeddings(
         [m for m, _v, _f in mask_tuples],
         identities,
@@ -4114,6 +4136,12 @@ def _read_labels_lazy_from_open_file(
         mask_embedding_map,
     )
     bbox_tuples = read_bboxes(labels_path, videos, tracks, _hdf5_file=f)
+    _attach_identity_and_embeddings(
+        [b for b, _v, _f in bbox_tuples],
+        identities,
+        bbox_identity_map,
+        bbox_embedding_map,
+    )
     centroid_tuples = read_centroids(labels_path, videos, tracks, _hdf5_file=f)
     _attach_identity_and_embeddings(
         [c for c, _v, _f in centroid_tuples],
@@ -6904,14 +6932,16 @@ def _read_labels_from_open_file(
     instance_identity_map = identity_links.get(OWNER_INSTANCE, {})
     mask_identity_map = identity_links.get(OWNER_MASK, {})
     centroid_identity_map = identity_links.get(OWNER_CENTROID, {})
+    bbox_identity_map = identity_links.get(OWNER_BBOX, {})
+    roi_identity_map = identity_links.get(OWNER_ROI, {})
     for inst_id, (identity_idx, identity_score) in instance_identity_map.items():
         if 0 <= inst_id < len(instances) and 0 <= identity_idx < len(identities):
             instances[inst_id].identity = identities[identity_idx]
             instances[inst_id].identity_score = identity_score
 
     # Attach appearance / re-ID embeddings (SLP format 2.6+). Additive: absent
-    # /embeddings group -> empty mappings and a no-op. Mask/centroid embeddings are
-    # attached after read_masks / read_centroids.
+    # /embeddings group -> empty mappings and a no-op. Mask/centroid/bbox/ROI
+    # embeddings are attached after their respective read_* calls.
     embeddings_by_owner = read_embeddings(labels_path, _hdf5_file=f)
     for inst_id, emb_map in embeddings_by_owner.get(OWNER_INSTANCE, {}).items():
         if 0 <= inst_id < len(instances):
@@ -6921,6 +6951,8 @@ def _read_labels_from_open_file(
             identities[identity_idx].embeddings.update(emb_map)
     mask_embedding_map = embeddings_by_owner.get(OWNER_MASK, {})
     centroid_embedding_map = embeddings_by_owner.get(OWNER_CENTROID, {})
+    bbox_embedding_map = embeddings_by_owner.get(OWNER_BBOX, {})
+    roi_embedding_map = embeddings_by_owner.get(OWNER_ROI, {})
 
     # Attach per-instance categories (SLP format 2.7+). Additive: absent
     # /instance_categories dataset -> empty mapping and a no-op. Identity-level
@@ -6935,6 +6967,14 @@ def _read_labels_from_open_file(
         labels_path, videos, labeled_frames, identities=identities, _hdf5_file=f
     )
     roi_tuples = read_rois(labels_path, videos, tracks, instances, _hdf5_file=f)
+    # Attach per-ROI identity links + embeddings (global ROI-list index: frame ROIs
+    # then static ROIs, the same order write_rois emits).
+    _attach_identity_and_embeddings(
+        [r for r, _v, _f in roi_tuples],
+        identities,
+        roi_identity_map,
+        roi_embedding_map,
+    )
     mask_tuples = read_masks(labels_path, videos, tracks, instances, _hdf5_file=f)
     # Attach per-mask identity links + embeddings (SLP format 2.5+/2.6+). Masks
     # are returned in global mask-list index order, the same id space written by
@@ -6946,6 +6986,13 @@ def _read_labels_from_open_file(
         mask_embedding_map,
     )
     bbox_tuples = read_bboxes(labels_path, videos, tracks, instances, _hdf5_file=f)
+    # Attach per-bbox identity links + embeddings (global bbox-list index).
+    _attach_identity_and_embeddings(
+        [b for b, _v, _f in bbox_tuples],
+        identities,
+        bbox_identity_map,
+        bbox_embedding_map,
+    )
     centroid_tuples = read_centroids(
         labels_path, videos, tracks, instances, _hdf5_file=f
     )
@@ -7331,6 +7378,12 @@ def _write_labels_lazy(
     lazy_centroids = [
         c for ann_list in lazy_store._centroid_by_frame.values() for c in ann_list
     ] + list(lazy_store._undistributed_centroids)
+    lazy_bboxes = [
+        b for ann_list in lazy_store._bbox_by_frame.values() for b in ann_list
+    ] + list(lazy_store._undistributed_bboxes)
+    lazy_rois = [
+        r for ann_list in lazy_store._roi_by_frame.values() for r in ann_list
+    ] + list(lazy_store._undistributed_rois)
     write_identities(labels_path, lazy_store.identities)
     uuid_to_idx = {ident.uuid: i for i, ident in enumerate(lazy_store.identities)}
     identity_rows = _identity_link_rows_from_store(lazy_store)
@@ -7340,6 +7393,12 @@ def _write_labels_lazy(
     identity_rows.extend(
         _identity_link_rows_for_owner(lazy_centroids, uuid_to_idx, OWNER_CENTROID)
     )
+    identity_rows.extend(
+        _identity_link_rows_for_owner(lazy_bboxes, uuid_to_idx, OWNER_BBOX)
+    )
+    identity_rows.extend(
+        _identity_link_rows_for_owner(lazy_rois, uuid_to_idx, OWNER_ROI)
+    )
     _write_identity_link_rows(labels_path, identity_rows)
     # Identity links always persist; the appearance vectors are gated by
     # save_embedding_vectors (mirrors the eager path).
@@ -7347,6 +7406,8 @@ def _write_labels_lazy(
         by_space = _embedding_groups_from_store(lazy_store, lazy_store.identities)
         _add_owner_embedding_groups(by_space, lazy_masks, OWNER_MASK)
         _add_owner_embedding_groups(by_space, lazy_centroids, OWNER_CENTROID)
+        _add_owner_embedding_groups(by_space, lazy_bboxes, OWNER_BBOX)
+        _add_owner_embedding_groups(by_space, lazy_rois, OWNER_ROI)
         _write_embedding_groups(labels_path, by_space)
     _write_instance_category_rows(
         labels_path, _instance_category_rows_from_store(lazy_store)

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1803,16 +1803,19 @@ def write_identity_links(labels_path: str, labels: Labels) -> None:
 
     Creates the ``identity_links`` dataset (SLP format 2.5+) as a structured array
     of ``(owner_type, owner_id, identity_idx, identity_score)`` rows for every
-    detection carrying an `Identity` that is registered in ``labels.identities``.
-    Today only instance owners (``OWNER_INSTANCE``) are written; the ``owner_type``
-    column is owner-type-aware (same scheme as the ``/embeddings`` join) so other
-    detection modalities can be linked later without a new dataset or format bump.
+    detection carrying an `Identity` registered in ``labels.identities``. Instance
+    (``OWNER_INSTANCE``) and mask (``OWNER_MASK``) owners are written; the
+    ``owner_type`` column is owner-type-aware (same scheme as the ``/embeddings``
+    join) so other detection modalities can be added without a new dataset.
 
-    The instance ``owner_id`` matches the global id assigned by `write_lfs`
-    (enumeration order over frames then instances), so the link is resolved by
-    joining on that id at read time. This keeps identity out of the fixed-layout
-    ``instances`` dataset, making it purely additive: old readers simply ignore
-    the dataset.
+    The instance ``owner_id`` matches the global id assigned by `write_lfs` and the
+    mask ``owner_id`` matches the global mask-list index assigned by `write_masks`
+    (both enumeration order over frames then the modality), so the link is resolved
+    by joining on that id at read time. Identity is resolved to a catalog index by
+    the stable ``uuid`` (not Python object identity), so a producer attaching a
+    distinct `Identity` object that shares a uuid with a catalog entry still links
+    correctly. This keeps identity out of the fixed-layout ``instances`` dataset,
+    making it purely additive: old readers simply ignore the dataset.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
@@ -1821,25 +1824,66 @@ def write_identity_links(labels_path: str, labels: Labels) -> None:
     if not labels.identities:
         return
 
+    uuid_to_idx = {ident.uuid: i for i, ident in enumerate(labels.identities)}
     rows = []
     instance_id = 0
+    masks: list = []
     for lf in labels:
         for inst in lf:
             identity = getattr(inst, "identity", None)
-            if identity is not None and identity in labels.identities:
-                identity_idx = labels.identities.index(identity)
-                score = inst.identity_score
-                rows.append(
-                    (
-                        OWNER_INSTANCE,
-                        instance_id,
-                        identity_idx,
-                        float("nan") if score is None else float(score),
+            if identity is not None:
+                idx = uuid_to_idx.get(identity.uuid)
+                if idx is not None:
+                    score = inst.identity_score
+                    rows.append(
+                        (
+                            OWNER_INSTANCE,
+                            instance_id,
+                            idx,
+                            float("nan") if score is None else float(score),
+                        )
                     )
-                )
             instance_id += 1
+        masks.extend(lf.masks)
 
+    rows.extend(_identity_link_rows_from_masks(masks, uuid_to_idx))
     _write_identity_link_rows(labels_path, rows)
+
+
+def _identity_link_rows_from_masks(
+    masks: list, uuid_to_idx: dict[str, int]
+) -> list[tuple[int, int, int, float]]:
+    """Build ``OWNER_MASK`` identity-link rows from an ordered mask list.
+
+    Masks join on their global mask-list index (the same enumeration as
+    `write_masks`), so ``masks`` must be supplied in that exact order. Identity is
+    resolved to a catalog index by ``uuid``.
+
+    Args:
+        masks: The ordered global mask list.
+        uuid_to_idx: Mapping from `Identity.uuid` to its catalog index.
+
+    Returns:
+        A list of ``(owner_type, owner_id, identity_idx, identity_score)`` tuples.
+    """
+    rows = []
+    for mask_id, mask in enumerate(masks):
+        identity = getattr(mask, "identity", None)
+        if identity is None:
+            continue
+        idx = uuid_to_idx.get(identity.uuid)
+        if idx is None:
+            continue
+        score = mask.identity_score
+        rows.append(
+            (
+                OWNER_MASK,
+                mask_id,
+                idx,
+                float("nan") if score is None else float(score),
+            )
+        )
+    return rows
 
 
 def _identity_link_rows_from_store(
@@ -2025,7 +2069,7 @@ OWNER_TRACK = 7
 
 def read_embeddings(
     labels_path: str, *, _hdf5_file: h5py.File | None = None
-) -> tuple[dict[int, dict], dict[int, dict]]:
+) -> dict[int, dict[int, dict]]:
     """Read appearance / re-ID embeddings from a SLEAP labels file.
 
     Embeddings are stored in the optional ``/embeddings`` group (SLP format 2.6+),
@@ -2039,14 +2083,17 @@ def read_embeddings(
         _hdf5_file: An already-open `h5py.File` handle to read from.
 
     Returns:
-        A 2-tuple ``(instance_embeddings, identity_embeddings)`` where each maps
-        the owner index (global ``instance_id`` / index into the identity catalog)
-        to a ``{space_name: Embedding}`` dict. Both are empty for older files.
+        A dict mapping each supported ``owner_type`` (``OWNER_INSTANCE`` keyed by
+        global instance id, ``OWNER_IDENTITY`` keyed by identity-catalog index,
+        ``OWNER_MASK`` keyed by global mask-list index) to a
+        ``{owner_id: {space_name: Embedding}}`` mapping. Rows with an unsupported
+        owner type are skipped with a warning (rather than mis-routed onto an
+        instance). Empty for older files.
     """
     from sleap_io.model.embedding import Embedding
 
-    instance_embeddings: dict[int, dict] = {}
-    identity_embeddings: dict[int, dict] = {}
+    supported = (OWNER_INSTANCE, OWNER_IDENTITY, OWNER_MASK)
+    by_owner: dict[int, dict[int, dict]] = {}
 
     cm = (
         nullcontext(_hdf5_file)
@@ -2055,7 +2102,7 @@ def read_embeddings(
     )
     with cm as f:
         if "embeddings" not in f:
-            return instance_embeddings, identity_embeddings
+            return by_owner
 
         group = f["embeddings"]
         unknown_owner_types: set[int] = set()
@@ -2068,21 +2115,15 @@ def read_embeddings(
             for i in range(len(vectors)):
                 otype = int(owner_type[i])
                 oid = int(owner_id[i])
-                # Build the Embedding lazily-ish: only after the owner type is one
-                # we attach, to avoid materializing vectors we are about to skip.
-                if otype == OWNER_IDENTITY:
-                    target = identity_embeddings
-                elif otype == OWNER_INSTANCE:
-                    target = instance_embeddings
-                else:
-                    # Reserved owner types (centroid/mask/bbox/roi/frame/track) are
-                    # not attached on read yet. Skip rather than fall through to
-                    # instances, which would silently bind the vector to a different
-                    # object (wrong-object corruption). Collected for one warning.
+                # Build the Embedding only after the owner type is one we attach,
+                # to avoid materializing vectors we are about to skip. Skipping
+                # (rather than falling through to instances) prevents binding a
+                # vector to a different object (wrong-object corruption).
+                if otype not in supported:
                     unknown_owner_types.add(otype)
                     continue
                 meta = json.loads(meta_json[i])
-                target.setdefault(oid, {})[space] = Embedding(
+                by_owner.setdefault(otype, {}).setdefault(oid, {})[space] = Embedding(
                     vector=vectors[i],
                     name=space,
                     normalized=meta.get("normalized", True),
@@ -2093,13 +2134,44 @@ def read_embeddings(
         if unknown_owner_types:
             warnings.warn(
                 "Skipped /embeddings rows with unsupported owner_type(s) "
-                f"{sorted(unknown_owner_types)}: only instance and identity "
+                f"{sorted(unknown_owner_types)}: only instance, identity, and mask "
                 "embeddings are attached on read. These vectors were written by a "
                 "newer sleap-io and are ignored here.",
                 stacklevel=2,
             )
 
-    return instance_embeddings, identity_embeddings
+    return by_owner
+
+
+def _attach_mask_identity_and_embeddings(
+    masks: list,
+    identities: list[Identity],
+    mask_identity_map: dict[int, tuple[int, float | None]],
+    mask_embedding_map: dict[int, dict],
+) -> None:
+    """Attach per-mask identity links + embeddings by global mask-list index.
+
+    Shared by the eager and lazy read paths. ``masks`` must be in the global
+    mask-list index order (as returned by `read_masks`), which is the id space the
+    ``OWNER_MASK`` rows were written against.
+
+    Args:
+        masks: The ordered global mask list.
+        identities: The identity catalog (links resolve by catalog index).
+        mask_identity_map: ``{mask_id: (identity_idx, identity_score)}`` from
+            `read_identity_links`.
+        mask_embedding_map: ``{mask_id: {space: Embedding}}`` from `read_embeddings`.
+    """
+    for mask_id, mask in enumerate(masks):
+        link = mask_identity_map.get(mask_id)
+        if link is not None:
+            identity_idx, identity_score = link
+            if 0 <= identity_idx < len(identities):
+                mask.identity = identities[identity_idx]
+                mask.identity_score = identity_score
+        emb_map = mask_embedding_map.get(mask_id)
+        if emb_map:
+            mask.embeddings.update(emb_map)
 
 
 def write_embeddings(labels_path: str, labels: Labels) -> None:
@@ -2108,14 +2180,14 @@ def write_embeddings(labels_path: str, labels: Labels) -> None:
     Creates the ``/embeddings`` group (SLP format 2.6+) with one subgroup per
     named embedding space. Per-instance embeddings join on the global
     ``instance_id`` (enumeration order over frames then instances, matching
-    `write_lfs`); per-identity prototype embeddings join on the identity catalog
-    index. Large float vectors live in their own gzipped numeric datasets,
-    keeping them out of any JSON blob and out of the fixed instance row layout
-    (purely additive: old readers ignore the group).
+    `write_lfs`); per-mask embeddings join on the global mask-list index (same
+    enumeration as `write_masks`); per-identity prototype embeddings join on the
+    identity catalog index. Large float vectors live in their own gzipped numeric
+    datasets, keeping them out of any JSON blob and out of the fixed instance row
+    layout (purely additive: old readers ignore the group).
 
-    Embeddings attached to non-instance detection modalities (centroids, masks,
-    bounding boxes, ROIs) are not yet persisted; a warning is emitted if any are
-    present so they are not silently dropped.
+    Embeddings attached to the centroid/bbox/ROI modalities are not yet persisted;
+    a warning is emitted if any are present so they are not silently dropped.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
@@ -2128,18 +2200,19 @@ def write_embeddings(labels_path: str, labels: Labels) -> None:
     # space name -> list of (owner_type, owner_id, Embedding)
     by_space = _embedding_groups_from_labels(labels)
 
-    # Warn about embeddings on modalities whose persistence is not yet supported.
+    # Warn about embeddings on modalities whose persistence is not yet supported
+    # (instance, identity, and mask embeddings are persisted; the rest are not).
     unpersisted = sum(
         1
-        for attr in ("centroids", "bboxes", "masks", "rois")
+        for attr in ("centroids", "bboxes", "rois")
         for ann in getattr(labels, attr, [])
         if getattr(ann, "embeddings", None)
     )
     if unpersisted:
         warnings.warn(
-            f"{unpersisted} embedding(s) on centroid/mask/bbox/ROI detections are "
-            "not yet persisted to SLP and will be dropped on save. Only "
-            "Instance and Identity embeddings are currently written.",
+            f"{unpersisted} embedding(s) on centroid/bbox/ROI detections are not "
+            "yet persisted to SLP and will be dropped on save. Only Instance, "
+            "Identity, and SegmentationMask embeddings are currently written.",
             stacklevel=2,
         )
 
@@ -2156,23 +2229,43 @@ def _embedding_groups_from_labels(labels: Labels) -> dict[str, list]:
     Returns:
         A mapping ``{space_name: [(owner_type, owner_id, Embedding), ...]}`` where
         per-instance embeddings join on the global ``instance_id`` (enumeration
-        order over frames then instances, matching `write_lfs`) and per-identity
-        prototype embeddings join on the identity catalog index.
+        order over frames then instances, matching `write_lfs`), per-mask
+        embeddings join on the global mask-list index (matching `write_masks`),
+        and per-identity prototype embeddings join on the identity catalog index.
     """
     by_space: dict[str, list] = {}
 
     instance_id = 0
+    masks: list = []
     for lf in labels:
         for inst in lf:
             for name, emb in getattr(inst, "embeddings", {}).items():
                 by_space.setdefault(name, []).append((OWNER_INSTANCE, instance_id, emb))
             instance_id += 1
+        masks.extend(lf.masks)
 
     for idx, identity in enumerate(labels.identities):
         for name, emb in identity.embeddings.items():
             by_space.setdefault(name, []).append((OWNER_IDENTITY, idx, emb))
 
+    _add_mask_embedding_groups(by_space, masks)
     return by_space
+
+
+def _add_mask_embedding_groups(by_space: dict[str, list], masks: list) -> None:
+    """Append per-mask embedding entries to ``by_space`` (shared eager/lazy).
+
+    Masks join on their global mask-list index (the same enumeration as
+    `write_masks`), so ``masks`` must be supplied in that exact order.
+
+    Args:
+        by_space: The ``{space_name: [(owner_type, owner_id, Embedding), ...]}``
+            accumulator to extend in place.
+        masks: The ordered global mask list.
+    """
+    for mask_id, mask in enumerate(masks):
+        for name, emb in getattr(mask, "embeddings", {}).items():
+            by_space.setdefault(name, []).append((OWNER_MASK, mask_id, emb))
 
 
 def _embedding_groups_from_store(
@@ -2775,9 +2868,16 @@ def write_metadata(labels_path: str, labels: Labels):
     # what the fast-path writer persists without materializing any frames.
     if labels.is_lazy:
         store = labels._lazy_store
-        has_instance_identities = bool(store._instance_identities)
-        has_embeddings = bool(store._instance_embeddings) or any(
-            identity.embeddings for identity in labels.identities
+        lazy_masks = [m for lst in store._mask_by_frame.values() for m in lst] + list(
+            store._undistributed_masks
+        )
+        has_instance_identities = bool(store._instance_identities) or any(
+            getattr(m, "identity", None) is not None for m in lazy_masks
+        )
+        has_embeddings = (
+            bool(store._instance_embeddings)
+            or any(identity.embeddings for identity in labels.identities)
+            or any(getattr(m, "embeddings", None) for m in lazy_masks)
         )
         has_categories = any(store._instance_categories.values()) or any(
             identity.categories for identity in labels.identities
@@ -2785,10 +2885,14 @@ def write_metadata(labels_path: str, labels: Labels):
     else:
         has_instance_identities = any(
             getattr(inst, "identity", None) is not None for lf in labels for inst in lf
+        ) or any(
+            getattr(m, "identity", None) is not None for lf in labels for m in lf.masks
         )
-        has_embeddings = any(
-            getattr(inst, "embeddings", None) for lf in labels for inst in lf
-        ) or any(identity.embeddings for identity in labels.identities)
+        has_embeddings = (
+            any(getattr(inst, "embeddings", None) for lf in labels for inst in lf)
+            or any(identity.embeddings for identity in labels.identities)
+            or any(getattr(m, "embeddings", None) for lf in labels for m in lf.masks)
+        )
         has_categories = any(
             getattr(inst, "categories", None) for lf in labels for inst in lf
         ) or any(identity.categories for identity in labels.identities)
@@ -3923,18 +4027,18 @@ def _read_labels_lazy_from_open_file(
     skeletons = read_skeletons(labels_path, _hdf5_file=f)
     tracks = read_tracks(labels_path, _hdf5_file=f)
     identities = read_identities(labels_path, _hdf5_file=f)
-    # Identity links: only instance owners ride on the lazy store (keyed by global
-    # instance_id) and attach at materialization time. Other owner types, when
-    # present, are handled by their own eager readers.
-    instance_identities = read_identity_links(labels_path, _hdf5_file=f).get(
-        OWNER_INSTANCE, {}
-    )
+    # Identity links: instance owners ride on the lazy store (keyed by global
+    # instance_id) and attach at materialization time; mask owners attach eagerly
+    # to the masks read below.
+    identity_links = read_identity_links(labels_path, _hdf5_file=f)
+    instance_identities = identity_links.get(OWNER_INSTANCE, {})
+    mask_identity_map = identity_links.get(OWNER_MASK, {})
     # Embeddings: identity prototypes attach to the eager catalog now; per-instance
-    # embeddings ride on the lazy store and attach at materialization time.
-    instance_embeddings, identity_embeddings = read_embeddings(
-        labels_path, _hdf5_file=f
-    )
-    for identity_idx, emb_map in identity_embeddings.items():
+    # embeddings ride on the lazy store; mask embeddings attach to the masks below.
+    embeddings_by_owner = read_embeddings(labels_path, _hdf5_file=f)
+    instance_embeddings = embeddings_by_owner.get(OWNER_INSTANCE, {})
+    mask_embedding_map = embeddings_by_owner.get(OWNER_MASK, {})
+    for identity_idx, emb_map in embeddings_by_owner.get(OWNER_IDENTITY, {}).items():
         if 0 <= identity_idx < len(identities):
             identities[identity_idx].embeddings.update(emb_map)
     # Categories: identity-level categories are already on the eager catalog (read
@@ -3977,6 +4081,14 @@ def _read_labels_lazy_from_open_file(
     # Read ROIs, masks, bboxes, and label images eagerly (typically small count)
     roi_tuples = read_rois(labels_path, videos, tracks, _hdf5_file=f)
     mask_tuples = read_masks(labels_path, videos, tracks, _hdf5_file=f)
+    # Attach per-mask identity links + embeddings by global mask-list index (same
+    # id space written by write_masks). Masks are eager even in lazy mode.
+    _attach_mask_identity_and_embeddings(
+        [m for m, _v, _f in mask_tuples],
+        identities,
+        mask_identity_map,
+        mask_embedding_map,
+    )
     bbox_tuples = read_bboxes(labels_path, videos, tracks, _hdf5_file=f)
     centroid_tuples = read_centroids(labels_path, videos, tracks, _hdf5_file=f)
     li_tuples, li_file = read_label_images(
@@ -6754,28 +6866,29 @@ def _read_labels_from_open_file(
         )
 
     identities = read_identities(labels_path, _hdf5_file=f)
-    # Attach per-instance identity links (SLP format 2.5+). Additive: when the
-    # dataset is absent (older files) this is an empty mapping and a no-op. The
-    # global instances list is ordered by instance_id, so it indexes directly.
-    # Only instance owners are consumed here; other owner types have their own
-    # eager readers.
-    instance_identity_map = read_identity_links(labels_path, _hdf5_file=f).get(
-        OWNER_INSTANCE, {}
-    )
+    # Attach identity links (SLP format 2.5+). Additive: when the dataset is absent
+    # (older files) these are empty mappings and a no-op. The global instances list
+    # is ordered by instance_id, so it indexes directly; mask owners are attached
+    # after read_masks (mask-list index order).
+    identity_links = read_identity_links(labels_path, _hdf5_file=f)
+    instance_identity_map = identity_links.get(OWNER_INSTANCE, {})
+    mask_identity_map = identity_links.get(OWNER_MASK, {})
     for inst_id, (identity_idx, identity_score) in instance_identity_map.items():
         if 0 <= inst_id < len(instances) and 0 <= identity_idx < len(identities):
             instances[inst_id].identity = identities[identity_idx]
             instances[inst_id].identity_score = identity_score
 
     # Attach appearance / re-ID embeddings (SLP format 2.6+). Additive: absent
-    # /embeddings group -> empty mappings and a no-op.
-    inst_embeddings, ident_embeddings = read_embeddings(labels_path, _hdf5_file=f)
-    for inst_id, emb_map in inst_embeddings.items():
+    # /embeddings group -> empty mappings and a no-op. Mask embeddings are attached
+    # after read_masks.
+    embeddings_by_owner = read_embeddings(labels_path, _hdf5_file=f)
+    for inst_id, emb_map in embeddings_by_owner.get(OWNER_INSTANCE, {}).items():
         if 0 <= inst_id < len(instances):
             instances[inst_id].embeddings.update(emb_map)
-    for identity_idx, emb_map in ident_embeddings.items():
+    for identity_idx, emb_map in embeddings_by_owner.get(OWNER_IDENTITY, {}).items():
         if 0 <= identity_idx < len(identities):
             identities[identity_idx].embeddings.update(emb_map)
+    mask_embedding_map = embeddings_by_owner.get(OWNER_MASK, {})
 
     # Attach per-instance categories (SLP format 2.7+). Additive: absent
     # /instance_categories dataset -> empty mapping and a no-op. Identity-level
@@ -6791,6 +6904,15 @@ def _read_labels_from_open_file(
     )
     roi_tuples = read_rois(labels_path, videos, tracks, instances, _hdf5_file=f)
     mask_tuples = read_masks(labels_path, videos, tracks, instances, _hdf5_file=f)
+    # Attach per-mask identity links + embeddings (SLP format 2.5+/2.6+). Masks
+    # are returned in global mask-list index order, the same id space written by
+    # write_masks / write_identity_links / write_embeddings.
+    _attach_mask_identity_and_embeddings(
+        [m for m, _v, _f in mask_tuples],
+        identities,
+        mask_identity_map,
+        mask_embedding_map,
+    )
     bbox_tuples = read_bboxes(labels_path, videos, tracks, instances, _hdf5_file=f)
     centroid_tuples = read_centroids(
         labels_path, videos, tracks, instances, _hdf5_file=f
@@ -7156,15 +7278,21 @@ def _write_labels_lazy(
     # Persist identities + per-detection identity links + embeddings directly from
     # the lazy store, mirroring the eager writer (write_identities /
     # write_identity_links / write_embeddings) but driven by the store dicts so no
-    # LabeledFrame/Instance is materialized. The store keys ARE the global
-    # instance_ids written above, so the join stays consistent with the raw
-    # instances emitted by the fast path.
+    # LabeledFrame/Instance is materialized. Instance owners come from the store
+    # (keyed by the global instance_ids written above); mask owners come from the
+    # store's mask objects in the SAME order write_masks emits below, so the mask
+    # owner_id (global mask-list index) stays consistent.
+    lazy_masks = [
+        m for ann_list in lazy_store._mask_by_frame.values() for m in ann_list
+    ] + list(lazy_store._undistributed_masks)
     write_identities(labels_path, lazy_store.identities)
-    _write_identity_link_rows(labels_path, _identity_link_rows_from_store(lazy_store))
-    _write_embedding_groups(
-        labels_path,
-        _embedding_groups_from_store(lazy_store, lazy_store.identities),
-    )
+    uuid_to_idx = {ident.uuid: i for i, ident in enumerate(lazy_store.identities)}
+    identity_rows = _identity_link_rows_from_store(lazy_store)
+    identity_rows.extend(_identity_link_rows_from_masks(lazy_masks, uuid_to_idx))
+    _write_identity_link_rows(labels_path, identity_rows)
+    by_space = _embedding_groups_from_store(lazy_store, lazy_store.identities)
+    _add_mask_embedding_groups(by_space, lazy_masks)
+    _write_embedding_groups(labels_path, by_space)
     _write_instance_category_rows(
         labels_path, _instance_category_rows_from_store(lazy_store)
     )
@@ -7430,6 +7558,10 @@ def write_labels(
     # entirely when no video is cropped (uncropped files stay byte-identical).
     write_video_crops(labels_path, labels)
     write_tracks(labels_path, labels.tracks)
+    # Auto-collect any detection identity not yet registered in the catalog
+    # (uuid-deduped) so post-hoc `inst.identity` / `mask.identity` assignments are
+    # not silently dropped on save. Mutates labels.identities (eager path only).
+    labels._collect_identities()
     write_identities(labels_path, labels.identities)
     write_identity_links(labels_path, labels)
     write_embeddings(labels_path, labels)

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -7202,7 +7202,7 @@ def _write_labels_lazy(
     verbose: bool = True,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
-    save_id_embeddings: bool = True,
+    save_embedding_vectors: bool = True,
 ) -> None:
     """Write lazy Labels to SLP file using fast path.
 
@@ -7233,7 +7233,7 @@ def _write_labels_lazy(
         preserve_unknown: If `True`, top-level HDF5 datasets/groups in the source
             file not recognized by sleap-io are carried over into the saved file.
             See `write_labels`.
-        save_id_embeddings: If `True` (the default), write attached re-ID
+        save_embedding_vectors: If `True` (the default), write attached re-ID
             appearance embeddings (the `/embeddings` group). If `False`, skip them
             while still writing identity links. See `write_labels`.
 
@@ -7295,8 +7295,8 @@ def _write_labels_lazy(
     identity_rows.extend(_identity_link_rows_from_masks(lazy_masks, uuid_to_idx))
     _write_identity_link_rows(labels_path, identity_rows)
     # Identity links always persist; the appearance vectors are gated by
-    # save_id_embeddings (mirrors the eager path).
-    if save_id_embeddings:
+    # save_embedding_vectors (mirrors the eager path).
+    if save_embedding_vectors:
         by_space = _embedding_groups_from_store(lazy_store, lazy_store.identities)
         _add_mask_embedding_groups(by_space, lazy_masks)
         _write_embedding_groups(labels_path, by_space)
@@ -7416,7 +7416,7 @@ def write_labels(
     progress_callback: Callable[[int, int], bool] | None = None,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
-    save_id_embeddings: bool = True,
+    save_embedding_vectors: bool = True,
 ):
     """Write a SLEAP labels file.
 
@@ -7469,7 +7469,7 @@ def write_labels(
             version (which would otherwise drop them, since saving rebuilds the file
             from the in-memory model). Default `False`. Best-effort: requires the
             source file to still exist and be readable HDF5.
-        save_id_embeddings: If `True` (the default), write attached re-ID appearance
+        save_embedding_vectors: If `True` (the default), write attached re-ID appearance
             embeddings (the `/embeddings` group). If `False`, skip them -- appearance
             vectors are large on disk, so a producer may persist only the identity
             *links* (`/identity_links`, always written) while keeping the vectors in
@@ -7504,7 +7504,7 @@ def write_labels(
                 verbose=verbose,
                 prefer_metadata=prefer_metadata,
                 preserve_unknown=preserve_unknown,
-                save_id_embeddings=save_id_embeddings,
+                save_embedding_vectors=save_embedding_vectors,
             )
             return
 
@@ -7579,8 +7579,8 @@ def write_labels(
     write_identities(labels_path, labels.identities)
     write_identity_links(labels_path, labels)
     # Identity links always persist; the (large) appearance vectors are gated by
-    # save_id_embeddings so a producer can keep them in memory but off disk.
-    if save_id_embeddings:
+    # save_embedding_vectors so a producer can keep them in memory but off disk.
+    if save_embedding_vectors:
         write_embeddings(labels_path, labels)
     write_instance_categories(labels_path, labels)
     write_suggestions(labels_path, labels.suggestions, labels.videos)

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -1804,14 +1804,16 @@ def write_identity_links(labels_path: str, labels: Labels) -> None:
     Creates the ``identity_links`` dataset (SLP format 2.5+) as a structured array
     of ``(owner_type, owner_id, identity_idx, identity_score)`` rows for every
     detection carrying an `Identity` registered in ``labels.identities``. Instance
-    (``OWNER_INSTANCE``) and mask (``OWNER_MASK``) owners are written; the
-    ``owner_type`` column is owner-type-aware (same scheme as the ``/embeddings``
-    join) so other detection modalities can be added without a new dataset.
+    (``OWNER_INSTANCE``), mask (``OWNER_MASK``), and centroid (``OWNER_CENTROID``)
+    owners are written; the ``owner_type`` column is owner-type-aware (same scheme
+    as the ``/embeddings`` join) so other modalities can be added without a new
+    dataset.
 
-    The instance ``owner_id`` matches the global id assigned by `write_lfs` and the
-    mask ``owner_id`` matches the global mask-list index assigned by `write_masks`
-    (both enumeration order over frames then the modality), so the link is resolved
-    by joining on that id at read time. Identity is resolved to a catalog index by
+    The instance ``owner_id`` matches the global id assigned by `write_lfs`, and the
+    mask / centroid ``owner_id`` matches the global per-modality list index assigned
+    by `write_masks` / `write_centroids` (each enumeration order over frames then
+    the modality), so the link is resolved by joining on that id at read time.
+    Identity is resolved to a catalog index by
     the stable ``uuid`` (not Python object identity), so a producer attaching a
     distinct `Identity` object that shares a uuid with a catalog entry still links
     correctly. This keeps identity out of the fixed-layout ``instances`` dataset,
@@ -1828,6 +1830,7 @@ def write_identity_links(labels_path: str, labels: Labels) -> None:
     rows = []
     instance_id = 0
     masks: list = []
+    centroids: list = []
     for lf in labels:
         for inst in lf:
             identity = getattr(inst, "identity", None)
@@ -1845,40 +1848,44 @@ def write_identity_links(labels_path: str, labels: Labels) -> None:
                     )
             instance_id += 1
         masks.extend(lf.masks)
+        centroids.extend(lf.centroids)
 
-    rows.extend(_identity_link_rows_from_masks(masks, uuid_to_idx))
+    rows.extend(_identity_link_rows_for_owner(masks, uuid_to_idx, OWNER_MASK))
+    rows.extend(_identity_link_rows_for_owner(centroids, uuid_to_idx, OWNER_CENTROID))
     _write_identity_link_rows(labels_path, rows)
 
 
-def _identity_link_rows_from_masks(
-    masks: list, uuid_to_idx: dict[str, int]
+def _identity_link_rows_for_owner(
+    anns: list, uuid_to_idx: dict[str, int], owner_type: int
 ) -> list[tuple[int, int, int, float]]:
-    """Build ``OWNER_MASK`` identity-link rows from an ordered mask list.
+    """Build identity-link rows for an ordered annotation list under one owner type.
 
-    Masks join on their global mask-list index (the same enumeration as
-    `write_masks`), so ``masks`` must be supplied in that exact order. Identity is
-    resolved to a catalog index by ``uuid``.
+    Annotations join on their global per-modality list index (the same enumeration
+    as the modality's writer, e.g. `write_masks` / `write_centroids`), so ``anns``
+    must be supplied in that exact order. Identity is resolved to a catalog index
+    by ``uuid``.
 
     Args:
-        masks: The ordered global mask list.
+        anns: The ordered global annotation list for one modality.
         uuid_to_idx: Mapping from `Identity.uuid` to its catalog index.
+        owner_type: The ``OWNER_*`` code for this modality (e.g. ``OWNER_MASK``).
 
     Returns:
         A list of ``(owner_type, owner_id, identity_idx, identity_score)`` tuples.
     """
     rows = []
-    for mask_id, mask in enumerate(masks):
-        identity = getattr(mask, "identity", None)
+    for owner_id, ann in enumerate(anns):
+        identity = getattr(ann, "identity", None)
         if identity is None:
             continue
         idx = uuid_to_idx.get(identity.uuid)
         if idx is None:
             continue
-        score = mask.identity_score
+        score = ann.identity_score
         rows.append(
             (
-                OWNER_MASK,
-                mask_id,
+                owner_type,
+                owner_id,
                 idx,
                 float("nan") if score is None else float(score),
             )
@@ -2092,7 +2099,7 @@ def read_embeddings(
     """
     from sleap_io.model.embedding import Embedding
 
-    supported = (OWNER_INSTANCE, OWNER_IDENTITY, OWNER_MASK)
+    supported = (OWNER_INSTANCE, OWNER_IDENTITY, OWNER_MASK, OWNER_CENTROID)
     by_owner: dict[int, dict[int, dict]] = {}
 
     cm = (
@@ -2134,44 +2141,46 @@ def read_embeddings(
         if unknown_owner_types:
             warnings.warn(
                 "Skipped /embeddings rows with unsupported owner_type(s) "
-                f"{sorted(unknown_owner_types)}: only instance, identity, and mask "
-                "embeddings are attached on read. These vectors were written by a "
-                "newer sleap-io and are ignored here.",
+                f"{sorted(unknown_owner_types)}: only instance, identity, mask, and "
+                "centroid embeddings are attached on read. These vectors were "
+                "written by a newer sleap-io and are ignored here.",
                 stacklevel=2,
             )
 
     return by_owner
 
 
-def _attach_mask_identity_and_embeddings(
-    masks: list,
+def _attach_identity_and_embeddings(
+    anns: list,
     identities: list[Identity],
-    mask_identity_map: dict[int, tuple[int, float | None]],
-    mask_embedding_map: dict[int, dict],
+    identity_map: dict[int, tuple[int, float | None]],
+    embedding_map: dict[int, dict],
 ) -> None:
-    """Attach per-mask identity links + embeddings by global mask-list index.
+    """Attach per-annotation identity links + embeddings by global-list index.
 
-    Shared by the eager and lazy read paths. ``masks`` must be in the global
-    mask-list index order (as returned by `read_masks`), which is the id space the
-    ``OWNER_MASK`` rows were written against.
+    Shared by the eager and lazy read paths for any detection modality (e.g.
+    masks, centroids). ``anns`` must be in the global per-modality list index order
+    (as returned by `read_masks` / `read_centroids`), which is the id space the
+    owner rows were written against.
 
     Args:
-        masks: The ordered global mask list.
+        anns: The ordered global annotation list for one modality.
         identities: The identity catalog (links resolve by catalog index).
-        mask_identity_map: ``{mask_id: (identity_idx, identity_score)}`` from
-            `read_identity_links`.
-        mask_embedding_map: ``{mask_id: {space: Embedding}}`` from `read_embeddings`.
+        identity_map: ``{owner_id: (identity_idx, identity_score)}`` from
+            `read_identity_links` for this modality's owner type.
+        embedding_map: ``{owner_id: {space: Embedding}}`` from `read_embeddings`
+            for this modality's owner type.
     """
-    for mask_id, mask in enumerate(masks):
-        link = mask_identity_map.get(mask_id)
+    for owner_id, ann in enumerate(anns):
+        link = identity_map.get(owner_id)
         if link is not None:
             identity_idx, identity_score = link
             if 0 <= identity_idx < len(identities):
-                mask.identity = identities[identity_idx]
-                mask.identity_score = identity_score
-        emb_map = mask_embedding_map.get(mask_id)
+                ann.identity = identities[identity_idx]
+                ann.identity_score = identity_score
+        emb_map = embedding_map.get(owner_id)
         if emb_map:
-            mask.embeddings.update(emb_map)
+            ann.embeddings.update(emb_map)
 
 
 def write_embeddings(labels_path: str, labels: Labels) -> None:
@@ -2180,14 +2189,15 @@ def write_embeddings(labels_path: str, labels: Labels) -> None:
     Creates the ``/embeddings`` group (SLP format 2.6+) with one subgroup per
     named embedding space. Per-instance embeddings join on the global
     ``instance_id`` (enumeration order over frames then instances, matching
-    `write_lfs`); per-mask embeddings join on the global mask-list index (same
-    enumeration as `write_masks`); per-identity prototype embeddings join on the
-    identity catalog index. Large float vectors live in their own gzipped numeric
-    datasets, keeping them out of any JSON blob and out of the fixed instance row
-    layout (purely additive: old readers ignore the group).
+    `write_lfs`); per-mask and per-centroid embeddings join on the global
+    per-modality list index (same enumeration as `write_masks` / `write_centroids`);
+    per-identity prototype embeddings join on the identity catalog index. Large
+    float vectors live in their own gzipped numeric datasets, keeping them out of
+    any JSON blob and out of the fixed instance row layout (purely additive: old
+    readers ignore the group).
 
-    Embeddings attached to the centroid/bbox/ROI modalities are not yet persisted;
-    a warning is emitted if any are present so they are not silently dropped.
+    Embeddings attached to the bbox/ROI modalities are not yet persisted; a warning
+    is emitted if any are present so they are not silently dropped.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
@@ -2201,18 +2211,19 @@ def write_embeddings(labels_path: str, labels: Labels) -> None:
     by_space = _embedding_groups_from_labels(labels)
 
     # Warn about embeddings on modalities whose persistence is not yet supported
-    # (instance, identity, and mask embeddings are persisted; the rest are not).
+    # (instance, identity, mask, and centroid embeddings are persisted; bbox/ROI
+    # are not).
     unpersisted = sum(
         1
-        for attr in ("centroids", "bboxes", "rois")
+        for attr in ("bboxes", "rois")
         for ann in getattr(labels, attr, [])
         if getattr(ann, "embeddings", None)
     )
     if unpersisted:
         warnings.warn(
-            f"{unpersisted} embedding(s) on centroid/bbox/ROI detections are not "
-            "yet persisted to SLP and will be dropped on save. Only Instance, "
-            "Identity, and SegmentationMask embeddings are currently written.",
+            f"{unpersisted} embedding(s) on bbox/ROI detections are not yet "
+            "persisted to SLP and will be dropped on save. Only Instance, Identity, "
+            "SegmentationMask, and Centroid embeddings are currently written.",
             stacklevel=2,
         )
 
@@ -2229,43 +2240,51 @@ def _embedding_groups_from_labels(labels: Labels) -> dict[str, list]:
     Returns:
         A mapping ``{space_name: [(owner_type, owner_id, Embedding), ...]}`` where
         per-instance embeddings join on the global ``instance_id`` (enumeration
-        order over frames then instances, matching `write_lfs`), per-mask
-        embeddings join on the global mask-list index (matching `write_masks`),
-        and per-identity prototype embeddings join on the identity catalog index.
+        order over frames then instances, matching `write_lfs`), per-mask and
+        per-centroid embeddings join on the global per-modality list index (matching
+        `write_masks` / `write_centroids`), and per-identity prototype embeddings
+        join on the identity catalog index.
     """
     by_space: dict[str, list] = {}
 
     instance_id = 0
     masks: list = []
+    centroids: list = []
     for lf in labels:
         for inst in lf:
             for name, emb in getattr(inst, "embeddings", {}).items():
                 by_space.setdefault(name, []).append((OWNER_INSTANCE, instance_id, emb))
             instance_id += 1
         masks.extend(lf.masks)
+        centroids.extend(lf.centroids)
 
     for idx, identity in enumerate(labels.identities):
         for name, emb in identity.embeddings.items():
             by_space.setdefault(name, []).append((OWNER_IDENTITY, idx, emb))
 
-    _add_mask_embedding_groups(by_space, masks)
+    _add_owner_embedding_groups(by_space, masks, OWNER_MASK)
+    _add_owner_embedding_groups(by_space, centroids, OWNER_CENTROID)
     return by_space
 
 
-def _add_mask_embedding_groups(by_space: dict[str, list], masks: list) -> None:
-    """Append per-mask embedding entries to ``by_space`` (shared eager/lazy).
+def _add_owner_embedding_groups(
+    by_space: dict[str, list], anns: list, owner_type: int
+) -> None:
+    """Append per-annotation embedding entries to ``by_space`` (shared eager/lazy).
 
-    Masks join on their global mask-list index (the same enumeration as
-    `write_masks`), so ``masks`` must be supplied in that exact order.
+    Annotations join on their global per-modality list index (the same enumeration
+    as the modality's writer, e.g. `write_masks` / `write_centroids`), so ``anns``
+    must be supplied in that exact order.
 
     Args:
         by_space: The ``{space_name: [(owner_type, owner_id, Embedding), ...]}``
             accumulator to extend in place.
-        masks: The ordered global mask list.
+        anns: The ordered global annotation list for one modality.
+        owner_type: The ``OWNER_*`` code for this modality (e.g. ``OWNER_MASK``).
     """
-    for mask_id, mask in enumerate(masks):
-        for name, emb in getattr(mask, "embeddings", {}).items():
-            by_space.setdefault(name, []).append((OWNER_MASK, mask_id, emb))
+    for owner_id, ann in enumerate(anns):
+        for name, emb in getattr(ann, "embeddings", {}).items():
+            by_space.setdefault(name, []).append((owner_type, owner_id, emb))
 
 
 def _embedding_groups_from_store(
@@ -2868,30 +2887,32 @@ def write_metadata(labels_path: str, labels: Labels):
     # what the fast-path writer persists without materializing any frames.
     if labels.is_lazy:
         store = labels._lazy_store
-        lazy_masks = [m for lst in store._mask_by_frame.values() for m in lst] + list(
-            store._undistributed_masks
+        lazy_dets = (
+            [m for lst in store._mask_by_frame.values() for m in lst]
+            + list(store._undistributed_masks)
+            + [c for lst in store._centroid_by_frame.values() for c in lst]
+            + list(store._undistributed_centroids)
         )
         has_instance_identities = bool(store._instance_identities) or any(
-            getattr(m, "identity", None) is not None for m in lazy_masks
+            getattr(d, "identity", None) is not None for d in lazy_dets
         )
         has_embeddings = (
             bool(store._instance_embeddings)
             or any(identity.embeddings for identity in labels.identities)
-            or any(getattr(m, "embeddings", None) for m in lazy_masks)
+            or any(getattr(d, "embeddings", None) for d in lazy_dets)
         )
         has_categories = any(store._instance_categories.values()) or any(
             identity.categories for identity in labels.identities
         )
     else:
+        dets = [d for lf in labels for d in (*lf.masks, *lf.centroids)]
         has_instance_identities = any(
             getattr(inst, "identity", None) is not None for lf in labels for inst in lf
-        ) or any(
-            getattr(m, "identity", None) is not None for lf in labels for m in lf.masks
-        )
+        ) or any(getattr(d, "identity", None) is not None for d in dets)
         has_embeddings = (
             any(getattr(inst, "embeddings", None) for lf in labels for inst in lf)
             or any(identity.embeddings for identity in labels.identities)
-            or any(getattr(m, "embeddings", None) for lf in labels for m in lf.masks)
+            or any(getattr(d, "embeddings", None) for d in dets)
         )
         has_categories = any(
             getattr(inst, "categories", None) for lf in labels for inst in lf
@@ -4033,11 +4054,14 @@ def _read_labels_lazy_from_open_file(
     identity_links = read_identity_links(labels_path, _hdf5_file=f)
     instance_identities = identity_links.get(OWNER_INSTANCE, {})
     mask_identity_map = identity_links.get(OWNER_MASK, {})
+    centroid_identity_map = identity_links.get(OWNER_CENTROID, {})
     # Embeddings: identity prototypes attach to the eager catalog now; per-instance
-    # embeddings ride on the lazy store; mask embeddings attach to the masks below.
+    # embeddings ride on the lazy store; mask/centroid embeddings attach to those
+    # (eagerly-read) annotations below.
     embeddings_by_owner = read_embeddings(labels_path, _hdf5_file=f)
     instance_embeddings = embeddings_by_owner.get(OWNER_INSTANCE, {})
     mask_embedding_map = embeddings_by_owner.get(OWNER_MASK, {})
+    centroid_embedding_map = embeddings_by_owner.get(OWNER_CENTROID, {})
     for identity_idx, emb_map in embeddings_by_owner.get(OWNER_IDENTITY, {}).items():
         if 0 <= identity_idx < len(identities):
             identities[identity_idx].embeddings.update(emb_map)
@@ -4082,8 +4106,8 @@ def _read_labels_lazy_from_open_file(
     roi_tuples = read_rois(labels_path, videos, tracks, _hdf5_file=f)
     mask_tuples = read_masks(labels_path, videos, tracks, _hdf5_file=f)
     # Attach per-mask identity links + embeddings by global mask-list index (same
-    # id space written by write_masks). Masks are eager even in lazy mode.
-    _attach_mask_identity_and_embeddings(
+    # id space written by write_masks). Masks/centroids are eager even in lazy mode.
+    _attach_identity_and_embeddings(
         [m for m, _v, _f in mask_tuples],
         identities,
         mask_identity_map,
@@ -4091,6 +4115,12 @@ def _read_labels_lazy_from_open_file(
     )
     bbox_tuples = read_bboxes(labels_path, videos, tracks, _hdf5_file=f)
     centroid_tuples = read_centroids(labels_path, videos, tracks, _hdf5_file=f)
+    _attach_identity_and_embeddings(
+        [c for c, _v, _f in centroid_tuples],
+        identities,
+        centroid_identity_map,
+        centroid_embedding_map,
+    )
     li_tuples, li_file = read_label_images(
         labels_path,
         videos,
@@ -6873,14 +6903,15 @@ def _read_labels_from_open_file(
     identity_links = read_identity_links(labels_path, _hdf5_file=f)
     instance_identity_map = identity_links.get(OWNER_INSTANCE, {})
     mask_identity_map = identity_links.get(OWNER_MASK, {})
+    centroid_identity_map = identity_links.get(OWNER_CENTROID, {})
     for inst_id, (identity_idx, identity_score) in instance_identity_map.items():
         if 0 <= inst_id < len(instances) and 0 <= identity_idx < len(identities):
             instances[inst_id].identity = identities[identity_idx]
             instances[inst_id].identity_score = identity_score
 
     # Attach appearance / re-ID embeddings (SLP format 2.6+). Additive: absent
-    # /embeddings group -> empty mappings and a no-op. Mask embeddings are attached
-    # after read_masks.
+    # /embeddings group -> empty mappings and a no-op. Mask/centroid embeddings are
+    # attached after read_masks / read_centroids.
     embeddings_by_owner = read_embeddings(labels_path, _hdf5_file=f)
     for inst_id, emb_map in embeddings_by_owner.get(OWNER_INSTANCE, {}).items():
         if 0 <= inst_id < len(instances):
@@ -6889,6 +6920,7 @@ def _read_labels_from_open_file(
         if 0 <= identity_idx < len(identities):
             identities[identity_idx].embeddings.update(emb_map)
     mask_embedding_map = embeddings_by_owner.get(OWNER_MASK, {})
+    centroid_embedding_map = embeddings_by_owner.get(OWNER_CENTROID, {})
 
     # Attach per-instance categories (SLP format 2.7+). Additive: absent
     # /instance_categories dataset -> empty mapping and a no-op. Identity-level
@@ -6907,7 +6939,7 @@ def _read_labels_from_open_file(
     # Attach per-mask identity links + embeddings (SLP format 2.5+/2.6+). Masks
     # are returned in global mask-list index order, the same id space written by
     # write_masks / write_identity_links / write_embeddings.
-    _attach_mask_identity_and_embeddings(
+    _attach_identity_and_embeddings(
         [m for m, _v, _f in mask_tuples],
         identities,
         mask_identity_map,
@@ -6916,6 +6948,13 @@ def _read_labels_from_open_file(
     bbox_tuples = read_bboxes(labels_path, videos, tracks, instances, _hdf5_file=f)
     centroid_tuples = read_centroids(
         labels_path, videos, tracks, instances, _hdf5_file=f
+    )
+    # Attach per-centroid identity links + embeddings (global centroid-list index).
+    _attach_identity_and_embeddings(
+        [c for c, _v, _f in centroid_tuples],
+        identities,
+        centroid_identity_map,
+        centroid_embedding_map,
     )
     li_tuples, _li_file = read_label_images(
         labels_path,
@@ -7289,16 +7328,25 @@ def _write_labels_lazy(
     lazy_masks = [
         m for ann_list in lazy_store._mask_by_frame.values() for m in ann_list
     ] + list(lazy_store._undistributed_masks)
+    lazy_centroids = [
+        c for ann_list in lazy_store._centroid_by_frame.values() for c in ann_list
+    ] + list(lazy_store._undistributed_centroids)
     write_identities(labels_path, lazy_store.identities)
     uuid_to_idx = {ident.uuid: i for i, ident in enumerate(lazy_store.identities)}
     identity_rows = _identity_link_rows_from_store(lazy_store)
-    identity_rows.extend(_identity_link_rows_from_masks(lazy_masks, uuid_to_idx))
+    identity_rows.extend(
+        _identity_link_rows_for_owner(lazy_masks, uuid_to_idx, OWNER_MASK)
+    )
+    identity_rows.extend(
+        _identity_link_rows_for_owner(lazy_centroids, uuid_to_idx, OWNER_CENTROID)
+    )
     _write_identity_link_rows(labels_path, identity_rows)
     # Identity links always persist; the appearance vectors are gated by
     # save_embedding_vectors (mirrors the eager path).
     if save_embedding_vectors:
         by_space = _embedding_groups_from_store(lazy_store, lazy_store.identities)
-        _add_mask_embedding_groups(by_space, lazy_masks)
+        _add_owner_embedding_groups(by_space, lazy_masks, OWNER_MASK)
+        _add_owner_embedding_groups(by_space, lazy_centroids, OWNER_CENTROID)
         _write_embedding_groups(labels_path, by_space)
     _write_instance_category_rows(
         labels_path, _instance_category_rows_from_store(lazy_store)

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -19,9 +19,14 @@ Format version history:
     - 2.3: Virtual on-read video crops (/video_crops dataset)
     - 2.4: Persisted mask from_predicted provenance (from_predicted column in
             mask_dtype storing the source prediction's index in the mask list)
-    - 2.5: Added per-instance global identity links (/instance_identities dataset:
-            instance_id, identity_idx, identity_score) joining instances to the
-            identity catalog; additive, read with try/except on dataset presence
+    - 2.5: Added per-detection global identity links (/identity_links dataset:
+            owner_type, owner_id, identity_idx, identity_score) joining a detection
+            to the identity catalog. The owner_type column reuses the shared OWNER_*
+            codes (same scheme as the /embeddings join), so additional detection
+            modalities can be linked without a new dataset or format bump; only
+            instance owners are written today. Additive, read with try/except on
+            dataset presence. (Pre-rename dev files using the instance-only
+            /instance_identities dataset are still read back as instance owners.)
     - 2.6: Added appearance / re-ID embeddings (/embeddings group, one subgroup
             per named space: vectors (n, D) float + owner_type/owner_id join
             columns + per-row meta_json); additive, read on group presence
@@ -1705,16 +1710,23 @@ def write_identities(labels_path: str, identities: list[Identity]):
         f.create_dataset("identities_json", data=identities_json, maxshape=(None,))
 
 
-def read_instance_identities(
+def read_identity_links(
     labels_path: str, *, _hdf5_file: h5py.File | None = None
-) -> dict[int, tuple[int, float | None]]:
-    """Read per-instance identity links from a SLEAP labels file.
+) -> dict[int, dict[int, tuple[int, float | None]]]:
+    """Read per-detection identity links from a SLEAP labels file.
 
-    Links are stored in the optional ``instance_identities`` dataset (SLP format
-    2.5+), a structured array of ``(instance_id, identity_idx, identity_score)``
-    rows joining the global instance id to an index into the file's identity
-    catalog. The dataset is absent in older files, in which case an empty mapping
-    is returned (purely additive; reads are gated on dataset presence).
+    Links are stored in the optional ``identity_links`` dataset (SLP format 2.5+),
+    a structured array of ``(owner_type, owner_id, identity_idx, identity_score)``
+    rows joining a detection -- identified by ``owner_type`` (one of the ``OWNER_*``
+    codes) and ``owner_id`` -- to an index into the file's identity catalog.
+    ``owner_id`` is the per-owner-type positional id (e.g. the global
+    ``instance_id`` assigned by `write_lfs` for instance owners), mirroring the
+    ``/embeddings`` join. The dataset is absent in older files, in which case an
+    empty mapping is returned (purely additive; reads are gated on dataset
+    presence).
+
+    Pre-rename dev files that wrote the instance-only ``instance_identities``
+    dataset (3 columns, no ``owner_type``) are read back as instance owners.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
@@ -1723,67 +1735,82 @@ def read_instance_identities(
             otherwise `labels_path` is opened and closed internally.
 
     Returns:
-        A dict mapping the global ``instance_id`` to a
-        ``(identity_idx, identity_score)`` tuple. ``identity_score`` is ``None``
-        when it was not recorded (stored as NaN).
+        A dict mapping each ``owner_type`` to a ``{owner_id: (identity_idx,
+        identity_score)}`` mapping. ``identity_score`` is ``None`` when it was not
+        recorded (stored as NaN). Empty for older files.
     """
-    try:
-        data = read_hdf5_dataset(
-            labels_path, "instance_identities", _hdf5_file=_hdf5_file
-        )
-    except KeyError:
+    data = None
+    for dataset_name in ("identity_links", "instance_identities"):
+        try:
+            data = read_hdf5_dataset(labels_path, dataset_name, _hdf5_file=_hdf5_file)
+            break
+        except KeyError:
+            continue
+    if data is None:
         return {}
-    result: dict[int, tuple[int, float | None]] = {}
+    fields = data.dtype.names
+    has_owner_type = "owner_type" in fields
+    id_field = "owner_id" if "owner_id" in fields else "instance_id"
+    result: dict[int, dict[int, tuple[int, float | None]]] = {}
     for row in data:
+        owner_type = int(row["owner_type"]) if has_owner_type else OWNER_INSTANCE
         score = float(row["identity_score"])
-        result[int(row["instance_id"])] = (
+        result.setdefault(owner_type, {})[int(row[id_field])] = (
             int(row["identity_idx"]),
             None if np.isnan(score) else score,
         )
     return result
 
 
-def _write_instance_identity_rows(
-    labels_path: str, rows: list[tuple[int, int, float]]
+def _write_identity_link_rows(
+    labels_path: str, rows: list[tuple[int, int, int, float]]
 ) -> None:
-    """Write ``(instance_id, identity_idx, identity_score)`` rows to a SLP file.
+    """Write ``(owner_type, owner_id, identity_idx, identity_score)`` rows.
 
-    Shared dataset-writing core for the per-instance identity link. The rows can
+    Shared dataset-writing core for the per-detection identity link. The rows can
     be built either by iterating a `Labels` (the eager path, see
-    `write_instance_identities`) or from a lazy store dict (the lazy save path),
-    keeping the on-disk ``instance_identities`` layout identical for both.
+    `write_identity_links`) or from a lazy store dict (the lazy save path), keeping
+    the on-disk ``identity_links`` layout identical for both.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
-        rows: A list of ``(instance_id, identity_idx, identity_score)`` tuples.
-            ``identity_score`` is a float (NaN encodes an unrecorded score). An
-            empty list is a no-op (no dataset is created).
+        rows: A list of ``(owner_type, owner_id, identity_idx, identity_score)``
+            tuples. ``owner_type`` is one of the ``OWNER_*`` codes; ``owner_id`` is
+            the per-owner-type positional id. ``identity_score`` is a float (NaN
+            encodes an unrecorded score). An empty list is a no-op (no dataset is
+            created).
     """
     if not rows:
         return
 
-    instance_identity_dtype = np.dtype(
+    identity_link_dtype = np.dtype(
         [
-            ("instance_id", "i8"),
+            ("owner_type", "u1"),
+            ("owner_id", "i8"),
             ("identity_idx", "i4"),
             ("identity_score", "f4"),
         ]
     )
-    arr = np.array(rows, dtype=instance_identity_dtype)
+    arr = np.array(rows, dtype=identity_link_dtype)
     with h5py.File(labels_path, "a") as f:
-        f.create_dataset("instance_identities", data=arr, maxshape=(None,))
+        f.create_dataset("identity_links", data=arr, maxshape=(None,))
 
 
-def write_instance_identities(labels_path: str, labels: Labels) -> None:
-    """Write per-instance identity links to a SLEAP labels file.
+def write_identity_links(labels_path: str, labels: Labels) -> None:
+    """Write per-detection identity links to a SLEAP labels file.
 
-    Creates the ``instance_identities`` dataset (SLP format 2.5+) as a structured
-    array of ``(instance_id, identity_idx, identity_score)`` rows for every
-    instance carrying an `Identity` that is registered in ``labels.identities``.
-    The ``instance_id`` matches the global id assigned by `write_lfs` (enumeration
-    order over frames then instances), so the link is resolved by joining on that
-    id at read time. This keeps identity out of the fixed-layout ``instances``
-    dataset, making it purely additive: old readers simply ignore the dataset.
+    Creates the ``identity_links`` dataset (SLP format 2.5+) as a structured array
+    of ``(owner_type, owner_id, identity_idx, identity_score)`` rows for every
+    detection carrying an `Identity` that is registered in ``labels.identities``.
+    Today only instance owners (``OWNER_INSTANCE``) are written; the ``owner_type``
+    column is owner-type-aware (same scheme as the ``/embeddings`` join) so other
+    detection modalities can be linked later without a new dataset or format bump.
+
+    The instance ``owner_id`` matches the global id assigned by `write_lfs`
+    (enumeration order over frames then instances), so the link is resolved by
+    joining on that id at read time. This keeps identity out of the fixed-layout
+    ``instances`` dataset, making it purely additive: old readers simply ignore
+    the dataset.
 
     Args:
         labels_path: A string path to the SLEAP labels file.
@@ -1802,6 +1829,7 @@ def write_instance_identities(labels_path: str, labels: Labels) -> None:
                 score = inst.identity_score
                 rows.append(
                     (
+                        OWNER_INSTANCE,
                         instance_id,
                         identity_idx,
                         float("nan") if score is None else float(score),
@@ -1809,31 +1837,33 @@ def write_instance_identities(labels_path: str, labels: Labels) -> None:
                 )
             instance_id += 1
 
-    _write_instance_identity_rows(labels_path, rows)
+    _write_identity_link_rows(labels_path, rows)
 
 
-def _instance_identity_rows_from_store(
+def _identity_link_rows_from_store(
     store: "LazyDataStore",
-) -> list[tuple[int, int, float]]:
-    """Build ``instance_identities`` rows from a lazy store without materializing.
+) -> list[tuple[int, int, int, float]]:
+    """Build ``identity_links`` rows from a lazy store without materializing.
 
     The lazy store already holds the per-instance identity links keyed by the
     global ``instance_id`` (the same id space written by the fast path), so the
-    rows can be emitted directly without rebuilding `Instance` objects. Rows are
-    sorted by ``instance_id`` for deterministic output.
+    rows can be emitted directly as ``OWNER_INSTANCE`` owners without rebuilding
+    `Instance` objects. Rows are sorted by ``instance_id`` for deterministic
+    output.
 
     Args:
         store: The `LazyDataStore` backing a lazy `Labels`.
 
     Returns:
-        A list of ``(instance_id, identity_idx, identity_score)`` tuples matching
-        the format expected by `_write_instance_identity_rows`.
+        A list of ``(owner_type, owner_id, identity_idx, identity_score)`` tuples
+        matching the format expected by `_write_identity_link_rows`.
     """
     rows = []
     for instance_id in sorted(store._instance_identities):
         identity_idx, score = store._instance_identities[instance_id]
         rows.append(
             (
+                OWNER_INSTANCE,
                 int(instance_id),
                 int(identity_idx),
                 float("nan") if score is None else float(score),
@@ -1962,29 +1992,33 @@ def _instance_category_rows_from_store(
     return rows
 
 
-# Owner-type codes for the /embeddings owner_type join column.
+# Owner-type codes for the owner_type join column shared by the /embeddings group
+# and the /identity_links dataset.
 #
-# Only instance and identity owners are written today. Codes 2-7 are reserved
-# (not yet implemented) so per-modality embedding persistence can be completed
-# later without renumbering or breaking existing files:
+# Both subsystems join a detection (or, for embeddings, an identity prototype) to a
+# per-row payload via an (owner_type, owner_id) pair, so they share one code set:
+# this guarantees the two join schemes can never drift (e.g. mask=3 in one table
+# and mask=4 in the other). Only instance and identity owners are written today.
+# Codes 2-7 are reserved (not yet written or read) so per-modality persistence can
+# be completed later without renumbering or breaking existing files:
 #   2 = centroid
 #   3 = mask
 #   4 = bbox
 #   5 = roi
 #   6 = frame
 #   7 = track
-# When adding a new owner type, define its named constant here and extend both
-# the builders feeding `_write_embedding_groups` and the `read_embeddings`
-# dispatch on `owner_type`.
-EMBEDDING_OWNER_INSTANCE = 0
-EMBEDDING_OWNER_IDENTITY = 1
+# When adding a new owner type, define its named constant here and extend the
+# relevant builders (feeding `_write_embedding_groups` / `_write_identity_link_rows`)
+# and the `read_embeddings` / `read_identity_links` dispatch on `owner_type`.
+OWNER_INSTANCE = 0
+OWNER_IDENTITY = 1
 # Reserved for future use (see note above); not yet written or read.
-EMBEDDING_OWNER_CENTROID = 2
-EMBEDDING_OWNER_MASK = 3
-EMBEDDING_OWNER_BBOX = 4
-EMBEDDING_OWNER_ROI = 5
-EMBEDDING_OWNER_FRAME = 6
-EMBEDDING_OWNER_TRACK = 7
+OWNER_CENTROID = 2
+OWNER_MASK = 3
+OWNER_BBOX = 4
+OWNER_ROI = 5
+OWNER_FRAME = 6
+OWNER_TRACK = 7
 
 
 def read_embeddings(
@@ -2022,6 +2056,7 @@ def read_embeddings(
             return instance_embeddings, identity_embeddings
 
         group = f["embeddings"]
+        unknown_owner_types: set[int] = set()
         for space in group:
             sub = group[space]
             vectors = sub["vectors"][:]
@@ -2029,8 +2064,23 @@ def read_embeddings(
             owner_id = sub["owner_id"][:]
             meta_json = sub["meta_json"][:]
             for i in range(len(vectors)):
+                otype = int(owner_type[i])
+                oid = int(owner_id[i])
+                # Build the Embedding lazily-ish: only after the owner type is one
+                # we attach, to avoid materializing vectors we are about to skip.
+                if otype == OWNER_IDENTITY:
+                    target = identity_embeddings
+                elif otype == OWNER_INSTANCE:
+                    target = instance_embeddings
+                else:
+                    # Reserved owner types (centroid/mask/bbox/roi/frame/track) are
+                    # not attached on read yet. Skip rather than fall through to
+                    # instances, which would silently bind the vector to a different
+                    # object (wrong-object corruption). Collected for one warning.
+                    unknown_owner_types.add(otype)
+                    continue
                 meta = json.loads(meta_json[i])
-                emb = Embedding(
+                target.setdefault(oid, {})[space] = Embedding(
                     vector=vectors[i],
                     name=space,
                     normalized=meta.get("normalized", True),
@@ -2038,11 +2088,14 @@ def read_embeddings(
                     centroid_xy=meta.get("centroid_xy"),
                     metadata=meta.get("metadata", {}),
                 )
-                oid = int(owner_id[i])
-                if int(owner_type[i]) == EMBEDDING_OWNER_IDENTITY:
-                    identity_embeddings.setdefault(oid, {})[space] = emb
-                else:
-                    instance_embeddings.setdefault(oid, {})[space] = emb
+        if unknown_owner_types:
+            warnings.warn(
+                "Skipped /embeddings rows with unsupported owner_type(s) "
+                f"{sorted(unknown_owner_types)}: only instance and identity "
+                "embeddings are attached on read. These vectors were written by a "
+                "newer sleap-io and are ignored here.",
+                stacklevel=2,
+            )
 
     return instance_embeddings, identity_embeddings
 
@@ -2110,14 +2163,12 @@ def _embedding_groups_from_labels(labels: Labels) -> dict[str, list]:
     for lf in labels:
         for inst in lf:
             for name, emb in getattr(inst, "embeddings", {}).items():
-                by_space.setdefault(name, []).append(
-                    (EMBEDDING_OWNER_INSTANCE, instance_id, emb)
-                )
+                by_space.setdefault(name, []).append((OWNER_INSTANCE, instance_id, emb))
             instance_id += 1
 
     for idx, identity in enumerate(labels.identities):
         for name, emb in identity.embeddings.items():
-            by_space.setdefault(name, []).append((EMBEDDING_OWNER_IDENTITY, idx, emb))
+            by_space.setdefault(name, []).append((OWNER_IDENTITY, idx, emb))
 
     return by_space
 
@@ -2147,12 +2198,12 @@ def _embedding_groups_from_store(
     for instance_id in sorted(store._instance_embeddings):
         for name, emb in store._instance_embeddings[instance_id].items():
             by_space.setdefault(name, []).append(
-                (EMBEDDING_OWNER_INSTANCE, int(instance_id), emb)
+                (OWNER_INSTANCE, int(instance_id), emb)
             )
 
     for idx, identity in enumerate(identities):
         for name, emb in identity.embeddings.items():
-            by_space.setdefault(name, []).append((EMBEDDING_OWNER_IDENTITY, idx, emb))
+            by_space.setdefault(name, []).append((OWNER_IDENTITY, idx, emb))
 
     return by_space
 
@@ -3870,7 +3921,12 @@ def _read_labels_lazy_from_open_file(
     skeletons = read_skeletons(labels_path, _hdf5_file=f)
     tracks = read_tracks(labels_path, _hdf5_file=f)
     identities = read_identities(labels_path, _hdf5_file=f)
-    instance_identities = read_instance_identities(labels_path, _hdf5_file=f)
+    # Identity links: only instance owners ride on the lazy store (keyed by global
+    # instance_id) and attach at materialization time. Other owner types, when
+    # present, are handled by their own eager readers.
+    instance_identities = read_identity_links(labels_path, _hdf5_file=f).get(
+        OWNER_INSTANCE, {}
+    )
     # Embeddings: identity prototypes attach to the eager catalog now; per-instance
     # embeddings ride on the lazy store and attach at materialization time.
     instance_embeddings, identity_embeddings = read_embeddings(
@@ -6699,7 +6755,11 @@ def _read_labels_from_open_file(
     # Attach per-instance identity links (SLP format 2.5+). Additive: when the
     # dataset is absent (older files) this is an empty mapping and a no-op. The
     # global instances list is ordered by instance_id, so it indexes directly.
-    instance_identity_map = read_instance_identities(labels_path, _hdf5_file=f)
+    # Only instance owners are consumed here; other owner types have their own
+    # eager readers.
+    instance_identity_map = read_identity_links(labels_path, _hdf5_file=f).get(
+        OWNER_INSTANCE, {}
+    )
     for inst_id, (identity_idx, identity_score) in instance_identity_map.items():
         if 0 <= inst_id < len(instances) and 0 <= identity_idx < len(identities):
             instances[inst_id].identity = identities[identity_idx]
@@ -6904,6 +6964,10 @@ _KNOWN_TOPLEVEL_HDF5_NAMES = frozenset(
         "suggestions_json",
         "sessions_json",
         "identities_json",
+        "identity_links",
+        # Legacy name for the pre-rename instance-only identity-link dataset; kept
+        # known so in-flight dev files written before the rename are not treated as
+        # unknown and stashed (they are read back via read_identity_links).
         "instance_identities",
         "embeddings",
         "instance_categories",
@@ -7087,16 +7151,14 @@ def _write_labels_lazy(
 
     # Write other metadata
     write_tracks(labels_path, labels.tracks)
-    # Persist identities + per-instance identity links + embeddings directly from
+    # Persist identities + per-detection identity links + embeddings directly from
     # the lazy store, mirroring the eager writer (write_identities /
-    # write_instance_identities / write_embeddings) but driven by the store dicts
-    # so no LabeledFrame/Instance is materialized. The store keys ARE the global
+    # write_identity_links / write_embeddings) but driven by the store dicts so no
+    # LabeledFrame/Instance is materialized. The store keys ARE the global
     # instance_ids written above, so the join stays consistent with the raw
     # instances emitted by the fast path.
     write_identities(labels_path, lazy_store.identities)
-    _write_instance_identity_rows(
-        labels_path, _instance_identity_rows_from_store(lazy_store)
-    )
+    _write_identity_link_rows(labels_path, _identity_link_rows_from_store(lazy_store))
     _write_embedding_groups(
         labels_path,
         _embedding_groups_from_store(lazy_store, lazy_store.identities),
@@ -7367,7 +7429,7 @@ def write_labels(
     write_video_crops(labels_path, labels)
     write_tracks(labels_path, labels.tracks)
     write_identities(labels_path, labels.identities)
-    write_instance_identities(labels_path, labels)
+    write_identity_links(labels_path, labels)
     write_embeddings(labels_path, labels)
     write_instance_categories(labels_path, labels)
     write_suggestions(labels_path, labels.suggestions, labels.videos)

--- a/sleap_io/model/bbox.py
+++ b/sleap_io/model/bbox.py
@@ -22,6 +22,7 @@ from sleap_io.model.embedding import EmbeddingMixin
 
 if TYPE_CHECKING:
     from sleap_io.model.embedding import Embedding
+    from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, Track
     from sleap_io.model.mask import SegmentationMask
     from sleap_io.model.roi import ROI
@@ -43,6 +44,13 @@ class BoundingBox(EmbeddingMixin):
         track: Optional tracking identity.
         tracking_score: Confidence of the track identity assignment. ``None``
             if unassigned or manually assigned.
+        identity: Optional global, ground-truth `Identity` for this box -- the
+            persistent cross-video animal identity / re-identification key. ``None``
+            if no global identity is assigned. Mirrors `Instance.identity`.
+        identity_score: Score associated with the `identity` assignment (e.g. the
+            re-ID match similarity). ``None`` if unassigned or assigned manually.
+            Kept separate from `tracking_score` (short-term tracklet vs long-term
+            identity).
         instance: Optional linked pose instance.
         category: Class label (e.g., "mouse", "fly").
         name: Human-readable name.
@@ -65,6 +73,8 @@ class BoundingBox(EmbeddingMixin):
     angle: float = attrs.field(default=0.0)
     track: "Track | None" = attrs.field(default=None)
     tracking_score: float | None = attrs.field(default=None)
+    identity: "Identity | None" = attrs.field(default=None)
+    identity_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
     category: str = attrs.field(default="")
     name: str = attrs.field(default="")
@@ -279,6 +289,8 @@ class BoundingBox(EmbeddingMixin):
             source=self.source,
             track=self.track,
             tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
             instance=self.instance,
         )
 

--- a/sleap_io/model/centroid.py
+++ b/sleap_io/model/centroid.py
@@ -24,6 +24,7 @@ from sleap_io.model.embedding import EmbeddingMixin
 
 if TYPE_CHECKING:
     from sleap_io.model.embedding import Embedding
+    from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, PredictedInstance, Track
     from sleap_io.model.skeleton import Skeleton
 
@@ -76,6 +77,13 @@ class Centroid(EmbeddingMixin):
         track: Optional tracking identity.
         tracking_score: Confidence of the track identity assignment. ``None``
             if unassigned or manually assigned.
+        identity: Optional global, ground-truth `Identity` for this centroid -- the
+            persistent cross-video animal identity / re-identification key. ``None``
+            if no global identity is assigned. Mirrors `Instance.identity`.
+        identity_score: Score associated with the `identity` assignment (e.g. the
+            re-ID match similarity). ``None`` if unassigned or assigned manually.
+            Kept separate from `tracking_score` (short-term tracklet vs long-term
+            identity).
         instance: Optional linked pose instance.
         category: Class label (e.g., ``"lysosome"``, ``"cell"``).
         name: Human-readable name (e.g., ``"ID43008"``).
@@ -97,6 +105,8 @@ class Centroid(EmbeddingMixin):
     z: float | None = attrs.field(default=None)
     track: "Track | None" = attrs.field(default=None)
     tracking_score: float | None = attrs.field(default=None)
+    identity: "Identity | None" = attrs.field(default=None)
+    identity_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
     category: str = attrs.field(default="")
     name: str = attrs.field(default="")
@@ -169,6 +179,8 @@ class Centroid(EmbeddingMixin):
                 score=self.score,
                 track=self.track,
                 tracking_score=self.tracking_score,
+                identity=self.identity,
+                identity_score=self.identity_score,
             )
         else:
             return Instance.from_numpy(
@@ -176,6 +188,8 @@ class Centroid(EmbeddingMixin):
                 skeleton=skeleton,
                 track=self.track,
                 tracking_score=self.tracking_score,
+                identity=self.identity,
+                identity_score=self.identity_score,
             )
 
     @classmethod
@@ -251,6 +265,8 @@ class Centroid(EmbeddingMixin):
             y=y,
             track=instance.track,
             tracking_score=instance.tracking_score,
+            identity=instance.identity,
+            identity_score=instance.identity_score,
             instance=instance,
             source=method if method != "anchor" else f"anchor:{node}",
         )

--- a/sleap_io/model/identity.py
+++ b/sleap_io/model/identity.py
@@ -87,8 +87,13 @@ class Identity(EmbeddingMixin, CategoriesMixin):
             raise ValueError(f"Unknown matching method: {method}")
 
     def __repr__(self) -> str:
-        """Return a readable string representation."""
-        parts = [f'Identity(name="{self.name}"']
+        """Return a readable string representation.
+
+        Surfaces a truncated `uuid` so two identities that differ only by their
+        (object-identity) `uuid` do not `repr()` identically -- useful when
+        spotting cross-file mismatches in logs.
+        """
+        parts = [f'Identity(name="{self.name}", uuid="{self.uuid[:8]}…"']
         if self.color is not None:
             parts.append(f', color="{self.color}"')
         parts.append(")")

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -512,8 +512,9 @@ class Labels:
                 if inst.identity is not None and inst.identity not in self.identities:
                     self.identities.append(inst.identity)
 
-            # Collect tracks from nested annotations
+            # Collect tracks and identities from nested annotations
             self._collect_annotation_tracks(lf)
+            self._collect_annotation_identities(lf)
 
         # Collect multi-view identities bound only on InstanceGroups (sessions).
         self._collect_session_identities()
@@ -903,6 +904,49 @@ class Labels:
                 if info.track is not None and info.track not in self.tracks:
                     self.tracks.append(info.track)
 
+    def _collect_annotation_identities(self, lf: LabeledFrame):
+        """Collect identities from non-instance annotations on a frame.
+
+        Mirrors `_collect_annotation_tracks` for the global `Identity` catalog.
+        Currently only `SegmentationMask` carries an `identity`; deduped by object
+        identity (``not in``), matching the instance-identity collection in
+        update/append/extend.
+        """
+        for m in lf.masks:
+            if m.identity is not None and m.identity not in self.identities:
+                self.identities.append(m.identity)
+
+    def _collect_identities(self):
+        """Register every detection's `Identity` in the catalog, deduped by uuid.
+
+        Called at save time so a producer that sets ``inst.identity`` /
+        ``mask.identity`` without also registering it in ``self.identities`` does
+        not silently drop the link on write. Unlike the build-path collectors
+        (object-identity dedup), this dedupes by the stable cross-file ``uuid``:
+        any pre-existing uuid-duplicate catalog entries are first collapsed (the
+        first per uuid is kept), then every detection identity is registered via
+        `add_identity` (uuid match). The on-disk link resolves by uuid, so all
+        detections sharing a uuid point at the one canonical entry. Mutates
+        ``self.identities`` (eager labels only).
+        """
+        # Collapse any uuid-duplicate catalog entries (keep first seen per uuid).
+        seen: set[str] = set()
+        deduped: list[Identity] = []
+        for ident in self.identities:
+            if ident.uuid not in seen:
+                seen.add(ident.uuid)
+                deduped.append(ident)
+        self.identities[:] = deduped
+
+        for lf in self.labeled_frames:
+            for inst in lf:
+                if inst.identity is not None:
+                    self.add_identity(inst.identity)
+            for m in lf.masks:
+                if m.identity is not None:
+                    self.add_identity(m.identity)
+        self._collect_session_identities()
+
     def _collect_session_identities(self):
         """Collect multi-view identities bound only on `InstanceGroup`s.
 
@@ -950,6 +994,7 @@ class Labels:
                     self.identities.append(inst.identity)
 
             self._collect_annotation_tracks(lf)
+            self._collect_annotation_identities(lf)
             self._collect_session_identities()
 
     def extend(self, lfs: list[LabeledFrame], update: bool = True):
@@ -985,6 +1030,7 @@ class Labels:
                         self.identities.append(inst.identity)
 
                 self._collect_annotation_tracks(lf)
+                self._collect_annotation_identities(lf)
 
             self._collect_session_identities()
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1663,7 +1663,11 @@ class Labels:
             verbose: If `True` (the default), display a progress bar when embedding
                 frames.
             **kwargs: Additional format-specific arguments passed to the save function.
-                See `save_file` for format-specific options.
+                See `save_file` for format-specific options. For SLP this includes
+                `save_id_embeddings` (default `True`): set `False` to persist
+                identity *links* but skip the large re-ID appearance `/embeddings`
+                vectors (kept in memory). Note this is distinct from `embed`, which
+                embeds *video frames*.
         """
         from pathlib import Path
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -908,19 +908,20 @@ class Labels:
         """Collect identities from non-instance annotations on a frame.
 
         Mirrors `_collect_annotation_tracks` for the global `Identity` catalog.
-        `SegmentationMask` and `Centroid` carry an `identity`; deduped by object
-        identity (``not in``), matching the instance-identity collection in
-        update/append/extend.
+        `SegmentationMask`, `Centroid`, `BoundingBox`, and `ROI` carry an
+        `identity`; deduped by object identity (``not in``), matching the
+        instance-identity collection in update/append/extend. Static ROIs (not
+        frame-bound) are swept by the save-time `_collect_identities`.
         """
-        for ann in (*lf.masks, *lf.centroids):
+        for ann in (*lf.masks, *lf.centroids, *lf.bboxes, *lf.rois):
             if ann.identity is not None and ann.identity not in self.identities:
                 self.identities.append(ann.identity)
 
     def _collect_identities(self):
         """Register every detection's `Identity` in the catalog, deduped by uuid.
 
-        Called at save time so a producer that sets ``inst.identity`` /
-        ``mask.identity`` / ``centroid.identity`` without also registering it in
+        Called at save time so a producer that sets an `identity` on any detection
+        (instance / mask / centroid / bbox / ROI) without also registering it in
         ``self.identities`` does not silently drop the link on write. Unlike the
         build-path collectors (object-identity dedup), this dedupes by the stable
         cross-file ``uuid``: any pre-existing uuid-duplicate catalog entries are
@@ -942,9 +943,12 @@ class Labels:
             for inst in lf:
                 if inst.identity is not None:
                     self.add_identity(inst.identity)
-            for ann in (*lf.masks, *lf.centroids):
+            for ann in (*lf.masks, *lf.centroids, *lf.bboxes, *lf.rois):
                 if ann.identity is not None:
                     self.add_identity(ann.identity)
+        for roi in self.static_rois:
+            if roi.identity is not None:
+                self.add_identity(roi.identity)
         self._collect_session_identities()
 
     def _collect_session_identities(self):

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -908,26 +908,26 @@ class Labels:
         """Collect identities from non-instance annotations on a frame.
 
         Mirrors `_collect_annotation_tracks` for the global `Identity` catalog.
-        Currently only `SegmentationMask` carries an `identity`; deduped by object
+        `SegmentationMask` and `Centroid` carry an `identity`; deduped by object
         identity (``not in``), matching the instance-identity collection in
         update/append/extend.
         """
-        for m in lf.masks:
-            if m.identity is not None and m.identity not in self.identities:
-                self.identities.append(m.identity)
+        for ann in (*lf.masks, *lf.centroids):
+            if ann.identity is not None and ann.identity not in self.identities:
+                self.identities.append(ann.identity)
 
     def _collect_identities(self):
         """Register every detection's `Identity` in the catalog, deduped by uuid.
 
         Called at save time so a producer that sets ``inst.identity`` /
-        ``mask.identity`` without also registering it in ``self.identities`` does
-        not silently drop the link on write. Unlike the build-path collectors
-        (object-identity dedup), this dedupes by the stable cross-file ``uuid``:
-        any pre-existing uuid-duplicate catalog entries are first collapsed (the
-        first per uuid is kept), then every detection identity is registered via
-        `add_identity` (uuid match). The on-disk link resolves by uuid, so all
-        detections sharing a uuid point at the one canonical entry. Mutates
-        ``self.identities`` (eager labels only).
+        ``mask.identity`` / ``centroid.identity`` without also registering it in
+        ``self.identities`` does not silently drop the link on write. Unlike the
+        build-path collectors (object-identity dedup), this dedupes by the stable
+        cross-file ``uuid``: any pre-existing uuid-duplicate catalog entries are
+        first collapsed (the first per uuid is kept), then every detection identity
+        is registered via `add_identity` (uuid match). The on-disk link resolves by
+        uuid, so all detections sharing a uuid point at the one canonical entry.
+        Mutates ``self.identities`` (eager labels only).
         """
         # Collapse any uuid-duplicate catalog entries (keep first seen per uuid).
         seen: set[str] = set()
@@ -942,9 +942,9 @@ class Labels:
             for inst in lf:
                 if inst.identity is not None:
                     self.add_identity(inst.identity)
-            for m in lf.masks:
-                if m.identity is not None:
-                    self.add_identity(m.identity)
+            for ann in (*lf.masks, *lf.centroids):
+                if ann.identity is not None:
+                    self.add_identity(ann.identity)
         self._collect_session_identities()
 
     def _collect_session_identities(self):

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -2409,6 +2409,57 @@ class Labels:
         self.videos.append(video)
         return video
 
+    def add_identity(self, identity: Identity, match: str = "uuid") -> Identity:
+        """Add an `Identity` to the catalog, deduping by the given match method.
+
+        Idempotent registration helper for `Labels.identities` (mirrors
+        `add_video`). Because `Identity` is ``eq=False`` (object-identity
+        equality), the plain catalog list does not dedup by the stable cross-file
+        ``uuid``, so a producer attaching one shared `Identity` to many detections
+        must funnel through this method to avoid catalog duplication.
+
+        Args:
+            identity: The identity to register.
+            match: Matching method passed to `Identity.matches` -- one of
+                ``"uuid"`` (default; the canonical cross-file key), ``"name"``, or
+                ``"identity"`` (Python object identity). This selects a single
+                method; it is not a uuid-then-name fallback chain.
+
+        Returns:
+            The canonical `Identity` to use: the pre-existing catalog entry if one
+            matches, otherwise the input ``identity`` (now appended).
+        """
+        for existing in self.identities:
+            if existing.matches(identity, method=match):
+                return existing
+        self.identities.append(identity)
+        return identity
+
+    def get_identity(
+        self, *, uuid: str | None = None, name: str | None = None
+    ) -> Identity | None:
+        """Find an `Identity` in the catalog by ``uuid`` or ``name``.
+
+        Args:
+            uuid: The stable ``uuid`` to look up. Mutually exclusive with ``name``.
+            name: The ``name`` to look up. Mutually exclusive with ``uuid``. Names
+                are not required to be unique, so the first match is returned.
+
+        Returns:
+            The first matching `Identity`, or ``None`` if none matches.
+
+        Raises:
+            ValueError: If neither or both of ``uuid`` / ``name`` are provided.
+        """
+        if (uuid is None) == (name is None):
+            raise ValueError("Provide exactly one of `uuid` or `name`.")
+        for identity in self.identities:
+            if uuid is not None and identity.uuid == uuid:
+                return identity
+            if name is not None and identity.name == name:
+                return identity
+        return None
+
     def replace_videos(
         self,
         old_videos: list[Video] | None = None,

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1664,7 +1664,7 @@ class Labels:
                 frames.
             **kwargs: Additional format-specific arguments passed to the save function.
                 See `save_file` for format-specific options. For SLP this includes
-                `save_id_embeddings` (default `True`): set `False` to persist
+                `save_embedding_vectors` (default `True`): set `False` to persist
                 identity *links* but skip the large re-ID appearance `/embeddings`
                 vectors (kept in memory). Note this is distinct from `embed`, which
                 embeds *video frames*.

--- a/sleap_io/model/mask.py
+++ b/sleap_io/model/mask.py
@@ -353,8 +353,8 @@ class SegmentationMask(EmbeddingMixin):
         """Convert to a BoundingBox object.
 
         Returns a ``UserBoundingBox`` or ``PredictedBoundingBox`` with metadata
-        (track, category, name, instance) inherited from this mask. Coordinates
-        are in image space (respecting scale/offset).
+        (track, identity, category, name, instance) inherited from this mask.
+        Coordinates are in image space (respecting scale/offset).
 
         Returns:
             A ``BoundingBox`` matching this mask's tight bounding box.
@@ -366,6 +366,8 @@ class SegmentationMask(EmbeddingMixin):
         kwargs: dict = dict(
             track=self.track,
             tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
             instance=self.instance,
             category=self.category,
             name=self.name,
@@ -421,6 +423,8 @@ class SegmentationMask(EmbeddingMixin):
             source=self.source,
             track=self.track,
             tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
             instance=self.instance,
         )
 

--- a/sleap_io/model/mask.py
+++ b/sleap_io/model/mask.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
     from sleap_io.model.bbox import BoundingBox
     from sleap_io.model.embedding import Embedding
+    from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, Track
     from sleap_io.model.roi import ROI
 
@@ -130,6 +131,13 @@ class SegmentationMask(EmbeddingMixin):
         track: Optional `Track` this mask is associated with.
         tracking_score: Confidence of the track identity assignment. ``None``
             if unassigned or manually assigned.
+        identity: Optional global, ground-truth `Identity` for this mask -- the
+            persistent cross-video animal identity / re-identification key. ``None``
+            if no global identity is assigned. Mirrors `Instance.identity`.
+        identity_score: Score associated with the `identity` assignment (e.g. the
+            re-ID match similarity). ``None`` if unassigned or assigned manually.
+            Kept separate from `tracking_score` (short-term tracklet vs long-term
+            identity).
         instance: Optional `Instance` this mask is associated with.
         scale: Resolution ratio ``(sx, sy)`` where ``sx = mask_width / image_width``
             and ``sy = mask_height / image_height``. ``(1.0, 1.0)`` means full
@@ -156,6 +164,8 @@ class SegmentationMask(EmbeddingMixin):
     source: str = attrs.field(default="")
     track: "Track | None" = attrs.field(default=None)
     tracking_score: float | None = attrs.field(default=None)
+    identity: "Identity | None" = attrs.field(default=None)
+    identity_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
     _instance_idx: int = attrs.field(default=-1, repr=False, eq=False, init=False)
     scale: tuple[float, float] = attrs.field(default=(1.0, 1.0))
@@ -213,6 +223,8 @@ class SegmentationMask(EmbeddingMixin):
             source=self.source,
             track=self.track,
             tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
             instance=self.instance,
             scale=(1.0, 1.0),
             offset=(0.0, 0.0),
@@ -458,7 +470,8 @@ class PredictedSegmentationMask(SegmentationMask):
 
         Returns a new `UserSegmentationMask` carrying a copy of the RLE raster
         and all shared metadata (`name`, `category`, `source`, `track`,
-        `tracking_score`, `instance`, `scale`, `offset`). The prediction-only
+        `tracking_score`, `identity`, `identity_score`, `instance`, `scale`,
+        `offset`). The prediction-only
         fields (`score`, `score_map`, `score_map_scale`, `score_map_offset`)
         are dropped. This is the predicted -> user adoption path for the
         inference -> human-correct -> retrain loop, mirroring
@@ -490,6 +503,8 @@ class PredictedSegmentationMask(SegmentationMask):
             source=self.source,
             track=self.track,
             tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
             instance=self.instance,
             scale=self.scale,
             offset=self.offset,

--- a/sleap_io/model/roi.py
+++ b/sleap_io/model/roi.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from shapely.geometry.base import BaseGeometry
 
     from sleap_io.model.embedding import Embedding
+    from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, Track
     from sleap_io.model.mask import SegmentationMask
     from sleap_io.model.video import Video
@@ -62,6 +63,13 @@ class ROI(EmbeddingMixin):
         track: Optional `Track` this ROI is associated with.
         tracking_score: Confidence of the track identity assignment. ``None``
             if unassigned or manually assigned.
+        identity: Optional global, ground-truth `Identity` for this ROI -- the
+            persistent cross-video animal identity / re-identification key. ``None``
+            if no global identity is assigned. Mirrors `Instance.identity`.
+        identity_score: Score associated with the `identity` assignment (e.g. the
+            re-ID match similarity). ``None`` if unassigned or assigned manually.
+            Kept separate from `tracking_score` (short-term tracklet vs long-term
+            identity).
         instance: Optional `Instance` this ROI is associated with. Persisted in
             SLP format (v1.6+) via instance index.
         embeddings: Mapping from embedding-space name to an `Embedding` describing
@@ -91,6 +99,8 @@ class ROI(EmbeddingMixin):
     video: "Video | None" = attrs.field(default=None)
     track: "Track | None" = attrs.field(default=None)
     tracking_score: float | None = attrs.field(default=None)
+    identity: "Identity | None" = attrs.field(default=None)
+    identity_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
     embeddings: dict[str, Embedding] = attrs.field(factory=dict, repr=False)
 
@@ -317,6 +327,8 @@ class ROI(EmbeddingMixin):
             source=self.source,
             track=self.track,
             tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
             instance=self.instance,
         )
         if self.is_predicted:
@@ -352,6 +364,8 @@ class ROI(EmbeddingMixin):
                     video=self.video,
                     track=self.track,
                     tracking_score=self.tracking_score,
+                    identity=self.identity,
+                    identity_score=self.identity_score,
                     instance=self.instance,
                     **extra,
                 )

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -43,13 +43,14 @@ from sleap_io.io.slp import (
     METADATA_ATTR_SIZE_LIMIT,
     OBJ_DTYPE,
     OWNER_BBOX,
+    OWNER_CENTROID,
     OWNER_IDENTITY,
     OWNER_INSTANCE,
     OWNER_MASK,
     ExportCancelled,
     LabelImageWriter,
     _encode_metadata_attr,
-    _identity_link_rows_from_masks,
+    _identity_link_rows_for_owner,
     _is_known_toplevel_name,
     _points_from_hdf5_data,
     _read_source_video_json,
@@ -1363,6 +1364,59 @@ def test_mask_identity_round_trip_lazy_save(tmp_path):
     np.testing.assert_array_equal(rm.embedding.vector, np.ones(5))
 
 
+def test_centroid_identity_and_embedding_round_trip(tmp_path):
+    """Per-centroid identity links + embeddings round-trip via SLP (owner_type=2)."""
+    video = Video(filename="test.mp4")
+    id_a = Identity(name="cell_A")
+    c1 = UserCentroid(x=5.0, y=6.0, identity=id_a, identity_score=0.8)
+    c1.set_embedding(np.arange(4, dtype=np.float32))
+    c2 = PredictedCentroid(x=1.0, y=2.0, score=0.9)  # no identity / embedding
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, centroids=[c1, c2])])
+    labels.update()
+
+    path = str(tmp_path / "centroid_ids.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] >= 2.6
+        links = f["identity_links"][:]
+        assert set(links["owner_type"].tolist()) == {OWNER_CENTROID}
+        assert links["owner_id"].tolist() == [0]
+        assert set(f["embeddings/reid/owner_type"][:].tolist()) == {OWNER_CENTROID}
+
+    loaded = load_slp(path)
+    lc = list(loaded[0].centroids)
+    assert lc[0].identity is not None and lc[0].identity.uuid == id_a.uuid
+    assert lc[0].identity_score == pytest.approx(0.8)
+    np.testing.assert_array_equal(lc[0].embedding.vector, np.arange(4))
+    assert lc[1].identity is None
+    assert lc[1].embedding is None
+
+
+def test_centroid_identity_round_trip_lazy_save(tmp_path):
+    """Centroid identity/embedding survive the lazy fast-path writer."""
+    video = Video(filename="test.mp4")
+    ident = Identity(name="cell_A")
+    c = UserCentroid(x=3.0, y=4.0, identity=ident, identity_score=0.5)
+    c.set_embedding(np.ones(6, dtype=np.float32))
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, centroids=[c])])
+    labels.update()
+
+    a = str(tmp_path / "a.slp")
+    save_slp(labels, a)
+    lazy = load_slp(a, lazy=True)
+    assert lazy.is_lazy
+    b = str(tmp_path / "b.slp")
+    save_slp(lazy, b)
+    assert lazy.is_lazy
+
+    reloaded = load_slp(b)
+    rc = list(reloaded[0].centroids)[0]
+    assert rc.identity is not None and rc.identity.uuid == ident.uuid
+    assert rc.identity_score == pytest.approx(0.5)
+    np.testing.assert_array_equal(rc.embedding.vector, np.ones(6))
+
+
 def test_save_time_autocollect_unregistered_identity(tmp_path):
     """Post-hoc inst.identity not in the catalog is auto-collected + persisted."""
     skel = Skeleton(["A", "B"])
@@ -1413,8 +1467,8 @@ def test_save_time_autocollect_dedupes_by_uuid(tmp_path):
     assert li[1].identity is not None and li[1].identity.uuid == uuid
 
 
-def test_identity_link_rows_from_masks_skips_unregistered():
-    """A mask whose identity uuid is not in the catalog is skipped (defensive)."""
+def test_identity_link_rows_for_owner_skips_unregistered():
+    """An annotation whose identity uuid is not in the catalog is skipped."""
     d = np.zeros((4, 4), dtype=bool)
     d[1:3, 1:3] = True
     registered = Identity(name="A")
@@ -1423,8 +1477,10 @@ def test_identity_link_rows_from_masks_skips_unregistered():
     m_none = UserSegmentationMask.from_numpy(d)
     uuid_to_idx = {registered.uuid: 0}
 
-    rows = _identity_link_rows_from_masks([m_ok, m_unregistered, m_none], uuid_to_idx)
-    # Only the registered mask (at index 0) yields a row.
+    rows = _identity_link_rows_for_owner(
+        [m_ok, m_unregistered, m_none], uuid_to_idx, OWNER_MASK
+    )
+    # Only the registered mask (at index 0) yields a row, under the given owner type.
     assert rows == [(OWNER_MASK, 0, 0, pytest.approx(0.5))]
 
 
@@ -1568,13 +1624,13 @@ def test_embeddings_inconsistent_dim_raises(tmp_path):
 
 
 def test_modality_embeddings_warn_on_save(tmp_path):
-    """Test a warning fires for not-yet-persisted modality embeddings."""
+    """Test a warning fires for not-yet-persisted modality embeddings (bbox/ROI)."""
     skel = Skeleton(["A", "B"])
     video = Video(filename="test.mp4")
     inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
-    centroid = UserCentroid(x=1.0, y=2.0)
-    centroid.set_embedding(np.ones(8))  # not yet persisted
-    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst], centroids=[centroid])
+    bbox = UserBoundingBox(x1=0.0, y1=0.0, x2=10.0, y2=10.0)
+    bbox.set_embedding(np.ones(8))  # bbox embeddings not yet persisted
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst], bboxes=[bbox])
     labels = Labels([lf])
 
     with pytest.warns(UserWarning, match="not yet persisted"):

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -49,6 +49,7 @@ from sleap_io.io.slp import (
     ExportCancelled,
     LabelImageWriter,
     _encode_metadata_attr,
+    _identity_link_rows_from_masks,
     _is_known_toplevel_name,
     _points_from_hdf5_data,
     _read_source_video_json,
@@ -1410,6 +1411,21 @@ def test_save_time_autocollect_dedupes_by_uuid(tmp_path):
     li = list(loaded[0].instances)
     assert li[0].identity is not None and li[0].identity.uuid == uuid
     assert li[1].identity is not None and li[1].identity.uuid == uuid
+
+
+def test_identity_link_rows_from_masks_skips_unregistered():
+    """A mask whose identity uuid is not in the catalog is skipped (defensive)."""
+    d = np.zeros((4, 4), dtype=bool)
+    d[1:3, 1:3] = True
+    registered = Identity(name="A")
+    m_ok = UserSegmentationMask.from_numpy(d, identity=registered, identity_score=0.5)
+    m_unregistered = UserSegmentationMask.from_numpy(d, identity=Identity(name="B"))
+    m_none = UserSegmentationMask.from_numpy(d)
+    uuid_to_idx = {registered.uuid: 0}
+
+    rows = _identity_link_rows_from_masks([m_ok, m_unregistered, m_none], uuid_to_idx)
+    # Only the registered mask (at index 0) yields a row.
+    assert rows == [(OWNER_MASK, 0, 0, pytest.approx(0.5))]
 
 
 def _labels_with_identity_and_embedding():

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -47,6 +47,8 @@ from sleap_io.io.slp import (
     OWNER_IDENTITY,
     OWNER_INSTANCE,
     OWNER_MASK,
+    OWNER_ROI,
+    OWNER_TRACK,
     ExportCancelled,
     LabelImageWriter,
     _encode_metadata_attr,
@@ -1272,24 +1274,24 @@ def test_read_embeddings_skips_unknown_owner_type(tmp_path):
     path = str(tmp_path / "emb.slp")
     save_slp(labels, path)
 
-    # Inject a bbox-owner (owner_type=4) row that no current reader attaches.
+    # Inject a track-owner (owner_type=7, reserved/unattached) row.
     with h5py.File(path, "a") as f:
         sub = f["embeddings/reid"]
         for name in ("vectors", "owner_type", "owner_id", "meta_json"):
             ds = sub[name]
             ds.resize(ds.shape[0] + 1, axis=0)
         sub["vectors"][-1] = np.full(4, 2.0, dtype=np.float32)
-        sub["owner_type"][-1] = OWNER_BBOX
+        sub["owner_type"][-1] = OWNER_TRACK
         sub["owner_id"][-1] = 0
         sub["meta_json"][-1] = np.bytes_("{}")
 
     with pytest.warns(UserWarning, match="unsupported owner_type"):
         embeddings_by_owner = read_embeddings(path)
 
-    # The instance embedding still loads; the bbox row is dropped, not mis-bound.
+    # The instance embedding still loads; the track row is dropped, not mis-bound.
     assert set(embeddings_by_owner[OWNER_INSTANCE]) == {0}
     assert "reid" in embeddings_by_owner[OWNER_INSTANCE][0]
-    assert OWNER_BBOX not in embeddings_by_owner
+    assert OWNER_TRACK not in embeddings_by_owner
     assert OWNER_IDENTITY not in embeddings_by_owner
 
 
@@ -1623,18 +1625,59 @@ def test_embeddings_inconsistent_dim_raises(tmp_path):
         save_slp(labels, str(tmp_path / "bad.slp"))
 
 
-def test_modality_embeddings_warn_on_save(tmp_path):
-    """Test a warning fires for not-yet-persisted modality embeddings (bbox/ROI)."""
-    skel = Skeleton(["A", "B"])
+def test_bbox_identity_and_embedding_round_trip(tmp_path):
+    """Per-bbox identity links + embeddings round-trip via SLP (owner_type=4)."""
     video = Video(filename="test.mp4")
-    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
-    bbox = UserBoundingBox(x1=0.0, y1=0.0, x2=10.0, y2=10.0)
-    bbox.set_embedding(np.ones(8))  # bbox embeddings not yet persisted
-    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst], bboxes=[bbox])
-    labels = Labels([lf])
+    id_a = Identity(name="fly_A")
+    b1 = UserBoundingBox(
+        x1=0.0, y1=0.0, x2=10.0, y2=10.0, identity=id_a, identity_score=0.8
+    )
+    b1.set_embedding(np.arange(4, dtype=np.float32))
+    b2 = PredictedBoundingBox(x1=5.0, y1=5.0, x2=9.0, y2=9.0, score=0.7)  # no identity
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, bboxes=[b1, b2])])
+    labels.update()
 
-    with pytest.warns(UserWarning, match="not yet persisted"):
-        save_slp(labels, str(tmp_path / "modality.slp"))
+    path = str(tmp_path / "bbox_ids.slp")
+    save_slp(labels, path)
+    with h5py.File(path, "r") as f:
+        links = f["identity_links"][:]
+        assert set(links["owner_type"].tolist()) == {OWNER_BBOX}
+        assert links["owner_id"].tolist() == [0]
+        assert set(f["embeddings/reid/owner_type"][:].tolist()) == {OWNER_BBOX}
+
+    loaded = load_slp(path)
+    lb = list(loaded[0].bboxes)
+    assert lb[0].identity is not None and lb[0].identity.uuid == id_a.uuid
+    assert lb[0].identity_score == pytest.approx(0.8)
+    np.testing.assert_array_equal(lb[0].embedding.vector, np.arange(4))
+    assert lb[1].identity is None and lb[1].embedding is None
+
+
+def test_roi_identity_and_embedding_round_trip(tmp_path):
+    """Per-ROI identity links + embeddings round-trip via SLP (owner_type=5)."""
+    from shapely.geometry import box
+
+    from sleap_io.model.roi import UserROI
+
+    video = Video(filename="test.mp4")
+    id_a = Identity(name="arena_A")
+    r = UserROI(geometry=box(0, 0, 5, 5), identity=id_a, identity_score=0.6)
+    r.set_embedding(np.ones(3, dtype=np.float32))
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, rois=[r])])
+    labels.update()
+
+    path = str(tmp_path / "roi_ids.slp")
+    save_slp(labels, path)
+    with h5py.File(path, "r") as f:
+        links = f["identity_links"][:]
+        assert set(links["owner_type"].tolist()) == {OWNER_ROI}
+        assert set(f["embeddings/reid/owner_type"][:].tolist()) == {OWNER_ROI}
+
+    loaded = load_slp(path)
+    lr = list(loaded[0].rois)[0]
+    assert lr.identity is not None and lr.identity.uuid == id_a.uuid
+    assert lr.identity_score == pytest.approx(0.6)
+    np.testing.assert_array_equal(lr.embedding.vector, np.ones(3))
 
 
 def test_per_instance_categories_round_trip(tmp_path):

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -1412,6 +1412,68 @@ def test_save_time_autocollect_dedupes_by_uuid(tmp_path):
     assert li[1].identity is not None and li[1].identity.uuid == uuid
 
 
+def _labels_with_identity_and_embedding():
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    ident = Identity(name="mouse_A")
+    inst = Instance.from_numpy(
+        np.array([[0, 1], [2, 3]]), skel, identity=ident, identity_score=0.9
+    )
+    inst.set_embedding(np.ones(8, dtype=np.float32))
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[inst])])
+    labels.update()
+    return labels
+
+
+def test_save_id_embeddings_false_skips_embeddings_keeps_links(tmp_path):
+    """save_id_embeddings=False drops /embeddings but keeps /identity_links."""
+    labels = _labels_with_identity_and_embedding()
+    path = str(tmp_path / "no_emb.slp")
+    save_slp(labels, path, save_id_embeddings=False)
+
+    with h5py.File(path, "r") as f:
+        assert "embeddings" not in f  # vectors skipped
+        assert "identity_links" in f  # links still persisted
+
+    # Vectors remain in memory on the original object (not mutated by save).
+    assert list(labels[0].instances)[0].embedding is not None
+
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)[0]
+    assert li.identity is not None and li.identity.name == "mouse_A"
+    assert li.embedding is None  # not persisted
+
+
+def test_save_id_embeddings_default_writes_embeddings(tmp_path):
+    """Default save_id_embeddings=True writes the /embeddings group."""
+    labels = _labels_with_identity_and_embedding()
+    path = str(tmp_path / "with_emb.slp")
+    save_slp(labels, path)
+    with h5py.File(path, "r") as f:
+        assert "embeddings" in f
+
+    # Also reachable through Labels.save(...) via **kwargs.
+    path2 = str(tmp_path / "via_save.slp")
+    labels.save(path2, save_id_embeddings=False)
+    with h5py.File(path2, "r") as f:
+        assert "embeddings" not in f
+        assert "identity_links" in f
+
+
+def test_save_id_embeddings_false_lazy(tmp_path):
+    """save_id_embeddings=False is honored on the lazy fast-path writer."""
+    labels = _labels_with_identity_and_embedding()
+    a = str(tmp_path / "a.slp")
+    save_slp(labels, a)
+    lazy = load_slp(a, lazy=True)
+    assert lazy.is_lazy
+    b = str(tmp_path / "b.slp")
+    save_slp(lazy, b, save_id_embeddings=False)
+    with h5py.File(b, "r") as f:
+        assert "embeddings" not in f
+        assert "identity_links" in f
+
+
 def test_embeddings_round_trip(tmp_path):
     """Test instance + identity embeddings round-trip through SLP (format 2.6)."""
     skel = Skeleton(["A", "B"])

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -1441,11 +1441,11 @@ def _labels_with_identity_and_embedding():
     return labels
 
 
-def test_save_id_embeddings_false_skips_embeddings_keeps_links(tmp_path):
-    """save_id_embeddings=False drops /embeddings but keeps /identity_links."""
+def test_save_embedding_vectors_false_skips_embeddings_keeps_links(tmp_path):
+    """save_embedding_vectors=False drops /embeddings but keeps /identity_links."""
     labels = _labels_with_identity_and_embedding()
     path = str(tmp_path / "no_emb.slp")
-    save_slp(labels, path, save_id_embeddings=False)
+    save_slp(labels, path, save_embedding_vectors=False)
 
     with h5py.File(path, "r") as f:
         assert "embeddings" not in f  # vectors skipped
@@ -1460,8 +1460,8 @@ def test_save_id_embeddings_false_skips_embeddings_keeps_links(tmp_path):
     assert li.embedding is None  # not persisted
 
 
-def test_save_id_embeddings_default_writes_embeddings(tmp_path):
-    """Default save_id_embeddings=True writes the /embeddings group."""
+def test_save_embedding_vectors_default_writes_embeddings(tmp_path):
+    """Default save_embedding_vectors=True writes the /embeddings group."""
     labels = _labels_with_identity_and_embedding()
     path = str(tmp_path / "with_emb.slp")
     save_slp(labels, path)
@@ -1470,21 +1470,21 @@ def test_save_id_embeddings_default_writes_embeddings(tmp_path):
 
     # Also reachable through Labels.save(...) via **kwargs.
     path2 = str(tmp_path / "via_save.slp")
-    labels.save(path2, save_id_embeddings=False)
+    labels.save(path2, save_embedding_vectors=False)
     with h5py.File(path2, "r") as f:
         assert "embeddings" not in f
         assert "identity_links" in f
 
 
-def test_save_id_embeddings_false_lazy(tmp_path):
-    """save_id_embeddings=False is honored on the lazy fast-path writer."""
+def test_save_embedding_vectors_false_lazy(tmp_path):
+    """save_embedding_vectors=False is honored on the lazy fast-path writer."""
     labels = _labels_with_identity_and_embedding()
     a = str(tmp_path / "a.slp")
     save_slp(labels, a)
     lazy = load_slp(a, lazy=True)
     assert lazy.is_lazy
     b = str(tmp_path / "b.slp")
-    save_slp(lazy, b, save_id_embeddings=False)
+    save_slp(lazy, b, save_embedding_vectors=False)
     with h5py.File(b, "r") as f:
         assert "embeddings" not in f
         assert "identity_links" in f

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -42,6 +42,8 @@ from sleap_io.io.slp import (
     LI_DTYPE,
     METADATA_ATTR_SIZE_LIMIT,
     OBJ_DTYPE,
+    OWNER_BBOX,
+    OWNER_IDENTITY,
     OWNER_INSTANCE,
     OWNER_MASK,
     ExportCancelled,
@@ -1268,24 +1270,146 @@ def test_read_embeddings_skips_unknown_owner_type(tmp_path):
     path = str(tmp_path / "emb.slp")
     save_slp(labels, path)
 
-    # Inject a mask-owner (owner_type=3) row that no current reader attaches.
+    # Inject a bbox-owner (owner_type=4) row that no current reader attaches.
     with h5py.File(path, "a") as f:
         sub = f["embeddings/reid"]
         for name in ("vectors", "owner_type", "owner_id", "meta_json"):
             ds = sub[name]
             ds.resize(ds.shape[0] + 1, axis=0)
         sub["vectors"][-1] = np.full(4, 2.0, dtype=np.float32)
-        sub["owner_type"][-1] = OWNER_MASK
+        sub["owner_type"][-1] = OWNER_BBOX
         sub["owner_id"][-1] = 0
         sub["meta_json"][-1] = np.bytes_("{}")
 
     with pytest.warns(UserWarning, match="unsupported owner_type"):
-        instance_embeddings, identity_embeddings = read_embeddings(path)
+        embeddings_by_owner = read_embeddings(path)
 
-    # The instance embedding still loads; the mask row is dropped, not mis-bound.
-    assert set(instance_embeddings) == {0}
-    assert "reid" in instance_embeddings[0]
-    assert identity_embeddings == {}
+    # The instance embedding still loads; the bbox row is dropped, not mis-bound.
+    assert set(embeddings_by_owner[OWNER_INSTANCE]) == {0}
+    assert "reid" in embeddings_by_owner[OWNER_INSTANCE][0]
+    assert OWNER_BBOX not in embeddings_by_owner
+    assert OWNER_IDENTITY not in embeddings_by_owner
+
+
+def _mask_frame(video, frame_idx, masks):
+    return LabeledFrame(video=video, frame_idx=frame_idx, masks=masks)
+
+
+def test_mask_identity_and_embedding_round_trip(tmp_path):
+    """Per-mask identity links + embeddings round-trip via SLP (owner_type=3)."""
+    video = Video(filename="test.mp4")
+    id_a = Identity(name="gerbil_A")
+    id_b = Identity(name="gerbil_B")
+    d1 = np.zeros((8, 8), dtype=bool)
+    d1[1:4, 1:4] = True
+    d2 = np.zeros((8, 8), dtype=bool)
+    d2[4:7, 4:7] = True
+    m1 = UserSegmentationMask.from_numpy(d1, identity=id_a, identity_score=0.9)
+    m1.set_embedding(np.arange(6, dtype=np.float32))
+    m2 = PredictedSegmentationMask.from_numpy(d2, score=0.8, identity=id_b)
+    m3 = UserSegmentationMask.from_numpy(d1)  # no identity / no embedding
+    labels = Labels([_mask_frame(video, 0, [m1, m2, m3])])
+    labels.update()
+
+    path = str(tmp_path / "mask_ids.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] >= 2.6
+        links = f["identity_links"][:]
+        # Both mask owners present (owner_type == OWNER_MASK).
+        assert set(links["owner_type"].tolist()) == {OWNER_MASK}
+        assert sorted(links["owner_id"].tolist()) == [0, 1]
+
+    loaded = load_slp(path)
+    lm = list(loaded[0].masks)
+    assert lm[0].identity is not None and lm[0].identity.name == "gerbil_A"
+    assert lm[0].identity.uuid == id_a.uuid
+    assert lm[0].identity_score == pytest.approx(0.9)
+    np.testing.assert_array_equal(lm[0].embedding.vector, np.arange(6))
+    assert lm[1].identity is not None and lm[1].identity.name == "gerbil_B"
+    assert lm[1].identity_score is None
+    assert lm[2].identity is None
+    assert lm[2].embedding is None
+    # Mask identities reuse the shared catalog (same objects as instances would).
+    assert {i.name for i in loaded.identities} == {"gerbil_A", "gerbil_B"}
+
+
+def test_mask_identity_round_trip_lazy_save(tmp_path):
+    """Mask identity/embedding survive the lazy fast-path writer."""
+    video = Video(filename="test.mp4")
+    ident = Identity(name="gerbil_A")
+    d = np.zeros((8, 8), dtype=bool)
+    d[1:4, 1:4] = True
+    m = UserSegmentationMask.from_numpy(d, identity=ident, identity_score=0.5)
+    m.set_embedding(np.ones(5, dtype=np.float32))
+    labels = Labels([_mask_frame(video, 0, [m])])
+    labels.update()
+
+    a = str(tmp_path / "a.slp")
+    save_slp(labels, a)
+    lazy = load_slp(a, lazy=True)
+    assert lazy.is_lazy
+
+    b = str(tmp_path / "b.slp")
+    save_slp(lazy, b)
+    assert lazy.is_lazy  # fast path did not materialize
+
+    reloaded = load_slp(b)
+    rm = list(reloaded[0].masks)[0]
+    assert rm.identity is not None and rm.identity.uuid == ident.uuid
+    assert rm.identity_score == pytest.approx(0.5)
+    np.testing.assert_array_equal(rm.embedding.vector, np.ones(5))
+
+
+def test_save_time_autocollect_unregistered_identity(tmp_path):
+    """Post-hoc inst.identity not in the catalog is auto-collected + persisted."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[inst])])
+    labels.update()
+    assert labels.identities == []  # nothing registered yet
+
+    # Producer assigns an identity AFTER the instance is in Labels, bypassing the
+    # build-path collectors -- previously this was silently dropped on save.
+    inst.identity = Identity(name="mouse_X")
+    inst.identity_score = 0.42
+
+    path = str(tmp_path / "autocollect.slp")
+    save_slp(labels, path)
+
+    # Save mutated the catalog (auto-collect) so the link is honored.
+    assert [i.name for i in labels.identities] == ["mouse_X"]
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)[0]
+    assert li.identity is not None and li.identity.name == "mouse_X"
+    assert li.identity_score == pytest.approx(0.42)
+
+
+def test_save_time_autocollect_dedupes_by_uuid(tmp_path):
+    """Distinct Identity objects sharing a uuid collapse + resolve correctly."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    uuid = "0123456789abcdef0123456789abcdef"
+    i0 = Instance.from_numpy(
+        np.array([[0, 1], [2, 3]]), skel, identity=Identity(name="A", uuid=uuid)
+    )
+    # Second instance: a *different* Identity object with the SAME uuid.
+    i1 = Instance.from_numpy(
+        np.array([[4, 5], [6, 7]]), skel, identity=Identity(name="A2", uuid=uuid)
+    )
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[i0, i1])])
+    labels.update()
+    path = str(tmp_path / "dup_uuid.slp")
+    save_slp(labels, path)
+
+    # Catalog collapsed to a single entry for the shared uuid.
+    assert len(labels.identities) == 1
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)
+    assert li[0].identity is not None and li[0].identity.uuid == uuid
+    assert li[1].identity is not None and li[1].identity.uuid == uuid
 
 
 def test_embeddings_round_trip(tmp_path):

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -42,6 +42,8 @@ from sleap_io.io.slp import (
     LI_DTYPE,
     METADATA_ATTR_SIZE_LIMIT,
     OBJ_DTYPE,
+    OWNER_INSTANCE,
+    OWNER_MASK,
     ExportCancelled,
     LabelImageWriter,
     _encode_metadata_attr,
@@ -70,7 +72,9 @@ from sleap_io.io.slp import (
     process_and_embed_frames,
     read_bboxes,
     read_centroids,
+    read_embeddings,
     read_identities,
+    read_identity_links,
     read_instance_categories,
     read_instances,
     read_label_images,
@@ -1148,7 +1152,11 @@ def test_per_instance_identity_round_trip(tmp_path):
     # Format bumped to 2.5 and the additive dataset is present.
     with h5py.File(path, "r") as f:
         assert f["metadata"].attrs["format_id"] >= 2.5
-        assert "instance_identities" in f
+        assert "identity_links" in f
+        # Owner-type-aware: instance owners are written as OWNER_INSTANCE (0).
+        links = f["identity_links"][:]
+        assert "owner_type" in links.dtype.names
+        assert set(links["owner_type"].tolist()) == {0}
 
     loaded = load_slp(path)
     li = list(loaded[0].instances)
@@ -1184,10 +1192,100 @@ def test_no_identity_keeps_low_format_and_no_dataset(tmp_path):
 
     with h5py.File(path, "r") as f:
         assert f["metadata"].attrs["format_id"] < 2.5
+        assert "identity_links" not in f
         assert "instance_identities" not in f
 
     loaded = load_slp(path)
     assert list(loaded[0].instances)[0].identity is None
+
+
+def test_read_identity_links_owner_type_keyed(tmp_path):
+    """read_identity_links buckets rows by owner_type (instance owners under 0)."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    id_a = Identity(name="mouse_A")
+    insts = [
+        Instance.from_numpy(
+            np.array([[0, 1], [2, 3]]), skel, identity=id_a, identity_score=0.5
+        ),
+        Instance.from_numpy(np.array([[4, 5], [6, 7]]), skel),  # no identity
+    ]
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=insts)])
+    labels.update()
+    path = str(tmp_path / "links.slp")
+    save_slp(labels, path)
+
+    links = read_identity_links(path)
+    # Only the instance-owner bucket is present; keyed by global instance_id.
+    assert set(links) == {OWNER_INSTANCE}
+    assert links[OWNER_INSTANCE] == {0: (0, pytest.approx(0.5))}
+
+
+def test_read_identity_links_legacy_instance_identities(tmp_path):
+    """Pre-rename instance_identities (3-col, no owner_type) reads as instances."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    id_a = Identity(name="mouse_A")
+    insts = [
+        Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel, identity=id_a),
+        Instance.from_numpy(np.array([[4, 5], [6, 7]]), skel),
+    ]
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=insts)])
+    labels.update()
+    path = str(tmp_path / "legacy.slp")
+    save_slp(labels, path)
+
+    # Rewrite the new dataset as the legacy instance-only layout (no owner_type).
+    legacy_dtype = np.dtype(
+        [("instance_id", "i8"), ("identity_idx", "i4"), ("identity_score", "f4")]
+    )
+    with h5py.File(path, "a") as f:
+        del f["identity_links"]
+        f.create_dataset(
+            "instance_identities",
+            data=np.array([(0, 0, np.float32("nan"))], dtype=legacy_dtype),
+            maxshape=(None,),
+        )
+
+    # The fallback reads the legacy dataset back as instance owners.
+    links = read_identity_links(path)
+    assert links == {OWNER_INSTANCE: {0: (0, None)}}
+
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)
+    assert li[0].identity is not None and li[0].identity.name == "mouse_A"
+    assert li[1].identity is None
+
+
+def test_read_embeddings_skips_unknown_owner_type(tmp_path):
+    """Unknown owner_type embeddings are skipped (not mis-routed) with a warning."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    inst = Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)
+    inst.set_embedding(np.ones(4, dtype=np.float32))
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[inst])])
+    labels.update()
+    path = str(tmp_path / "emb.slp")
+    save_slp(labels, path)
+
+    # Inject a mask-owner (owner_type=3) row that no current reader attaches.
+    with h5py.File(path, "a") as f:
+        sub = f["embeddings/reid"]
+        for name in ("vectors", "owner_type", "owner_id", "meta_json"):
+            ds = sub[name]
+            ds.resize(ds.shape[0] + 1, axis=0)
+        sub["vectors"][-1] = np.full(4, 2.0, dtype=np.float32)
+        sub["owner_type"][-1] = OWNER_MASK
+        sub["owner_id"][-1] = 0
+        sub["meta_json"][-1] = np.bytes_("{}")
+
+    with pytest.warns(UserWarning, match="unsupported owner_type"):
+        instance_embeddings, identity_embeddings = read_embeddings(path)
+
+    # The instance embedding still loads; the mask row is dropped, not mis-bound.
+    assert set(instance_embeddings) == {0}
+    assert "reid" in instance_embeddings[0]
+    assert identity_embeddings == {}
 
 
 def test_embeddings_round_trip(tmp_path):

--- a/tests/io/test_slp_lazy.py
+++ b/tests/io/test_slp_lazy.py
@@ -1790,7 +1790,7 @@ def test_lazy_save_persists_identities_and_embeddings(tmp_path):
     with h5py.File(b, "r") as f:
         assert f["metadata"].attrs["format_id"] >= 2.6
         assert "identities_json" in f
-        assert "instance_identities" in f
+        assert "identity_links" in f
         assert "embeddings" in f
         # Aux join columns are gzip-compressed (compression fix).
         sub = f["embeddings/reid"]

--- a/tests/model/test_bbox.py
+++ b/tests/model/test_bbox.py
@@ -6,12 +6,31 @@ import numpy as np
 import pytest
 
 from sleap_io.model.bbox import BoundingBox, PredictedBoundingBox, UserBoundingBox
+from sleap_io.model.identity import Identity
 
 
 def test_bbox_abstract():
     """BoundingBox cannot be instantiated directly."""
     with pytest.raises(TypeError, match="BoundingBox is abstract"):
         BoundingBox(x1=0, y1=0, x2=10, y2=10)
+
+
+def test_bbox_identity_field_and_to_roi():
+    """BoundingBox carries identity; from_xywh + to_roi() preserve it."""
+    ident = Identity(name="fly_A")
+    b = UserBoundingBox(
+        x1=0.0, y1=0.0, x2=10.0, y2=10.0, identity=ident, identity_score=0.7
+    )
+    assert b.identity is ident
+    assert b.identity_score == pytest.approx(0.7)
+    # from_xywh threads identity via **kwargs.
+    assert UserBoundingBox.from_xywh(0, 0, 5, 5, identity=ident).identity is ident
+    # to_roi carries identity onto the ROI.
+    roi = b.to_roi()
+    assert roi.identity is ident
+    assert roi.identity_score == pytest.approx(0.7)
+    # Defaults to None.
+    assert UserBoundingBox(x1=0, y1=0, x2=1, y2=1).identity is None
 
 
 def test_bbox_basic():

--- a/tests/model/test_centroid.py
+++ b/tests/model/test_centroid.py
@@ -9,6 +9,7 @@ from sleap_io.model.centroid import (
     UserCentroid,
     get_centroid_skeleton,
 )
+from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, PredictedInstance, Track
 from sleap_io.model.skeleton import Skeleton
 
@@ -125,6 +126,42 @@ def test_to_instance_predicted():
     np.testing.assert_allclose(pts[0], [50.0, 60.0])
     assert inst.score == 0.9
     assert inst.track is track
+
+
+def test_centroid_identity_field():
+    """Centroid carries identity / identity_score (defaults None)."""
+    ident = Identity(name="cell_A")
+    c = UserCentroid(x=1.0, y=2.0, identity=ident, identity_score=0.7)
+    assert c.identity is ident
+    assert c.identity_score == pytest.approx(0.7)
+
+    plain = UserCentroid(x=1.0, y=2.0)
+    assert plain.identity is None
+    assert plain.identity_score is None
+
+
+def test_to_instance_carries_identity():
+    """to_instance() preserves identity / identity_score onto the instance."""
+    ident = Identity(name="cell_A")
+    c = UserCentroid(x=1.0, y=2.0, identity=ident, identity_score=0.6)
+    inst = c.to_instance()
+    assert inst.identity is ident
+    assert inst.identity_score == pytest.approx(0.6)
+
+
+def test_from_instance_carries_identity():
+    """from_instance() copies the instance's identity onto the centroid."""
+    skel = Skeleton(["a", "b"])
+    ident = Identity(name="cell_A")
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [30.0, 40.0]]),
+        skel,
+        identity=ident,
+        identity_score=0.55,
+    )
+    c = UserCentroid.from_instance(inst)
+    assert c.identity is ident
+    assert c.identity_score == pytest.approx(0.55)
 
 
 def test_to_instance_custom_skeleton():

--- a/tests/model/test_identity.py
+++ b/tests/model/test_identity.py
@@ -32,12 +32,17 @@ def test_identity_eq_false():
 
 
 def test_identity_repr():
-    """Test Identity string representation."""
-    id1 = Identity(name="mouse_A")
-    assert repr(id1) == 'Identity(name="mouse_A")'
+    """Test Identity string representation surfaces name, truncated uuid, color."""
+    id1 = Identity(name="mouse_A", uuid="0123456789abcdef0123456789abcdef")
+    assert repr(id1) == 'Identity(name="mouse_A", uuid="01234567…")'
 
-    id2 = Identity(name="mouse_A", color="#ff0000")
-    assert repr(id2) == 'Identity(name="mouse_A", color="#ff0000")'
+    id2 = Identity(
+        name="mouse_A", uuid="0123456789abcdef0123456789abcdef", color="#ff0000"
+    )
+    assert repr(id2) == 'Identity(name="mouse_A", uuid="01234567…", color="#ff0000")'
+
+    # Two identities differing only by uuid no longer repr identically.
+    assert repr(Identity(name="x")) != repr(Identity(name="x"))
 
 
 def test_identity_hashable():

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -172,6 +172,54 @@ def test_append_extend():
     assert labels.tracks == [new_track, new_track2]
 
 
+def test_add_identity_dedupes_by_uuid():
+    """add_identity is idempotent and returns the canonical catalog object."""
+    labels = Labels()
+    id_a = Identity(name="mouse_A")
+    assert labels.add_identity(id_a) is id_a
+    assert labels.identities == [id_a]
+
+    # A distinct object sharing the uuid returns the canonical entry, no dup.
+    id_a_dup = Identity(name="mouse_A_renamed", uuid=id_a.uuid)
+    assert labels.add_identity(id_a_dup) is id_a
+    assert labels.identities == [id_a]
+
+    # A different uuid is appended.
+    id_b = Identity(name="mouse_B")
+    assert labels.add_identity(id_b) is id_b
+    assert labels.identities == [id_a, id_b]
+
+
+def test_add_identity_match_name():
+    """add_identity(match="name") dedupes by name instead of uuid."""
+    labels = Labels()
+    id_a = Identity(name="mouse_A")
+    labels.add_identity(id_a)
+    # Same name, different uuid -> returns existing under name matching.
+    other = Identity(name="mouse_A")
+    assert labels.add_identity(other, match="name") is id_a
+    assert labels.identities == [id_a]
+
+
+def test_get_identity():
+    """get_identity finds by uuid or name, returns None when absent."""
+    labels = Labels()
+    id_a = Identity(name="mouse_A")
+    id_b = Identity(name="mouse_B")
+    labels.identities.extend([id_a, id_b])
+
+    assert labels.get_identity(uuid=id_b.uuid) is id_b
+    assert labels.get_identity(name="mouse_A") is id_a
+    assert labels.get_identity(uuid="0" * 32) is None
+    assert labels.get_identity(name="nope") is None
+
+    # Exactly one selector is required.
+    with pytest.raises(ValueError):
+        labels.get_identity()
+    with pytest.raises(ValueError):
+        labels.get_identity(uuid=id_a.uuid, name="mouse_A")
+
+
 def test_identities_auto_collected():
     """Test that Labels auto-collects per-instance Identity objects."""
     skel = Skeleton(["A", "B"])

--- a/tests/model/test_mask.py
+++ b/tests/model/test_mask.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
+from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, Track
 from sleap_io.model.mask import (
     PredictedSegmentationMask,
@@ -560,6 +561,45 @@ def test_to_user_metadata():
     assert user.category == "cell"
     assert user.name == "obj1"
     assert user.source == "model"
+
+
+def test_mask_identity_field():
+    """SegmentationMask carries identity / identity_score via from_numpy kwargs."""
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 1:4] = True
+    ident = Identity(name="mouse_A")
+    mask = UserSegmentationMask.from_numpy(data, identity=ident, identity_score=0.9)
+    assert mask.identity is ident
+    assert mask.identity_score == pytest.approx(0.9)
+
+    # Defaults to None when unset.
+    plain = UserSegmentationMask.from_numpy(data)
+    assert plain.identity is None
+    assert plain.identity_score is None
+
+
+def test_mask_resampled_preserves_identity():
+    """resampled() carries identity / identity_score across the transform."""
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 1:4] = True
+    ident = Identity(name="mouse_A")
+    mask = UserSegmentationMask.from_numpy(data, identity=ident, identity_score=0.6)
+    out = mask.resampled(5, 5)
+    assert out.identity is ident
+    assert out.identity_score == pytest.approx(0.6)
+
+
+def test_to_user_preserves_identity():
+    """to_user() carries identity / identity_score onto the user mask."""
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 1:4] = True
+    ident = Identity(name="mouse_A")
+    pred = PredictedSegmentationMask.from_numpy(
+        data, score=0.8, identity=ident, identity_score=0.75
+    )
+    user = pred.to_user()
+    assert user.identity is ident
+    assert user.identity_score == pytest.approx(0.75)
 
 
 def test_to_user_drops_score_and_score_map():

--- a/tests/model/test_mask.py
+++ b/tests/model/test_mask.py
@@ -602,6 +602,20 @@ def test_to_user_preserves_identity():
     assert user.identity_score == pytest.approx(0.75)
 
 
+def test_mask_to_bbox_and_to_polygon_carry_identity():
+    """mask.to_bbox / to_polygon now carry identity (targets adopted the field)."""
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 1:4] = True
+    ident = Identity(name="mouse_A")
+    mask = UserSegmentationMask.from_numpy(data, identity=ident, identity_score=0.8)
+    bbox = mask.to_bbox()
+    assert bbox.identity is ident
+    assert bbox.identity_score == pytest.approx(0.8)
+    roi = mask.to_polygon()
+    assert roi.identity is ident
+    assert roi.identity_score == pytest.approx(0.8)
+
+
 def test_to_user_drops_score_and_score_map():
     data = np.zeros((10, 10), dtype=bool)
     data[2:5, 3:7] = True

--- a/tests/model/test_roi.py
+++ b/tests/model/test_roi.py
@@ -3,6 +3,7 @@
 import pytest
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon, box
 
+from sleap_io.model.identity import Identity
 from sleap_io.model.roi import (
     ROI,
     AnnotationType,
@@ -11,6 +12,33 @@ from sleap_io.model.roi import (
     _rasterize_geometry,
 )
 from sleap_io.model.video import Video
+
+
+def test_roi_identity_field_and_to_mask():
+    """ROI carries identity; from_xyxy + to_mask() preserve it."""
+    ident = Identity(name="arena_A")
+    r = UserROI(geometry=box(0, 0, 10, 10), identity=ident, identity_score=0.6)
+    assert r.identity is ident
+    assert r.identity_score == pytest.approx(0.6)
+    # from_xyxy threads identity via **kwargs.
+    assert UserROI.from_xyxy(0, 0, 5, 5, identity=ident).identity is ident
+    # to_mask carries identity onto the SegmentationMask.
+    mask = r.to_mask(height=12, width=12)
+    assert mask.identity is ident
+    assert mask.identity_score == pytest.approx(0.6)
+    # Defaults to None.
+    assert UserROI(geometry=box(0, 0, 1, 1)).identity is None
+
+
+def test_roi_explode_preserves_identity():
+    """explode() preserves identity on each split ROI."""
+    ident = Identity(name="arena_A")
+    multi = MultiPolygon([box(0, 0, 2, 2), box(5, 5, 7, 7)])
+    r = UserROI(geometry=multi, identity=ident, identity_score=0.4)
+    parts = r.explode()
+    assert len(parts) == 2
+    assert all(p.identity is ident for p in parts)
+    assert all(p.identity_score == pytest.approx(0.4) for p in parts)
 
 
 def test_annotation_type_enum():


### PR DESCRIPTION
Implements the sleap-io side of #525 — per-detection identity + re-ID embedding persistence for sleap-nn's embedding re-ID model — built on an owner-type-aware foundation so identity links and appearance embeddings work uniformly across **every** detection modality.

> Supersedes #526 (auto-closed by a branch rename; no review activity there).

## Why

sleap-nn is wiring an embedding re-ID model + predicted-identity outputs into the identity/embedding data model. Mask-only datasets (e.g. segmentation-only gerbils) carry detections on `lf.masks`, not `lf.instances`, and could not persist identity or appearance vectors at all. This PR closes that gap, generalizes it to all detection modalities, and adds the producer ergonomics the integration needs.

The persistence-schema generalization was done **now**, while SLP formats 2.5/2.6 are unreleased (not in `v0.8.0`), so it needs no migration / back-compat code.

## Summary

- A single **owner-type-aware** persistence scheme for both identity links (`/identity_links`) and re-ID embeddings (`/embeddings`), keyed by a shared `OWNER_*` enum.
- `identity` / `identity_score` and embeddings now persist for **all** detection modalities: `Instance`, `Centroid`, `SegmentationMask`, `BoundingBox`, `ROI`, plus `Identity` (prototype/gallery) embeddings.
- Producer ergonomics: a uuid-keyed identity registry (`add_identity`/`get_identity`), save-time identity auto-collect, and a `save_embedding_vectors` opt-out for the large appearance vectors.

## Key changes

**1. Owner-type-aware persistence foundation**
- Renamed the SLP 2.5 dataset `instance_identities` → `identity_links` and added an `owner_type` column, mirroring the `(owner_type, owner_id)` join the `/embeddings` group already used. Hoisted `EMBEDDING_OWNER_*` → a single shared `OWNER_*` enum used by **both** datasets, so the two join schemes can't drift.
- `read_embeddings` now returns an owner-type-keyed dict and **skips + warns** on unsupported owner types instead of the old catch-all `else` that would have mis-routed a non-instance vector onto an `Instance` (wrong-object corruption — caught in the design review).
- Pre-rename `instance_identities` (3-col, no `owner_type`) is still read back as instance owners.

**2. Per-detection identity + embedding persistence for every modality**
- Added `identity` / `identity_score` to `SegmentationMask` (3), `Centroid` (2), `BoundingBox` (4), and `ROI` (5), mirroring `Instance` (0). Identity prototypes are owner type 1.
- Threaded identity through the copy/convert methods so it isn't silently dropped at modality boundaries: `mask.resampled`/`to_user`/`to_bbox`/`to_polygon`, `centroid.to_instance`/`from_instance`, `bbox.to_roi`, `roi.to_mask`/`explode`. `from_*` constructors flow it via `**kwargs`.
- `write_identity_links` + `write_embeddings` emit owners for all five detection modalities, joining on the global per-modality list index (matching `write_lfs` / `write_masks` / `write_centroids` / `write_bboxes` / `write_rois`; static ROIs follow frame ROIs). Read paths attach them back. Works on **both** the eager and lazy fast-path writers/readers.
- Identity is resolved to a catalog index by the stable **uuid** (not Python object identity), fixing the `.index()` footgun where a distinct same-uuid object dropped the link.
- The helpers are owner-type-parameterized (`_identity_link_rows_for_owner`, `_add_owner_embedding_groups`, `_attach_identity_and_embeddings`), so each modality is a few call-sites. The old "not yet persisted" save warning is gone — every modality persists.

**3. Save-time identity auto-collect** (#525 req 2)
- `Labels._collect_identities()` registers every detection's `Identity` by uuid at save (collapsing pre-existing uuid duplicates), so a post-hoc `inst.identity = ...` / `mask.identity = ...` that bypassed the build-path collectors is no longer silently dropped. `_collect_annotation_identities()` collects non-instance identities on the build path (update/append/extend); static ROIs are swept at save.

**4. `Labels.add_identity` / `get_identity` registry helpers** (#525 req 3)
- Idempotent uuid-deduping registration (mirrors `add_video`); `match` selects a single method via `Identity.matches` (no uuid→name fallback). `get_identity(*, uuid=…, name=…)` returns the first match or `None`, exactly one selector required.

**5. `save_embedding_vectors` opt-out** (#525 req 4)
- `labels.save(path, save_embedding_vectors=False)` skips the large `/embeddings` vectors while still writing `/identity_links` (vectors stay in memory). Named to avoid colliding with the existing `embed=` *video-frame* param; flows via `**kwargs` (consistent with `plugin`/`prefer_metadata`), so non-SLP formats are unaffected. Shipped as a plain `bool` (widening to a `Literal` later is back-compatible).

**6. Cosmetics** (#525 req 5)
- `Identity.__repr__` surfaces a truncated uuid (so different-uuid identities don't `repr()` identically); fixed a stale "before format 2.5 lacks uuid" comment (uuid ships unbumped in the format-1.9 `identities_json`).

## Example usage

```python
import numpy as np
import sleap_io as sio

# Attach a global identity + appearance vector to any detection modality.
ident = sio.Identity(name="gerbil_A")               # stable cross-video uuid
mask = sio.UserSegmentationMask.from_numpy(seg, identity=ident, identity_score=0.9)
mask.set_embedding(reid_vector)                       # re-ID appearance vector
bbox = sio.UserBoundingBox.from_xywh(0, 0, 64, 64, identity=ident)

labels.append(sio.LabeledFrame(video=vid, frame_idx=0, masks=[mask], bboxes=[bbox]))

# Idempotent catalog registration (deduped by uuid).
labels.add_identity(ident)
same = labels.get_identity(uuid=ident.uuid)           # -> the canonical object

labels.save("out.slp")                                # links + appearance vectors
labels.save("light.slp", save_embedding_vectors=False)  # links only; vectors stay in RAM
```

A post-hoc identity assignment is auto-collected on save (no silent drop):

```python
inst = list(labels[0].instances)[0]
inst.identity = sio.Identity(name="mouse_X")          # not yet in labels.identities
labels.save("out.slp")                                # auto-collected + persisted
```

## API changes

New public API:
- `Labels.add_identity(identity, match="uuid") -> Identity`
- `Labels.get_identity(*, uuid=None, name=None) -> Identity | None`
- `SegmentationMask.identity` / `identity_score`; `Centroid.identity` / `identity_score`; `BoundingBox.identity` / `identity_score`; `ROI.identity` / `identity_score` (all mirror `Instance.identity`)
- `save_slp(..., save_embedding_vectors=True)`, reachable via `labels.save(...)` / `save_file(...)` (SLP only).

On-disk SLP format (unreleased 2.5 / 2.6):
- `/identity_links` (owner-type-aware: `owner_type`, `owner_id`, `identity_idx`, `identity_score`) replaces the instance-only `/instance_identities`.
- `/embeddings` now carries instance / centroid / mask / bbox / ROI / identity-prototype owners.
- Shared owner-type codes: `0`=instance, `1`=identity, `2`=centroid, `3`=mask, `4`=bbox, `5`=roi (`6`=frame, `7`=track reserved/unused).

Behavior changes (internal):
- `read_embeddings` return shape changed to an owner-type-keyed dict, and it now warns (instead of mis-routing) on unsupported owner types.
- `read_identity_links` returns an owner-type-keyed dict.
- The "embeddings on X not yet persisted" save warning was removed (every modality now persists).

No change to any non-SLP format, and no change for files that carry no identities/embeddings (purely additive; gated on dataset/group presence).

## Testing

- Owner-type-keyed read, legacy `instance_identities` read fallback, unknown-owner skip/warn (reserved track code).
- Identity + embedding round-trip for `Instance`, `SegmentationMask`, `Centroid`, `BoundingBox`, `ROI` — eager **and** lazy fast-path, including lazy resave.
- Save-time auto-collect of unregistered identities, uuid-dedup collapse, registry helpers, `Identity.__repr__`, and `save_embedding_vectors` gating (eager + lazy + via `Labels.save`).
- Model-side: field defaults + identity carried through every conversion (`to_instance`/`from_instance`, `to_roi`, `to_mask`, `to_bbox`/`to_polygon`, `explode`).
- Full suite: **3948 passed, 1 skipped**; new model files at 100% patch coverage; CI green across macOS/Ubuntu/Windows × Python 3.10/3.13, with codecov patch + project passing.

## Design decisions

- **One owner-type-aware dataset over parallel per-modality datasets** (#525 offered both). Identity links are structurally "embeddings minus the vector," so one `(owner_type, owner_id)` table reuses the proven `/embeddings` scheme and absorbs all modalities with zero new datasets. Decided now, while it's migration-free.
- **uuid-keyed resolution + uuid-deduped auto-collect.** `Identity` is `eq=False`, so the catalog is made uuid-canonical at save and the `.index()` object-identity footgun is removed. The build-path collectors keep object-identity dedup (correct within one in-memory graph); the save-time pass and merge use uuid (correct across object/file boundaries).
- **Model fields copy-pasted, no `IdentityMixin`.** Matches the existing `track`/`tracking_score` per-class pattern; attrs can't inject fields via a mixin, and there's no shared behavior to host. The real cross-modality DRY win is the single owner-type-aware I/O path + parameterized helpers.
- **`save_embedding_vectors` (bool, default keep) over `embeddings=`.** Back-compatible and avoids the `embed` / `embeddings` name collision on `save()`; flows through `**kwargs` so non-SLP formats are untouched.
- **Skip-and-warn (not error, not silent) on unknown embedding owner types** — forward-compatible with files written by a newer sleap-io.

## Deferred (out of scope, per #525)

- The reserved `owner_type` frame (6) / track (7) codes (no detection objects carry embeddings there yet).
- The re-ID resolve loop (`cosine_similarity`, gallery-prototype matching, `IdentityMatchMethod.EMBEDDING`, `Labels.resolve_identities`) — assignment policy stays model-side in sleap-nn.
- A stable per-instance `uuid` embedding join key (positional is sufficient for write-then-save; in-memory objects carry their own embeddings/identity, so positional is only the on-disk encoding) and multi-embedding multiplicity (multi-crop/temporal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
