### PR TITLE
fix(io): name the video in out-of-range embed errors

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -996,10 +996,20 @@ def process_and_embed_frames(
         # /video_crops and re-applied on load, so it is baked exactly once. This
         # matches the crop-over-embedded path (which already embeds the uncropped
         # source) and keeps the reloaded video a CropVideoBackend over full frames.
-        if isinstance(video.backend, CropVideoBackend):
-            frame = video.backend.inner.get_frame(frame_idx)
-        else:
-            frame = video[frame_idx]
+        try:
+            if isinstance(video.backend, CropVideoBackend):
+                frame = video.backend.inner.get_frame(frame_idx)
+            else:
+                frame = video[frame_idx]
+        except IndexError as e:
+            # Surface which video the missing frame belongs to. The bare backend
+            # error only reports the frame index, which is not actionable when a
+            # project has more than one video.
+            raise IndexError(
+                f"Frame index {frame_idx} out of range for video "
+                f"{frame_meta['video_ind']} ({video.filename}), which has "
+                f"{len(video)} frames."
+            ) from e
 
         # Encode the frame
         if image_format == "hdf5":

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -2583,6 +2583,29 @@ def test_embed_invalid_value(tmpdir, slp_real_data):
         write_labels(labels_path, base_labels, embed="invalid_embed_value")
 
 
+def test_embed_out_of_range_frame_reports_video(tmpdir, slp_real_data):
+    """Out-of-range embed error names the video, not just the frame index."""
+    base_labels = read_labels(slp_real_data)
+    video = base_labels.video
+    n_frames = len(video)
+    video_ind = base_labels.videos.index(video)
+
+    labels_path = Path(tmpdir / "labels.pkg.slp").as_posix()
+    bad_frame_idx = n_frames + 100
+    frames_metadata = prepare_frames_to_embed(
+        labels_path, base_labels, [(video, bad_frame_idx)]
+    )
+
+    with pytest.raises(IndexError) as exc_info:
+        process_and_embed_frames(labels_path, frames_metadata)
+
+    message = str(exc_info.value)
+    assert f"Frame index {bad_frame_idx} out of range" in message
+    assert f"video {video_ind}" in message
+    assert str(video.filename) in message
+    assert f"{n_frames} frames" in message
+
+
 def test_process_and_embed_frames_verbose():
     """Test that process_and_embed_frames uses tqdm when verbose=True."""
     # Since we only want to test if tqdm is imported, we can simplify


### PR DESCRIPTION
## Problem

When exporting a labels package (e.g. a training job package from the SLEAP GUI), a labeled frame or suggestion whose index no longer exists in its video — usually because the video was re-encoded/trimmed after labeling — fails embedding with a bare error:

> Frame index 1587 out of range.

The frame index alone isn't actionable when a project has more than one video: you can't tell *which* video the missing frame is in.

Reported in talmolab/sleap#2802 (the SLEAP export dialog displays this exception text verbatim, so improving it here flows straight through to the GUI).

## Fix

`process_and_embed_frames` already tracks each frame's video index (`frame_meta["video_ind"]`). This wraps the slow-path frame read and re-raises the `IndexError` with the video index, filename, and frame count:

> Frame index 1587 out of range for video 2 (`session.mp4`), which has 1200 frames.

The fast path can't hit this — it's guarded by `has_frame` — so only the slow-path read needs wrapping.

## Testing

- New `test_embed_out_of_range_frame_reports_video` asserts the message names the frame index, video index, filename, and frame count.
- All 53 embed tests in `tests/io/test_slp.py` pass; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)