### PR TITLE
feat(io): add sio.download() + `sio download` CLI for fetching remote files

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,6 +67,7 @@ sio merge --help
 sio embed --help
 sio unembed --help
 sio filenames --help
+sio download --help
 sio fix --help
 sio render --help
 sio trim --help
@@ -126,6 +127,11 @@ sio filenames labels.slp                                   # List video paths
 sio filenames labels.slp -o out.slp --filename /new/video.mp4
 sio filenames labels.slp -o out.slp --map old.mp4 /new/video.mp4
 sio filenames labels.slp -o out.slp --prefix /old/path /new/path
+
+# Download a remote file to disk (curl/wget replacement)
+sio download https://example.com/labels.slp                # -> ./labels.slp
+sio download s3://my-bucket/run/video.mp4 data/            # Into a directory
+sio download https://example.com/a.slp out.slp -f          # Exact path, overwrite
 
 # Fix common issues in labels files
 sio fix labels.slp                                         # Auto-fix with defaults
@@ -2552,6 +2558,52 @@ sio transform labels.slp --config transforms.yaml -o output.slp
 ```
 
 See the [Transforms Guide](transforms.md#config-file-format) for config file format and examples.
+
+---
+
+## `sio download`
+
+Download a remote file to local disk — a drop-in replacement for `curl`/`wget`.
+Accepts the same URL schemes as the loaders: `http`/`https`, cloud storage
+(`s3`/`gs`/`gcs`/`az`/`abfs`, needs the `[cloud]` extra), and Google Drive share
+links. HTTP and cloud files are streamed straight to disk with a progress bar;
+Google Drive files are buffered in memory first and have no byte progress bar.
+
+### Basic Usage
+
+```bash
+sio download <url> [dest] [options]
+sio download <url> -o <dest> [options]
+```
+
+```bash
+# Into the current directory (filename taken from the URL)
+sio download https://example.com/labels.slp
+
+# Into a directory, or to an exact path
+sio download s3://my-bucket/run/video.mp4 data/
+sio download https://example.com/a.slp out.slp
+
+# Authenticated source, forcing a fresh download
+sio download https://example.com/a.slp -H 'Authorization: Bearer <token>' -f
+```
+
+If the destination already exists it is returned without re-downloading (pass
+`-f/--overwrite` to refetch).
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output PATH` | Destination path or directory (alternative to the positional `DEST`). |
+| `-f, --overwrite` | Re-download even if the destination already exists. |
+| `--progress / --no-progress` | Show a download progress bar (default: on). |
+| `-H, --header 'NAME: VALUE'` | Extra HTTP header (repeatable), e.g. `-H 'Authorization: Bearer <token>'`. |
+| `--retries N` | Retries for transient HTTP errors (429/5xx). Default: 3. |
+
+See the [Remote loading guide](remote.md#downloading-files-to-disk) for the
+Python [`sio.download`][sleap_io.download] equivalent, authentication, and
+supported schemes.
 
 ---
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -647,6 +647,15 @@ This also covers `.pkg.slp` embedded-frame streaming, remote media video over
 authentication, security notes, and troubleshooting, see the
 [Remote loading](remote.md) guide.
 
+To instead fetch a remote file to local disk (a `curl`/`wget` replacement), use
+[`download`][sleap_io.download]:
+
+```python
+# Download to the current directory, or to a chosen path.
+path = sio.download("https://example.com/labels.slp")  # -> ./labels.slp
+sio.download("s3://my-bucket/run/video.mp4", "data/")  # -> data/video.mp4
+```
+
 ## Editing labels data
 
 ### Fix video paths

--- a/docs/remote.md
+++ b/docs/remote.md
@@ -34,7 +34,8 @@ so the same call works for local and remote files.
     URL loading covers `.slp`/`.pkg.slp` labels and remote *media video* over
     `http`/`https` only. Every other labels format (NWB, COCO, Label Studio,
     JABS, DLC, CSV, TrackMate, LEAP, GeoJSON, Ultralytics) raises
-    `NotImplementedError` over a URL — download the file locally first.
+    `NotImplementedError` over a URL — fetch it to disk first with
+    [`sio.download`](#downloading-files-to-disk), then load the local copy.
 
 ### Command-line interface
 
@@ -62,6 +63,56 @@ local `-o/--output` (for `fix`, `--dry-run` works on a URL without `-o`). The
 
 Output paths and commands that re-encode video locally (`trim`, `reencode`,
 `transform`, `apply-crops`) require local filesystem paths.
+
+---
+
+## Downloading files to disk
+
+To simply fetch a remote file to local disk — a drop-in replacement for `curl`
+or `wget` in notebooks and demos — use [`sio.download`][sleap_io.download]. It
+accepts the same schemes as the loaders (http/https, cloud, Google Drive). HTTP
+and cloud files are streamed straight to disk with a progress bar; Google Drive
+files are buffered in memory first (see [Google Drive](#google-drive)):
+
+```python
+import sleap_io as sio
+
+# Into the current directory, using the filename from the URL.
+path = sio.download("https://example.com/labels.slp")  # -> ./labels.slp
+
+# Into a directory, or to an exact path.
+sio.download("s3://my-bucket/run/video.mp4", "data/")          # -> data/video.mp4
+sio.download("https://example.com/a.slp", "downloads/b.slp")    # -> downloads/b.slp
+
+# Fetch-then-load (handy for formats not yet loadable directly over a URL):
+labels = sio.load_nwb(sio.download("https://example.com/labels.nwb"))
+```
+
+By default the download is **idempotent**: if the destination already exists it
+is returned without re-downloading, so re-running a cell does not refetch a large
+file. Pass `overwrite=True` to force a fresh download. Authenticated sources work
+via `headers=`, e.g. `sio.download(url, headers={"Authorization": "Bearer …"})`.
+
+!!! tip "`download()` vs. `stream_mode="download"`"
+    [`sio.download`][sleap_io.download] writes a **reusable file to disk** and
+    returns its path. The `stream_mode="download"` option on the loaders instead
+    reads the bytes into **memory** for a single load (see
+    [Streaming modes & caching](#streaming-modes-caching)).
+
+On the command line, `sio download` is the equivalent (and a true `curl`/`wget`
+replacement):
+
+```bash
+# Into the current directory (filename from the URL)
+sio download https://example.com/labels.slp
+
+# Into a directory, or to an exact path
+sio download s3://my-bucket/run/video.mp4 data/
+sio download https://example.com/a.slp out.slp
+
+# With an auth header (repeatable) and forced overwrite
+sio download https://example.com/a.slp -H 'Authorization: Bearer <token>' -f
+```
 
 ---
 

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -68,7 +68,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
         # Streaming label image writer from sleap_io.io.slp
         "io.slp": ["LabelImageWriter"],
         # Remote URL loading helpers from sleap_io.io._remote
-        "io._remote": ["clear_remote_cache", "RemoteIOError"],
+        "io._remote": ["clear_remote_cache", "RemoteIOError", "download"],
         # Rendering from sleap_io.rendering
         "rendering.core": ["render_video", "render_image"],
         "rendering.colors": ["get_palette"],

--- a/sleap_io/io/_gdrive.py
+++ b/sleap_io/io/_gdrive.py
@@ -24,8 +24,10 @@ from __future__ import annotations
 
 import html
 import io
+import posixpath
 import re
 import urllib.parse
+from email.message import EmailMessage
 from html.parser import HTMLParser
 
 from sleap_io.io._remote import (
@@ -361,6 +363,37 @@ def _url_from_confirmation(confirmation_html: str) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _filename_from_disposition(value: str | None) -> str | None:
+    """Parse the ``filename`` from a ``Content-Disposition`` header value.
+
+    Handles both the plain ``filename="…"`` form and the RFC 2231/5987
+    ``filename*=UTF-8''…`` extended form via :class:`email.message.EmailMessage`.
+    Any directory components in the returned name are stripped so a malicious
+    header cannot redirect the write outside the chosen directory.
+
+    Args:
+        value: The raw ``Content-Disposition`` header value, or None.
+
+    Returns:
+        The bare filename, or None if the header is absent or carries no
+        filename.
+    """
+    if not value:
+        return None
+    msg = EmailMessage()
+    msg["Content-Disposition"] = value
+    name = msg.get_filename()
+    if not name:
+        return None
+    # Strip any path components (defense against ``filename="../../x"``); URL/POSIX
+    # and Windows separators are both normalized before taking the basename. A bare
+    # dot-segment (``.``/``..``) survives basename, so reject it explicitly.
+    name = posixpath.basename(name.replace("\\", "/"))
+    if name in ("", ".", ".."):
+        return None
+    return name
+
+
 async def _read_body_capped(resp, max_bytes: int, url: str) -> bytes:
     """Drain a response body fully while enforcing a maximum byte budget.
 
@@ -404,8 +437,8 @@ async def _read_body_capped(resp, max_bytes: int, url: str) -> bytes:
 
 async def _resolve_and_fetch(
     file_id: str, headers: dict[str, str] | None, max_bytes: int | None = None
-) -> bytes:
-    """Run the Drive GET loop and return the resolved file bytes.
+) -> tuple[bytes, str | None]:
+    """Run the Drive GET loop and return the resolved file bytes and name.
 
     This coroutine is driven from :func:`_open_gdrive` via
     :func:`fsspec.asyn.sync` on fsspec's background event loop, so it is safe to
@@ -420,7 +453,9 @@ async def _resolve_and_fetch(
             :data:`_DEFAULT_MAX_BYTES`.
 
     Returns:
-        The fully-downloaded file bytes.
+        A ``(bytes, filename)`` tuple where ``filename`` is the name parsed from
+        the resolved response's ``Content-Disposition`` header, or None if the
+        header carried no filename.
 
     Raises:
         RemoteIOError: For quota/permission pages, an oversize file, or if
@@ -459,9 +494,14 @@ async def _resolve_and_fetch(
 
                 # A Content-Disposition header (or any non-HTML body) means we
                 # have reached the file itself: read it fully (capped) in this
-                # session.
+                # session. The Content-Disposition (when present) also carries the
+                # real filename, which has no other source on the Drive path.
                 if has_disposition or not is_html:
-                    return await _read_body_capped(resp, cap, url)
+                    name = _filename_from_disposition(
+                        resp.headers.get("Content-Disposition")
+                    )
+                    body = await _read_body_capped(resp, cap, url)
+                    return body, name
 
                 # Otherwise this is the interstitial HTML; scrape the next URL.
                 page = await resp.text()
@@ -474,6 +514,59 @@ async def _resolve_and_fetch(
     )
 
 
+def _open_gdrive_with_name(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    max_bytes: int | None = None,
+) -> tuple[io.BytesIO, str | None]:
+    """Resolve a Google Drive share URL to its bytes and filename.
+
+    The Drive download URL carries no file extension and Drive rejects ``HEAD``
+    with 405, both of which break the lazy fsspec open path; the resolved bytes
+    are therefore fully prefetched here (within one cookie-carrying session) and
+    returned as an in-memory :class:`io.BytesIO`, mirroring ``open_url``'s
+    ``stream_mode="download"`` shape. The prefetch is bounded by ``max_bytes``
+    (default :data:`_DEFAULT_MAX_BYTES`) so a hostile or accidentally-huge file
+    cannot exhaust memory. The filename (from the resolved response's
+    ``Content-Disposition``) is returned alongside the bytes for callers that
+    need to name a local file (e.g. :func:`~sleap_io.download`).
+
+    Args:
+        url: A Google Drive / Docs share URL.
+        headers: Optional extra HTTP headers to forward.
+        max_bytes: Maximum number of bytes to buffer in memory. ``None`` uses
+            :data:`_DEFAULT_MAX_BYTES`.
+
+    Returns:
+        A ``(BytesIO, filename)`` tuple. The buffer is positioned at the start of
+        the downloaded bytes; ``filename`` is None when Drive returned no
+        ``Content-Disposition`` filename.
+
+    Raises:
+        ValueError: For folder URLs, unparsable file IDs, or confirmation
+            pages with no download link.
+        RemoteIOError: For HTTP failures, quota/permission pages, an oversize
+            file, or non-convergent resolution.
+    """
+    import fsspec.asyn
+
+    file_id, _is_folder = _parse_gdrive(url)
+
+    loop = fsspec.asyn.get_loop()
+    try:
+        data, name = fsspec.asyn.sync(
+            loop, _resolve_and_fetch, file_id, headers, max_bytes
+        )
+    except (RemoteIOError, ValueError):
+        raise
+    except Exception as e:  # noqa: BLE001 - normalize transport errors
+        from sleap_io.io._remote import _raise_remote
+
+        _raise_remote(e, url=url)
+    return io.BytesIO(data), name
+
+
 def _open_gdrive(
     url: str,
     *,
@@ -482,13 +575,9 @@ def _open_gdrive(
 ) -> io.BytesIO:
     """Resolve a Google Drive share URL and return its bytes as a BytesIO.
 
-    The Drive download URL carries no file extension and Drive rejects ``HEAD``
-    with 405, both of which break the lazy fsspec open path; the resolved bytes
-    are therefore fully prefetched here (within one cookie-carrying session) and
-    returned as an in-memory :class:`io.BytesIO`, mirroring ``open_url``'s
-    ``stream_mode="download"`` shape. The prefetch is bounded by ``max_bytes``
-    (default :data:`_DEFAULT_MAX_BYTES`) so a hostile or accidentally-huge file
-    cannot exhaust memory.
+    Thin wrapper around :func:`_open_gdrive_with_name` for callers that only need
+    the bytes (e.g. the loaders in :mod:`sleap_io.io.main`). See that function
+    for the full resolution/prefetch semantics.
 
     Args:
         url: A Google Drive / Docs share URL.
@@ -505,17 +594,5 @@ def _open_gdrive(
         RemoteIOError: For HTTP failures, quota/permission pages, an oversize
             file, or non-convergent resolution.
     """
-    import fsspec.asyn
-
-    file_id, _is_folder = _parse_gdrive(url)
-
-    loop = fsspec.asyn.get_loop()
-    try:
-        data = fsspec.asyn.sync(loop, _resolve_and_fetch, file_id, headers, max_bytes)
-    except (RemoteIOError, ValueError):
-        raise
-    except Exception as e:  # noqa: BLE001 - normalize transport errors
-        from sleap_io.io._remote import _raise_remote
-
-        _raise_remote(e, url=url)
-    return io.BytesIO(data)
+    buf, _name = _open_gdrive_with_name(url, headers=headers, max_bytes=max_bytes)
+    return buf

--- a/sleap_io/io/_remote.py
+++ b/sleap_io/io/_remote.py
@@ -20,7 +20,9 @@ import importlib
 import io
 import os
 import pathlib
+import posixpath
 import re
+import tempfile
 import time
 import urllib.parse
 import warnings
@@ -1023,6 +1025,329 @@ def clear_remote_cache(
         deleted += 1
 
     return deleted
+
+
+# ---------------------------------------------------------------------------
+# Download to local disk
+# ---------------------------------------------------------------------------
+
+
+def _filename_from_url(url: str) -> str | None:
+    """Derive a safe local filename from the path component of ``url``.
+
+    The URL path is percent-decoded *before* the basename is taken so that
+    encoded separators (``%2F``) or dot-segments (``%2E%2E``) cannot survive into
+    the result and turn a directory destination into a path-traversal write. The
+    returned value is always a bare filename (no directory components); bare
+    ``.``/``..`` and empty results yield None. URL paths are always
+    ``/``-separated, so :mod:`posixpath` is used regardless of the host platform.
+
+    Args:
+        url: The remote URL.
+
+    Returns:
+        The decoded basename of the URL path (e.g. ``labels.slp`` for
+        ``https://host/data/labels.slp``), or None if the URL has no usable
+        basename (e.g. it ends in ``/``, has an empty path, or reduces to a
+        dot-segment). Query strings and fragments are ignored.
+    """
+    path = urllib.parse.urlparse(url).path
+    decoded = urllib.parse.unquote(path).replace("\\", "/")
+    base = posixpath.basename(decoded)
+    if base in ("", ".", ".."):
+        return None
+    return base
+
+
+def _resolve_target_path(
+    dest: str | os.PathLike | None, filename: str | None
+) -> pathlib.Path | None:
+    """Resolve the local file path to download into.
+
+    Args:
+        dest: The user-provided destination. ``None`` means the current
+            directory; a path to an existing directory (or a string ending in a
+            path separator) means "into that directory"; anything else is treated
+            as the exact output file path.
+        filename: The filename to use when ``dest`` designates a directory (or is
+            None). May itself be None if it could not be derived yet.
+
+    Returns:
+        The resolved output :class:`~pathlib.Path`, or None if a directory
+        destination was given (or ``dest`` is None) but no ``filename`` is
+        available yet -- the caller must resolve the name another way (e.g. by
+        inspecting a Google Drive ``Content-Disposition`` after fetching).
+    """
+    if dest is None:
+        return pathlib.Path(filename) if filename else None
+
+    dest_path = pathlib.Path(dest)
+    is_dir = dest_path.is_dir() or os.fspath(dest).endswith(("/", os.sep))
+    if is_dir:
+        return (dest_path / filename) if filename else None
+    return dest_path
+
+
+def _download_callback(progress: bool, url: str):
+    """Build an fsspec transfer callback (a ``tqdm`` bar or a no-op).
+
+    Args:
+        progress: Whether to show a progress bar.
+        url: The URL being downloaded (its basename labels the bar; no
+            credentials are included).
+
+    Returns:
+        An ``fsspec`` callback object to pass to ``fs.get_file(..., callback=)``.
+    """
+    import fsspec.callbacks
+
+    if not progress:
+        return fsspec.callbacks.DEFAULT_CALLBACK
+    return fsspec.callbacks.TqdmCallback(
+        tqdm_kwargs={
+            "desc": f"Downloading {_filename_from_url(url) or 'file'}",
+            "unit": "B",
+            "unit_scale": True,
+            "unit_divisor": 1024,
+        }
+    )
+
+
+def _write_atomic(target: pathlib.Path, write_fn) -> pathlib.Path:
+    """Write ``target`` atomically via a uniquely-named sibling temp file.
+
+    ``write_fn(tmp_path)`` performs the actual write to a temporary sibling path;
+    on success it is atomically renamed onto ``target`` (same directory, so the
+    rename is atomic and never crosses a filesystem boundary). On any error the
+    partial file is removed so an interrupted transfer never leaves a truncated
+    file at ``target``. The temp name is unique (via :func:`tempfile.mkstemp`) so
+    two concurrent downloads to the same target do not clobber each other's
+    in-flight file.
+
+    Args:
+        target: The final output path. Its parent is created if needed.
+        write_fn: A callable taking the temporary :class:`~pathlib.Path` to write.
+
+    Returns:
+        The resolved (absolute) ``target`` path.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(target.parent), prefix=target.name + ".", suffix=".part"
+    )
+    os.close(fd)
+    tmp = pathlib.Path(tmp_name)
+    try:
+        write_fn(tmp)
+        os.replace(tmp, target)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+    return target.resolve()
+
+
+def _download_fsspec(
+    url: str,
+    target: pathlib.Path,
+    *,
+    headers: dict[str, str] | None,
+    progress: bool,
+    retries: int,
+) -> pathlib.Path:
+    """Stream an HTTP/cloud URL to ``target`` (atomic, retried).
+
+    Args:
+        url: The HTTP/HTTPS or cloud URL to download.
+        target: The local output path.
+        headers: Optional HTTP headers (HTTP/HTTPS only).
+        progress: Whether to show a ``tqdm`` progress bar.
+        retries: Maximum retries for transient HTTP errors.
+
+    Returns:
+        The resolved local path of the downloaded file.
+
+    Raises:
+        RemoteIOError: For HTTP / connection failures.
+        ImportError: For cloud schemes when the ``[cloud]`` extra is missing.
+    """
+    scheme = urllib.parse.urlparse(url).scheme.lower()
+    fs = _build_fsspec_filesystem(scheme, headers=headers)
+
+    def _write(tmp: pathlib.Path) -> None:
+        def _fetch():
+            # Build a fresh callback per attempt so a retried transfer starts a
+            # clean progress bar rather than reusing a half-finished one. Both
+            # fsspec callbacks (TqdmCallback / DEFAULT_CALLBACK) expose close().
+            callback = _download_callback(progress, url)
+            try:
+                fs.get_file(url, str(tmp), callback=callback)
+            finally:
+                callback.close()
+
+        _open_with_retries(_fetch, url=url, retries=retries)
+
+    return _write_atomic(target, _write)
+
+
+def _download_gdrive(
+    url: str,
+    *,
+    dest: str | os.PathLike | None,
+    headers: dict[str, str] | None,
+    overwrite: bool,
+) -> pathlib.Path:
+    """Download a Google Drive share URL to local disk.
+
+    Drive files are fully buffered in memory by the resolver (Drive rejects
+    ``HEAD`` and can interrupt ranged reads), so the buffered bytes are written
+    to disk here. The output filename comes from ``dest`` when it names a file,
+    otherwise from the Drive ``Content-Disposition`` filename.
+
+    Args:
+        url: A Google Drive / Docs share URL.
+        dest: The destination (see :func:`download`).
+        headers: Optional HTTP headers to forward.
+        overwrite: Whether to overwrite an existing destination.
+
+    Returns:
+        The resolved local path of the downloaded (or already-present) file.
+
+    Raises:
+        ValueError: If no destination filename can be determined.
+        RemoteIOError: For HTTP failures, quota/permission pages, or an oversize
+            file.
+    """
+    from sleap_io.io._gdrive import _open_gdrive_with_name
+
+    buf, name = _open_gdrive_with_name(url, headers=headers)
+    target = _resolve_target_path(dest, name)
+    if target is None:
+        raise ValueError(
+            "Could not determine a destination filename for the Google Drive "
+            f"file ({_redact_url(url)}); pass an explicit file path as `dest`."
+        )
+    if target.is_dir():
+        raise IsADirectoryError(
+            f"Destination resolves to an existing directory: {target} (the "
+            "resolved filename collides with a subdirectory); pass an explicit "
+            "file path as `dest`."
+        )
+    if target.exists() and not overwrite:
+        return target.resolve()
+    return _write_atomic(target, lambda tmp: tmp.write_bytes(buf.getvalue()))
+
+
+def download(
+    url: str,
+    dest: str | os.PathLike | None = None,
+    *,
+    headers: dict[str, str] | None = None,
+    overwrite: bool = False,
+    progress: bool = True,
+    retries: int = 3,
+) -> pathlib.Path:
+    """Download a remote file to local disk.
+
+    A simple, protocol-agnostic replacement for ``curl``/``wget`` in notebooks
+    and demos. Supports the same URL schemes as :func:`~sleap_io.load_file`:
+    ``http``/``https``, cloud storage (``s3``/``gs``/``gcs``/``az``/``abfs`` --
+    requires ``pip install 'sleap-io[cloud]'``), and Google Drive share links.
+    Unlike the streaming :func:`~sleap_io.load_slp` path, this writes the bytes
+    to a local file (streamed to disk for HTTP/cloud, buffered in memory for
+    Drive) and returns the path.
+
+    Args:
+        url: The remote URL to download.
+        dest: Where to write the file. If ``None`` (default), the file is written
+            to the current directory using the filename from the URL. If ``dest``
+            is an existing directory (or a string ending in a path separator), the
+            file is written inside it using the URL filename. Otherwise ``dest``
+            is treated as the exact output path. Parent directories are created as
+            needed.
+        headers: Optional HTTP headers (HTTP/HTTPS only), e.g.
+            ``{"Authorization": "Bearer <token>"}``.
+        overwrite: If False (default) and the destination already exists, the
+            existing file is returned without re-downloading (idempotent, so
+            re-running a notebook cell does not re-fetch large files). Set True to
+            force a fresh download.
+        progress: If True (default), show a ``tqdm`` progress bar (HTTP/cloud
+            only; Drive downloads are buffered in memory without a byte bar).
+        retries: Maximum retries for transient HTTP errors (429/500/502/503/504),
+            with exponential backoff honoring ``Retry-After``. Applies to
+            HTTP/cloud only; Google Drive files are fetched in a single buffered
+            request and are not retried. Default: 3.
+
+    Returns:
+        The local :class:`~pathlib.Path` of the downloaded (or already-present)
+        file, resolved to an absolute path.
+
+    Raises:
+        ValueError: If ``url`` is not a remote URL, or no destination filename
+            could be determined (the URL has no basename and ``dest`` does not
+            name a file).
+        IsADirectoryError: If the destination resolves to an existing directory.
+        RemoteIOError: For HTTP / connection failures.
+        ImportError: For cloud schemes when the ``[cloud]`` extra is not
+            installed.
+
+    Examples:
+        Download to the current directory (filename from the URL)::
+
+            import sleap_io as sio
+
+            path = sio.download("https://example.com/labels.slp")  # ./labels.slp
+
+        Download into a directory, or to an exact path::
+
+            sio.download("s3://bucket/run/video.mp4", "data/")  # data/video.mp4
+            sio.download("https://example.com/a.slp", "downloads/b.slp")
+
+        Fetch then load::
+
+            labels = sio.load_slp(sio.download(url))
+    """
+    if not _is_url(url):
+        raise ValueError(
+            "download() expects a remote URL (http/https/s3/gs/gcs/az/abfs or a "
+            f"Google Drive link), got: {_redact_url(os.fspath(url))!r}. There is "
+            "nothing to download for a local path or unsupported scheme."
+        )
+
+    is_gdrive = _is_gdrive_url(url)
+
+    # For HTTP/cloud the filename is known up front (URL basename), so an existing
+    # destination can be returned without any network access. Google Drive URLs
+    # carry no filename, so the target may be unknown until the bytes (and their
+    # Content-Disposition) are fetched -- defer those to _download_gdrive.
+    filename = None if is_gdrive else _filename_from_url(url)
+    target = _resolve_target_path(dest, filename)
+
+    if target is not None and target.is_dir():
+        raise IsADirectoryError(
+            f"Destination resolves to an existing directory: {target} (the URL "
+            "basename collides with a subdirectory); pass an explicit file path "
+            "as `dest`."
+        )
+
+    if target is not None and target.exists() and not overwrite:
+        return target.resolve()
+
+    if is_gdrive:
+        return _download_gdrive(url, dest=dest, headers=headers, overwrite=overwrite)
+
+    if target is None:
+        raise ValueError(
+            "Could not determine a destination filename from the URL "
+            f"({_redact_url(url)}); pass an explicit file path as `dest`."
+        )
+
+    return _download_fsspec(
+        url,
+        target,
+        headers=headers,
+        progress=progress,
+        retries=retries,
+    )
 
 
 # Run the aiohttp version check at import time (cheap; warns on downgrade).

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -123,6 +123,7 @@ click.rich_click.COMMAND_GROUPS = {
         },
         {"name": "Export", "commands": ["export"]},
         {"name": "Embedding", "commands": ["embed", "unembed"]},
+        {"name": "Remote", "commands": ["download"]},
         {"name": "Maintenance", "commands": ["fix"]},
         {"name": "Rendering", "commands": ["render"]},
     ]
@@ -8291,6 +8292,112 @@ def _transform_video_file(
         )
 
     console.print(f"[bold green]Saved:[/] {output_path}")
+
+
+def _parse_cli_headers(headers: tuple[str, ...]) -> dict[str, str] | None:
+    """Parse ``--header 'Name: Value'`` CLI options into a header dict.
+
+    Args:
+        headers: The raw ``--header`` option values (possibly empty).
+
+    Returns:
+        A mapping of header names to values, or None if no headers were given.
+
+    Raises:
+        click.ClickException: If any value is not of the form ``Name: Value``.
+    """
+    if not headers:
+        return None
+    parsed: dict[str, str] = {}
+    for raw in headers:
+        name, sep, value = raw.partition(":")
+        name = name.strip()
+        if not sep or not name:
+            raise click.ClickException(
+                f"Invalid --header {raw!r}; expected the form 'Name: Value'."
+            )
+        parsed[name] = value.strip()
+    return parsed
+
+
+@cli.command()
+@click.argument("url")
+@click.argument("dest", required=False, type=click.Path())
+@click.option(
+    "-o",
+    "--output",
+    "output",
+    type=click.Path(),
+    default=None,
+    help="Destination path or directory (alternative to the positional DEST).",
+)
+@click.option(
+    "-f",
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="Re-download even if the destination already exists.",
+)
+@click.option(
+    "--progress/--no-progress",
+    default=True,
+    help="Show a download progress bar (default: on).",
+)
+@click.option(
+    "-H",
+    "--header",
+    "headers",
+    multiple=True,
+    metavar="'NAME: VALUE'",
+    help="Extra HTTP header (repeatable), e.g. -H 'Authorization: Bearer <token>'.",
+)
+@click.option(
+    "--retries",
+    type=int,
+    default=3,
+    show_default=True,
+    help="Retries for transient HTTP errors (429/5xx).",
+)
+def download(url, dest, output, overwrite, progress, headers, retries):
+    """Download a remote file to local disk (a curl/wget replacement).
+
+    [bold]URL[/] may be an http/https, cloud (s3/gs/gcs/az/abfs), or Google Drive
+    link. With no [bold]DEST[/], the file is written to the current directory
+    using the filename from the URL; a directory DEST writes inside it; any other
+    DEST is the exact output path.
+
+    [dim]Examples:[/]
+
+        $ sio download https://example.com/labels.slp
+
+        $ sio download s3://bucket/run/video.mp4 data/
+
+        $ sio download https://host/a.slp out.slp -H 'Authorization: Bearer TKN'
+    """
+    from sleap_io.io._remote import RemoteIOError
+    from sleap_io.io._remote import download as _download
+
+    if dest is not None and output is not None:
+        raise click.ClickException(
+            "Specify the destination once: as the positional DEST or with "
+            "-o/--output, not both."
+        )
+    target = dest if dest is not None else output
+    header_dict = _parse_cli_headers(headers)
+
+    try:
+        path = _download(
+            url,
+            target,
+            headers=header_dict,
+            overwrite=overwrite,
+            progress=progress,
+            retries=retries,
+        )
+    except (RemoteIOError, ValueError, ImportError) as e:
+        raise click.ClickException(str(e))
+
+    console.print(f"[bold green]Downloaded:[/] {path}")
 
 
 if __name__ == "__main__":

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 import rich_click as click
 from click.testing import CliRunner
+from werkzeug.wrappers import Response
 
 from sleap_io import load_slp, save_slp, save_video
 from sleap_io.io.cli import (
@@ -29,6 +30,7 @@ from sleap_io.io.cli import (
     _is_ffmpeg_available,
     _load_images,
     _load_overlay,
+    _parse_cli_headers,
     _parse_overlay_outline_color,
     _RemoteInputPath,
     _run_subprocess_with_progress,
@@ -12457,3 +12459,144 @@ def test_ensure_utf8_streams_swallows_reconfigure_errors():
 
     # Must not raise.
     _ensure_utf8_streams([RaisingStream()])
+
+
+# ---------------------------------------------------------------------------
+# `sio download`
+# ---------------------------------------------------------------------------
+
+_DL_BODY = b"\x89HDF\r\n\x1a\n" + b"\x00" * 64
+
+
+def test_parse_cli_headers_empty():
+    """No --header options yields None."""
+    assert _parse_cli_headers(()) is None
+
+
+def test_parse_cli_headers_parses_pairs():
+    """`Name: Value` pairs are parsed and stripped."""
+    assert _parse_cli_headers(("Authorization: Bearer x", "X-Foo:bar")) == {
+        "Authorization": "Bearer x",
+        "X-Foo": "bar",
+    }
+
+
+@pytest.mark.parametrize("bad", ["no-colon", ": novalue-name"])
+def test_parse_cli_headers_invalid_raises(bad):
+    """A malformed --header value raises a ClickException."""
+    with pytest.raises(click.ClickException, match="Invalid --header"):
+        _parse_cli_headers((bad,))
+
+
+def test_download_cli_help():
+    """`sio download --help` documents the command."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["download", "--help"])
+    assert result.exit_code == 0
+    assert "Download a remote file" in result.output
+
+
+def test_download_cli_to_explicit_path(httpserver, tmp_path):
+    """`sio download URL DEST` writes the file and reports success."""
+    httpserver.expect_request("/labels.slp").respond_with_data(_DL_BODY)
+    url = httpserver.url_for("/labels.slp")
+    out = tmp_path / "out.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["download", url, str(out), "--no-progress"])
+
+    assert result.exit_code == 0, result.output
+    assert "Downloaded:" in result.output
+    assert out.read_bytes() == _DL_BODY
+
+
+def test_download_cli_into_directory(httpserver, tmp_path):
+    """A directory DEST writes inside it using the URL filename."""
+    httpserver.expect_request("/labels.slp").respond_with_data(_DL_BODY)
+    url = httpserver.url_for("/labels.slp")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["download", url, str(tmp_path), "--no-progress"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "labels.slp").read_bytes() == _DL_BODY
+
+
+def test_download_cli_output_option(httpserver, tmp_path):
+    """`-o/--output` is accepted as an alternative to the positional DEST."""
+    httpserver.expect_request("/labels.slp").respond_with_data(_DL_BODY)
+    url = httpserver.url_for("/labels.slp")
+    out = tmp_path / "out.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["download", url, "-o", str(out), "--no-progress"])
+
+    assert result.exit_code == 0, result.output
+    assert out.read_bytes() == _DL_BODY
+
+
+def test_download_cli_dest_conflict(httpserver, tmp_path):
+    """Specifying both positional DEST and -o is an error."""
+    url = httpserver.url_for("/labels.slp")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["download", url, str(tmp_path / "a.slp"), "-o", str(tmp_path / "b.slp")]
+    )
+    assert result.exit_code != 0
+    assert "Specify the destination once" in result.output
+
+
+def test_download_cli_bad_header(httpserver, tmp_path):
+    """A malformed --header is reported as a usage error."""
+    url = httpserver.url_for("/labels.slp")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["download", url, str(tmp_path / "x.slp"), "-H", "no-colon"]
+    )
+    assert result.exit_code != 0
+    assert "Invalid --header" in result.output
+
+
+def test_download_cli_header_forwarded(httpserver, tmp_path):
+    """`-H 'Name: Value'` is forwarded to the server."""
+    seen: list[str | None] = []
+
+    def _handler(request):
+        seen.append(request.headers.get("X-Token"))
+        return Response(_DL_BODY, status=200)
+
+    httpserver.expect_request("/labels.slp").respond_with_handler(_handler)
+    url = httpserver.url_for("/labels.slp")
+    out = tmp_path / "out.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["download", url, str(out), "--no-progress", "-H", "X-Token: secret123"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen and all(v == "secret123" for v in seen)
+
+
+def test_download_cli_local_path_rejected(tmp_path):
+    """A local path is rejected with a clear error."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["download", str(tmp_path / "local.slp")])
+    assert result.exit_code != 0
+    assert "expects a remote URL" in result.output
+
+
+def test_download_cli_404_reports_error(httpserver, tmp_path):
+    """A 404 is reported as a clean CLI error (no traceback)."""
+    httpserver.expect_request("/missing.slp").respond_with_data("no", status=404)
+    url = httpserver.url_for("/missing.slp")
+    out = tmp_path / "out.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["download", url, str(out), "--no-progress", "--retries", "0"]
+    )
+
+    assert result.exit_code != 0
+    assert not out.exists()

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -12554,7 +12554,10 @@ def test_download_cli_bad_header(httpserver, tmp_path):
         cli, ["download", url, str(tmp_path / "x.slp"), "-H", "no-colon"]
     )
     assert result.exit_code != 0
-    assert "Invalid --header" in result.output
+    # rich-click colorizes option-like tokens (e.g. ``--header``) with ANSI
+    # escapes, so strip them before the substring check (color is on in CI).
+    clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "Invalid --header" in clean
 
 
 def test_download_cli_header_forwarded(httpserver, tmp_path):

--- a/tests/io/test_remote.py
+++ b/tests/io/test_remote.py
@@ -32,8 +32,10 @@ from werkzeug.wrappers import Response
 from yarl import URL
 
 from sleap_io.io._gdrive import (
+    _filename_from_disposition,
     _is_gdrive_url,
     _open_gdrive,
+    _open_gdrive_with_name,
     _parse_gdrive,
     _url_from_confirmation,
 )
@@ -42,6 +44,7 @@ from sleap_io.io._remote import (
     _RETRY_BACKOFF_BASE,
     RemoteIOError,
     _build_fsspec_filesystem,
+    _filename_from_url,
     _find_response_error,
     _head_or_range_probe,
     _http_inner_options,
@@ -54,6 +57,7 @@ from sleap_io.io._remote import (
     _redacted_cause_summary,
     _redirect_target,
     _require_package,
+    _resolve_target_path,
     _retry_after_seconds,
     _retry_sleep_seconds,
     _sniff_format,
@@ -61,6 +65,7 @@ from sleap_io.io._remote import (
     _strip_cross_origin_headers,
     _warn_if_old_aiohttp,
     clear_remote_cache,
+    download,
     open_remote_h5,
     open_url,
 )
@@ -1865,3 +1870,385 @@ def test_sniff_over_http_live():
     ``SLEAP_IO_RUN_LIVE=1`` and select ``-m live``.
     """
     assert _sniff_format("https://slp.sh/4M16VD/labels.slp") == "hdf5"
+
+
+# ---------------------------------------------------------------------------
+# download(): destination/filename resolution (pure, no network)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://host/data/labels.slp", "labels.slp"),
+        ("https://host/labels.slp?token=abc#frag", "labels.slp"),
+        ("https://host/a/b/c/my%20file.slp", "my file.slp"),
+        ("s3://bucket/run/video.mp4", "video.mp4"),
+        ("https://host/dir/", None),
+        ("https://host", None),
+        # Path-traversal vectors: encoded separators / dot-segments must NOT
+        # survive into the result as real separators (would escape the dest dir).
+        ("https://host/%2E%2E%2F%2E%2E%2Fevil.slp", "evil.slp"),
+        ("https://host/foo%2F..%2F..%2Fevil.slp", "evil.slp"),
+        ("https://host/%2Fetc%2Fpasswd", "passwd"),
+        ("https://evil/a%5C..%5C..%5Cevil.slp", "evil.slp"),  # backslash sep
+        ("https://host/files/..", None),
+        ("https://host/files/.", None),
+        ("https://host/%2E%2E", None),
+    ],
+)
+def test_filename_from_url(url, expected):
+    """`_filename_from_url` returns a safe decoded basename (or None)."""
+    assert _filename_from_url(url) == expected
+
+
+def test_resolve_target_path_none_dest_uses_filename():
+    """`dest=None` writes the URL filename into the current directory."""
+    assert _resolve_target_path(None, "labels.slp") == Path("labels.slp")
+
+
+def test_resolve_target_path_none_dest_no_filename_is_none():
+    """`dest=None` with no derivable filename returns None (caller must error)."""
+    assert _resolve_target_path(None, None) is None
+
+
+def test_resolve_target_path_existing_dir(tmp_path):
+    """An existing-directory dest writes inside it using the filename."""
+    assert _resolve_target_path(tmp_path, "labels.slp") == tmp_path / "labels.slp"
+
+
+def test_resolve_target_path_trailing_slash_is_dir():
+    """A dest string ending in a separator is treated as a directory."""
+    assert _resolve_target_path("out/", "labels.slp") == Path("out/labels.slp")
+
+
+def test_resolve_target_path_dir_without_filename_is_none(tmp_path):
+    """A directory dest with no filename yet returns None."""
+    assert _resolve_target_path(tmp_path, None) is None
+
+
+def test_resolve_target_path_file_dest_is_literal(tmp_path):
+    """A non-directory dest is used as the exact output path."""
+    out = tmp_path / "sub" / "out.slp"
+    assert _resolve_target_path(out, "ignored.slp") == out
+
+
+@pytest.mark.parametrize("bad", ["/abs/local/path.slp", "relative/path.slp", "x.slp"])
+def test_download_rejects_local_path(bad):
+    """`download` raises ValueError for a non-URL input."""
+    with pytest.raises(ValueError, match="expects a remote URL"):
+        download(bad)
+
+
+def test_download_no_filename_no_dest_raises():
+    """A URL with no basename and no usable dest raises a clear ValueError."""
+    with pytest.raises(ValueError, match="determine a destination filename"):
+        download("https://host/dir/")
+
+
+def test_download_url_traversal_contained(tmp_path):
+    """A malicious encoded URL basename cannot escape a directory destination."""
+    url = "https://host/%2E%2E%2F%2E%2E%2Fevil.slp"
+    name = _filename_from_url(url)
+    assert name == "evil.slp"
+    target = _resolve_target_path(tmp_path, name)
+    # The resolved target stays strictly inside the destination directory.
+    assert target.parent.resolve() == tmp_path.resolve()
+    assert tmp_path.resolve() in target.resolve().parents
+
+
+def test_download_rejects_unsupported_scheme_and_redacts_credentials():
+    """An unsupported scheme is rejected without leaking embedded credentials."""
+    with pytest.raises(ValueError) as exc:
+        download("ftp://user:s3cr3t@host/file.slp")
+    msg = str(exc.value)
+    assert "s3cr3t" not in msg
+    assert "expects a remote URL" in msg
+
+
+# ---------------------------------------------------------------------------
+# download(): over HTTP (loopback pytest-httpserver)
+# ---------------------------------------------------------------------------
+
+
+def test_download_to_explicit_path(httpserver, tmp_path):
+    """`download` writes the bytes to an explicit destination path."""
+    httpserver.expect_request("/labels.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/labels.slp")
+    out = tmp_path / "out.slp"
+
+    result = download(url, out, progress=False)
+
+    assert result == out.resolve()
+    assert out.read_bytes() == _HDF5_BODY
+
+
+def test_download_default_dest_uses_url_basename(httpserver, tmp_path, monkeypatch):
+    """`dest=None` writes the URL filename into the current directory."""
+    httpserver.expect_request("/labels.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/labels.slp")
+    monkeypatch.chdir(tmp_path)
+
+    result = download(url, progress=False)
+
+    assert result == (tmp_path / "labels.slp").resolve()
+    assert (tmp_path / "labels.slp").read_bytes() == _HDF5_BODY
+
+
+def test_download_into_directory(httpserver, tmp_path):
+    """A directory dest writes inside it using the URL filename."""
+    httpserver.expect_request("/labels.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/labels.slp")
+    out_dir = tmp_path / "downloads"
+    out_dir.mkdir()
+
+    result = download(url, out_dir, progress=False)
+
+    assert result == (out_dir / "labels.slp").resolve()
+    assert (out_dir / "labels.slp").read_bytes() == _HDF5_BODY
+
+
+def test_download_creates_parent_dirs(httpserver, tmp_path):
+    """Missing parent directories of the destination are created."""
+    httpserver.expect_request("/labels.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/labels.slp")
+    out = tmp_path / "a" / "b" / "out.slp"
+
+    download(url, out, progress=False)
+
+    assert out.read_bytes() == _HDF5_BODY
+
+
+def test_download_skips_existing_without_network(httpserver, tmp_path):
+    """An existing destination is returned without re-downloading (idempotent)."""
+    hits: list[int] = []
+
+    def _handler(request):
+        hits.append(1)
+        return Response(_HDF5_BODY, status=200)
+
+    httpserver.expect_request("/labels.slp").respond_with_handler(_handler)
+    url = httpserver.url_for("/labels.slp")
+    out = tmp_path / "out.slp"
+    out.write_bytes(b"sentinel")
+
+    result = download(url, out, progress=False)
+
+    assert result == out.resolve()
+    assert out.read_bytes() == b"sentinel"
+    assert hits == [], "server was contacted despite an existing destination"
+
+
+def test_download_overwrite_refetches(httpserver, tmp_path):
+    """`overwrite=True` re-downloads over an existing destination."""
+    httpserver.expect_request("/labels.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/labels.slp")
+    out = tmp_path / "out.slp"
+    out.write_bytes(b"old")
+
+    download(url, out, overwrite=True, progress=False)
+
+    assert out.read_bytes() == _HDF5_BODY
+
+
+def test_download_dir_collision_raises(httpserver, tmp_path):
+    """A resolved target that is an existing directory raises IsADirectoryError."""
+    httpserver.expect_request("/data").respond_with_data(_HDF5_BODY)
+    url = httpserver.url_for("/data")  # basename "data"
+    (tmp_path / "data").mkdir()
+
+    with pytest.raises(IsADirectoryError, match="existing directory"):
+        download(url, tmp_path, progress=False)
+
+
+def test_download_no_part_file_left_on_success(httpserver, tmp_path):
+    """A successful download leaves no `.part` temp file behind."""
+    httpserver.expect_request("/labels.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/labels.slp")
+    out = tmp_path / "out.slp"
+
+    download(url, out, progress=False)
+
+    assert list(tmp_path.glob("*.part")) == []
+
+
+def test_download_404_raises_and_cleans_up(httpserver, tmp_path):
+    """A 404 raises RemoteIOError and leaves no file or `.part` behind."""
+    httpserver.expect_request("/missing.slp").respond_with_data("no", status=404)
+    url = httpserver.url_for("/missing.slp")
+    out = tmp_path / "out.slp"
+
+    with pytest.raises(RemoteIOError):
+        download(url, out, progress=False, retries=0)
+
+    assert not out.exists()
+    assert list(tmp_path.glob("*.part")) == []
+
+
+def test_download_with_progress_bar(httpserver, tmp_path):
+    """`progress=True` (default) still produces a correct file."""
+    httpserver.expect_request("/labels.slp").respond_with_handler(
+        _make_range_handler(_HDF5_BODY)
+    )
+    url = httpserver.url_for("/labels.slp")
+    out = tmp_path / "out.slp"
+
+    download(url, out, progress=True)
+
+    assert out.read_bytes() == _HDF5_BODY
+
+
+def test_download_retries_then_succeeds(httpserver, tmp_path):
+    """A transient 503 is retried and the download then succeeds."""
+    state = {"n": 0}
+
+    def _handler(request):
+        state["n"] += 1
+        if state["n"] == 1:
+            return Response("busy", status=503)
+        return Response(_HDF5_BODY, status=200)
+
+    httpserver.expect_request("/flaky.slp").respond_with_handler(_handler)
+    url = httpserver.url_for("/flaky.slp")
+    out = tmp_path / "out.slp"
+
+    download(url, out, progress=False, retries=2)
+
+    assert out.read_bytes() == _HDF5_BODY
+    assert state["n"] >= 2
+
+
+# ---------------------------------------------------------------------------
+# download(): Google Drive
+# ---------------------------------------------------------------------------
+
+
+def test_filename_from_disposition_plain():
+    """A plain `filename="..."` Content-Disposition is parsed."""
+    assert _filename_from_disposition('attachment; filename="data.slp"') == "data.slp"
+
+
+def test_filename_from_disposition_rfc5987():
+    """An RFC 5987 `filename*=UTF-8''...` extended value is parsed and decoded."""
+    value = "attachment; filename*=UTF-8''na%C3%AFve.slp"
+    assert _filename_from_disposition(value) == "naïve.slp"
+
+
+def test_filename_from_disposition_strips_path_components():
+    """Directory components in the filename are stripped (path-traversal guard)."""
+    assert _filename_from_disposition('attachment; filename="../../etc/x"') == "x"
+
+
+@pytest.mark.parametrize("value", [None, "", "inline", "attachment"])
+def test_filename_from_disposition_none(value):
+    """Missing/filename-less Content-Disposition values yield None."""
+    assert _filename_from_disposition(value) is None
+
+
+@pytest.mark.parametrize(
+    "value", ['attachment; filename="."', 'attachment; filename=".."']
+)
+def test_filename_from_disposition_dot_segments_rejected(value):
+    """Bare dot-segment filenames are rejected (would target the dir itself)."""
+    assert _filename_from_disposition(value) is None
+
+
+def test_open_gdrive_with_name_returns_filename(gdrive_uc_template):
+    """`_open_gdrive_with_name` returns the Content-Disposition filename."""
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=_HDF5_BODY)
+
+    bio, name = _open_gdrive_with_name("https://drive.google.com/file/d/FILEID/view")
+
+    assert bio.read() == _HDF5_BODY
+    assert name == "data.bin"
+
+
+def test_download_gdrive_uses_disposition_filename(gdrive_uc_template, tmp_path):
+    """A Drive download into a directory uses the Content-Disposition filename."""
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=_HDF5_BODY)
+
+    result = download("https://drive.google.com/file/d/FILEID/view", tmp_path)
+
+    assert result == (tmp_path / "data.bin").resolve()
+    assert (tmp_path / "data.bin").read_bytes() == _HDF5_BODY
+
+
+def test_download_gdrive_explicit_dest(gdrive_uc_template, tmp_path):
+    """A Drive download to an explicit path writes there."""
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=_HDF5_BODY)
+    out = tmp_path / "labels.slp"
+
+    result = download("https://drive.google.com/file/d/FILEID/view", out)
+
+    assert result == out.resolve()
+    assert out.read_bytes() == _HDF5_BODY
+
+
+def test_download_gdrive_skips_existing_explicit_dest(gdrive_uc_template, tmp_path):
+    """An existing explicit dest skips the Drive fetch entirely (idempotent)."""
+    hits: list[int] = []
+
+    def _uc_handler(request):
+        hits.append(1)
+        return Response("<html></html>", status=200, content_type="text/html")
+
+    gdrive_uc_template.expect_request("/uc").respond_with_handler(_uc_handler)
+    out = tmp_path / "labels.slp"
+    out.write_bytes(b"sentinel")
+
+    result = download("https://drive.google.com/file/d/FILEID/view", out)
+
+    assert result == out.resolve()
+    assert out.read_bytes() == b"sentinel"
+    assert hits == [], "Drive was contacted despite an existing destination"
+
+
+def test_download_gdrive_dir_dest_skips_existing(gdrive_uc_template, tmp_path):
+    """A dir-dest Drive download skips writing if the resolved name exists.
+
+    The Drive filename is only known after fetching, so the existence check
+    happens inside ``_download_gdrive`` (not the up-front path in ``download``).
+    """
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=_HDF5_BODY)
+    existing = tmp_path / "data.bin"
+    existing.write_bytes(b"sentinel")
+
+    result = download("https://drive.google.com/file/d/FILEID/view", tmp_path)
+
+    assert result == existing.resolve()
+    assert existing.read_bytes() == b"sentinel"
+
+
+def test_download_gdrive_dir_collision_raises(gdrive_uc_template, tmp_path):
+    """A Drive filename that collides with an existing subdir raises clearly."""
+    _serve_gdrive_two_hop(gdrive_uc_template, file_bytes=_HDF5_BODY)
+    (tmp_path / "data.bin").mkdir()  # collides with the Content-Disposition name
+
+    with pytest.raises(IsADirectoryError, match="existing directory"):
+        download("https://drive.google.com/file/d/FILEID/view", tmp_path)
+
+
+def test_download_gdrive_no_filename_dir_dest_raises(gdrive_uc_template, tmp_path):
+    """A Drive file with no Content-Disposition filename + dir dest raises."""
+
+    def _handler(request):
+        # Reach the file directly (non-HTML) with NO Content-Disposition, so no
+        # filename can be derived.
+        return Response(_HDF5_BODY, status=200, content_type="application/octet-stream")
+
+    gdrive_uc_template.expect_request("/uc").respond_with_handler(_handler)
+
+    with pytest.raises(ValueError, match="determine a destination filename"):
+        download("https://drive.google.com/uc?id=FILEID", tmp_path)


### PR DESCRIPTION
## Summary

Adds a high-level **`sio.download(url, dest)`** helper (and a matching **`sio download`** CLI command) that fetches a remote file to local disk — a simple, protocol-agnostic replacement for `curl`/`wget` in notebooks and demos.

0.8.0 added remote *reading* (passing a URL to `load_slp`/`load_file`/`load_video`), but there was no public "fetch this URL to a file" primitive. The closest internals (`open_url(stream_mode="download")`, `_open_gdrive`) only read into memory. This fills that gap, reusing the existing `_remote`/`_gdrive` plumbing.

## Key Changes

- **`sleap_io/io/_remote.py`** — new public `download()` plus helpers:
  - Same schemes as the loaders: `http`/`https`, cloud (`s3`/`gs`/`gcs`/`az`/`abfs`, `[cloud]` extra), and Google Drive share links.
  - HTTP/cloud files **stream straight to disk** (`fs.get_file`, bounded memory) with a `tqdm` progress bar; Drive files are buffered in memory (Drive can't be range-read).
  - **Atomic writes** via a unique `tempfile.mkstemp` `.part` sibling + `os.replace` (safe under concurrent writers; no truncated files on interrupt).
  - **Idempotent**: skips re-download if the destination exists (`overwrite=True` to force).
  - Inherits retries/backoff, auth headers, credential redaction, `RemoteIOError`, and `[cloud]`-extra gating from the existing remote stack.
- **`sleap_io/io/_gdrive.py`** — `_open_gdrive_with_name()` surfaces the resolved `Content-Disposition` filename (so a directory/`None` dest gets the real name); `_open_gdrive()` kept as a thin BytesIO wrapper (existing callers unchanged).
- **`sleap_io/__init__.py`** — export `sio.download`.
- **`sleap_io/io/cli.py`** — `sio download <url> [dest]` command (positional or `-o`, `-f/--overwrite`, `--no-progress`, repeatable `-H/--header`, `--retries`); reuses the library core; new "Remote" help panel.
- **docs** — Remote loading guide (`docs/remote.md`), examples, and CLI reference (`docs/cli.md`).

## Example Usage

```python
import sleap_io as sio

# Into the current dir (filename from the URL), a directory, or an exact path.
sio.download("https://example.com/labels.slp")            # -> ./labels.slp
sio.download("s3://bucket/run/video.mp4", "data/")        # -> data/video.mp4
sio.download("https://example.com/a.slp", "downloads/b.slp")

# Authenticated; fetch-then-load for formats not loadable directly over a URL.
sio.download(url, headers={"Authorization": "Bearer <token>"})
labels = sio.load_nwb(sio.download("https://example.com/labels.nwb"))
```

```bash
sio download https://example.com/labels.slp
sio download s3://bucket/run/video.mp4 data/
sio download https://example.com/a.slp out.slp -H 'Authorization: Bearer <token>' -f
```

## API Changes

- **New public API:** `sio.download(url, dest=None, *, headers=None, overwrite=False, progress=True, retries=3) -> pathlib.Path`.
- **New CLI command:** `sio download`.
- No breaking changes. No new dependencies (`fsspec`/`aiohttp`/`tqdm` are already base deps; cloud schemes use the existing `[cloud]` extra).

## Testing

- Library tests (`tests/io/test_remote.py`) and CLI tests (`tests/io/test_cli.py`) via loopback `pytest-httpserver` (no live network), covering: destination resolution, idempotent skip (asserts no network hit), overwrite, parent-dir creation, atomic `.part` cleanup on success/failure, retries, directory-collision, Google Drive (filename from `Content-Disposition`, explicit/dir dest, skip-existing), and CLI help/options/error mapping.
- **Security**: path-traversal vectors (encoded separators, absolute, backslash, dot-segments) and credential redaction in errors.
- New `download` code is at 100% line/branch coverage; full `tests/io/` suite passes; `ruff` clean.

## Design Decisions

- **Streaming for HTTP/cloud, buffering for Drive.** `fs.get_file` streams with bounded memory (good for large videos); Drive rejects `HEAD`/range so it must buffer (capped) — documented in the helper and docs.
- **Idempotent by default.** Skip-if-exists makes re-running notebook cells cheap; `overwrite=True` forces a refetch. (Chosen over always-overwrite per discussion.)
- **Filenames are sanitized.** URL/`Content-Disposition` names are reduced to a bare basename (decode-then-basename, dot-segment rejection) so a server-controlled name can't escape the destination directory — mirroring the existing Drive guard. A directory-collision destination raises a clear `IsADirectoryError`.
- **One code path.** The CLI calls the library `download()` rather than reimplementing the transfer, so behavior/security are tested once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)