### PR TITLE
feat(model): unified interconversion between detection modalities (pose ⇄ centroid ⇄ bbox ⇄ mask/ROI)

### DIFF
--- a/docs/model/boxes.md
+++ b/docs/model/boxes.md
@@ -86,6 +86,38 @@ meaningful for axis-aligned rectangles:
 
 ```
 
+## Converting to other modalities
+
+A `BoundingBox` participates in the unified
+[conversion matrix](segmentation.md#converting-between-annotation-types): it can
+be reduced to a [`Centroid`](centroids.md) at its center, inflated with
+`pad()`, or projected to an [`ROI`](rois.md) / `SegmentationMask`. Predicted
+boxes produce predicted outputs carrying their `score`:
+
+```pycon
+>>> import sleap_io as sio
+>>> bbox = sio.UserBoundingBox(x1=75, y1=160, x2=125, y2=240)
+>>> print(bbox.to_centroid().xy)   # center of the box
+>>> print(bbox.pad(10).xyxy)       # inflate 10 px on every side
+>>> print(bbox.to_roi().area)
+
+```
+
+`pad(padding)` returns a new box of the same type inflated by `padding` (scalar
+or `(px, py)`; negatives shrink), preserving `angle`, `score`, and metadata.
+`to_centroid()` and the other verbs accept `error_on_empty=False`; a degenerate
+box (NaN corners) yields a degenerate target unless you pass
+`error_on_empty=True`. The companion `is_empty` property reports whether any
+corner is NaN:
+
+```pycon
+>>> import sleap_io as sio
+>>> bbox = sio.UserBoundingBox(x1=75, y1=160, x2=125, y2=240)
+>>> print(bbox.is_empty)
+False
+
+```
+
 ## Metadata fields
 
 Every bounding box can carry optional metadata:
@@ -111,7 +143,7 @@ Every bounding box can carry optional metadata:
     - **[Centroids](centroids.md)**, **[ROIs](rois.md)**, **[Segmentation](segmentation.md)** — the other spatial annotation types.
     - **[Labels & Frames](labels.md)**: Accessing boxes via `labels.bboxes` and filtered queries with `get_bboxes()`.
     - **[Formats: COCO](../formats/coco.md)** and **[Ultralytics YOLO](../formats/ultralytics.md)**: Bounding-box detection round-trips.
-    - **[Converting between annotation types](segmentation.md#converting-between-annotation-types)**: `bbox.to_roi()`, `bbox.to_mask()`, and more.
+    - **[Converting between annotation types](segmentation.md#converting-between-annotation-types)**: `bbox.to_centroid()`, `bbox.pad()`, `bbox.to_roi()`, `bbox.to_mask()`, and the full modality matrix.
 
 ---
 

--- a/docs/model/centroids.md
+++ b/docs/model/centroids.md
@@ -25,9 +25,11 @@ single-node [`Instance`](poses.md) objects, and the same track/instance metadata
 
 ```
 
-## From an Instance
+## From a pose Instance
 
-Create a centroid from an existing pose `Instance` using one of three methods:
+Create a centroid from an existing pose `Instance` with
+[`Centroid.from_pose`][sleap_io.Centroid.from_pose] (equivalently
+[`Instance.to_centroid`][sleap_io.Instance.to_centroid]):
 
 ```pycon
 >>> import numpy as np
@@ -37,18 +39,25 @@ Create a centroid from an existing pose `Instance` using one of three methods:
 ...     np.array([[10, 20], [30, 40], [50, 60]]),
 ...     skeleton=skeleton,
 ... )
->>> centroid = sio.UserCentroid.from_instance(inst)
+>>> centroid = sio.UserCentroid.from_pose(inst)
 >>> print(centroid.xy)
+>>> print(centroid.source)  # records the method used
 
 ```
 
 The `method` parameter controls how the center point is computed:
 
-| Method | Behavior |
-|--------|----------|
-| `"center_of_mass"` | Mean of all visible point coordinates (default) |
-| `"bbox_center"` | Center of the bounding box of visible points |
-| `"anchor"` | Coordinates of a specific node (requires `node` argument) |
+| Method | Behavior | `source` tag |
+|--------|----------|--------------|
+| `"center_of_mass"` | NaN-ignoring (unweighted) mean of visible points (default) | `"center_of_mass"` |
+| `"bbox_center"` | Center of the bounding box of visible points | `"bbox_center"` |
+| `"geometric_median"` | Weiszfeld geometric median of visible points (outlier-robust) | `"geometric_median"` |
+| `"anchor"` | Coordinates of a specific node (requires `node`) | `"anchor:<node>"` |
+
+For `method="anchor"`, pass `node` (a node name or index). If the anchor node is
+occluded, supply a `fallback` method (one of the non-anchor methods) to compute
+the centroid from the visible points instead; the `source` tag then records the
+chain, e.g. `"anchor:nose->center_of_mass"`:
 
 ```pycon
 >>> import numpy as np
@@ -58,23 +67,73 @@ The `method` parameter controls how the center point is computed:
 ...     np.array([[10, 20], [30, 40], [50, 60]]),
 ...     skeleton=skeleton,
 ... )
->>> anchor_c = sio.UserCentroid.from_instance(inst, method="anchor", node="head")
+>>> anchor_c = sio.UserCentroid.from_pose(inst, method="anchor", node="head")
 >>> print(anchor_c.xy)
+>>> print(anchor_c.source)
 
 ```
 
-## Converting back to an Instance
+When there are no visible points (or an occluded anchor with no fallback), the
+result is a degenerate centroid (`x = y = nan`); pass `error_on_empty=True` to
+raise a `ValueError` instead. The `is_empty` property reports this cheaply:
 
-A centroid can be converted to a single-node `Instance` for interoperability
-with pose-based workflows:
+```pycon
+>>> import sleap_io as sio
+>>> print(sio.UserCentroid(x=float("nan"), y=float("nan")).is_empty)
+True
+
+```
+
+!!! note "Renamed from `from_instance`"
+    `Centroid.from_instance()` was renamed to `Centroid.from_pose()` (the pose
+    modality is named `pose` everywhere, even though the backing class is
+    `Instance`). `from_instance()` is kept as a deprecated alias that forwards to
+    `from_pose()` and emits a `DeprecationWarning`.
+
+## Converting back to a pose Instance
+
+A centroid can be converted to a single-node `Instance` with
+[`Centroid.to_pose`][sleap_io.Centroid.to_pose] for interoperability with
+pose-based workflows:
 
 ```pycon
 >>> import sleap_io as sio
 >>> centroid = sio.UserCentroid(x=30.0, y=40.0)
->>> inst = centroid.to_instance()
+>>> inst = centroid.to_pose()
 >>> print(inst.numpy())
 
 ```
+
+!!! note "Renamed from `to_instance`"
+    `Centroid.to_instance()` was renamed to `Centroid.to_pose()`.
+    `to_instance()` is kept as a deprecated alias that forwards to `to_pose()`
+    and emits a `DeprecationWarning`.
+
+## Constructing boxes, ROIs, and masks
+
+A centroid is a single point, so it can seed a fixed-size
+[`BoundingBox`](boxes.md), a circular [`ROI`](rois.md), or a rasterized
+`SegmentationMask` around itself. These complete the
+[conversion matrix](segmentation.md#converting-between-annotation-types) for the
+centroid modality:
+
+```pycon
+>>> import sleap_io as sio
+>>> centroid = sio.UserCentroid(x=30.0, y=40.0)
+>>> box = centroid.to_bbox(size=20)                 # 20x20 box centered on the point
+>>> print(box.xyxy)
+>>> roi = centroid.to_roi(radius=5)                 # disc of radius 5
+>>> print(round(roi.area, 2))
+>>> mask = centroid.to_mask(100, 100, radius=5)     # rasterized disc
+>>> print(mask.area)
+
+```
+
+`to_bbox` requires `size` (a scalar for a square box or `(w, h)`) and accepts
+`padding`. `to_roi` and `to_mask` require `radius`. A `PredictedCentroid`
+produces predicted outputs carrying its `score`. A degenerate (NaN) centroid
+yields an empty target (NaN box / empty-`Polygon` ROI / all-background mask)
+unless `error_on_empty=True`.
 
 ## User vs. predicted centroids
 
@@ -91,7 +150,7 @@ model predictions. `PredictedCentroid` adds a `score` field for confidence:
 
 ```
 
-When using `from_instance()`, the return type matches the input:
+When using `from_pose()`, the return type matches the input:
 `PredictedInstance` produces `PredictedCentroid`, `Instance` produces
 `UserCentroid`.
 
@@ -112,7 +171,7 @@ Every centroid can carry optional metadata:
 | `source`    | `str`              | How the centroid was computed (e.g., `"center_of_mass"`) |
 
 !!! tip "Rendering"
-    Centroids compose with pose rendering in [`sio.render_image`][sleap_io.render_image] / [`sio.render_video`][sleap_io.render_video] and are listed in [Rendering → Segmentation Overlays](../rendering.md#segmentation-overlays). For standalone canvases, pair [`sio.draw_bboxes`][sleap_io.draw_bboxes] with `Centroid.to_instance()` or use the pose drawing helpers directly.
+    Centroids compose with pose rendering in [`sio.render_image`][sleap_io.render_image] / [`sio.render_video`][sleap_io.render_video] and are listed in [Rendering → Segmentation Overlays](../rendering.md#segmentation-overlays). For standalone canvases, pair [`sio.draw_bboxes`][sleap_io.draw_bboxes] with `Centroid.to_pose()` or use the pose drawing helpers directly.
 
 ---
 
@@ -121,6 +180,7 @@ Every centroid can carry optional metadata:
     - **[Boxes](boxes.md)**, **[ROIs](rois.md)**, **[Segmentation](segmentation.md)** — the other spatial annotation types.
     - **[Labels & Frames](labels.md)**: Accessing centroids via `labels.centroids` and filtered queries with `get_centroids()`.
     - **[Formats: TrackMate](../formats/trackmate.md)**: Importing point-tracking detections as `PredictedCentroid`.
+    - **[Converting between annotation types](segmentation.md#converting-between-annotation-types)**: `centroid.to_pose()`, `centroid.to_bbox()`, `centroid.to_roi()`, `centroid.to_mask()`, and the full modality matrix.
 
 ---
 

--- a/docs/model/poses.md
+++ b/docs/model/poses.md
@@ -179,27 +179,73 @@ Create an instance with no visible points (all coordinates are unset):
     [`LabeledFrame`](labels.md#labeled-frames) and [`Labels`](labels.md#labels).
     See the [Labels & Frames](labels.md) page for the full picture.
 
-### Centroid integration
+### Converting to other modalities
 
-A pose `Instance` can be summarized as a single point without losing its metadata. [`Instance.centroid_xy`][sleap_io.Instance.centroid_xy] returns the `(x, y)` of the visible landmarks, and [`Instance.to_centroid()`][sleap_io.Instance.to_centroid] produces a full [`UserCentroid`][sleap_io.UserCentroid] (or [`PredictedCentroid`][sleap_io.PredictedCentroid] for a `PredictedInstance`) carrying the same track, category, and confidence metadata.
+A pose `Instance` can be projected onto any of the other spatial detection
+modalities without losing its metadata, through the unified
+[conversion matrix](segmentation.md#converting-between-annotation-types). Every
+verb returns the `User*`/`Predicted*` variant matching the instance (a
+`PredictedInstance` carries its `score`) and propagates `track`,
+`tracking_score`, and an `instance=self` backref.
+
+[`Instance.centroid_xy`][sleap_io.Instance.centroid_xy] returns the raw `(x, y)`
+of the visible landmarks, while [`Instance.to_centroid()`][sleap_io.Instance.to_centroid]
+produces a full [`Centroid`](centroids.md) object:
 
 ```pycon
 >>> import numpy as np
 >>> import sleap_io as sio
->>> skeleton = sio.Skeleton(["head", "thorax", "abdomen"])
+>>> skeleton = sio.Skeleton(
+...     ["head", "thorax", "abdomen"],
+...     edges=[("head", "thorax"), ("thorax", "abdomen")],
+... )
 >>> inst = sio.Instance.from_numpy(
 ...     np.array([[10, 20], [30, 40], [50, 60]]),
 ...     skeleton=skeleton,
 ... )
->>> print(inst.centroid_xy)       # (mean_x, mean_y) of the visible points
+>>> print(inst.centroid_xy)        # (mean_x, mean_y) of the visible points
 >>> c = inst.to_centroid()
 >>> print(type(c).__name__, c.xy)
 
 ```
 
+[`Instance.to_bbox()`][sleap_io.Instance.to_bbox],
+[`Instance.to_roi()`][sleap_io.Instance.to_roi], and
+[`Instance.to_mask()`][sleap_io.Instance.to_mask] fit a
+[`BoundingBox`](boxes.md), [`ROI`](rois.md), or `SegmentationMask` to the pose:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(
+...     ["head", "thorax", "abdomen"],
+...     edges=[("head", "thorax"), ("thorax", "abdomen")],
+... )
+>>> inst = sio.Instance.from_numpy(
+...     np.array([[10, 20], [30, 40], [50, 60]]),
+...     skeleton=skeleton,
+... )
+>>> print(inst.to_bbox().xyxy)                      # tight box of visible points
+>>> print(inst.to_bbox(mode="centered", size=30).xyxy)
+>>> roi = inst.to_roi(method="shapes", node_radius=5, edge_radius=2)
+>>> print(roi.is_empty)
+>>> mask = inst.to_mask(80, 80, method="shapes", node_radius=5, edge_radius=2)
+>>> print(mask.area > 0)
+
+```
+
+`to_bbox` supports `mode="tight"` (axis-aligned or `rotated=True`) and
+`mode="centered"` (a fixed `size` box around a computed centroid). `to_roi`
+"burns in" the pose with `method="shapes"` (union of discs around nodes and
+capsules around edges; at least one of `node_radius`/`edge_radius` must be
+`> 0`) or `method="convex_hull"`. `to_mask(height, width, **roi_kwargs)` is
+exactly `to_roi(**roi_kwargs).to_mask(height, width)`. All verbs accept
+`error_on_empty=False` and return an empty target for an instance with no
+visible points.
+
 Centroids can be turned back into single-node instances with
-[`Centroid.to_instance`][sleap_io.Centroid.to_instance], so the two
-representations are fully interchangeable. See
+[`Centroid.to_pose`][sleap_io.Centroid.to_pose] (formerly `to_instance`, now a
+deprecated alias), so the two representations are fully interchangeable. See
 [Regions → Centroids](centroids.md) for the full data model.
 
 ---

--- a/docs/model/rois.md
+++ b/docs/model/rois.md
@@ -69,6 +69,41 @@ Any `BoundingBox` can be converted to an `ROI` with `.to_roi()`:
 
 ```
 
+## Reducing an ROI to a point or box
+
+An `ROI` participates in the unified
+[conversion matrix](segmentation.md#converting-between-annotation-types). Reduce
+it to a [`Centroid`](centroids.md) with `to_centroid()`, or fit a
+[`BoundingBox`](boxes.md) with `to_bbox()`. Predicted ROIs produce predicted
+outputs carrying their `score`:
+
+```pycon
+>>> import sleap_io as sio
+>>> from shapely.geometry import box
+>>> roi = sio.UserROI(geometry=box(10, 20, 100, 200))
+>>> print(roi.to_centroid().xy)            # geometric centroid
+>>> print(roi.to_bbox().xyxy)              # axis-aligned bounds
+>>> print(roi.to_bbox(padding=5).xyxy)     # inflated box
+
+```
+
+`to_centroid(representative=True)` uses Shapely's `representative_point()` (a
+point guaranteed to lie inside the geometry) instead of the geometric centroid.
+`to_bbox(rotated=True)` fits a minimum-area oriented box from the geometry's
+`minimum_rotated_rectangle`. Both verbs accept `error_on_empty=False`; an empty
+geometry yields a degenerate target unless you pass `error_on_empty=True`. The
+companion `is_empty` property reports whether the geometry is empty:
+
+```pycon
+>>> import sleap_io as sio
+>>> from shapely.geometry import Polygon, box
+>>> print(sio.UserROI(geometry=box(0, 0, 10, 10)).is_empty)
+False
+>>> print(sio.UserROI(geometry=Polygon()).is_empty)
+True
+
+```
+
 ## Multi-polygon ROIs
 
 For disjoint regions, use `from_multi_polygon`:
@@ -164,7 +199,7 @@ Every ROI can carry optional metadata:
 
     - **[Centroids](centroids.md)**, **[Boxes](boxes.md)**, **[Segmentation](segmentation.md)** — the other spatial annotation types.
     - **[Labels & Frames](labels.md)**: Accessing ROIs via `labels.rois`, video-level `labels.static_rois`, and `get_rois()`.
-    - **[Converting between annotation types](segmentation.md#converting-between-annotation-types)**: `roi.to_mask()` and more.
+    - **[Converting between annotation types](segmentation.md#converting-between-annotation-types)**: `roi.to_centroid()`, `roi.to_bbox()`, `roi.to_mask()`, and the full modality matrix.
 
 ---
 

--- a/docs/model/segmentation.md
+++ b/docs/model/segmentation.md
@@ -688,34 +688,91 @@ by the `Labels` object and can be explicitly closed with `labels.close()`.
 
 ## Converting between annotation types
 
-The four spatial annotation types can be converted between each other where
-geometrically meaningful:
+sleap-io models five spatial detection modalities — **pose** ([`Instance`](poses.md)),
+[`Centroid`](centroids.md), [`BoundingBox`](boxes.md), `SegmentationMask`, and
+[`ROI`](rois.md) (polygon) — and every modality exposes the same verb set
+(`.to_centroid()`, `.to_bbox()`, `.to_mask()`, `.to_roi()`) so you can move
+freely between them. Geometry conversions are centralized on the two hubs that
+already exist — `ROI` (Shapely) for vector ops and `SegmentationMask` for raster
+— so `obj.to_mask(height, width)` is always `obj.to_roi(...).to_mask(height, width)`.
 
-| From                | To                    | Method                            |
-| ------------------- | --------------------- | --------------------------------- |
-| `BoundingBox`       | `ROI`                 | `bbox.to_roi()`                   |
-| `BoundingBox`       | `SegmentationMask`    | `bbox.to_mask(height, width)`     |
-| `ROI`               | `SegmentationMask`    | `roi.to_mask(height, width)`      |
-| `SegmentationMask`  | `ROI` (polygon)       | `mask.to_polygon()`               |
-| `SegmentationMask`  | `BoundingBox`         | `mask.to_bbox()`                  |
-| `PredictedSegmentationMask` | `UserSegmentationMask` | `pred_mask.to_user()`     |
-| `LabelImage`        | `list[SegmentationMask]` | `li.to_masks()`                |
-| `LabelImage`        | `list[BoundingBox]`   | `li.to_bboxes()`                  |
-| `list[SegmentationMask]` | `LabelImage`     | `UserLabelImage.from_masks(masks)` |
+### The conversion matrix
 
-All conversions preserve metadata (track, instance, name,
-category, source) when applicable. `to_bbox()` and `to_bboxes()` preserve
-prediction semantics (`Predicted*` inputs produce `Predicted*` outputs with
-scores). Other conversions return `User*` types.
+| from ↓ \ to →        | Centroid                          | BoundingBox                          | SegmentationMask                          | ROI (polygon)                         |
+| -------------------- | --------------------------------- | ------------------------------------ | ----------------------------------------- | ------------------------------------- |
+| **Pose** (`Instance`) | `to_centroid(method=, node=, fallback=)` | `to_bbox(mode=, size=, padding=, rotated=)` | `to_mask(height, width, **roi_kwargs)` | `to_roi(method=, node_radius=, edge_radius=, radius=)` |
+| **Centroid**         | —                                 | `to_bbox(size, padding=)`            | `to_mask(height, width, radius)`          | `to_roi(radius)`                      |
+| **BoundingBox**      | `to_centroid()`                   | `pad(padding)`                       | `to_mask(height, width)`                  | `to_roi()`                            |
+| **SegmentationMask** | `to_centroid(method=)`            | `to_bbox(padding=)`                  | —                                         | `to_polygon()` / `to_roi()`           |
+| **ROI**              | `to_centroid(representative=)`    | `to_bbox(padding=, rotated=)`        | `to_mask(height, width)`                  | —                                     |
 
-The geometry conversions above project to a different shape, so they carry the
-identifying metadata but drop `tracking_score` (the geometry, not the track
-assignment, is what's being reinterpreted). `to_user()` is different: it is the
-predicted -> user *adoption* path (see
-[below](#user-vs-predicted-segmentation-masks)), so it faithfully carries the
+The reverse direction back to pose is [`Centroid.to_pose(skeleton=None)`][sleap_io.Centroid.to_pose],
+which reconstructs a single-node `Instance` (the only modality→pose conversion
+that is geometrically well-defined). `bbox→pose` and `mask→pose` are out of
+scope — they would require a target skeleton.
+
+Key kwargs by verb:
+
+| Verb                         | Key kwargs                                                                                         |
+| ---------------------------- | -------------------------------------------------------------------------------------------------- |
+| `Instance.to_centroid`       | `method` (`center_of_mass` \| `bbox_center` \| `anchor` \| `geometric_median`), `node`, `fallback` |
+| `Instance.to_bbox`           | `mode` (`tight` \| `centered`), `size`, `padding`, `node`, `center_method`, `rotated`              |
+| `Instance.to_roi`            | `method` (`shapes` \| `convex_hull`), `node_radius`, `edge_radius`, `radius`, `quad_segs`          |
+| `Centroid.to_bbox`           | `size` (required), `padding`                                                                        |
+| `Centroid.to_roi` / `to_mask` | `radius` (required)                                                                                |
+| `*.to_bbox`                  | `padding` (scalar or `(px, py)`); `rotated` on `ROI`                                                |
+| `SegmentationMask.to_centroid` | `method` (`center_of_mass` \| `bbox_center`)                                                      |
+| `ROI.to_centroid`            | `representative`                                                                                    |
+
+### Predicted variants, metadata, and degenerate inputs
+
+Every conversion returns the `User*`/`Predicted*` variant matching the source:
+a `Predicted*` input produces a `Predicted*` output carrying its `score`. The
+identifying metadata (`track`, `category`, `name`, `source`, and the
+`instance=` backref) is propagated where present; the geometry conversions drop
+`tracking_score` (the shape, not the track assignment, is being reinterpreted).
+`to_user()` is the separate predicted → user *adoption* path (see
+[below](#user-vs-predicted-segmentation-masks)), which faithfully carries the
 full annotation — including `tracking_score`, `scale`, and `offset` — dropping
-only the prediction-only fields (`score`, `score_map`) and recording the source
-prediction on `from_predicted`.
+only the prediction-only fields (`score`, `score_map`).
+
+The `to_X()` verbs are **return-type stable**: they always return the target
+class, never `None`. When the input is degenerate (no visible points, an empty
+mask, or an occluded `anchor` whose fallback is exhausted), the result is an
+*empty* target instance:
+
+- `Centroid` / `BoundingBox` → NaN coordinates (`x = y = nan`, all corners NaN).
+- `ROI` → empty `Polygon()`.
+- `SegmentationMask` → all-background mask (zero foreground pixels).
+
+Each verb accepts `error_on_empty=False`; pass `error_on_empty=True` to raise a
+`ValueError` instead of returning an empty result. A companion **`is_empty`**
+property is available on `Centroid`, `BoundingBox`, `ROI`, and
+`SegmentationMask` (mirroring [`Instance.is_empty`][sleap_io.Instance.is_empty])
+so an empty result is cheap to detect:
+
+```pycon
+>>> import sleap_io as sio
+>>> empty_box = sio.UserBoundingBox(
+...     x1=float("nan"), y1=float("nan"), x2=float("nan"), y2=float("nan"),
+... )
+>>> print(empty_box.is_empty)
+True
+
+```
+
+One case is *not* degenerate input: `Instance.to_roi(method="shapes")` with both
+`node_radius == 0` and `edge_radius == 0` is a misconfiguration and **always**
+raises `ValueError`, regardless of `error_on_empty`.
+
+The `LabelImage` decompositions round out the table:
+
+| From                | To                       | Method                             |
+| ------------------- | ------------------------ | ---------------------------------- |
+| `PredictedSegmentationMask` | `UserSegmentationMask` | `pred_mask.to_user()`        |
+| `LabelImage`        | `list[SegmentationMask]` | `li.to_masks()`                    |
+| `LabelImage`        | `list[BoundingBox]`      | `li.to_bboxes()`                   |
+| `list[SegmentationMask]` | `LabelImage`        | `UserLabelImage.from_masks(masks)` |
 
 ```pycon
 >>> import sleap_io as sio
@@ -731,6 +788,97 @@ prediction on `from_predicted`.
 >>> print(polygon_roi.area)
 
 ```
+
+`mask.to_polygon()` (and its `to_roi()` alias) preserves prediction semantics: a
+`PredictedSegmentationMask` produces a `PredictedROI` carrying the mask's
+`score` (earlier versions always returned a `UserROI`, silently dropping the
+predicted variant):
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> mask_data = np.zeros((100, 100), dtype=bool)
+>>> mask_data[20:40, 30:60] = True
+>>> pred_mask = sio.PredictedSegmentationMask.from_numpy(mask_data, score=0.9)
+>>> pred_roi = pred_mask.to_roi()
+>>> print(type(pred_roi).__name__)
+>>> print(pred_roi.score)
+
+```
+
+### Reducing a mask to a point or box
+
+`SegmentationMask.to_centroid()` reduces a mask to a single
+[`Centroid`](centroids.md). `method="center_of_mass"` (default) takes the mean
+of the foreground pixels; `method="bbox_center"` takes the midpoint of the
+pixel bounding box (concave-robust). Both map back to image space via the mask's
+`scale`/`offset`. `to_bbox(padding=)` adds optional padding to the tight box:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> mask_data = np.zeros((100, 100), dtype=bool)
+>>> mask_data[20:40, 30:60] = True
+>>> mask = sio.UserSegmentationMask.from_numpy(mask_data)
+>>> print(mask.to_centroid().xy)
+>>> print(mask.to_centroid(method="bbox_center").xy)
+>>> print(mask.to_bbox(padding=4).xyxy)
+
+```
+
+### Batch conversion: `LabeledFrame.convert` / `Labels.convert`
+
+Rather than a combinatorial set of helpers, [`LabeledFrame.convert`][sleap_io.LabeledFrame.convert]
+(and [`Labels.convert`][sleap_io.Labels.convert]) names the `source` and `to`
+modalities and forwards all remaining kwargs to the matching per-object
+`to_<target>()`. This reaches every cell of the matrix through one entry point.
+`source` reads from the matching per-frame list (`instances`, `centroids`,
+`bboxes`, `masks`, `rois`); `inplace=True` also appends the results to the frame:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> video = sio.Video("test.mp4", open_backend=False)
+>>> skeleton = sio.Skeleton(["head", "thorax", "abdomen"])
+>>> inst = sio.Instance.from_numpy(
+...     np.array([[10, 20], [30, 40], [50, 60]]), skeleton=skeleton,
+... )
+>>> lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
+>>> # pose -> centroid with an anchor node + fallback
+>>> centroids = lf.convert(
+...     to="centroid", method="anchor", node="thorax", fallback="center_of_mass",
+... )
+>>> print(centroids[0].xy, centroids[0].source)
+>>> # pose -> mask (burns nodes + edges into a raster)
+>>> masks = lf.convert(
+...     to="mask", source="pose", method="shapes",
+...     node_radius=6, edge_radius=3, height=80, width=80,
+... )
+>>> print(masks[0].area > 0)
+
+```
+
+`Labels.convert` maps `LabeledFrame.convert` over every frame and returns a
+single flat list of all produced annotations:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> video = sio.Video("test.mp4", open_backend=False)
+>>> mask_data = np.zeros((100, 100), dtype=bool)
+>>> mask_data[20:40, 30:60] = True
+>>> mask = sio.UserSegmentationMask.from_numpy(mask_data)
+>>> lf = sio.LabeledFrame(video=video, frame_idx=0, masks=[mask])
+>>> labels = sio.Labels([lf])
+>>> boxes = labels.convert(to="bbox", source="mask", padding=4, inplace=True)
+>>> print(boxes[0].xyxy)
+>>> print(len(lf.bboxes))  # appended in place
+
+```
+
+Converting `to="pose"` is only defined from a `centroid` source (it calls
+`Centroid.to_pose`); any other source raises a clear `ValueError`. Unknown
+modality strings also raise.
 
 ---
 

--- a/sleap_io/model/bbox.py
+++ b/sleap_io/model/bbox.py
@@ -21,6 +21,7 @@ import numpy as np
 from sleap_io.model.embedding import EmbeddingMixin
 
 if TYPE_CHECKING:
+    from sleap_io.model.centroid import Centroid
     from sleap_io.model.embedding import Embedding
     from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, Track
@@ -154,6 +155,16 @@ class BoundingBox(EmbeddingMixin):
     def is_rotated(self) -> bool:
         """Whether this bounding box is rotated (non-axis-aligned)."""
         return abs(self.angle) > 1e-10
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether this box is degenerate (any corner coordinate is NaN)."""
+        return bool(
+            np.isnan(self.x1)
+            or np.isnan(self.y1)
+            or np.isnan(self.x2)
+            or np.isnan(self.y2)
+        )
 
     @property
     def x_center(self) -> float:
@@ -306,6 +317,94 @@ class BoundingBox(EmbeddingMixin):
         """
         roi = self.to_roi()
         return roi.to_mask(height, width)
+
+    def to_centroid(self, error_on_empty: bool = False) -> "Centroid":
+        """Convert this bounding box to a centroid at its center.
+
+        A ``PredictedBoundingBox`` produces a ``PredictedCentroid`` carrying its
+        ``score``; any other box produces a ``UserCentroid``. Metadata (track,
+        tracking_score, identity, identity_score, category, name, source,
+        instance) is inherited.
+
+        Args:
+            error_on_empty: If ``True``, raise ``ValueError`` when this box is
+                degenerate (NaN corners) instead of returning a degenerate
+                (NaN) centroid.
+
+        Returns:
+            A ``Centroid`` located at this box's center (or NaN coordinates if
+            the box is degenerate).
+
+        Raises:
+            ValueError: If the box is degenerate and ``error_on_empty`` is
+                ``True``.
+        """
+        from sleap_io.model.centroid import PredictedCentroid, UserCentroid
+
+        if self.is_empty:
+            if error_on_empty:
+                raise ValueError(
+                    "Cannot compute centroid of a degenerate (NaN) bounding box."
+                )
+            nan = float("nan")
+            x, y = nan, nan
+        else:
+            x, y = self.centroid_xy
+
+        kwargs = dict(
+            x=x,
+            y=y,
+            track=self.track,
+            tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
+            instance=self.instance,
+            category=self.category,
+            name=self.name,
+            source=self.source,
+        )
+        if self.is_predicted:
+            return PredictedCentroid(score=self.score, **kwargs)
+        return UserCentroid(**kwargs)
+
+    def pad(self, padding: float | tuple[float, float]) -> "BoundingBox":
+        """Return a new box inflated outward by ``padding``.
+
+        The returned box is the same type as this one (``UserBoundingBox`` or
+        ``PredictedBoundingBox``) and preserves ``angle``, ``score``, and all
+        metadata. For rotated boxes the pre-rotation extent is inflated about
+        the center, keeping the angle fixed.
+
+        Args:
+            padding: Amount to inflate the box outward. A scalar applies to both
+                axes; a ``(px, py)`` tuple applies per-axis. Negative values
+                shrink the box; values are not clamped.
+
+        Returns:
+            A new ``BoundingBox`` of the same type with padded corners.
+        """
+        from sleap_io.model.roi import _apply_padding
+
+        x1, y1, x2, y2 = _apply_padding(self.x1, self.y1, self.x2, self.y2, padding)
+
+        kwargs = dict(
+            x1=x1,
+            y1=y1,
+            x2=x2,
+            y2=y2,
+            angle=self.angle,
+            track=self.track,
+            tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
+            instance=self.instance,
+            category=self.category,
+            name=self.name,
+            source=self.source,
+        )
+        if self.is_predicted:
+            return PredictedBoundingBox(score=self.score, **kwargs)
+        return UserBoundingBox(**kwargs)
 
 
 @attrs.define(eq=False)

--- a/sleap_io/model/centroid.py
+++ b/sleap_io/model/centroid.py
@@ -23,9 +23,12 @@ import numpy as np
 from sleap_io.model.embedding import EmbeddingMixin
 
 if TYPE_CHECKING:
+    from sleap_io.model.bbox import BoundingBox
     from sleap_io.model.embedding import Embedding
     from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, PredictedInstance, Track
+    from sleap_io.model.mask import SegmentationMask
+    from sleap_io.model.roi import ROI
     from sleap_io.model.skeleton import Skeleton
 
 
@@ -61,6 +64,37 @@ def __getattr__(name):
     if name == "CENTROID_SKELETON":
         return get_centroid_skeleton()
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def _geometric_median(pts: np.ndarray) -> tuple[float, float]:
+    """Compute the geometric median of 2D points via Weiszfeld's algorithm.
+
+    The geometric median minimizes the sum of Euclidean distances to all input
+    points. It is computed iteratively (pure numpy, no scipy) starting from the
+    arithmetic mean and reweighting by inverse distance until convergence.
+
+    Args:
+        pts: An ``(k, 2)`` array of visible point coordinates. Must contain at
+            least one point.
+
+    Returns:
+        The geometric median as an ``(x, y)`` tuple of floats.
+    """
+    pts = np.asarray(pts, dtype=float)
+    estimate = pts.mean(axis=0)
+    for _ in range(100):
+        dist = np.linalg.norm(pts - estimate, axis=1)
+        nonzero = dist > 1e-12
+        if not nonzero.any():
+            # All points coincide with the current estimate.
+            break
+        weights = 1.0 / dist[nonzero]
+        new_estimate = (weights[:, None] * pts[nonzero]).sum(axis=0) / weights.sum()
+        if np.linalg.norm(new_estimate - estimate) < 1e-6:
+            estimate = new_estimate
+            break
+        estimate = new_estimate
+    return float(estimate[0]), float(estimate[1])
 
 
 @attrs.define(eq=False)
@@ -143,7 +177,12 @@ class Centroid(EmbeddingMixin):
         """Return ``True`` if this is a ``PredictedCentroid``."""
         return isinstance(self, PredictedCentroid)
 
-    def to_instance(
+    @property
+    def is_empty(self) -> bool:
+        """Whether this centroid is degenerate (NaN ``x`` or ``y``)."""
+        return bool(np.isnan(self.x) or np.isnan(self.y))
+
+    def to_pose(
         self, skeleton: "Skeleton | None" = None
     ) -> "Instance | PredictedInstance":
         """Convert this centroid to a single-node ``Instance``.
@@ -192,71 +231,140 @@ class Centroid(EmbeddingMixin):
                 identity_score=self.identity_score,
             )
 
+    def to_instance(
+        self, skeleton: "Skeleton | None" = None
+    ) -> "Instance | PredictedInstance":
+        """Convert this centroid to a single-node ``Instance`` (deprecated).
+
+        .. deprecated::
+            Use :meth:`to_pose` instead.
+
+        Args:
+            skeleton: Skeleton to use for the instance. Must have exactly one
+                node. Defaults to the shared ``CENTROID_SKELETON``.
+
+        Returns:
+            A ``PredictedInstance`` if this is a ``PredictedCentroid``,
+            otherwise an ``Instance``.
+        """
+        import warnings
+
+        warnings.warn(
+            "Centroid.to_instance() is deprecated; use Centroid.to_pose() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.to_pose(skeleton=skeleton)
+
     @classmethod
-    def from_instance(
+    def from_pose(
         cls,
         instance: "Instance",
         method: str = "center_of_mass",
         node: "str | int | None" = None,
+        fallback: "str | None" = None,
+        error_on_empty: bool = False,
         **kwargs,
     ) -> "Centroid":
-        """Create a centroid from an ``Instance``.
+        """Create a centroid from a pose ``Instance``.
 
         Args:
             instance: The source instance.
             method: Computation method:
-                - ``"center_of_mass"``: Mean of visible point coordinates.
-                - ``"bbox_center"``: Center of bounding box of visible points.
-                - ``"anchor"``: Coordinates of a specific node.
-            node: Node specification for ``"anchor"`` method. Can be a node
-                name (str) or index (int).
+                - ``"center_of_mass"``: NaN-ignoring unweighted mean of visible
+                  node coordinates.
+                - ``"bbox_center"``: Center of the bounding box of visible points.
+                - ``"geometric_median"``: Weiszfeld geometric median of visible
+                  points (robust to outliers).
+                - ``"anchor"``: Coordinates of a specific node (requires ``node``).
+            node: Node specification for the ``"anchor"`` method. Can be a node
+                name (str) or index (int). Required for ``"anchor"``.
+            fallback: For the ``"anchor"`` method, a non-anchor method
+                (``"center_of_mass"``, ``"bbox_center"``, or
+                ``"geometric_median"``) to fall back to when the anchor node is
+                occluded. If ``None``, an occluded anchor yields a degenerate
+                centroid (or raises when ``error_on_empty`` is ``True``).
+            error_on_empty: If ``True``, raise ``ValueError`` when there are no
+                visible points to compute the requested centroid instead of
+                returning a degenerate (NaN) centroid.
             **kwargs: Additional keyword arguments passed to the centroid
                 constructor (e.g., ``video``, ``frame_idx``, ``category``).
 
         Returns:
             A ``PredictedCentroid`` if the instance is a ``PredictedInstance``,
-            otherwise a ``UserCentroid``.
+            otherwise a ``UserCentroid``. The ``source`` attribute records the
+            computation method (e.g. ``"center_of_mass"``, ``"anchor:nose"``, or
+            ``"anchor:nose->center_of_mass"`` when a fallback was used).
 
         Raises:
-            ValueError: If no visible points, or invalid method/node.
+            ValueError: For an unknown ``method``, a missing ``node`` for the
+                ``"anchor"`` method, an invalid ``node`` type, or (when
+                ``error_on_empty`` is ``True``) when there are no visible points.
         """
         from sleap_io.model.instance import PredictedInstance
 
         pts = instance.numpy(invisible_as_nan=True)
         visible = ~np.isnan(pts[:, 0])
+        nan = float("nan")
 
-        if method == "center_of_mass":
-            if not visible.any():
-                raise ValueError("No visible points for center_of_mass.")
-            x = float(pts[visible, 0].mean())
-            y = float(pts[visible, 1].mean())
+        def _compute(reduce_method: str) -> tuple[float, float]:
+            """Compute a non-anchor centroid; returns NaN if no visible points."""
+            if reduce_method == "center_of_mass":
+                if not visible.any():
+                    return nan, nan
+                return (
+                    float(pts[visible, 0].mean()),
+                    float(pts[visible, 1].mean()),
+                )
+            elif reduce_method == "bbox_center":
+                if not visible.any():
+                    return nan, nan
+                return (
+                    float((pts[visible, 0].min() + pts[visible, 0].max()) / 2),
+                    float((pts[visible, 1].min() + pts[visible, 1].max()) / 2),
+                )
+            elif reduce_method == "geometric_median":
+                if not visible.any():
+                    return nan, nan
+                return _geometric_median(pts[visible])
+            else:
+                raise ValueError(
+                    f"Unknown method {reduce_method!r}. Expected 'center_of_mass', "
+                    f"'bbox_center', 'geometric_median', or 'anchor'."
+                )
 
-        elif method == "bbox_center":
-            if not visible.any():
-                raise ValueError("No visible points for bbox_center.")
-            x = float((pts[visible, 0].min() + pts[visible, 0].max()) / 2)
-            y = float((pts[visible, 1].min() + pts[visible, 1].max()) / 2)
-
-        elif method == "anchor":
+        if method == "anchor":
             if node is None:
                 raise ValueError("Must specify 'node' for anchor method.")
             if isinstance(node, str):
                 node_idx = instance.skeleton.index(node)
-            elif isinstance(node, int):
-                node_idx = node
+            elif isinstance(node, (int, np.integer)):
+                node_idx = int(node)
             else:
                 raise ValueError(f"node must be str or int, got {type(node).__name__}")
-            if np.isnan(pts[node_idx, 0]):
-                raise ValueError(
-                    f"Anchor node {node!r} is not visible in this instance."
-                )
-            x = float(pts[node_idx, 0])
-            y = float(pts[node_idx, 1])
 
+            if not np.isnan(pts[node_idx, 0]):
+                x = float(pts[node_idx, 0])
+                y = float(pts[node_idx, 1])
+                source = f"anchor:{node}"
+            elif fallback is not None:
+                x, y = _compute(fallback)
+                source = f"anchor:{node}->{fallback}"
+            else:
+                x = y = nan
+                source = f"anchor:{node}"
+        elif method in ("center_of_mass", "bbox_center", "geometric_median"):
+            x, y = _compute(method)
+            source = method
         else:
             raise ValueError(
-                f"Unknown method {method!r}. "
-                f"Expected 'center_of_mass', 'bbox_center', or 'anchor'."
+                f"Unknown method {method!r}. Expected 'center_of_mass', "
+                f"'bbox_center', 'geometric_median', or 'anchor'."
+            )
+
+        if (np.isnan(x) or np.isnan(y)) and error_on_empty:
+            raise ValueError(
+                f"No visible points to compute centroid (method={method!r})."
             )
 
         # Build constructor kwargs.
@@ -268,7 +376,7 @@ class Centroid(EmbeddingMixin):
             identity=instance.identity,
             identity_score=instance.identity_score,
             instance=instance,
-            source=method if method != "anchor" else f"anchor:{node}",
+            source=source,
         )
         centroid_kwargs.update(kwargs)
 
@@ -276,6 +384,225 @@ class Centroid(EmbeddingMixin):
             return PredictedCentroid(score=instance.score, **centroid_kwargs)
         else:
             return UserCentroid(**centroid_kwargs)
+
+    @classmethod
+    def from_instance(
+        cls,
+        instance: "Instance",
+        method: str = "center_of_mass",
+        node: "str | int | None" = None,
+        fallback: "str | None" = None,
+        error_on_empty: bool = False,
+        **kwargs,
+    ) -> "Centroid":
+        """Create a centroid from an ``Instance`` (deprecated).
+
+        .. deprecated::
+            Use :meth:`from_pose` instead.
+
+        Args:
+            instance: The source instance.
+            method: Computation method (see :meth:`from_pose`).
+            node: Node specification for the ``"anchor"`` method.
+            fallback: Fallback method for an occluded anchor.
+            error_on_empty: Whether to raise instead of returning a degenerate
+                centroid.
+            **kwargs: Additional keyword arguments passed to the constructor.
+
+        Returns:
+            A ``PredictedCentroid`` or ``UserCentroid`` (see :meth:`from_pose`).
+        """
+        import warnings
+
+        warnings.warn(
+            "Centroid.from_instance() is deprecated; use Centroid.from_pose() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.from_pose(
+            instance,
+            method=method,
+            node=node,
+            fallback=fallback,
+            error_on_empty=error_on_empty,
+            **kwargs,
+        )
+
+    def to_bbox(
+        self,
+        size: float | tuple[float, float],
+        padding: float | tuple[float, float] = 0.0,
+        error_on_empty: bool = False,
+    ) -> "BoundingBox":
+        """Construct a fixed-size bounding box centered on this centroid.
+
+        A ``PredictedCentroid`` produces a ``PredictedBoundingBox`` carrying its
+        ``score``; any other centroid produces a ``UserBoundingBox``. Metadata
+        (track, tracking_score, identity, identity_score, category, name, source,
+        instance) is inherited.
+
+        Args:
+            size: Box size centered on the centroid. A scalar yields a square box
+                of that side length; a ``(w, h)`` tuple sets width and height
+                independently. Required.
+            padding: Amount to inflate the box outward after sizing. Scalar
+                applies to both axes; a ``(px, py)`` tuple applies per-axis.
+                Negative values shrink the box.
+            error_on_empty: If ``True``, raise ``ValueError`` when this centroid
+                is degenerate (NaN) instead of returning a degenerate box.
+
+        Returns:
+            A ``BoundingBox`` centered on the centroid (or NaN corners if empty).
+
+        Raises:
+            ValueError: If ``size`` is ``None``, or if the centroid is degenerate
+                and ``error_on_empty`` is ``True``.
+        """
+        if size is None:
+            raise ValueError("'size' is required for Centroid.to_bbox().")
+
+        from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
+        from sleap_io.model.roi import _apply_padding
+
+        if self.is_empty:
+            if error_on_empty:
+                raise ValueError(
+                    "Cannot compute bounding box of a degenerate (NaN) centroid."
+                )
+            nan = float("nan")
+            x1 = y1 = x2 = y2 = nan
+        else:
+            if isinstance(size, (tuple, list)):
+                w, h = size
+            else:
+                w = h = size
+            x1 = self.x - w / 2
+            y1 = self.y - h / 2
+            x2 = self.x + w / 2
+            y2 = self.y + h / 2
+            x1, y1, x2, y2 = _apply_padding(x1, y1, x2, y2, padding)
+
+        kwargs = dict(
+            x1=x1,
+            y1=y1,
+            x2=x2,
+            y2=y2,
+            angle=0.0,
+            track=self.track,
+            tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
+            instance=self.instance,
+            category=self.category,
+            name=self.name,
+            source=self.source,
+        )
+        if self.is_predicted:
+            return PredictedBoundingBox(score=self.score, **kwargs)
+        return UserBoundingBox(**kwargs)
+
+    def to_roi(self, radius: float, error_on_empty: bool = False) -> "ROI":
+        """Construct a circular ROI centered on this centroid.
+
+        A ``PredictedCentroid`` produces a ``PredictedROI`` carrying its
+        ``score``; any other centroid produces a ``UserROI``. Metadata (track,
+        tracking_score, identity, identity_score, category, name, source,
+        instance) is inherited.
+
+        Args:
+            radius: Radius of the circular ROI. Required.
+            error_on_empty: If ``True``, raise ``ValueError`` when this centroid
+                is degenerate (NaN) instead of returning an empty-geometry ROI.
+
+        Returns:
+            A ``ROI`` with a buffered-point (circular) geometry, or an empty
+            ``Polygon`` geometry if the centroid is degenerate.
+
+        Raises:
+            ValueError: If the centroid is degenerate and ``error_on_empty`` is
+                ``True``.
+        """
+        from shapely.geometry import Point, Polygon
+
+        from sleap_io.model.roi import PredictedROI, UserROI
+
+        if self.is_empty:
+            if error_on_empty:
+                raise ValueError("Cannot compute ROI of a degenerate (NaN) centroid.")
+            geom = Polygon()
+        else:
+            geom = Point(self.x, self.y).buffer(radius)
+
+        kwargs = dict(
+            geometry=geom,
+            track=self.track,
+            tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
+            instance=self.instance,
+            category=self.category,
+            name=self.name,
+            source=self.source,
+        )
+        if self.is_predicted:
+            return PredictedROI(score=self.score, **kwargs)
+        return UserROI(**kwargs)
+
+    def to_mask(
+        self,
+        height: int,
+        width: int,
+        radius: float,
+        error_on_empty: bool = False,
+    ) -> "SegmentationMask":
+        """Rasterize a circular ROI around this centroid into a mask.
+
+        Equivalent to ``self.to_roi(radius).to_mask(height, width)``. A
+        ``PredictedCentroid`` produces a ``PredictedSegmentationMask`` carrying
+        its ``score``; any other centroid produces a ``UserSegmentationMask``.
+        Metadata is inherited.
+
+        Args:
+            height: Height of the output mask in pixels.
+            width: Width of the output mask in pixels.
+            radius: Radius of the circular region around the centroid. Required.
+            error_on_empty: If ``True``, raise ``ValueError`` when this centroid
+                is degenerate (NaN) instead of returning an all-background mask.
+
+        Returns:
+            A ``SegmentationMask`` with the rasterized circular region (all
+            background if the centroid is degenerate).
+
+        Raises:
+            ValueError: If the centroid is degenerate and ``error_on_empty`` is
+                ``True``.
+        """
+        if self.is_empty:
+            if error_on_empty:
+                raise ValueError("Cannot compute mask of a degenerate (NaN) centroid.")
+            from sleap_io.model.mask import (
+                PredictedSegmentationMask,
+                UserSegmentationMask,
+            )
+
+            empty = np.zeros((height, width), dtype=bool)
+            kwargs = dict(
+                track=self.track,
+                tracking_score=self.tracking_score,
+                identity=self.identity,
+                identity_score=self.identity_score,
+                instance=self.instance,
+                category=self.category,
+                name=self.name,
+                source=self.source,
+            )
+            if self.is_predicted:
+                return PredictedSegmentationMask.from_numpy(
+                    empty, score=self.score, **kwargs
+                )
+            return UserSegmentationMask.from_numpy(empty, **kwargs)
+
+        return self.to_roi(radius).to_mask(height, width)
 
 
 @attrs.define(eq=False)

--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -9,6 +9,8 @@ estimated, such as confidence scores.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import attrs
 import numpy as np
 
@@ -16,6 +18,12 @@ from sleap_io.model.categories import CategoriesMixin
 from sleap_io.model.embedding import Embedding, EmbeddingMixin
 from sleap_io.model.identity import Identity
 from sleap_io.model.skeleton import Node, Skeleton
+
+if TYPE_CHECKING:
+    from sleap_io.model.bbox import BoundingBox
+    from sleap_io.model.centroid import Centroid
+    from sleap_io.model.mask import SegmentationMask
+    from sleap_io.model.roi import ROI
 
 
 class PointsArray(np.ndarray):
@@ -600,25 +608,297 @@ class Instance(EmbeddingMixin, CategoriesMixin):
             return None
         return float(pts[visible, 0].mean()), float(pts[visible, 1].mean())
 
-    def to_centroid(self, method: str = "center_of_mass", node=None, **kwargs):
+    def to_centroid(
+        self,
+        method: str = "center_of_mass",
+        node: int | str | None = None,
+        fallback: str | None = None,
+        error_on_empty: bool = False,
+        **kwargs,
+    ) -> "Centroid":
         """Create a ``Centroid`` from this instance.
 
-        Delegates to ``Centroid.from_instance()``.
+        Delegates to ``Centroid.from_pose()``. A ``PredictedInstance`` yields a
+        ``PredictedCentroid`` carrying its ``score``; any other instance yields a
+        ``UserCentroid``. Metadata (``track``, ``tracking_score``, ``identity``,
+        ``identity_score``, ``instance=self``) is propagated.
 
         Args:
-            method: Computation method (``"center_of_mass"``,
-                ``"bbox_center"``, or ``"anchor"``).
-            node: Node specification for the ``"anchor"`` method.
+            method: Computation method (``"center_of_mass"``, ``"bbox_center"``,
+                ``"geometric_median"``, or ``"anchor"``).
+            node: Node specification for the ``"anchor"`` method. Can be a node
+                name (str) or index (int).
+            fallback: For the ``"anchor"`` method, a non-anchor method to fall
+                back to when the anchor node is occluded.
+            error_on_empty: If ``True``, raise ``ValueError`` when there are no
+                visible points instead of returning a degenerate (NaN) centroid.
             **kwargs: Additional keyword arguments passed to the centroid
                 constructor.
 
         Returns:
             A ``UserCentroid`` or ``PredictedCentroid`` depending on the
             instance type.
+
+        Raises:
+            ValueError: For an unknown ``method``, a missing ``node`` for the
+                ``"anchor"`` method, an invalid ``node`` type, or (when
+                ``error_on_empty`` is ``True``) when there are no visible points.
         """
         from sleap_io.model.centroid import Centroid
 
-        return Centroid.from_instance(self, method=method, node=node, **kwargs)
+        return Centroid.from_pose(
+            self,
+            method=method,
+            node=node,
+            fallback=fallback,
+            error_on_empty=error_on_empty,
+            **kwargs,
+        )
+
+    def to_bbox(
+        self,
+        mode: str = "tight",
+        size: float | tuple[float, float] | None = None,
+        padding: float | tuple[float, float] = 0.0,
+        node: int | str | None = None,
+        center_method: str = "center_of_mass",
+        rotated: bool = False,
+        error_on_empty: bool = False,
+    ) -> "BoundingBox":
+        """Create a bounding box from this instance.
+
+        A ``PredictedInstance`` yields a ``PredictedBoundingBox`` carrying its
+        ``score``; any other instance yields a ``UserBoundingBox``. Metadata
+        (``track``, ``tracking_score``, ``identity``, ``identity_score``,
+        ``instance=self``) is propagated.
+
+        Args:
+            mode: ``"tight"`` to fit the visible points, or ``"centered"`` to
+                build a fixed-``size`` box centered on a computed centroid.
+            size: Box size for ``mode="centered"``. A scalar yields a square box;
+                a ``(w, h)`` tuple sets width and height independently. Required
+                for ``mode="centered"``.
+            padding: Amount to inflate the box outward. Scalar applies to both
+                axes; a ``(px, py)`` tuple applies per-axis. Negative values
+                shrink the box.
+            node: Node specification passed to the centroid computation for
+                ``mode="centered"`` with ``center_method="anchor"``.
+            center_method: Centroid method used to locate the box center for
+                ``mode="centered"`` (see :meth:`to_centroid`).
+            rotated: For ``mode="tight"``, if ``True`` fit a minimum-area oriented
+                box from the convex hull of visible points; otherwise fit an
+                axis-aligned box.
+            error_on_empty: If ``True``, raise ``ValueError`` when there are no
+                visible points instead of returning a degenerate (NaN) box.
+
+        Returns:
+            A ``BoundingBox`` enclosing the instance (or NaN corners if empty).
+
+        Raises:
+            ValueError: For an unknown ``mode``, a missing ``size`` for
+                ``mode="centered"``, or (when ``error_on_empty`` is ``True``)
+                when there are no visible points.
+        """
+        from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
+        from sleap_io.model.roi import (
+            _apply_padding,
+            _geometry_to_bbox_coords,
+            _pose_to_geometry,
+        )
+
+        nan = float("nan")
+        angle = 0.0
+
+        if mode == "tight":
+            pts = self.numpy(invisible_as_nan=True)
+            visible = ~np.isnan(pts[:, 0])
+            if not visible.any():
+                if error_on_empty:
+                    raise ValueError("No visible points to compute bounding box.")
+                x1 = y1 = x2 = y2 = nan
+            elif rotated:
+                hull = _pose_to_geometry(
+                    pts, self.skeleton.edge_inds, method="convex_hull"
+                )
+                x1, y1, x2, y2, angle = _geometry_to_bbox_coords(hull, rotated=True)
+                x1, y1, x2, y2 = _apply_padding(x1, y1, x2, y2, padding)
+            else:
+                vis = pts[visible]
+                x1 = float(vis[:, 0].min())
+                y1 = float(vis[:, 1].min())
+                x2 = float(vis[:, 0].max())
+                y2 = float(vis[:, 1].max())
+                x1, y1, x2, y2 = _apply_padding(x1, y1, x2, y2, padding)
+        elif mode == "centered":
+            if size is None:
+                raise ValueError("'size' is required for mode='centered'.")
+            centroid = self.to_centroid(
+                method=center_method, node=node, error_on_empty=error_on_empty
+            )
+            if centroid.is_empty:
+                x1 = y1 = x2 = y2 = nan
+            else:
+                cx, cy = centroid.xy
+                if isinstance(size, (tuple, list)):
+                    w, h = size
+                else:
+                    w = h = size
+                x1 = cx - w / 2
+                y1 = cy - h / 2
+                x2 = cx + w / 2
+                y2 = cy + h / 2
+                x1, y1, x2, y2 = _apply_padding(x1, y1, x2, y2, padding)
+        else:
+            raise ValueError(f"Unknown mode {mode!r}. Expected 'tight' or 'centered'.")
+
+        kwargs = dict(
+            x1=x1,
+            y1=y1,
+            x2=x2,
+            y2=y2,
+            angle=angle,
+            track=self.track,
+            tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
+            instance=self,
+        )
+        if isinstance(self, PredictedInstance):
+            return PredictedBoundingBox(score=self.score, **kwargs)
+        return UserBoundingBox(**kwargs)
+
+    def to_roi(
+        self,
+        method: str = "shapes",
+        node_radius: float = 0.0,
+        edge_radius: float = 0.0,
+        radius: float = 0.0,
+        quad_segs: int = 8,
+        error_on_empty: bool = False,
+    ) -> "ROI":
+        """Create a region-of-interest geometry from this instance.
+
+        A ``PredictedInstance`` yields a ``PredictedROI`` carrying its ``score``;
+        any other instance yields a ``UserROI``. Metadata (``track``,
+        ``tracking_score``, ``identity``, ``identity_score``, ``instance=self``)
+        is propagated.
+
+        Args:
+            method: ``"shapes"`` to union buffered node points and/or edge
+                segments, or ``"convex_hull"`` to take the convex hull of the
+                visible points.
+            node_radius: Buffer radius around each visible node (``"shapes"``
+                only).
+            edge_radius: Buffer radius around each fully-visible edge segment
+                (``"shapes"`` only).
+            radius: Optional buffer applied to the convex hull
+                (``"convex_hull"`` only).
+            quad_segs: Number of segments used to approximate a quarter circle
+                when buffering.
+            error_on_empty: If ``True``, raise ``ValueError`` when the resulting
+                geometry is empty instead of returning an empty-geometry ROI.
+
+        Returns:
+            A ``ROI`` whose geometry encloses the instance (an empty ``Polygon``
+            if there are no visible points).
+
+        Raises:
+            ValueError: If ``method="shapes"`` with both ``node_radius`` and
+                ``edge_radius`` equal to 0 (a misconfiguration, always raised),
+                for an unknown ``method``, or (when ``error_on_empty`` is
+                ``True``) when the resulting geometry is empty.
+        """
+        from sleap_io.model.roi import PredictedROI, UserROI, _pose_to_geometry
+
+        # Misconfiguration: raise before the empty-points check so that an empty
+        # instance still surfaces the error.
+        if method == "shapes" and node_radius == 0 and edge_radius == 0:
+            raise ValueError(
+                "method='shapes' requires at least one of node_radius or "
+                "edge_radius to be > 0."
+            )
+
+        geom = _pose_to_geometry(
+            self.numpy(invisible_as_nan=True),
+            self.skeleton.edge_inds,
+            method=method,
+            node_radius=node_radius,
+            edge_radius=edge_radius,
+            radius=radius,
+            quad_segs=quad_segs,
+        )
+
+        if geom.is_empty and error_on_empty:
+            raise ValueError("No visible points to compute ROI geometry.")
+
+        kwargs = dict(
+            geometry=geom,
+            track=self.track,
+            tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
+            instance=self,
+        )
+        if isinstance(self, PredictedInstance):
+            return PredictedROI(score=self.score, **kwargs)
+        return UserROI(**kwargs)
+
+    def to_mask(self, height: int, width: int, **roi_kwargs) -> "SegmentationMask":
+        """Rasterize this instance's ROI geometry into a segmentation mask.
+
+        Equivalent to ``self.to_roi(**roi_kwargs).to_mask(height, width)``,
+        except that a zero-area hull (``method="convex_hull"`` over fewer than
+        three visible points yields a ``Point`` or ``LineString``) rasterizes to
+        an all-background mask here instead of raising. A ``PredictedInstance``
+        yields a ``PredictedSegmentationMask`` carrying its ``score``; any other
+        instance yields a ``UserSegmentationMask``. Metadata is propagated.
+
+        Args:
+            height: Height of the output mask in pixels.
+            width: Width of the output mask in pixels.
+            **roi_kwargs: Keyword arguments forwarded to :meth:`to_roi` (e.g.
+                ``method``, ``node_radius``, ``edge_radius``, ``radius``,
+                ``quad_segs``, ``error_on_empty``).
+
+        Returns:
+            A ``SegmentationMask`` with the rasterized geometry (all background
+            if the geometry is empty or has zero area).
+
+        Raises:
+            ValueError: Propagated from :meth:`to_roi` for a ``"shapes"``
+                misconfiguration, an unknown method, or (when
+                ``error_on_empty`` is ``True``) an empty geometry.
+        """
+        from shapely.geometry import MultiPolygon, Polygon
+
+        error_on_empty = roi_kwargs.pop("error_on_empty", False)
+        roi = self.to_roi(error_on_empty=error_on_empty, **roi_kwargs)
+
+        # A non-empty but non-fillable geometry (e.g. convex_hull of <3 visible
+        # points -> Point/LineString) has zero area; rasterize it as all
+        # background rather than letting _rasterize_geometry raise a TypeError.
+        rasterizable = isinstance(roi.geometry, (Polygon, MultiPolygon))
+        if roi.geometry.is_empty or not rasterizable:
+            from sleap_io.model.mask import (
+                PredictedSegmentationMask,
+                UserSegmentationMask,
+            )
+
+            empty = np.zeros((height, width), dtype=bool)
+            kwargs = dict(
+                track=self.track,
+                tracking_score=self.tracking_score,
+                identity=self.identity,
+                identity_score=self.identity_score,
+                instance=self,
+            )
+            if isinstance(self, PredictedInstance):
+                return PredictedSegmentationMask.from_numpy(
+                    empty, score=self.score, **kwargs
+                )
+            return UserSegmentationMask.from_numpy(empty, **kwargs)
+
+        return roi.to_mask(height, width)
 
     def __getitem__(self, node: int | str | Node) -> np.ndarray:
         """Return the point associated with a node."""

--- a/sleap_io/model/labeled_frame.py
+++ b/sleap_io/model/labeled_frame.py
@@ -591,6 +591,82 @@ class LabeledFrame:
         """Remove all instances with no visible points."""
         self.instances = [inst for inst in self.instances if not inst.is_empty]
 
+    def convert(
+        self,
+        to: str,
+        source: str = "pose",
+        inplace: bool = False,
+        **kwargs,
+    ) -> list:
+        """Convert annotations between detection modalities.
+
+        Reads every annotation of the ``source`` modality from this frame and
+        converts each one to the ``to`` modality by dispatching to the matching
+        per-object verb (``to_centroid``, ``to_bbox``, ``to_mask``, ``to_roi`` or
+        ``to_pose``). Keyword arguments are forwarded unchanged to the per-object
+        verb (e.g. ``height``/``width`` for ``to="mask"``).
+
+        Args:
+            to: Target modality, one of ``"pose"``, ``"centroid"``, ``"bbox"``,
+                ``"mask"`` or ``"roi"``.
+            source: Source modality, one of ``"pose"``, ``"centroid"``, ``"bbox"``,
+                ``"mask"`` or ``"roi"``. Reads from the matching frame list
+                (``instances``, ``centroids``, ``bboxes``, ``masks`` or ``rois``).
+            inplace: If ``True``, append each produced annotation to this frame
+                (via `append`) in addition to returning them. If ``False``
+                (default), the frame is left unmodified.
+            **kwargs: Forwarded to the per-object conversion verb.
+
+        Returns:
+            A list of the produced annotations (one per source annotation), of the
+            ``to`` modality.
+
+        Raises:
+            ValueError: If ``to`` or ``source`` is not a recognized modality, if
+                ``to="pose"`` is requested from a non-centroid source (only
+                ``centroid`` → ``pose`` is defined), or if a source annotation
+                lacks the target conversion verb.
+        """
+        modalities = {
+            "pose": "instances",
+            "centroid": "centroids",
+            "bbox": "bboxes",
+            "mask": "masks",
+            "roi": "rois",
+        }
+        if to not in modalities:
+            raise ValueError(
+                f"Unknown target modality {to!r}. Expected one of: "
+                f"{', '.join(modalities)}."
+            )
+        if source not in modalities:
+            raise ValueError(
+                f"Unknown source modality {source!r}. Expected one of: "
+                f"{', '.join(modalities)}."
+            )
+        if to == "pose" and source != "centroid":
+            raise ValueError(
+                f"Conversion from {source!r} to 'pose' is not supported; only "
+                "'centroid' -> 'pose' is defined."
+            )
+
+        verb = "to_pose" if to == "pose" else f"to_{to}"
+        sources = getattr(self, modalities[source])
+
+        results = []
+        for obj in sources:
+            method = getattr(obj, verb, None)
+            if method is None:
+                raise ValueError(
+                    f"Cannot convert {source!r} to {to!r}: "
+                    f"{type(obj).__name__} has no {verb}() method."
+                )
+            result = method(**kwargs)
+            results.append(result)
+            if inplace:
+                self.append(result)
+        return results
+
     def matches(self, other: "LabeledFrame", video_must_match: bool = True) -> bool:
         """Check if this frame matches another frame's identity.
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1878,6 +1878,51 @@ class Labels:
                 videos=False,
             )
 
+    def convert(
+        self,
+        to: str,
+        source: str = "pose",
+        inplace: bool = False,
+        **kwargs,
+    ) -> list:
+        """Convert annotations between detection modalities across all frames.
+
+        Applies `LabeledFrame.convert` to every frame in `labeled_frames` and
+        collects the produced annotations into a single flat list (annotations
+        from all frames concatenated together, not grouped per frame).
+
+        Args:
+            to: Target modality, one of ``"pose"``, ``"centroid"``, ``"bbox"``,
+                ``"mask"`` or ``"roi"``.
+            source: Source modality, one of ``"pose"``, ``"centroid"``, ``"bbox"``,
+                ``"mask"`` or ``"roi"``.
+            inplace: If ``True``, append each produced annotation to its frame in
+                addition to returning it. If ``False`` (default), frames are left
+                unmodified. Forwarded to `LabeledFrame.convert`.
+            **kwargs: Forwarded to the per-object conversion verb (e.g.
+                ``height``/``width`` for ``to="mask"``).
+
+        Returns:
+            A flat list of all produced annotations across every frame, of the
+            ``to`` modality.
+
+        Raises:
+            ValueError: If ``to`` or ``source`` is not a recognized modality, if
+                ``to="pose"`` is requested from a non-centroid source, or if a
+                source annotation lacks the target conversion verb.
+            RuntimeError: If ``inplace=True`` and Labels is lazy-loaded. In-place
+                mutation is not supported on lazy Labels because iterating
+                ``labeled_frames`` yields freshly materialized frames that are
+                discarded after each iteration, so the appended annotations would
+                be silently lost. Materialize first (``labels.materialize()``).
+        """
+        if inplace:
+            self._check_not_lazy("convert")
+        results = []
+        for lf in self.labeled_frames:
+            results.extend(lf.convert(to, source=source, inplace=inplace, **kwargs))
+        return results
+
     @property
     def user_labeled_frames(self) -> list[LabeledFrame]:
         """Return all labeled frames with user instances OR marked as negative.

--- a/sleap_io/model/mask.py
+++ b/sleap_io/model/mask.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
     from sleap_io.model.bbox import BoundingBox
+    from sleap_io.model.centroid import Centroid
     from sleap_io.model.embedding import Embedding
     from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, Track
@@ -318,6 +319,17 @@ class SegmentationMask(EmbeddingMixin):
         return int(sum(self.rle_counts[1::2]))
 
     @property
+    def is_empty(self) -> bool:
+        """Whether the mask has no foreground pixels.
+
+        Mirrors `Instance.is_empty`. ``True`` when the mask area is zero.
+
+        Returns:
+            ``True`` if there are no foreground (True) pixels, else ``False``.
+        """
+        return self.area == 0
+
+    @property
     def bbox(self) -> tuple[float, float, float, float]:
         """Bounding box of the mask as (x, y, width, height) in image coordinates.
 
@@ -349,19 +361,107 @@ class SegmentationMask(EmbeddingMixin):
             float((rmax - rmin + 1) / sy),
         )
 
-    def to_bbox(self) -> "BoundingBox":
+    def to_centroid(
+        self,
+        method: str = "center_of_mass",
+        error_on_empty: bool = False,
+    ) -> "Centroid":
+        """Convert the mask to a centroid point.
+
+        Returns a ``UserCentroid`` or ``PredictedCentroid`` with metadata
+        (track, tracking_score, identity, identity_score, category, name,
+        source, instance) inherited from this mask. Coordinates are in image
+        space (respecting
+        ``scale``/``offset``).
+
+        Args:
+            method: How to compute the centroid. ``"center_of_mass"`` (default)
+                uses the mean of foreground pixel coordinates mapped to image
+                space. ``"bbox_center"`` uses the midpoint of the mask's tight
+                bounding box (concave-robust).
+            error_on_empty: If ``True``, raise ``ValueError`` when the mask has no
+                foreground pixels instead of returning a degenerate (NaN)
+                centroid.
+
+        Returns:
+            A ``Centroid`` at the computed location. For an empty mask, returns a
+            degenerate centroid with ``x = y = nan`` (unless ``error_on_empty``).
+
+        Raises:
+            ValueError: If ``method`` is not recognized, or if the mask is empty
+                and ``error_on_empty`` is ``True``.
+        """
+        from sleap_io.model.centroid import PredictedCentroid, UserCentroid
+
+        if method not in ("center_of_mass", "bbox_center"):
+            raise ValueError(
+                f"Unknown method {method!r}. Expected 'center_of_mass' or "
+                f"'bbox_center'."
+            )
+
+        cls = PredictedCentroid if self.is_predicted else UserCentroid
+        kwargs: dict = dict(
+            track=self.track,
+            tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
+            instance=self.instance,
+            category=self.category,
+            name=self.name,
+            source=self.source,
+        )
+        if self.is_predicted:
+            kwargs["score"] = self.score
+
+        if self.is_empty:
+            if error_on_empty:
+                raise ValueError(
+                    "Cannot compute centroid of an empty mask (no foreground pixels)."
+                )
+            return cls(x=float("nan"), y=float("nan"), **kwargs)
+
+        if method == "center_of_mass":
+            sx, sy = self.scale
+            ox, oy = self.offset
+            rows, cols = np.nonzero(self.data)
+            x = float(cols.mean() / sx + ox)
+            y = float(rows.mean() / sy + oy)
+        else:  # bbox_center
+            bx, by, bw, bh = self.bbox
+            x = bx + bw / 2.0
+            y = by + bh / 2.0
+
+        return cls(x=x, y=y, **kwargs)
+
+    def to_bbox(
+        self,
+        padding: float | tuple[float, float] = 0.0,
+        error_on_empty: bool = False,
+    ) -> "BoundingBox":
         """Convert to a BoundingBox object.
 
         Returns a ``UserBoundingBox`` or ``PredictedBoundingBox`` with metadata
-        (track, identity, category, name, instance) inherited from this mask.
-        Coordinates are in image space (respecting scale/offset).
+        (track, tracking_score, identity, identity_score, category, name,
+        source, instance) inherited from this mask. Coordinates are in image
+        space (respecting scale/offset).
+
+        Args:
+            padding: Amount to inflate the tight bounding box, as a scalar (applied
+                to both axes) or ``(px, py)``. Positive values expand the box,
+                negative values shrink it. Defaults to ``0.0`` (no padding).
+            error_on_empty: If ``True``, raise ``ValueError`` when the mask has no
+                foreground pixels instead of returning a degenerate (NaN) box.
 
         Returns:
-            A ``BoundingBox`` matching this mask's tight bounding box.
+            A ``BoundingBox`` matching this mask's tight bounding box (with
+            optional padding). For an empty mask, returns a degenerate box with
+            all corners ``nan`` (unless ``error_on_empty``).
+
+        Raises:
+            ValueError: If the mask is empty and ``error_on_empty`` is ``True``.
         """
         from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
 
-        x, y, w, h = self.bbox
         cls = PredictedBoundingBox if self.is_predicted else UserBoundingBox
         kwargs: dict = dict(
             track=self.track,
@@ -375,7 +475,21 @@ class SegmentationMask(EmbeddingMixin):
         )
         if self.is_predicted:
             kwargs["score"] = self.score
-        return cls.from_xywh(x, y, w, h, **kwargs)
+
+        if self.is_empty:
+            if error_on_empty:
+                raise ValueError(
+                    "Cannot compute bounding box of an empty mask (no foreground "
+                    "pixels)."
+                )
+            nan = float("nan")
+            return cls(x1=nan, y1=nan, x2=nan, y2=nan, angle=0.0, **kwargs)
+
+        from sleap_io.model.roi import _apply_padding
+
+        x, y, w, h = self.bbox
+        x1, y1, x2, y2 = _apply_padding(x, y, x + w, y + h, padding)
+        return cls(x1=x1, y1=y1, x2=x2, y2=y2, angle=0.0, **kwargs)
 
     def to_polygon(self) -> "ROI":
         """Convert the mask to a polygon ROI via row-rectangle union.
@@ -394,7 +508,7 @@ class SegmentationMask(EmbeddingMixin):
         from shapely.geometry import Polygon, box
         from shapely.ops import unary_union
 
-        from sleap_io.model.roi import UserROI
+        from sleap_io.model.roi import PredictedROI, UserROI
 
         sx, sy = self.scale
         ox, oy = self.offset
@@ -416,7 +530,8 @@ class SegmentationMask(EmbeddingMixin):
         else:
             geometry = unary_union(rectangles)
 
-        return UserROI(
+        cls = PredictedROI if self.is_predicted else UserROI
+        kwargs: dict = dict(
             geometry=geometry,
             name=self.name,
             category=self.category,
@@ -427,6 +542,18 @@ class SegmentationMask(EmbeddingMixin):
             identity_score=self.identity_score,
             instance=self.instance,
         )
+        if self.is_predicted:
+            kwargs["score"] = self.score
+        return cls(**kwargs)
+
+    def to_roi(self) -> "ROI":
+        """Convert the mask to an ROI (alias for `to_polygon`).
+
+        Returns:
+            An `ROI` with polygon geometry derived from the mask. See
+            `to_polygon` for details.
+        """
+        return self.to_polygon()
 
 
 @attrs.define(eq=False)

--- a/sleap_io/model/roi.py
+++ b/sleap_io/model/roi.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
     from shapely.geometry import Polygon
     from shapely.geometry.base import BaseGeometry
 
+    from sleap_io.model.bbox import BoundingBox
+    from sleap_io.model.centroid import Centroid
     from sleap_io.model.embedding import Embedding
     from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, Track
@@ -118,6 +120,11 @@ class ROI(EmbeddingMixin):
     def is_predicted(self) -> bool:
         """Whether this ROI is a model prediction."""
         return isinstance(self, PredictedROI)
+
+    @property
+    def is_empty(self) -> bool:
+        """Whether this ROI's geometry is empty (no spatial extent)."""
+        return bool(self.geometry.is_empty)
 
     @classmethod
     def from_bbox(
@@ -337,6 +344,120 @@ class ROI(EmbeddingMixin):
             )
         return UserSegmentationMask.from_numpy(mask, **kwargs)
 
+    def to_centroid(
+        self, representative: bool = False, error_on_empty: bool = False
+    ) -> "Centroid":
+        """Reduce this ROI to a single centroid point.
+
+        A `PredictedROI` produces a `PredictedCentroid` carrying its `score`; any
+        other ROI produces a `UserCentroid`. Metadata (track, tracking_score,
+        identity, identity_score, category, name, source, instance) is inherited.
+
+        Args:
+            representative: If ``True``, use Shapely's ``representative_point()``
+                (a point guaranteed to lie within the geometry); otherwise use the
+                geometric ``centroid`` (which may fall outside concave shapes).
+            error_on_empty: If ``True``, raise ``ValueError`` when the geometry is
+                empty instead of returning a degenerate (NaN) centroid.
+
+        Returns:
+            A `Centroid` at the geometry's centroid (or NaN if empty).
+
+        Raises:
+            ValueError: If the geometry is empty and ``error_on_empty`` is ``True``.
+        """
+        from sleap_io.model.centroid import PredictedCentroid, UserCentroid
+
+        if self.geometry.is_empty:
+            if error_on_empty:
+                raise ValueError("Cannot compute centroid of an empty ROI geometry.")
+            x = y = float("nan")
+        else:
+            pt = (
+                self.geometry.representative_point()
+                if representative
+                else self.geometry.centroid
+            )
+            x, y = float(pt.x), float(pt.y)
+
+        kwargs = dict(
+            x=x,
+            y=y,
+            track=self.track,
+            tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
+            instance=self.instance,
+            category=self.category,
+            name=self.name,
+            source=self.source,
+        )
+        if self.is_predicted:
+            return PredictedCentroid(score=self.score, **kwargs)
+        return UserCentroid(**kwargs)
+
+    def to_bbox(
+        self,
+        padding: float | tuple[float, float] = 0.0,
+        rotated: bool = False,
+        error_on_empty: bool = False,
+    ) -> "BoundingBox":
+        """Reduce this ROI to a bounding box.
+
+        A `PredictedROI` produces a `PredictedBoundingBox` carrying its `score`;
+        any other ROI produces a `UserBoundingBox`. Metadata (track,
+        tracking_score, identity, identity_score, category, name, source,
+        instance) is inherited.
+
+        Args:
+            padding: Amount to inflate the box outward. Scalar applies to both
+                axes; a ``(px, py)`` tuple applies per-axis. Negative values
+                shrink the box. For rotated boxes, padding enlarges the
+                pre-rotation extent about the center while preserving the angle.
+            rotated: If ``True``, fit a minimum-area oriented box (rotated). If
+                ``False``, fit an axis-aligned box from the geometry bounds.
+            error_on_empty: If ``True``, raise ``ValueError`` when the geometry is
+                empty instead of returning a degenerate (NaN) box.
+
+        Returns:
+            A `BoundingBox` enclosing the geometry (or NaN corners if empty).
+
+        Raises:
+            ValueError: If the geometry is empty and ``error_on_empty`` is ``True``.
+        """
+        from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
+
+        if self.geometry.is_empty:
+            if error_on_empty:
+                raise ValueError(
+                    "Cannot compute bounding box of an empty ROI geometry."
+                )
+            nan = float("nan")
+            x1 = y1 = x2 = y2 = nan
+            angle = 0.0
+        else:
+            x1, y1, x2, y2, angle = _geometry_to_bbox_coords(self.geometry, rotated)
+            x1, y1, x2, y2 = _apply_padding(x1, y1, x2, y2, padding)
+
+        kwargs = dict(
+            x1=x1,
+            y1=y1,
+            x2=x2,
+            y2=y2,
+            angle=angle,
+            track=self.track,
+            tracking_score=self.tracking_score,
+            identity=self.identity,
+            identity_score=self.identity_score,
+            instance=self.instance,
+            category=self.category,
+            name=self.name,
+            source=self.source,
+        )
+        if self.is_predicted:
+            return PredictedBoundingBox(score=self.score, **kwargs)
+        return UserBoundingBox(**kwargs)
+
     def explode(self) -> list["ROI"]:
         """Split a multi-geometry ROI into individual ROIs.
 
@@ -474,6 +595,168 @@ def _scanline_fill(
             x_start = max(0, int(np.floor(intersections[j])))
             x_end = min(width, int(np.ceil(intersections[j + 1])))
             mask[y, x_start:x_end] = fill
+
+
+def _apply_padding(
+    x1: float,
+    y1: float,
+    x2: float,
+    y2: float,
+    padding: float | tuple[float, float],
+) -> tuple[float, float, float, float]:
+    """Inflate an axis-aligned box by a scalar or per-axis padding.
+
+    Shared padding logic used by centroid/bbox/instance conversions so that all
+    paths inflate boxes identically.
+
+    Args:
+        x1: Left edge x-coordinate.
+        y1: Top edge y-coordinate.
+        x2: Right edge x-coordinate.
+        y2: Bottom edge y-coordinate.
+        padding: Scalar applied to both axes, or a ``(px, py)`` tuple applied
+            per-axis. Negative values shrink the box; values are not clamped.
+
+    Returns:
+        The padded ``(x1, y1, x2, y2)`` tuple.
+    """
+    if isinstance(padding, (tuple, list)):
+        px, py = padding
+    else:
+        px = py = padding
+    return (x1 - px, y1 - py, x2 + px, y2 + py)
+
+
+def _pose_to_geometry(
+    points: np.ndarray,
+    edges: list[tuple[int, int]],
+    method: str = "shapes",
+    node_radius: float = 0.0,
+    edge_radius: float = 0.0,
+    radius: float = 0.0,
+    quad_segs: int = 8,
+) -> "BaseGeometry":
+    """Build a Shapely geometry from pose points (central pose->vector hub).
+
+    Args:
+        points: ``(n_nodes, 2)`` array of node coordinates; invisible nodes are
+            ``NaN``.
+        edges: List of ``(src, dst)`` node-index pairs (e.g.
+            ``skeleton.edge_inds``).
+        method: ``"shapes"`` to union buffered node points and/or edge segments,
+            or ``"convex_hull"`` to take the convex hull of visible points.
+        node_radius: Buffer radius around each visible node (``"shapes"`` only).
+        edge_radius: Buffer radius around each fully-visible edge segment
+            (``"shapes"`` only).
+        radius: Optional buffer applied to the convex hull (``"convex_hull"``
+            only).
+        quad_segs: Number of segments used to approximate a quarter circle when
+            buffering.
+
+    Returns:
+        A Shapely geometry. An empty ``Polygon`` is returned when there are no
+        visible points (or no shapes were produced).
+
+    Raises:
+        ValueError: If ``method="shapes"`` with both ``node_radius`` and
+            ``edge_radius`` equal to 0 (a misconfiguration), or if ``method`` is
+            not recognized.
+    """
+    from shapely.geometry import LineString, MultiPoint, Point, Polygon
+    from shapely.ops import unary_union
+
+    points = np.asarray(points, dtype=float)
+    visible = ~np.isnan(points[:, 0])
+
+    if method == "shapes":
+        if node_radius == 0 and edge_radius == 0:
+            raise ValueError(
+                "method='shapes' requires at least one of node_radius or "
+                "edge_radius to be > 0."
+            )
+        if not visible.any():
+            return Polygon()
+        shapes: list[BaseGeometry] = []
+        if node_radius > 0:
+            for i in np.nonzero(visible)[0]:
+                x, y = points[i]
+                shapes.append(
+                    Point(float(x), float(y)).buffer(node_radius, quad_segs=quad_segs)
+                )
+        if edge_radius > 0:
+            for src, dst in edges:
+                if visible[src] and visible[dst]:
+                    xs, ys = points[src]
+                    xd, yd = points[dst]
+                    shapes.append(
+                        LineString(
+                            [(float(xs), float(ys)), (float(xd), float(yd))]
+                        ).buffer(edge_radius, quad_segs=quad_segs)
+                    )
+        if shapes:
+            return unary_union(shapes)
+        return Polygon()
+
+    elif method == "convex_hull":
+        if not visible.any():
+            return Polygon()
+        visible_xy = points[visible]
+        hull = MultiPoint([tuple(p) for p in visible_xy]).convex_hull
+        if radius > 0:
+            hull = hull.buffer(radius, quad_segs=quad_segs)
+        return hull
+
+    else:
+        raise ValueError(
+            f"Unknown method {method!r}. Expected 'shapes' or 'convex_hull'."
+        )
+
+
+def _geometry_to_bbox_coords(
+    geometry: "BaseGeometry", rotated: bool = False
+) -> tuple[float, float, float, float, float]:
+    """Compute bounding-box ``(x1, y1, x2, y2, angle)`` from a geometry.
+
+    Args:
+        geometry: A Shapely geometry to enclose.
+        rotated: If ``True``, fit a minimum-area oriented box and return its
+            centered ``(x1, y1, x2, y2)`` plus rotation ``angle`` (radians),
+            consistent with ``BoundingBox.corners``. If ``False``, return the
+            axis-aligned bounds with ``angle=0``.
+
+    Returns:
+        A tuple ``(x1, y1, x2, y2, angle)``. For an empty geometry, all corner
+        values are ``NaN`` and ``angle`` is 0.
+    """
+    if geometry.is_empty:
+        nan = float("nan")
+        return (nan, nan, nan, nan, 0.0)
+
+    if not rotated:
+        minx, miny, maxx, maxy = geometry.bounds
+        return (float(minx), float(miny), float(maxx), float(maxy), 0.0)
+
+    from shapely.geometry import Polygon
+
+    mrr = geometry.minimum_rotated_rectangle
+    if not isinstance(mrr, Polygon) or mrr.is_empty:
+        # Degenerate MRR (Point/LineString): fall back to axis-aligned bounds.
+        minx, miny, maxx, maxy = geometry.bounds
+        return (float(minx), float(miny), float(maxx), float(maxy), 0.0)
+
+    pts = np.asarray(mrr.exterior.coords[:4], dtype=float)
+    cx = float(pts[:, 0].mean())
+    cy = float(pts[:, 1].mean())
+    edge0 = pts[1] - pts[0]
+    edge1 = pts[2] - pts[1]
+    width = float(np.hypot(edge0[0], edge0[1]))
+    height = float(np.hypot(edge1[0], edge1[1]))
+    angle = float(np.arctan2(edge0[1], edge0[0]))
+    x1 = cx - width / 2
+    y1 = cy - height / 2
+    x2 = cx + width / 2
+    y2 = cy + height / 2
+    return (x1, y1, x2, y2, angle)
 
 
 @attrs.define(eq=False)

--- a/tests/model/test_bbox.py
+++ b/tests/model/test_bbox.py
@@ -6,7 +6,9 @@ import numpy as np
 import pytest
 
 from sleap_io.model.bbox import BoundingBox, PredictedBoundingBox, UserBoundingBox
+from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 from sleap_io.model.identity import Identity
+from sleap_io.model.instance import Track
 
 
 def test_bbox_abstract():
@@ -308,3 +310,215 @@ def test_bbox_roundtrip_xyxy():
 def test_bbox_roundtrip_xywh():
     bbox = UserBoundingBox.from_xywh(10, 20, 40, 40)
     assert bbox.xywh == pytest.approx((10, 20, 40, 40))
+
+
+# ---------------------------------------------------------------------------
+# is_empty
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_is_empty_false():
+    """A box with finite corners is not empty."""
+    bbox = UserBoundingBox(x1=0, y1=10, x2=100, y2=90)
+    assert bbox.is_empty is False
+
+
+@pytest.mark.parametrize("corner", ["x1", "y1", "x2", "y2"])
+def test_bbox_is_empty_each_corner_nan(corner):
+    """Any single NaN corner makes the box empty."""
+    coords = dict(x1=0.0, y1=10.0, x2=100.0, y2=90.0)
+    coords[corner] = float("nan")
+    bbox = UserBoundingBox(**coords)
+    assert bbox.is_empty is True
+
+
+def test_bbox_is_empty_returns_plain_bool():
+    """is_empty returns a builtin bool, not a numpy bool."""
+    bbox = UserBoundingBox(x1=0, y1=0, x2=1, y2=1)
+    assert type(bbox.is_empty) is bool
+
+
+# ---------------------------------------------------------------------------
+# to_centroid
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_to_centroid_user():
+    """User box yields a UserCentroid at its center."""
+    bbox = UserBoundingBox(x1=0, y1=10, x2=100, y2=90)
+    centroid = bbox.to_centroid()
+    assert isinstance(centroid, UserCentroid)
+    assert not isinstance(centroid, PredictedCentroid)
+    assert centroid.x == pytest.approx(50.0)
+    assert centroid.y == pytest.approx(50.0)
+
+
+def test_bbox_to_centroid_propagates_metadata():
+    """Metadata is inherited onto the centroid."""
+    track = Track(name="t1")
+    ident = Identity(name="fly_A")
+    inst = object()
+    bbox = UserBoundingBox(
+        x1=0,
+        y1=10,
+        x2=100,
+        y2=90,
+        track=track,
+        tracking_score=0.6,
+        identity=ident,
+        identity_score=0.8,
+        instance=inst,
+        category="mouse",
+        name="b1",
+        source="manual",
+    )
+    centroid = bbox.to_centroid()
+    assert centroid.track is track
+    assert centroid.tracking_score == pytest.approx(0.6)
+    assert centroid.identity is ident
+    assert centroid.identity_score == pytest.approx(0.8)
+    assert centroid.instance is inst
+    assert centroid.category == "mouse"
+    assert centroid.name == "b1"
+    assert centroid.source == "manual"
+
+
+def test_bbox_to_centroid_predicted_carries_score():
+    """Predicted box yields a PredictedCentroid carrying its score."""
+    bbox = PredictedBoundingBox(
+        x1=10, y1=20, x2=50, y2=30, score=0.93, tracking_score=0.4
+    )
+    centroid = bbox.to_centroid()
+    assert isinstance(centroid, PredictedCentroid)
+    assert centroid.score == pytest.approx(0.93)
+    assert centroid.tracking_score == pytest.approx(0.4)
+    assert centroid.x == pytest.approx(30.0)
+    assert centroid.y == pytest.approx(25.0)
+
+
+def test_bbox_to_centroid_degenerate_returns_nan():
+    """Degenerate box returns a NaN (empty) centroid by default."""
+    bbox = UserBoundingBox(x1=float("nan"), y1=0, x2=10, y2=10)
+    centroid = bbox.to_centroid()
+    assert isinstance(centroid, UserCentroid)
+    assert centroid.is_empty
+    assert np.isnan(centroid.x)
+    assert np.isnan(centroid.y)
+
+
+def test_bbox_to_centroid_degenerate_predicted_returns_nan():
+    """Degenerate predicted box returns a NaN PredictedCentroid with score."""
+    bbox = PredictedBoundingBox(x1=0, y1=0, x2=10, y2=float("nan"), score=0.5)
+    centroid = bbox.to_centroid()
+    assert isinstance(centroid, PredictedCentroid)
+    assert centroid.score == pytest.approx(0.5)
+    assert centroid.is_empty
+
+
+def test_bbox_to_centroid_degenerate_error_on_empty():
+    """error_on_empty raises for degenerate boxes."""
+    bbox = UserBoundingBox(x1=float("nan"), y1=0, x2=10, y2=10)
+    with pytest.raises(ValueError, match="degenerate"):
+        bbox.to_centroid(error_on_empty=True)
+
+
+def test_bbox_to_centroid_error_on_empty_ok_when_finite():
+    """error_on_empty does not raise for finite boxes."""
+    bbox = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
+    centroid = bbox.to_centroid(error_on_empty=True)
+    assert centroid.x == pytest.approx(5.0)
+    assert centroid.y == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# pad
+# ---------------------------------------------------------------------------
+
+
+def test_bbox_pad_scalar():
+    """Scalar padding inflates both axes equally."""
+    bbox = UserBoundingBox(x1=10, y1=20, x2=30, y2=40)
+    padded = bbox.pad(5)
+    assert (padded.x1, padded.y1, padded.x2, padded.y2) == pytest.approx(
+        (5, 15, 35, 45)
+    )
+
+
+def test_bbox_pad_per_axis():
+    """Tuple padding inflates each axis independently."""
+    bbox = UserBoundingBox(x1=10, y1=20, x2=30, y2=40)
+    padded = bbox.pad((2, 7))
+    assert (padded.x1, padded.y1, padded.x2, padded.y2) == pytest.approx(
+        (8, 13, 32, 47)
+    )
+
+
+def test_bbox_pad_negative_shrinks():
+    """Negative padding shrinks the box and is not clamped."""
+    bbox = UserBoundingBox(x1=10, y1=20, x2=30, y2=40)
+    padded = bbox.pad(-3)
+    assert (padded.x1, padded.y1, padded.x2, padded.y2) == pytest.approx(
+        (13, 23, 27, 37)
+    )
+
+
+def test_bbox_pad_zero_is_noop():
+    """Zero padding leaves coordinates unchanged."""
+    bbox = UserBoundingBox(x1=10, y1=20, x2=30, y2=40)
+    padded = bbox.pad(0)
+    assert (padded.x1, padded.y1, padded.x2, padded.y2) == pytest.approx(
+        (10, 20, 30, 40)
+    )
+
+
+def test_bbox_pad_returns_new_object():
+    """Pad returns a new object, leaving the original unchanged."""
+    bbox = UserBoundingBox(x1=10, y1=20, x2=30, y2=40)
+    padded = bbox.pad(5)
+    assert padded is not bbox
+    assert (bbox.x1, bbox.y1, bbox.x2, bbox.y2) == (10, 20, 30, 40)
+
+
+def test_bbox_pad_preserves_angle_and_metadata():
+    """Pad preserves angle and all metadata on a user box."""
+    track = Track(name="t1")
+    ident = Identity(name="fly_A")
+    inst = object()
+    bbox = UserBoundingBox(
+        x1=10,
+        y1=20,
+        x2=30,
+        y2=40,
+        angle=0.5,
+        track=track,
+        tracking_score=0.6,
+        identity=ident,
+        identity_score=0.8,
+        instance=inst,
+        category="mouse",
+        name="b1",
+        source="manual",
+    )
+    padded = bbox.pad(5)
+    assert isinstance(padded, UserBoundingBox)
+    assert padded.angle == pytest.approx(0.5)
+    assert padded.track is track
+    assert padded.tracking_score == pytest.approx(0.6)
+    assert padded.identity is ident
+    assert padded.identity_score == pytest.approx(0.8)
+    assert padded.instance is inst
+    assert padded.category == "mouse"
+    assert padded.name == "b1"
+    assert padded.source == "manual"
+
+
+def test_bbox_pad_predicted_preserves_type_and_score():
+    """Padding a predicted box keeps the type and score."""
+    bbox = PredictedBoundingBox(x1=10, y1=20, x2=30, y2=40, score=0.9, angle=0.3)
+    padded = bbox.pad(5)
+    assert isinstance(padded, PredictedBoundingBox)
+    assert padded.score == pytest.approx(0.9)
+    assert padded.angle == pytest.approx(0.3)
+    assert (padded.x1, padded.y1, padded.x2, padded.y2) == pytest.approx(
+        (5, 15, 35, 45)
+    )

--- a/tests/model/test_centroid.py
+++ b/tests/model/test_centroid.py
@@ -3,14 +3,21 @@
 import numpy as np
 import pytest
 
+from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
 from sleap_io.model.centroid import (
     Centroid,
     PredictedCentroid,
     UserCentroid,
+    _geometric_median,
     get_centroid_skeleton,
 )
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, PredictedInstance, Track
+from sleap_io.model.mask import (
+    PredictedSegmentationMask,
+    UserSegmentationMask,
+)
+from sleap_io.model.roi import PredictedROI, UserROI
 from sleap_io.model.skeleton import Skeleton
 
 
@@ -90,6 +97,14 @@ def test_centroid_xyz():
     assert c2.xyz == (1.0, 2.0, None)
 
 
+def test_centroid_is_empty():
+    """is_empty reflects NaN coordinates."""
+    assert not UserCentroid(x=1.0, y=2.0).is_empty
+    assert UserCentroid(x=float("nan"), y=2.0).is_empty
+    assert UserCentroid(x=1.0, y=float("nan")).is_empty
+    assert UserCentroid(x=float("nan"), y=float("nan")).is_empty
+
+
 def test_centroid_skeleton():
     skel = get_centroid_skeleton()
     assert len(skel) == 1
@@ -106,9 +121,22 @@ def test_centroid_module_attr():
     assert skel.node_names == ["centroid"]
 
 
-def test_to_instance_user():
+def test_centroid_module_attr_unknown():
+    """Accessing an unknown module attribute raises AttributeError."""
+    from sleap_io.model import centroid
+
+    with pytest.raises(AttributeError, match="no attribute"):
+        _ = centroid.NOT_A_REAL_ATTR
+
+
+# ---------------------------------------------------------------------------
+# to_pose / from_pose (and deprecated to_instance / from_instance aliases)
+# ---------------------------------------------------------------------------
+
+
+def test_to_pose_user():
     c = UserCentroid(x=100.5, y=200.3, tracking_score=0.5)
-    inst = c.to_instance()
+    inst = c.to_pose()
     assert isinstance(inst, Instance)
     assert not isinstance(inst, PredictedInstance)
     pts = inst.numpy()
@@ -117,15 +145,387 @@ def test_to_instance_user():
     assert inst.tracking_score == 0.5
 
 
-def test_to_instance_predicted():
+def test_to_pose_predicted():
     track = Track(name="t1")
     c = PredictedCentroid(x=50.0, y=60.0, score=0.9, track=track)
-    inst = c.to_instance()
+    inst = c.to_pose()
     assert isinstance(inst, PredictedInstance)
     pts = inst.numpy()
     np.testing.assert_allclose(pts[0], [50.0, 60.0])
     assert inst.score == 0.9
     assert inst.track is track
+
+
+def test_to_pose_custom_skeleton():
+    skel = Skeleton(["center"])
+    c = UserCentroid(x=1.0, y=2.0)
+    inst = c.to_pose(skeleton=skel)
+    assert inst.skeleton is skel
+
+
+def test_to_pose_multi_node_raises():
+    skel = Skeleton(["a", "b"])
+    c = UserCentroid(x=1.0, y=2.0)
+    with pytest.raises(ValueError, match="exactly 1 node"):
+        c.to_pose(skeleton=skel)
+
+
+def test_to_instance_deprecated_alias():
+    """to_instance is a deprecated alias forwarding to to_pose."""
+    c = UserCentroid(x=3.0, y=4.0)
+    with pytest.warns(DeprecationWarning, match="to_pose"):
+        inst = c.to_instance()
+    np.testing.assert_allclose(inst.numpy()[0], [3.0, 4.0])
+
+
+def test_to_instance_deprecated_custom_skeleton():
+    """Deprecated to_instance forwards the skeleton argument."""
+    skel = Skeleton(["center"])
+    c = UserCentroid(x=1.0, y=2.0)
+    with pytest.warns(DeprecationWarning):
+        inst = c.to_instance(skeleton=skel)
+    assert inst.skeleton is skel
+
+
+def test_from_pose_center_of_mass():
+    skel = Skeleton(["a", "b", "c"])
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]]),
+        skeleton=skel,
+        track=Track(name="t1"),
+        tracking_score=0.7,
+    )
+    c = Centroid.from_pose(inst)
+    assert isinstance(c, UserCentroid)
+    assert c.x == pytest.approx(30.0)
+    assert c.y == pytest.approx(40.0)
+    assert c.track is inst.track
+    assert c.tracking_score == 0.7
+    assert c.instance is inst
+    assert c.source == "center_of_mass"
+
+
+def test_from_pose_center_of_mass_ignores_nan():
+    """center_of_mass is a NaN-ignoring mean over visible nodes."""
+    skel = Skeleton(["a", "b", "c"])
+    inst = Instance.from_numpy(
+        np.array([[0.0, 0.0], [10.0, 20.0], [np.nan, np.nan]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(inst, method="center_of_mass")
+    assert c.x == pytest.approx(5.0)
+    assert c.y == pytest.approx(10.0)
+
+
+def test_from_pose_bbox_center():
+    skel = Skeleton(["a", "b"])
+    inst = Instance.from_numpy(
+        np.array([[0.0, 0.0], [10.0, 20.0]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(inst, method="bbox_center")
+    assert c.x == pytest.approx(5.0)
+    assert c.y == pytest.approx(10.0)
+    assert c.source == "bbox_center"
+
+
+def test_from_pose_geometric_median():
+    """geometric_median of a symmetric square is the center."""
+    skel = Skeleton(["a", "b", "c", "d"])
+    inst = Instance.from_numpy(
+        np.array([[0.0, 0.0], [2.0, 0.0], [0.0, 2.0], [2.0, 2.0]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(inst, method="geometric_median")
+    assert c.x == pytest.approx(1.0, abs=1e-4)
+    assert c.y == pytest.approx(1.0, abs=1e-4)
+    assert c.source == "geometric_median"
+
+
+def test_from_pose_geometric_median_collinear():
+    """geometric_median of collinear points is the middle point."""
+    skel = Skeleton(["a", "b", "c"])
+    inst = Instance.from_numpy(
+        np.array([[0.0, 0.0], [1.0, 0.0], [10.0, 0.0]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(inst, method="geometric_median")
+    assert c.x == pytest.approx(1.0, abs=1e-4)
+    assert c.y == pytest.approx(0.0, abs=1e-4)
+
+
+def test_geometric_median_known_value():
+    """Direct geometric median of a known collinear triple."""
+    pts = np.array([[0.0, 0.0], [5.0, 0.0], [100.0, 0.0]])
+    x, y = _geometric_median(pts)
+    assert x == pytest.approx(5.0, abs=1e-4)
+    assert y == pytest.approx(0.0, abs=1e-4)
+
+
+def test_geometric_median_coincident_points():
+    """All-coincident points return that point (zero-distance branch)."""
+    pts = np.array([[7.0, 9.0], [7.0, 9.0], [7.0, 9.0]])
+    x, y = _geometric_median(pts)
+    assert x == pytest.approx(7.0)
+    assert y == pytest.approx(9.0)
+
+
+def test_geometric_median_iteration_cap():
+    """Slow-converging input exits via the 100-iteration safety cap.
+
+    This configuration does not reach the ``1e-6`` movement tolerance within
+    100 Weiszfeld iterations, exercising the natural loop-exhaustion path. The
+    result still approximates the true geometric median.
+    """
+    pts = np.array(
+        [
+            [0.74378048, -1.05813234],
+            [4.92023229, 4.23745357],
+            [-3.47992097, 0.89960593],
+            [1.96215106, -3.63456586],
+            [-1.87404353, 2.15917847],
+            [4.01108093, -1.5825735],
+        ]
+    )
+    x, y = _geometric_median(pts)
+    assert x == pytest.approx(0.7663, abs=1e-2)
+    assert y == pytest.approx(-1.0158, abs=1e-2)
+
+
+def test_geometric_median_single_point():
+    """A single point is its own geometric median."""
+    pts = np.array([[3.0, 4.0]])
+    x, y = _geometric_median(pts)
+    assert x == pytest.approx(3.0)
+    assert y == pytest.approx(4.0)
+
+
+def test_from_pose_anchor():
+    skel = Skeleton(["head", "thorax", "tail"])
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(inst, method="anchor", node="thorax")
+    assert c.x == 30.0
+    assert c.y == 40.0
+    assert c.source == "anchor:thorax"
+
+
+def test_from_pose_anchor_by_index():
+    skel = Skeleton(["a", "b"])
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [30.0, 40.0]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(inst, method="anchor", node=1)
+    assert c.x == 30.0
+    assert c.y == 40.0
+    assert c.source == "anchor:1"
+
+
+def test_from_pose_anchor_by_numpy_index():
+    """A numpy integer index is accepted for the anchor node."""
+    skel = Skeleton(["a", "b"])
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [30.0, 40.0]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(inst, method="anchor", node=np.int64(0))
+    assert c.x == 10.0
+    assert c.y == 20.0
+
+
+def test_from_pose_anchor_occluded_fallback():
+    """Occluded anchor falls back to a non-anchor method with combined tag."""
+    skel = Skeleton(["head", "thorax", "tail"])
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [np.nan, np.nan], [50.0, 60.0]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(
+        inst, method="anchor", node="thorax", fallback="center_of_mass"
+    )
+    assert c.x == pytest.approx(30.0)
+    assert c.y == pytest.approx(40.0)
+    assert c.source == "anchor:thorax->center_of_mass"
+
+
+def test_from_pose_anchor_occluded_no_fallback_degenerate():
+    """Occluded anchor with no fallback yields a degenerate centroid."""
+    skel = Skeleton(["head", "thorax"])
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [np.nan, np.nan]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(inst, method="anchor", node="thorax")
+    assert c.is_empty
+    assert c.source == "anchor:thorax"
+
+
+def test_from_pose_anchor_occluded_no_fallback_error():
+    """error_on_empty raises for an occluded anchor with no fallback."""
+    skel = Skeleton(["head", "thorax"])
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [np.nan, np.nan]]),
+        skeleton=skel,
+    )
+    with pytest.raises(ValueError, match="No visible points"):
+        Centroid.from_pose(inst, method="anchor", node="thorax", error_on_empty=True)
+
+
+def test_from_pose_anchor_fallback_exhausted():
+    """Occluded anchor whose fallback also has no visible points is degenerate."""
+    skel = Skeleton(["head", "thorax"])
+    inst = Instance.from_numpy(
+        np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(
+        inst, method="anchor", node="thorax", fallback="center_of_mass"
+    )
+    assert c.is_empty
+    assert c.source == "anchor:thorax->center_of_mass"
+
+
+def test_from_pose_anchor_fallback_exhausted_error():
+    """Fallback-exhausted occluded anchor raises with error_on_empty."""
+    skel = Skeleton(["head", "thorax"])
+    inst = Instance.from_numpy(
+        np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+        skeleton=skel,
+    )
+    with pytest.raises(ValueError, match="No visible points"):
+        Centroid.from_pose(
+            inst,
+            method="anchor",
+            node="thorax",
+            fallback="center_of_mass",
+            error_on_empty=True,
+        )
+
+
+def test_from_pose_anchor_invalid_fallback_raises():
+    """An unknown fallback method raises when the anchor is occluded."""
+    skel = Skeleton(["head", "thorax"])
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [np.nan, np.nan]]),
+        skeleton=skel,
+    )
+    with pytest.raises(ValueError, match="Unknown method"):
+        Centroid.from_pose(
+            inst, method="anchor", node="thorax", fallback="not_a_method"
+        )
+
+
+def test_from_pose_anchor_no_node_raises():
+    skel = Skeleton(["a"])
+    inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skel)
+    with pytest.raises(ValueError, match="Must specify"):
+        Centroid.from_pose(inst, method="anchor")
+
+
+def test_from_pose_anchor_invalid_node_type_raises():
+    """A non-str/int node specification raises."""
+    skel = Skeleton(["a"])
+    inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skel)
+    with pytest.raises(ValueError, match="node must be str or int"):
+        Centroid.from_pose(inst, method="anchor", node=1.5)
+
+
+def test_from_pose_predicted():
+    skel = Skeleton(["a"])
+    inst = PredictedInstance.from_numpy(
+        np.array([[5.0, 10.0]]),
+        skeleton=skel,
+        score=0.85,
+    )
+    c = Centroid.from_pose(inst)
+    assert isinstance(c, PredictedCentroid)
+    assert c.score == 0.85
+
+
+def test_from_pose_no_visible_degenerate():
+    """No visible points yields a degenerate centroid by default."""
+    skel = Skeleton(["a", "b"])
+    inst = Instance.from_numpy(
+        np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+        skeleton=skel,
+    )
+    c = Centroid.from_pose(inst)
+    assert c.is_empty
+    assert c.source == "center_of_mass"
+
+
+def test_from_pose_no_visible_raises():
+    skel = Skeleton(["a", "b"])
+    inst = Instance.from_numpy(
+        np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+        skeleton=skel,
+    )
+    with pytest.raises(ValueError, match="No visible points"):
+        Centroid.from_pose(inst, error_on_empty=True)
+
+
+def test_from_pose_bbox_center_no_visible_degenerate():
+    """bbox_center with no visible points is degenerate."""
+    skel = Skeleton(["a"])
+    inst = Instance.from_numpy(np.array([[np.nan, np.nan]]), skeleton=skel)
+    c = Centroid.from_pose(inst, method="bbox_center")
+    assert c.is_empty
+
+
+def test_from_pose_geometric_median_no_visible_degenerate():
+    """geometric_median with no visible points is degenerate."""
+    skel = Skeleton(["a"])
+    inst = Instance.from_numpy(np.array([[np.nan, np.nan]]), skeleton=skel)
+    c = Centroid.from_pose(inst, method="geometric_median")
+    assert c.is_empty
+
+
+def test_from_pose_invalid_method():
+    skel = Skeleton(["a"])
+    inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skel)
+    with pytest.raises(ValueError, match="Unknown method"):
+        Centroid.from_pose(inst, method="invalid")
+
+
+def test_from_pose_kwargs_passthrough():
+    """Extra kwargs are forwarded to the centroid constructor."""
+    skel = Skeleton(["a"])
+    inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skel)
+    c = Centroid.from_pose(inst, category="cell", name="c7")
+    assert c.category == "cell"
+    assert c.name == "c7"
+
+
+def test_from_pose_carries_identity():
+    """from_pose copies the instance's identity onto the centroid."""
+    skel = Skeleton(["a", "b"])
+    ident = Identity(name="cell_A")
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [30.0, 40.0]]),
+        skel,
+        identity=ident,
+        identity_score=0.55,
+    )
+    c = UserCentroid.from_pose(inst)
+    assert c.identity is ident
+    assert c.identity_score == pytest.approx(0.55)
+
+
+def test_from_instance_deprecated_alias():
+    """from_instance is a deprecated alias forwarding to from_pose."""
+    skel = Skeleton(["a", "b"])
+    inst = Instance.from_numpy(
+        np.array([[10.0, 20.0], [30.0, 40.0]]),
+        skel,
+    )
+    with pytest.warns(DeprecationWarning, match="from_pose"):
+        c = Centroid.from_instance(inst)
+    assert c.x == pytest.approx(20.0)
+    assert c.y == pytest.approx(30.0)
+    assert c.source == "center_of_mass"
 
 
 def test_centroid_identity_field():
@@ -140,131 +540,178 @@ def test_centroid_identity_field():
     assert plain.identity_score is None
 
 
-def test_to_instance_carries_identity():
-    """to_instance() preserves identity / identity_score onto the instance."""
+def test_to_pose_carries_identity():
+    """to_pose preserves identity / identity_score onto the instance."""
     ident = Identity(name="cell_A")
     c = UserCentroid(x=1.0, y=2.0, identity=ident, identity_score=0.6)
-    inst = c.to_instance()
+    inst = c.to_pose()
     assert inst.identity is ident
     assert inst.identity_score == pytest.approx(0.6)
 
 
-def test_from_instance_carries_identity():
-    """from_instance() copies the instance's identity onto the centroid."""
-    skel = Skeleton(["a", "b"])
-    ident = Identity(name="cell_A")
-    inst = Instance.from_numpy(
-        np.array([[10.0, 20.0], [30.0, 40.0]]),
-        skel,
-        identity=ident,
-        identity_score=0.55,
-    )
-    c = UserCentroid.from_instance(inst)
-    assert c.identity is ident
-    assert c.identity_score == pytest.approx(0.55)
+# ---------------------------------------------------------------------------
+# to_bbox
+# ---------------------------------------------------------------------------
 
 
-def test_to_instance_custom_skeleton():
-    skel = Skeleton(["center"])
-    c = UserCentroid(x=1.0, y=2.0)
-    inst = c.to_instance(skeleton=skel)
-    assert inst.skeleton is skel
+def test_to_bbox_scalar_size():
+    c = UserCentroid(x=10.0, y=20.0, source="anchor:thorax")
+    bb = c.to_bbox(size=4.0)
+    assert isinstance(bb, UserBoundingBox)
+    assert not isinstance(bb, PredictedBoundingBox)
+    assert bb.x1 == pytest.approx(8.0)
+    assert bb.y1 == pytest.approx(18.0)
+    assert bb.x2 == pytest.approx(12.0)
+    assert bb.y2 == pytest.approx(22.0)
+    assert bb.angle == 0.0
+    # Source metadata is inherited.
+    assert bb.source == "anchor:thorax"
 
 
-def test_to_instance_multi_node_raises():
-    skel = Skeleton(["a", "b"])
-    c = UserCentroid(x=1.0, y=2.0)
-    with pytest.raises(ValueError, match="exactly 1 node"):
-        c.to_instance(skeleton=skel)
+def test_to_bbox_tuple_size():
+    c = UserCentroid(x=0.0, y=0.0)
+    bb = c.to_bbox(size=(4.0, 6.0))
+    assert bb.width == pytest.approx(4.0)
+    assert bb.height == pytest.approx(6.0)
 
 
-def test_from_instance_center_of_mass():
-    skel = Skeleton(["a", "b", "c"])
-    inst = Instance.from_numpy(
-        np.array([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]]),
-        skeleton=skel,
-        track=Track(name="t1"),
-        tracking_score=0.7,
-    )
-    c = Centroid.from_instance(inst)
-    assert isinstance(c, UserCentroid)
-    assert c.x == pytest.approx(30.0)
-    assert c.y == pytest.approx(40.0)
-    assert c.track is inst.track
-    assert c.tracking_score == 0.7
-    assert c.instance is inst
-    assert c.source == "center_of_mass"
+def test_to_bbox_padding():
+    c = UserCentroid(x=0.0, y=0.0)
+    bb = c.to_bbox(size=4.0, padding=1.0)
+    assert bb.x1 == pytest.approx(-3.0)
+    assert bb.x2 == pytest.approx(3.0)
+    assert bb.y1 == pytest.approx(-3.0)
+    assert bb.y2 == pytest.approx(3.0)
 
 
-def test_from_instance_bbox_center():
-    skel = Skeleton(["a", "b"])
-    inst = Instance.from_numpy(
-        np.array([[0.0, 0.0], [10.0, 20.0]]),
-        skeleton=skel,
-    )
-    c = Centroid.from_instance(inst, method="bbox_center")
-    assert c.x == pytest.approx(5.0)
-    assert c.y == pytest.approx(10.0)
-    assert c.source == "bbox_center"
+def test_to_bbox_size_required():
+    c = UserCentroid(x=0.0, y=0.0)
+    with pytest.raises(ValueError, match="'size' is required"):
+        c.to_bbox(size=None)
 
 
-def test_from_instance_anchor():
-    skel = Skeleton(["head", "thorax", "tail"])
-    inst = Instance.from_numpy(
-        np.array([[10.0, 20.0], [30.0, 40.0], [50.0, 60.0]]),
-        skeleton=skel,
-    )
-    c = Centroid.from_instance(inst, method="anchor", node="thorax")
-    assert c.x == 30.0
-    assert c.y == 40.0
-    assert c.source == "anchor:thorax"
+def test_to_bbox_predicted():
+    track = Track(name="t1")
+    c = PredictedCentroid(x=5.0, y=5.0, score=0.7, track=track)
+    bb = c.to_bbox(size=2.0)
+    assert isinstance(bb, PredictedBoundingBox)
+    assert bb.score == pytest.approx(0.7)
+    assert bb.track is track
 
 
-def test_from_instance_anchor_by_index():
-    skel = Skeleton(["a", "b"])
-    inst = Instance.from_numpy(
-        np.array([[10.0, 20.0], [30.0, 40.0]]),
-        skeleton=skel,
-    )
-    c = Centroid.from_instance(inst, method="anchor", node=1)
-    assert c.x == 30.0
-    assert c.y == 40.0
+def test_to_bbox_empty_degenerate():
+    c = UserCentroid(x=float("nan"), y=float("nan"))
+    bb = c.to_bbox(size=4.0)
+    assert bb.is_empty
 
 
-def test_from_instance_predicted():
-    skel = Skeleton(["a"])
-    inst = PredictedInstance.from_numpy(
-        np.array([[5.0, 10.0]]),
-        skeleton=skel,
-        score=0.85,
-    )
-    c = Centroid.from_instance(inst)
-    assert isinstance(c, PredictedCentroid)
-    assert c.score == 0.85
+def test_to_bbox_empty_error():
+    c = UserCentroid(x=float("nan"), y=float("nan"))
+    with pytest.raises(ValueError, match="degenerate"):
+        c.to_bbox(size=4.0, error_on_empty=True)
 
 
-def test_from_instance_no_visible_raises():
-    skel = Skeleton(["a", "b"])
-    inst = Instance.from_numpy(
-        np.array([[np.nan, np.nan], [np.nan, np.nan]]),
-        skeleton=skel,
-    )
-    with pytest.raises(ValueError, match="No visible points"):
-        Centroid.from_instance(inst)
+# ---------------------------------------------------------------------------
+# to_roi
+# ---------------------------------------------------------------------------
 
 
-def test_from_instance_invalid_method():
-    skel = Skeleton(["a"])
-    inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skel)
-    with pytest.raises(ValueError, match="Unknown method"):
-        Centroid.from_instance(inst, method="invalid")
+def test_to_roi_basic():
+    c = UserCentroid(x=10.0, y=20.0, category="cell")
+    roi = c.to_roi(radius=3.0)
+    assert isinstance(roi, UserROI)
+    assert not roi.is_empty
+    # Circle area ~= pi * r^2.
+    assert roi.geometry.area == pytest.approx(np.pi * 9.0, abs=0.2)
+    cx, cy = roi.geometry.centroid.x, roi.geometry.centroid.y
+    assert cx == pytest.approx(10.0, abs=1e-6)
+    assert cy == pytest.approx(20.0, abs=1e-6)
+    assert roi.category == "cell"
 
 
-def test_from_instance_anchor_no_node_raises():
-    skel = Skeleton(["a"])
-    inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skel)
-    with pytest.raises(ValueError, match="Must specify"):
-        Centroid.from_instance(inst, method="anchor")
+def test_to_roi_predicted():
+    c = PredictedCentroid(x=1.0, y=1.0, score=0.42)
+    roi = c.to_roi(radius=2.0)
+    assert isinstance(roi, PredictedROI)
+    assert roi.score == pytest.approx(0.42)
+
+
+def test_to_roi_empty_degenerate():
+    c = UserCentroid(x=float("nan"), y=2.0)
+    roi = c.to_roi(radius=3.0)
+    assert roi.is_empty
+
+
+def test_to_roi_empty_error():
+    c = UserCentroid(x=float("nan"), y=2.0)
+    with pytest.raises(ValueError, match="degenerate"):
+        c.to_roi(radius=3.0, error_on_empty=True)
+
+
+# ---------------------------------------------------------------------------
+# to_mask
+# ---------------------------------------------------------------------------
+
+
+def test_to_mask_basic():
+    c = UserCentroid(x=10.0, y=10.0)
+    mask = c.to_mask(height=20, width=20, radius=3.0)
+    assert isinstance(mask, UserSegmentationMask)
+    assert not mask.is_empty
+    # Rasterized disk area approximates pi * r^2.
+    assert mask.area == pytest.approx(np.pi * 9.0, abs=6.0)
+
+
+def test_to_mask_matches_roi_to_mask():
+    """to_mask is equivalent to to_roi(radius).to_mask(h, w)."""
+    c = UserCentroid(x=12.0, y=8.0)
+    direct = c.to_mask(height=20, width=20, radius=4.0)
+    via_roi = c.to_roi(radius=4.0).to_mask(20, 20)
+    np.testing.assert_array_equal(direct.data, via_roi.data)
+
+
+def test_to_mask_predicted():
+    c = PredictedCentroid(x=5.0, y=5.0, score=0.33)
+    mask = c.to_mask(height=12, width=12, radius=2.0)
+    assert isinstance(mask, PredictedSegmentationMask)
+    assert mask.score == pytest.approx(0.33)
+
+
+def test_to_mask_empty_degenerate():
+    c = UserCentroid(x=float("nan"), y=float("nan"))
+    mask = c.to_mask(height=8, width=8, radius=3.0)
+    assert isinstance(mask, UserSegmentationMask)
+    assert mask.is_empty
+    assert mask.data.shape == (8, 8)
+
+
+def test_to_mask_empty_predicted_degenerate():
+    c = PredictedCentroid(x=float("nan"), y=float("nan"), score=0.9)
+    mask = c.to_mask(height=8, width=8, radius=3.0)
+    assert isinstance(mask, PredictedSegmentationMask)
+    assert mask.is_empty
+    assert mask.score == pytest.approx(0.9)
+
+
+def test_to_mask_empty_error():
+    c = UserCentroid(x=float("nan"), y=float("nan"))
+    with pytest.raises(ValueError, match="degenerate"):
+        c.to_mask(height=8, width=8, radius=3.0, error_on_empty=True)
+
+
+def test_to_mask_metadata_propagated():
+    """Metadata is carried through the to_mask conversion."""
+    track = Track(name="t1")
+    c = UserCentroid(x=10.0, y=10.0, track=track, category="cell", name="c1")
+    mask = c.to_mask(height=20, width=20, radius=3.0)
+    assert mask.track is track
+    assert mask.category == "cell"
+    assert mask.name == "c1"
+
+
+# ---------------------------------------------------------------------------
+# instance.to_centroid delegation
+# ---------------------------------------------------------------------------
 
 
 def test_instance_centroid_xy():
@@ -294,3 +741,4 @@ def test_instance_to_centroid():
     assert isinstance(c, UserCentroid)
     assert c.x == pytest.approx(20.0)
     assert c.y == pytest.approx(30.0)
+    assert c.instance is inst

--- a/tests/model/test_instance.py
+++ b/tests/model/test_instance.py
@@ -5,12 +5,16 @@ import pytest
 from numpy.testing import assert_array_equal, assert_equal
 
 from sleap_io import Skeleton
+from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
+from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import (
     Instance,
     PredictedInstance,
     Track,
 )
+from sleap_io.model.mask import PredictedSegmentationMask, UserSegmentationMask
+from sleap_io.model.roi import PredictedROI, UserROI
 
 
 def test_track():
@@ -655,3 +659,431 @@ def test_track_similarity_to():
     sim = track4.similarity_to(track4)
     assert sim["same_name"] is True
     assert sim["name_similarity"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Modality conversions (issue #529): to_centroid / to_bbox / to_roi / to_mask
+# ---------------------------------------------------------------------------
+
+
+def _tri_skeleton() -> Skeleton:
+    """Return a simple 3-node skeleton with two edges."""
+    skel = Skeleton(["a", "b", "c"])
+    skel.add_edge("a", "b")
+    skel.add_edge("a", "c")
+    return skel
+
+
+def test_instance_to_centroid_delegates_default():
+    """Instance.to_centroid delegates to Centroid.from_pose (center_of_mass)."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [9, 0], [0, 9]]), skeleton=skel)
+
+    cent = inst.to_centroid()
+
+    assert isinstance(cent, UserCentroid)
+    assert cent.source == "center_of_mass"
+    assert cent.instance is inst
+    assert cent.xy == pytest.approx((3.0, 3.0))
+
+
+def test_instance_to_centroid_anchor_with_fallback():
+    """Occluded anchor falls back and records the fallback in the source tag."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(
+        np.array([[np.nan, np.nan], [10, 0], [0, 10]]), skeleton=skel
+    )
+
+    cent = inst.to_centroid(method="anchor", node="a", fallback="center_of_mass")
+
+    assert cent.source == "anchor:a->center_of_mass"
+    assert cent.xy == pytest.approx((5.0, 5.0))
+
+
+def test_instance_to_centroid_predicted_carries_score():
+    """A PredictedInstance yields a PredictedCentroid carrying its score."""
+    skel = _tri_skeleton()
+    inst = PredictedInstance.from_numpy(
+        np.array([[0, 0], [4, 0], [0, 4]]), skeleton=skel, score=0.8
+    )
+
+    cent = inst.to_centroid()
+
+    assert isinstance(cent, PredictedCentroid)
+    assert cent.score == pytest.approx(0.8)
+    assert cent.instance is inst
+
+
+def test_instance_to_bbox_tight():
+    """Tight axis-aligned bbox encloses all visible points."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[5, 10], [15, 20], [10, 30]]), skeleton=skel)
+
+    bbox = inst.to_bbox()
+
+    assert isinstance(bbox, UserBoundingBox)
+    assert bbox.angle == 0.0
+    assert bbox.xyxy == pytest.approx((5.0, 10.0, 15.0, 30.0))
+    assert bbox.instance is inst
+
+
+def test_instance_to_bbox_tight_ignores_invisible():
+    """Tight bbox ignores invisible (NaN) points."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(
+        np.array([[5, 10], [np.nan, np.nan], [10, 30]]), skeleton=skel
+    )
+
+    bbox = inst.to_bbox()
+
+    assert bbox.xyxy == pytest.approx((5.0, 10.0, 10.0, 30.0))
+
+
+def test_instance_to_bbox_tight_padding():
+    """Padding inflates the tight bbox; tuple padding is per-axis."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [10, 0], [0, 10]]), skeleton=skel)
+
+    bbox = inst.to_bbox(padding=(2, 3))
+
+    assert bbox.xyxy == pytest.approx((-2.0, -3.0, 12.0, 13.0))
+
+
+def test_instance_to_bbox_tight_rotated():
+    """Rotated tight bbox fits an oriented box from the convex hull."""
+    skel = Skeleton(["a", "b", "c", "d"])
+    # Axis-aligned square rotated 45 degrees about the origin.
+    inst = Instance.from_numpy(
+        np.array([[1, 0], [0, 1], [-1, 0], [0, -1]]), skeleton=skel
+    )
+
+    bbox = inst.to_bbox(rotated=True)
+
+    # The minimum-area rectangle of a diamond is a square of side sqrt(2).
+    assert bbox.is_rotated
+    assert bbox.width == pytest.approx(np.sqrt(2), abs=1e-6)
+    assert bbox.height == pytest.approx(np.sqrt(2), abs=1e-6)
+
+
+def test_instance_to_bbox_tight_rotated_padding():
+    """Padding on a rotated tight bbox enlarges the pre-rotation extent."""
+    skel = Skeleton(["a", "b", "c", "d"])
+    inst = Instance.from_numpy(
+        np.array([[1, 0], [0, 1], [-1, 0], [0, -1]]), skeleton=skel
+    )
+
+    base = inst.to_bbox(rotated=True)
+    padded = inst.to_bbox(rotated=True, padding=1.0)
+
+    assert padded.width == pytest.approx(base.width + 2.0, abs=1e-6)
+    assert padded.height == pytest.approx(base.height + 2.0, abs=1e-6)
+    assert padded.angle == pytest.approx(base.angle)
+
+
+def test_instance_to_bbox_centered_scalar():
+    """Centered bbox builds a fixed square box around the centroid."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [9, 0], [0, 9]]), skeleton=skel)
+
+    bbox = inst.to_bbox(mode="centered", size=4)
+
+    # Centroid is (3, 3); a size-4 box spans +/- 2.
+    assert bbox.xyxy == pytest.approx((1.0, 1.0, 5.0, 5.0))
+
+
+def test_instance_to_bbox_centered_size_tuple():
+    """Centered bbox accepts a (w, h) tuple for size."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[2, 2], [2, 2], [2, 2]]), skeleton=skel)
+
+    bbox = inst.to_bbox(mode="centered", size=(4, 6))
+
+    assert bbox.xyxy == pytest.approx((0.0, -1.0, 4.0, 5.0))
+
+
+def test_instance_to_bbox_centered_anchor_node():
+    """Centered bbox can center on an anchor node."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[10, 20], [0, 0], [0, 0]]), skeleton=skel)
+
+    bbox = inst.to_bbox(mode="centered", size=2, center_method="anchor", node="a")
+
+    assert bbox.xyxy == pytest.approx((9.0, 19.0, 11.0, 21.0))
+
+
+def test_instance_to_bbox_centered_requires_size():
+    """mode='centered' without a size is a misconfiguration."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [9, 0], [0, 9]]), skeleton=skel)
+
+    with pytest.raises(ValueError, match="size"):
+        inst.to_bbox(mode="centered")
+
+
+def test_instance_to_bbox_unknown_mode_raises():
+    """An unknown bbox mode raises ValueError."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [9, 0], [0, 9]]), skeleton=skel)
+
+    with pytest.raises(ValueError, match="Unknown mode"):
+        inst.to_bbox(mode="bogus")
+
+
+def test_instance_to_bbox_empty_degenerate():
+    """No visible points yields a degenerate (NaN) bbox."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.full((3, 2), np.nan), skeleton=skel)
+
+    bbox = inst.to_bbox()
+
+    assert bbox.is_empty
+    assert np.isnan(bbox.x1)
+
+
+def test_instance_to_bbox_empty_error_on_empty():
+    """error_on_empty raises for an empty tight bbox."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.full((3, 2), np.nan), skeleton=skel)
+
+    with pytest.raises(ValueError, match="No visible points"):
+        inst.to_bbox(error_on_empty=True)
+
+
+def test_instance_to_bbox_centered_empty_degenerate():
+    """Centered mode with no visible points yields a degenerate bbox."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.full((3, 2), np.nan), skeleton=skel)
+
+    bbox = inst.to_bbox(mode="centered", size=4)
+
+    assert bbox.is_empty
+
+
+def test_instance_to_bbox_centered_empty_error_on_empty():
+    """Centered mode propagates error_on_empty through the centroid step."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.full((3, 2), np.nan), skeleton=skel)
+
+    with pytest.raises(ValueError):
+        inst.to_bbox(mode="centered", size=4, error_on_empty=True)
+
+
+def test_instance_to_bbox_predicted_carries_score():
+    """A PredictedInstance yields a PredictedBoundingBox carrying its score."""
+    skel = _tri_skeleton()
+    inst = PredictedInstance.from_numpy(
+        np.array([[0, 0], [9, 0], [0, 9]]), skeleton=skel, score=0.6
+    )
+
+    bbox = inst.to_bbox()
+
+    assert isinstance(bbox, PredictedBoundingBox)
+    assert bbox.score == pytest.approx(0.6)
+    assert bbox.instance is inst
+
+
+def test_instance_to_roi_shapes_nodes():
+    """method='shapes' with node_radius unions buffered node disks."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [10, 0], [0, 10]]), skeleton=skel)
+
+    roi = inst.to_roi(node_radius=2)
+
+    assert isinstance(roi, UserROI)
+    assert not roi.is_empty
+    assert roi.instance is inst
+
+
+def test_instance_to_roi_shapes_edges():
+    """method='shapes' with edge_radius buffers fully-visible edge segments."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [10, 0], [0, 10]]), skeleton=skel)
+
+    roi = inst.to_roi(edge_radius=1.0)
+
+    assert not roi.is_empty
+    # Two edges (a-b, a-c) each of length 10 buffered by 1 -> area roughly
+    # the union of two capsules.
+    assert roi.geometry.area > 0
+
+
+def test_instance_to_roi_convex_hull():
+    """method='convex_hull' returns the hull polygon of visible points."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [10, 0], [0, 10]]), skeleton=skel)
+
+    roi = inst.to_roi(method="convex_hull")
+
+    assert roi.geometry.geom_type == "Polygon"
+    assert roi.geometry.area == pytest.approx(50.0)
+
+
+def test_instance_to_roi_convex_hull_radius_quad_segs():
+    """convex_hull radius buffers the hull; quad_segs controls smoothness."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [10, 0], [0, 10]]), skeleton=skel)
+
+    coarse = inst.to_roi(method="convex_hull", radius=2.0, quad_segs=1)
+    fine = inst.to_roi(method="convex_hull", radius=2.0, quad_segs=16)
+
+    # Both enclose the bare hull (area 50); finer rounding has larger area.
+    assert coarse.geometry.area > 50.0
+    assert fine.geometry.area > coarse.geometry.area
+
+
+def test_instance_to_roi_shapes_misconfig_always_raises():
+    """Both radii zero is a misconfiguration that raises even with empty input."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [10, 0], [0, 10]]), skeleton=skel)
+    empty = Instance.from_numpy(np.full((3, 2), np.nan), skeleton=skel)
+
+    with pytest.raises(ValueError, match="at least one"):
+        inst.to_roi()
+    # Misconfiguration raises even when error_on_empty=True and no points.
+    with pytest.raises(ValueError, match="at least one"):
+        empty.to_roi(error_on_empty=True)
+
+
+def test_instance_to_roi_unknown_method_raises():
+    """An unknown ROI method raises ValueError."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[0, 0], [10, 0], [0, 10]]), skeleton=skel)
+
+    with pytest.raises(ValueError, match="Unknown method"):
+        inst.to_roi(method="bogus")
+
+
+def test_instance_to_roi_empty_degenerate():
+    """No visible points yields an empty-geometry ROI."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.full((3, 2), np.nan), skeleton=skel)
+
+    roi = inst.to_roi(node_radius=2)
+
+    assert roi.is_empty
+
+
+def test_instance_to_roi_empty_error_on_empty():
+    """error_on_empty raises for an empty ROI geometry."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.full((3, 2), np.nan), skeleton=skel)
+
+    with pytest.raises(ValueError, match="No visible points"):
+        inst.to_roi(node_radius=2, error_on_empty=True)
+
+
+def test_instance_to_roi_predicted_carries_score():
+    """A PredictedInstance yields a PredictedROI carrying its score."""
+    skel = _tri_skeleton()
+    inst = PredictedInstance.from_numpy(
+        np.array([[0, 0], [10, 0], [0, 10]]), skeleton=skel, score=0.9
+    )
+
+    roi = inst.to_roi(node_radius=2)
+
+    assert isinstance(roi, PredictedROI)
+    assert roi.score == pytest.approx(0.9)
+    assert roi.instance is inst
+
+
+def test_instance_to_mask_matches_roi_to_mask():
+    """to_mask equals to_roi(...).to_mask(h, w) for the same kwargs."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.array([[2, 2], [12, 2], [2, 12]]), skeleton=skel)
+
+    via_mask = inst.to_mask(20, 20, node_radius=3)
+    via_roi = inst.to_roi(node_radius=3).to_mask(20, 20)
+
+    assert isinstance(via_mask, UserSegmentationMask)
+    assert via_mask.area == via_roi.area
+    np.testing.assert_array_equal(via_mask.data, via_roi.data)
+    assert via_mask.instance is inst
+
+
+def test_instance_to_mask_empty_all_background():
+    """An empty instance rasterizes to an all-background mask."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.full((3, 2), np.nan), skeleton=skel)
+
+    mask = inst.to_mask(8, 12, node_radius=2)
+
+    assert isinstance(mask, UserSegmentationMask)
+    assert mask.area == 0
+    assert mask.data.shape == (8, 12)
+    assert mask.instance is inst
+
+
+def test_instance_to_mask_empty_error_on_empty():
+    """error_on_empty raises for an empty instance to_mask."""
+    skel = _tri_skeleton()
+    inst = Instance.from_numpy(np.full((3, 2), np.nan), skeleton=skel)
+
+    with pytest.raises(ValueError, match="No visible points"):
+        inst.to_mask(8, 8, node_radius=2, error_on_empty=True)
+
+
+def test_instance_to_mask_convex_hull_degenerate_all_background():
+    """A zero-area convex hull (<3 visible points) rasterizes to all background.
+
+    With fewer than three visible points the convex hull is a Point/LineString,
+    which is non-empty but non-fillable; ``to_mask`` returns an all-background
+    mask instead of leaking the rasterizer's ``TypeError``.
+    """
+    skel = _tri_skeleton()
+    # Only two visible points -> hull is a LineString (zero area).
+    inst = Instance.from_numpy(
+        np.array([[0.0, 0.0], [10.0, 10.0], [np.nan, np.nan]]), skeleton=skel
+    )
+
+    mask = inst.to_mask(20, 20, method="convex_hull", radius=0.0)
+
+    assert isinstance(mask, UserSegmentationMask)
+    assert mask.is_empty
+    assert mask.area == 0
+    assert mask.data.shape == (20, 20)
+    assert mask.instance is inst
+
+
+def test_instance_to_mask_convex_hull_degenerate_predicted_carries_score():
+    """The degenerate convex-hull path preserves the predicted variant + score."""
+    skel = _tri_skeleton()
+    inst = PredictedInstance.from_numpy(
+        np.array([[0.0, 0.0], [10.0, 10.0], [np.nan, np.nan]]),
+        skeleton=skel,
+        score=0.8,
+    )
+
+    mask = inst.to_mask(20, 20, method="convex_hull", radius=0.0)
+
+    assert isinstance(mask, PredictedSegmentationMask)
+    assert mask.score == pytest.approx(0.8)
+    assert mask.is_empty
+
+
+def test_instance_to_mask_predicted_carries_score():
+    """A PredictedInstance yields a PredictedSegmentationMask carrying its score."""
+    skel = _tri_skeleton()
+    inst = PredictedInstance.from_numpy(
+        np.array([[2, 2], [12, 2], [2, 12]]), skeleton=skel, score=0.75
+    )
+
+    mask = inst.to_mask(20, 20, node_radius=3)
+
+    assert isinstance(mask, PredictedSegmentationMask)
+    assert mask.score == pytest.approx(0.75)
+    assert mask.area > 0
+    assert mask.instance is inst
+
+
+def test_instance_to_mask_predicted_empty_carries_score():
+    """An empty PredictedInstance to_mask is all-background but keeps its score."""
+    skel = _tri_skeleton()
+    inst = PredictedInstance.from_numpy(
+        np.full((3, 2), np.nan), skeleton=skel, score=0.3
+    )
+
+    mask = inst.to_mask(6, 6, node_radius=2)
+
+    assert isinstance(mask, PredictedSegmentationMask)
+    assert mask.score == pytest.approx(0.3)
+    assert mask.area == 0

--- a/tests/model/test_labeled_frame.py
+++ b/tests/model/test_labeled_frame.py
@@ -1,11 +1,20 @@
 """Tests for methods in sleap_io.model.labeled_frame file."""
 
 import numpy as np
+import pytest
 from numpy.testing import assert_equal
+from shapely.geometry import box
 
 from sleap_io import Instance, PredictedInstance, Skeleton, Track, Video
+from sleap_io.model.bbox import BoundingBox, PredictedBoundingBox, UserBoundingBox
+from sleap_io.model.centroid import Centroid, PredictedCentroid, UserCentroid
 from sleap_io.model.labeled_frame import LabeledFrame
-from sleap_io.model.mask import PredictedSegmentationMask, UserSegmentationMask
+from sleap_io.model.mask import (
+    PredictedSegmentationMask,
+    SegmentationMask,
+    UserSegmentationMask,
+)
+from sleap_io.model.roi import ROI, PredictedROI, UserROI
 
 
 def test_labeled_frame():
@@ -1291,7 +1300,7 @@ def test_labeled_frame_is_user_labeled_with_annotations():
 
 def test_labeled_frame_is_user_labeled_with_rois():
     """is_user_labeled is True for a UserROI-only frame, False for predicted-only."""
-    from sleap_io.model.roi import PredictedROI, UserROI
+    from sleap_io.model.roi import UserROI
 
     video = Video(filename="test.mp4", open_backend=False)
 
@@ -1851,7 +1860,7 @@ def test_merge_annotations_auto_rois():
     """Auto spatial matching works for ROIs."""
     from shapely.geometry import box
 
-    from sleap_io.model.roi import PredictedROI, UserROI
+    from sleap_io.model.roi import UserROI
 
     video = Video(filename="test.mp4", open_backend=False)
 
@@ -2034,3 +2043,283 @@ def test_merge_is_negative_replace_predictions():
     base.merge(incoming, frame="replace_predictions")
 
     assert base.is_negative is True
+
+
+# -- LabeledFrame.convert ----------------------------------------------------
+
+
+def _pose_frame():
+    """Frame with a single two-node user instance at (0,0)-(10,10)."""
+    skel = Skeleton(["A", "B"])
+    inst = Instance([[0, 0], [10, 10]], skeleton=skel)
+    return LabeledFrame(video=Video("test.mp4"), frame_idx=0, instances=[inst]), inst
+
+
+def test_convert_pose_to_centroid():
+    """convert(pose -> centroid) dispatches to Instance.to_centroid."""
+    lf, inst = _pose_frame()
+    out = lf.convert("centroid", source="pose")
+    assert len(out) == 1
+    assert isinstance(out[0], Centroid)
+    # center_of_mass of (0,0) and (10,10) is (5,5)
+    assert out[0].x == pytest.approx(5.0)
+    assert out[0].y == pytest.approx(5.0)
+    # Default inplace=False does not mutate the frame.
+    assert lf.centroids == []
+
+
+def test_convert_pose_to_bbox():
+    """convert(pose -> bbox) produces a tight box of the visible points."""
+    lf, inst = _pose_frame()
+    out = lf.convert("bbox", source="pose")
+    assert len(out) == 1
+    assert isinstance(out[0], BoundingBox)
+    assert (out[0].x1, out[0].y1, out[0].x2, out[0].y2) == (0.0, 0.0, 10.0, 10.0)
+
+
+def test_convert_pose_to_roi_forwards_node_radius():
+    """convert(pose -> roi) forwards node_radius to Instance.to_roi."""
+    lf, inst = _pose_frame()
+    out = lf.convert("roi", source="pose", node_radius=2.0)
+    assert len(out) == 1
+    assert isinstance(out[0], ROI)
+    assert not out[0].is_empty
+
+
+def test_convert_pose_to_mask_forwards_size_kwargs():
+    """convert(pose -> mask) forwards height/width/node_radius."""
+    lf, inst = _pose_frame()
+    out = lf.convert("mask", source="pose", height=20, width=20, node_radius=3.0)
+    assert len(out) == 1
+    assert isinstance(out[0], SegmentationMask)
+    assert not out[0].is_empty
+
+
+def test_convert_pose_to_centroid_forwards_method_node_fallback():
+    """Convert forwards method/node/fallback to the anchor centroid computation."""
+    lf, inst = _pose_frame()
+    out = lf.convert(
+        "centroid", source="pose", method="anchor", node="A", fallback="center_of_mass"
+    )
+    assert out[0].x == pytest.approx(0.0)
+    assert out[0].y == pytest.approx(0.0)
+    assert out[0].source == "anchor:A"
+
+
+def test_convert_pose_to_centroid_anchor_fallback_engages():
+    """convert forwards fallback so an occluded anchor falls back end-to-end."""
+    skel = Skeleton(["A", "B"])
+    # Anchor node "A" is occluded (NaN); "B" is visible at (10, 10).
+    inst = Instance.from_numpy(
+        np.array([[np.nan, np.nan], [10.0, 10.0]]), skeleton=skel
+    )
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, instances=[inst])
+    out = lf.convert(
+        "centroid", source="pose", method="anchor", node="A", fallback="center_of_mass"
+    )
+    # Fallback center_of_mass over the single visible node "B" -> (10, 10).
+    assert out[0].x == pytest.approx(10.0)
+    assert out[0].y == pytest.approx(10.0)
+    assert out[0].source == "anchor:A->center_of_mass"
+
+
+def test_convert_centroid_to_bbox_forwards_size_padding():
+    """convert(centroid -> bbox) forwards size and padding kwargs."""
+    c = UserCentroid(x=5.0, y=5.0)
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, centroids=[c])
+    out = lf.convert("bbox", source="centroid", size=4.0, padding=1.0)
+    assert len(out) == 1
+    # 4x4 box centered at (5,5) -> (3,3,7,7), padded by 1 -> (2,2,8,8)
+    assert (out[0].x1, out[0].y1, out[0].x2, out[0].y2) == (2.0, 2.0, 8.0, 8.0)
+
+
+def test_convert_centroid_to_roi_forwards_radius():
+    """convert(centroid -> roi) forwards radius."""
+    c = UserCentroid(x=5.0, y=5.0)
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, centroids=[c])
+    out = lf.convert("roi", source="centroid", radius=3.0)
+    assert isinstance(out[0], ROI)
+    assert out[0].geometry.area == pytest.approx(np.pi * 9, rel=0.05)
+
+
+def test_convert_centroid_to_mask_forwards_radius_size():
+    """convert(centroid -> mask) forwards height/width/radius."""
+    c = UserCentroid(x=5.0, y=5.0)
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, centroids=[c])
+    out = lf.convert("mask", source="centroid", height=12, width=12, radius=3.0)
+    assert isinstance(out[0], SegmentationMask)
+    assert not out[0].is_empty
+
+
+def test_convert_centroid_to_pose():
+    """convert(centroid -> pose) is the only defined conversion into pose."""
+    c = UserCentroid(x=5.0, y=5.0)
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, centroids=[c])
+    out = lf.convert("pose", source="centroid")
+    assert len(out) == 1
+    assert isinstance(out[0], Instance)
+    assert out[0].numpy()[0].tolist() == [5.0, 5.0]
+
+
+def test_convert_bbox_to_centroid():
+    """convert(bbox -> centroid) uses the box center."""
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, bboxes=[b])
+    out = lf.convert("centroid", source="bbox")
+    assert out[0].x == pytest.approx(5.0)
+    assert out[0].y == pytest.approx(5.0)
+
+
+def test_convert_mask_to_centroid():
+    """convert(mask -> centroid) reduces a mask to its center of mass."""
+    m = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool))
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, masks=[m])
+    out = lf.convert("centroid", source="mask")
+    assert out[0].x == pytest.approx(2.0)
+    assert out[0].y == pytest.approx(2.0)
+
+
+def test_convert_mask_to_bbox_forwards_padding():
+    """convert(mask -> bbox) forwards padding."""
+    m = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool))
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, masks=[m])
+    out = lf.convert("bbox", source="mask")
+    assert isinstance(out[0], BoundingBox)
+    assert not out[0].is_empty
+
+
+def test_convert_mask_to_roi():
+    """convert(mask -> roi) produces a polygon ROI."""
+    m = UserSegmentationMask.from_numpy(np.ones((5, 5), dtype=bool))
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, masks=[m])
+    out = lf.convert("roi", source="mask")
+    assert isinstance(out[0], ROI)
+    assert not out[0].is_empty
+
+
+def test_convert_roi_to_centroid():
+    """convert(roi -> centroid)."""
+    r = UserROI(geometry=box(0, 0, 10, 10))
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, rois=[r])
+    out = lf.convert("centroid", source="roi")
+    assert out[0].x == pytest.approx(5.0)
+    assert out[0].y == pytest.approx(5.0)
+
+
+def test_convert_roi_to_bbox():
+    """convert(roi -> bbox)."""
+    r = UserROI(geometry=box(0, 0, 10, 10))
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, rois=[r])
+    out = lf.convert("bbox", source="roi")
+    assert (out[0].x1, out[0].y1, out[0].x2, out[0].y2) == (0.0, 0.0, 10.0, 10.0)
+
+
+def test_convert_roi_to_mask():
+    """convert(roi -> mask) forwards height/width."""
+    r = UserROI(geometry=box(0, 0, 10, 10))
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, rois=[r])
+    out = lf.convert("mask", source="roi", height=12, width=12)
+    assert isinstance(out[0], SegmentationMask)
+    assert not out[0].is_empty
+
+
+def test_convert_predicted_source_yields_predicted_target():
+    """A predicted source annotation converts to a predicted target carrying score."""
+    c = PredictedCentroid(x=5.0, y=5.0, score=0.7)
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, centroids=[c])
+    out = lf.convert("bbox", source="centroid", size=4.0)
+    assert isinstance(out[0], PredictedBoundingBox)
+    assert out[0].score == pytest.approx(0.7)
+
+
+def test_convert_inplace_appends_and_returns():
+    """inplace=True appends each result to the frame and returns them."""
+    lf, inst = _pose_frame()
+    out = lf.convert("centroid", source="pose", inplace=True)
+    assert len(out) == 1
+    # Returned objects are the same that were appended.
+    assert lf.centroids == out
+    # The source list is untouched.
+    assert lf.instances == [inst]
+
+
+@pytest.mark.parametrize(
+    "target,kwargs,list_attr",
+    [
+        ("bbox", {"size": 4.0}, "bboxes"),
+        ("roi", {"radius": 3.0}, "rois"),
+        ("mask", {"height": 12, "width": 12, "radius": 3.0}, "masks"),
+    ],
+)
+def test_convert_inplace_appends_non_centroid_targets(target, kwargs, list_attr):
+    """inplace=True routes non-centroid targets to their own frame lists."""
+    c = UserCentroid(x=5.0, y=5.0)
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, centroids=[c])
+    out = lf.convert(target, source="centroid", inplace=True, **kwargs)
+    assert getattr(lf, list_attr) == out
+    # The source list is untouched.
+    assert lf.centroids == [c]
+
+
+def test_convert_inplace_false_does_not_mutate():
+    """inplace=False leaves the frame's target list empty."""
+    lf, inst = _pose_frame()
+    before = list(lf.centroids)
+    lf.convert("centroid", source="pose", inplace=False)
+    assert lf.centroids == before == []
+
+
+def test_convert_multiple_sources():
+    """Convert maps over every source annotation in the list."""
+    c1 = UserCentroid(x=1.0, y=1.0)
+    c2 = UserCentroid(x=2.0, y=2.0)
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, centroids=[c1, c2])
+    out = lf.convert("bbox", source="centroid", size=2.0)
+    assert len(out) == 2
+
+
+def test_convert_empty_source_returns_empty_list():
+    """Convert over an empty source list returns an empty list."""
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0)
+    assert lf.convert("centroid", source="centroid") == []
+
+
+def test_convert_unknown_target_raises():
+    """An unrecognized target modality raises ValueError."""
+    lf, inst = _pose_frame()
+    with pytest.raises(ValueError, match="Unknown target modality"):
+        lf.convert("blob", source="pose")
+
+
+def test_convert_unknown_source_raises():
+    """An unrecognized source modality raises ValueError."""
+    lf, inst = _pose_frame()
+    with pytest.raises(ValueError, match="Unknown source modality"):
+        lf.convert("centroid", source="blob")
+
+
+def test_convert_pose_to_pose_raises():
+    """Pose -> pose is ill-defined and raises."""
+    lf, inst = _pose_frame()
+    with pytest.raises(ValueError, match="not supported"):
+        lf.convert("pose", source="pose")
+
+
+def test_convert_bbox_to_pose_raises():
+    """Only centroid -> pose is defined; other sources to pose raise."""
+    b = UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, bboxes=[b])
+    with pytest.raises(ValueError, match="not supported"):
+        lf.convert("pose", source="bbox")
+
+
+def test_convert_missing_verb_raises():
+    """A source object lacking the target verb raises a clear ValueError.
+
+    ``ROI`` has no ``to_roi`` method, so converting an ROI source to the roi
+    modality exercises the missing-verb guard.
+    """
+    r = UserROI(geometry=box(0, 0, 10, 10))
+    lf = LabeledFrame(video=Video("test.mp4"), frame_idx=0, rois=[r])
+    with pytest.raises(ValueError, match="has no to_roi"):
+        lf.convert("roi", source="roi")

--- a/tests/model/test_labeled_frame.py
+++ b/tests/model/test_labeled_frame.py
@@ -2107,7 +2107,7 @@ def test_convert_pose_to_centroid_forwards_method_node_fallback():
 
 
 def test_convert_pose_to_centroid_anchor_fallback_engages():
-    """convert forwards fallback so an occluded anchor falls back end-to-end."""
+    """Convert forwards fallback so an occluded anchor falls back end-to-end."""
     skel = Skeleton(["A", "B"])
     # Anchor node "A" is occluded (NaN); "B" is visible at (10, 10).
     inst = Instance.from_numpy(

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -8647,3 +8647,197 @@ def test_remap_frame_annotations_with_rois():
 
     assert roi.video is new_video
     assert roi.track is new_track
+
+
+def test_labels_convert_maps_over_frames_flat_list():
+    """Labels.convert returns one flat list of results across all frames."""
+    video = Video(filename="a.mp4", open_backend=False)
+    skeleton = Skeleton(["a", "b"])
+    i1 = Instance.from_numpy(np.array([[0.0, 0.0], [10.0, 10.0]]), skeleton)
+    i2 = Instance.from_numpy(np.array([[2.0, 2.0], [4.0, 4.0]]), skeleton)
+    i3 = Instance.from_numpy(np.array([[6.0, 6.0], [8.0, 8.0]]), skeleton)
+    lf1 = LabeledFrame(video=video, frame_idx=0, instances=[i1, i2])
+    lf2 = LabeledFrame(video=video, frame_idx=1, instances=[i3])
+    labels = Labels([lf1, lf2])
+
+    results = labels.convert("centroid", source="pose")
+
+    # Flat list: 2 from the first frame + 1 from the second, in frame order.
+    assert isinstance(results, list)
+    assert len(results) == 3
+    assert all(isinstance(r, UserCentroid) for r in results)
+    assert results[0].xy == pytest.approx((5.0, 5.0))
+    assert results[1].xy == pytest.approx((3.0, 3.0))
+    assert results[2].xy == pytest.approx((7.0, 7.0))
+
+
+def test_labels_convert_not_inplace_leaves_frames_unmodified():
+    """Labels.convert with inplace=False does not mutate any frame."""
+    video = Video(filename="a.mp4", open_backend=False)
+    skeleton = Skeleton(["a", "b"])
+    i1 = Instance.from_numpy(np.array([[0.0, 0.0], [10.0, 10.0]]), skeleton)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[i1])
+    labels = Labels([lf])
+
+    labels.convert("centroid", source="pose")
+
+    assert lf.centroids == []
+
+
+def test_labels_convert_inplace_appends_to_each_frame():
+    """Labels.convert with inplace=True appends results to their own frames."""
+    video = Video(filename="a.mp4", open_backend=False)
+    skeleton = Skeleton(["a", "b"])
+    i1 = Instance.from_numpy(np.array([[0.0, 0.0], [10.0, 10.0]]), skeleton)
+    i2 = Instance.from_numpy(np.array([[2.0, 2.0], [4.0, 4.0]]), skeleton)
+    lf1 = LabeledFrame(video=video, frame_idx=0, instances=[i1])
+    lf2 = LabeledFrame(video=video, frame_idx=1, instances=[i2])
+    labels = Labels([lf1, lf2])
+
+    results = labels.convert("centroid", source="pose", inplace=True)
+
+    assert len(results) == 2
+    assert lf1.centroids == [results[0]]
+    assert lf2.centroids == [results[1]]
+
+
+def test_labels_convert_empty_labels_returns_empty_list():
+    """Labels.convert over a Labels with no frames returns an empty list."""
+    assert Labels([]).convert("centroid", source="pose") == []
+
+
+def test_labels_convert_predicted_source_to_predicted_target():
+    """Predicted source maps to predicted target with score + metadata carried."""
+    video = Video(filename="a.mp4", open_backend=False)
+    skeleton = Skeleton(["a", "b"])
+    track = Track(name="t")
+    pred = PredictedInstance.from_numpy(
+        np.array([[0.0, 0.0], [10.0, 10.0]]),
+        skeleton,
+        score=0.75,
+        track=track,
+    )
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[pred])
+    labels = Labels([lf])
+
+    results = labels.convert("centroid", source="pose")
+
+    assert len(results) == 1
+    centroid = results[0]
+    assert isinstance(centroid, PredictedCentroid)
+    assert centroid.score == pytest.approx(0.75)
+    assert centroid.track is track
+    assert centroid.instance is pred
+
+
+def test_labels_convert_centroid_to_pose():
+    """Centroid -> pose is the only defined pose target and works via Labels."""
+    video = Video(filename="a.mp4", open_backend=False)
+    centroid = UserCentroid(x=5.0, y=6.0)
+    lf = LabeledFrame(video=video, frame_idx=0, centroids=[centroid])
+    labels = Labels([lf])
+
+    results = labels.convert("pose", source="centroid")
+
+    assert len(results) == 1
+    assert isinstance(results[0], Instance)
+    assert results[0].numpy()[0] == pytest.approx([5.0, 6.0])
+
+
+def test_labels_convert_bbox_to_centroid():
+    """Bbox -> centroid path forwards through Labels.convert."""
+    video = Video(filename="a.mp4", open_backend=False)
+    bbox = UserBoundingBox(x1=0.0, y1=0.0, x2=10.0, y2=20.0)
+    lf = LabeledFrame(video=video, frame_idx=0, bboxes=[bbox])
+    labels = Labels([lf])
+
+    results = labels.convert("centroid", source="bbox")
+
+    assert len(results) == 1
+    assert isinstance(results[0], UserCentroid)
+    assert results[0].xy == pytest.approx((5.0, 10.0))
+
+
+def test_labels_convert_roi_to_mask_forwards_kwargs():
+    """Roi -> mask forwards height/width kwargs to the per-object verb."""
+    video = Video(filename="a.mp4", open_backend=False)
+    roi = UserROI(geometry=box(0.0, 0.0, 4.0, 4.0))
+    lf = LabeledFrame(video=video, frame_idx=0, rois=[roi])
+    labels = Labels([lf])
+
+    results = labels.convert("mask", source="roi", height=8, width=8)
+
+    assert len(results) == 1
+    assert isinstance(results[0], UserSegmentationMask)
+    assert results[0].area == pytest.approx(16, abs=1)
+
+
+def test_labels_convert_unknown_target_raises():
+    """An unrecognized target modality raises ValueError."""
+    video = Video(filename="a.mp4", open_backend=False)
+    skeleton = Skeleton(["a", "b"])
+    i1 = Instance.from_numpy(np.array([[0.0, 0.0], [10.0, 10.0]]), skeleton)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[i1])
+    labels = Labels([lf])
+
+    with pytest.raises(ValueError, match="Unknown target modality"):
+        labels.convert("bogus", source="pose")
+
+
+def test_labels_convert_unknown_source_raises():
+    """An unrecognized source modality raises ValueError."""
+    video = Video(filename="a.mp4", open_backend=False)
+    skeleton = Skeleton(["a", "b"])
+    i1 = Instance.from_numpy(np.array([[0.0, 0.0], [10.0, 10.0]]), skeleton)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[i1])
+    labels = Labels([lf])
+
+    with pytest.raises(ValueError, match="Unknown source modality"):
+        labels.convert("centroid", source="bogus")
+
+
+def test_labels_convert_pose_to_pose_raises():
+    """Pose -> pose is undefined and raises a clear ValueError."""
+    video = Video(filename="a.mp4", open_backend=False)
+    skeleton = Skeleton(["a", "b"])
+    i1 = Instance.from_numpy(np.array([[0.0, 0.0], [10.0, 10.0]]), skeleton)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[i1])
+    labels = Labels([lf])
+
+    with pytest.raises(ValueError, match="to 'pose' is not supported"):
+        labels.convert("pose", source="pose")
+
+
+def test_labels_convert_missing_verb_raises():
+    """A source object lacking the target verb raises ValueError."""
+    video = Video(filename="a.mp4", open_backend=False)
+    bbox = UserBoundingBox(x1=0.0, y1=0.0, x2=10.0, y2=10.0)
+    lf = LabeledFrame(video=video, frame_idx=0, bboxes=[bbox])
+    labels = Labels([lf])
+
+    # BoundingBox has no to_bbox verb.
+    with pytest.raises(ValueError, match="Cannot convert 'bbox' to 'bbox'"):
+        labels.convert("bbox", source="bbox")
+
+
+def test_labels_convert_inplace_lazy_raises(slp_typical):
+    """inplace=True on a lazy-loaded Labels raises instead of silently no-op'ing.
+
+    Iterating ``labeled_frames`` on a lazy Labels yields freshly materialized
+    frames that are discarded each iteration, so the appended annotations would
+    be lost. The guard converts this silent failure into a clear RuntimeError.
+    """
+    lazy = load_slp(slp_typical, lazy=True)
+    assert lazy.is_lazy
+
+    with pytest.raises(RuntimeError, match="Cannot convert on lazy-loaded Labels"):
+        lazy.convert("centroid", source="pose", inplace=True)
+
+
+def test_labels_convert_lazy_read_only_allowed(slp_typical):
+    """inplace=False on a lazy-loaded Labels is read-only and works."""
+    lazy = load_slp(slp_typical, lazy=True)
+    assert lazy.is_lazy
+
+    results = lazy.convert("centroid", source="pose")
+    assert isinstance(results, list)

--- a/tests/model/test_mask.py
+++ b/tests/model/test_mask.py
@@ -774,7 +774,7 @@ def test_to_centroid_center_of_mass_with_scale_offset():
 
 
 def test_to_centroid_center_of_mass_anisotropic_scale():
-    """sx != sy: cols map to x via sx and rows map to y via sy (no axis swap)."""
+    """Anisotropic scale: cols map to x via sx, rows to y via sy (no axis swap)."""
     data = np.zeros((10, 10), dtype=bool)
     data[2:4, 3:6] = True  # rows mean 2.5, cols mean 4.0
     mask = UserSegmentationMask.from_numpy(data, scale=(0.5, 0.25), offset=(10.0, 20.0))

--- a/tests/model/test_mask.py
+++ b/tests/model/test_mask.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
+from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, Track
 from sleap_io.model.mask import (
@@ -14,6 +15,7 @@ from sleap_io.model.mask import (
     _encode_rle,
     _resize_nearest,
 )
+from sleap_io.model.roi import PredictedROI, UserROI
 from sleap_io.model.skeleton import Skeleton
 
 
@@ -527,7 +529,11 @@ def test_to_bbox_empty_mask():
     data = np.zeros((10, 10), dtype=bool)
     mask = UserSegmentationMask.from_numpy(data)
     bb = mask.to_bbox()
-    assert bb.xywh == pytest.approx((0.0, 0.0, 0.0, 0.0))
+    assert bb.is_empty
+    assert np.isnan(bb.x1) and np.isnan(bb.y1)
+    assert np.isnan(bb.x2) and np.isnan(bb.y2)
+    with pytest.raises(ValueError):
+        mask.to_bbox(error_on_empty=True)
 
 
 def test_to_user_basic():
@@ -727,3 +733,311 @@ def test_from_predicted_does_not_affect_identity_equality():
     assert user1.from_predicted is user2.from_predicted
     assert user1 != user2
     assert user1 == user1
+
+
+# -- is_empty property --------------------------------------------------------
+
+
+def test_is_empty_true_for_blank_mask():
+    mask = UserSegmentationMask.from_numpy(np.zeros((6, 6), dtype=bool))
+    assert mask.is_empty is True
+
+
+def test_is_empty_false_with_foreground():
+    data = np.zeros((6, 6), dtype=bool)
+    data[1, 1] = True
+    mask = UserSegmentationMask.from_numpy(data)
+    assert mask.is_empty is False
+
+
+# -- to_centroid: center_of_mass ----------------------------------------------
+
+
+def test_to_centroid_center_of_mass():
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:6, 4:8] = True  # rows 2..5 (mean 3.5), cols 4..7 (mean 5.5)
+    mask = UserSegmentationMask.from_numpy(data)
+    c = mask.to_centroid()  # default method
+    assert isinstance(c, UserCentroid)
+    assert c.x == pytest.approx(5.5)
+    assert c.y == pytest.approx(3.5)
+
+
+def test_to_centroid_center_of_mass_with_scale_offset():
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:4, 3:6] = True  # rows mean 2.5, cols mean 4.0
+    mask = UserSegmentationMask.from_numpy(data, scale=(0.5, 0.5), offset=(10.0, 20.0))
+    c = mask.to_centroid(method="center_of_mass")
+    # image = pixel / scale + offset
+    assert c.x == pytest.approx(4.0 / 0.5 + 10.0)  # 18.0
+    assert c.y == pytest.approx(2.5 / 0.5 + 20.0)  # 25.0
+
+
+def test_to_centroid_center_of_mass_anisotropic_scale():
+    """sx != sy: cols map to x via sx and rows map to y via sy (no axis swap)."""
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:4, 3:6] = True  # rows mean 2.5, cols mean 4.0
+    mask = UserSegmentationMask.from_numpy(data, scale=(0.5, 0.25), offset=(10.0, 20.0))
+    c = mask.to_centroid(method="center_of_mass")
+    assert c.x == pytest.approx(4.0 / 0.5 + 10.0)  # 18.0
+    assert c.y == pytest.approx(2.5 / 0.25 + 20.0)  # 30.0
+    # bbox_center applies sx to x and sy to y the same way (no axis swap): the
+    # pixel bbox is cols [3,6), rows [2,4) -> image center via self.bbox.
+    bx, by, bw, bh = mask.bbox
+    cb = mask.to_centroid(method="bbox_center")
+    assert cb.x == pytest.approx(bx + bw / 2)
+    assert cb.y == pytest.approx(by + bh / 2)
+    # x uses sx (0.5), y uses sy (0.25): distinct scales prove no swap.
+    assert cb.x == pytest.approx(3 / 0.5 + 10.0 + (3 / 0.5) / 2)  # 19.0
+    assert cb.y == pytest.approx(2 / 0.25 + 20.0 + (2 / 0.25) / 2)  # 32.0
+
+
+def test_to_centroid_center_of_mass_concave():
+    """center_of_mass can fall outside a concave shape (unlike bbox_center)."""
+    # C-shaped mask: the mean of foreground pixels sits left of the gap.
+    data = np.zeros((10, 10), dtype=bool)
+    data[0:3, 0:8] = True  # top bar
+    data[3:7, 0:3] = True  # left column
+    data[7:10, 0:8] = True  # bottom bar
+    rows, cols = np.nonzero(data)
+    mask = UserSegmentationMask.from_numpy(data)
+    c = mask.to_centroid(method="center_of_mass")
+    assert c.x == pytest.approx(cols.mean())
+    assert c.y == pytest.approx(rows.mean())
+
+
+# -- to_centroid: bbox_center -------------------------------------------------
+
+
+def test_to_centroid_bbox_center():
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:6, 4:8] = True  # bbox x=4,y=2,w=4,h=4 -> center (6,4)
+    mask = UserSegmentationMask.from_numpy(data)
+    c = mask.to_centroid(method="bbox_center")
+    assert c.x == pytest.approx(6.0)
+    assert c.y == pytest.approx(4.0)
+
+
+def test_to_centroid_bbox_center_concave_inside_bbox():
+    """bbox_center uses the tight pixel bbox midpoint (concave-robust)."""
+    data = np.zeros((10, 10), dtype=bool)
+    data[0:3, 0:8] = True
+    data[3:7, 0:3] = True
+    data[7:10, 0:8] = True
+    mask = UserSegmentationMask.from_numpy(data)
+    bx, by, bw, bh = mask.bbox
+    c = mask.to_centroid(method="bbox_center")
+    assert c.x == pytest.approx(bx + bw / 2.0)
+    assert c.y == pytest.approx(by + bh / 2.0)
+
+
+def test_to_centroid_bbox_center_with_scale_offset():
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:4, 3:6] = True
+    mask = UserSegmentationMask.from_numpy(data, scale=(0.5, 0.5), offset=(10.0, 20.0))
+    bx, by, bw, bh = mask.bbox
+    c = mask.to_centroid(method="bbox_center")
+    assert c.x == pytest.approx(bx + bw / 2.0)
+    assert c.y == pytest.approx(by + bh / 2.0)
+
+
+# -- to_centroid: degenerate / errors / predicted -----------------------------
+
+
+def test_to_centroid_empty_degenerate():
+    mask = UserSegmentationMask.from_numpy(np.zeros((8, 8), dtype=bool))
+    c = mask.to_centroid()
+    assert isinstance(c, UserCentroid)
+    assert np.isnan(c.x) and np.isnan(c.y)
+    assert c.is_empty is True
+
+
+def test_to_centroid_empty_bbox_center_degenerate():
+    """bbox_center on an empty mask is also degenerate (NaN), not (0,0)."""
+    mask = UserSegmentationMask.from_numpy(np.zeros((8, 8), dtype=bool))
+    c = mask.to_centroid(method="bbox_center")
+    assert np.isnan(c.x) and np.isnan(c.y)
+
+
+def test_to_centroid_empty_error_on_empty():
+    mask = UserSegmentationMask.from_numpy(np.zeros((8, 8), dtype=bool))
+    with pytest.raises(ValueError, match="empty mask"):
+        mask.to_centroid(error_on_empty=True)
+
+
+def test_to_centroid_unknown_method_raises():
+    data = np.zeros((8, 8), dtype=bool)
+    data[1:3, 1:3] = True
+    mask = UserSegmentationMask.from_numpy(data)
+    with pytest.raises(ValueError, match="Unknown method"):
+        mask.to_centroid(method="median")
+
+
+def test_to_centroid_predicted_carries_score():
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 3:6] = True
+    mask = PredictedSegmentationMask.from_numpy(data, score=0.77)
+    c = mask.to_centroid()
+    assert isinstance(c, PredictedCentroid)
+    assert c.score == pytest.approx(0.77)
+
+
+def test_to_centroid_predicted_empty_carries_score():
+    mask = PredictedSegmentationMask.from_numpy(
+        np.zeros((6, 6), dtype=bool), score=0.42
+    )
+    c = mask.to_centroid()
+    assert isinstance(c, PredictedCentroid)
+    assert c.score == pytest.approx(0.42)
+    assert np.isnan(c.x)
+
+
+def test_to_centroid_propagates_metadata():
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 1:4] = True
+    track = Track(name="t1")
+    ident = Identity(name="mouse_A")
+    mask = UserSegmentationMask.from_numpy(
+        data,
+        track=track,
+        tracking_score=0.6,
+        identity=ident,
+        identity_score=0.8,
+        category="cell",
+        name="obj1",
+        source="manual",
+    )
+    c = mask.to_centroid()
+    assert c.track is track
+    assert c.tracking_score == pytest.approx(0.6)
+    assert c.identity is ident
+    assert c.identity_score == pytest.approx(0.8)
+    assert c.category == "cell"
+    assert c.name == "obj1"
+    assert c.source == "manual"
+
+
+# -- to_bbox: padding ---------------------------------------------------------
+
+
+def test_to_bbox_scalar_padding():
+    data = np.zeros((10, 10), dtype=bool)
+    data[3:6, 2:5] = True  # x=2,y=3,w=3,h=3
+    mask = UserSegmentationMask.from_numpy(data)
+    bb = mask.to_bbox(padding=1.0)
+    assert bb.x1 == pytest.approx(1.0)
+    assert bb.y1 == pytest.approx(2.0)
+    assert bb.x2 == pytest.approx(6.0)  # 2 + 3 + 1
+    assert bb.y2 == pytest.approx(7.0)  # 3 + 3 + 1
+
+
+def test_to_bbox_tuple_padding():
+    data = np.zeros((10, 10), dtype=bool)
+    data[3:6, 2:5] = True
+    mask = UserSegmentationMask.from_numpy(data)
+    bb = mask.to_bbox(padding=(2.0, 1.0))
+    assert bb.x1 == pytest.approx(0.0)  # 2 - 2
+    assert bb.y1 == pytest.approx(2.0)  # 3 - 1
+    assert bb.x2 == pytest.approx(7.0)  # 2 + 3 + 2
+    assert bb.y2 == pytest.approx(7.0)  # 3 + 3 + 1
+
+
+# -- to_polygon predicted-variant fix + to_roi alias --------------------------
+
+
+def test_to_polygon_predicted_returns_predicted_roi():
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:6, 2:6] = True
+    mask = PredictedSegmentationMask.from_numpy(data, score=0.66)
+    roi = mask.to_polygon()
+    assert isinstance(roi, PredictedROI)
+    assert roi.score == pytest.approx(0.66)
+
+
+def test_to_polygon_user_returns_user_roi():
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:6, 2:6] = True
+    mask = UserSegmentationMask.from_numpy(data)
+    roi = mask.to_polygon()
+    assert isinstance(roi, UserROI)
+
+
+def test_to_roi_alias_matches_to_polygon():
+    data = np.zeros((10, 10), dtype=bool)
+    data[3:7, 3:7] = True
+    mask = UserSegmentationMask.from_numpy(data)
+    roi = mask.to_roi()
+    assert isinstance(roi, UserROI)
+    assert roi.geometry.equals(mask.to_polygon().geometry)
+
+
+def test_to_roi_alias_predicted():
+    data = np.zeros((10, 10), dtype=bool)
+    data[3:7, 3:7] = True
+    mask = PredictedSegmentationMask.from_numpy(data, score=0.9)
+    roi = mask.to_roi()
+    assert isinstance(roi, PredictedROI)
+    assert roi.score == pytest.approx(0.9)
+
+
+def test_to_polygon_propagates_metadata():
+    data = np.zeros((10, 10), dtype=bool)
+    data[2:5, 1:4] = True
+    track = Track(name="t1")
+    ident = Identity(name="mouse_A")
+    mask = UserSegmentationMask.from_numpy(
+        data,
+        track=track,
+        tracking_score=0.6,
+        identity=ident,
+        identity_score=0.8,
+        category="cell",
+        name="obj1",
+        source="manual",
+    )
+    roi = mask.to_polygon()
+    assert roi.track is track
+    assert roi.tracking_score == pytest.approx(0.6)
+    assert roi.identity is ident
+    assert roi.identity_score == pytest.approx(0.8)
+    assert roi.category == "cell"
+    assert roi.name == "obj1"
+    assert roi.source == "manual"
+
+
+# -- round-trip mask -> polygon -> mask ---------------------------------------
+
+
+def test_mask_polygon_mask_roundtrip_solid():
+    data = np.zeros((20, 20), dtype=bool)
+    data[5:15, 5:15] = True
+    mask = UserSegmentationMask.from_numpy(data)
+    roundtrip = mask.to_polygon().to_mask(20, 20)
+    assert roundtrip.area == pytest.approx(mask.area, abs=2)
+
+
+def test_mask_polygon_mask_roundtrip_concave():
+    data = np.zeros((20, 20), dtype=bool)
+    data[2:5, 2:16] = True  # top bar
+    data[5:14, 2:6] = True  # left column
+    data[14:17, 2:16] = True  # bottom bar
+    mask = UserSegmentationMask.from_numpy(data)
+    roundtrip = mask.to_polygon().to_mask(20, 20)
+    assert roundtrip.area == pytest.approx(mask.area, abs=4)
+
+
+def test_mask_polygon_mask_roundtrip_predicted_keeps_score():
+    data = np.zeros((20, 20), dtype=bool)
+    data[5:15, 5:15] = True
+    mask = PredictedSegmentationMask.from_numpy(data, score=0.81)
+    roundtrip = mask.to_polygon().to_mask(20, 20)
+    assert isinstance(roundtrip, PredictedSegmentationMask)
+    assert roundtrip.score == pytest.approx(0.81)
+
+
+def test_from_numpy_all_zero_nonbool_int_is_empty():
+    """An all-zero non-bool int array has no nonzero values to validate."""
+    arr = np.zeros((4, 4), dtype=np.int32)
+    mask = UserSegmentationMask.from_numpy(arr)
+    assert mask.area == 0
+    assert mask.is_empty is True

--- a/tests/model/test_roi.py
+++ b/tests/model/test_roi.py
@@ -1,16 +1,25 @@
 """Tests for ROI data model."""
 
+import numpy as np
 import pytest
+from shapely.affinity import rotate
 from shapely.geometry import LineString, MultiPolygon, Point, Polygon, box
 
+from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
+from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 from sleap_io.model.identity import Identity
+from sleap_io.model.instance import Instance, Track
 from sleap_io.model.roi import (
     ROI,
     AnnotationType,
     PredictedROI,
     UserROI,
+    _apply_padding,
+    _geometry_to_bbox_coords,
+    _pose_to_geometry,
     _rasterize_geometry,
 )
+from sleap_io.model.skeleton import Skeleton
 from sleap_io.model.video import Video
 
 
@@ -395,3 +404,370 @@ def test_roi_from_xyxy_deprecation():
     with pytest.warns(DeprecationWarning, match="ROI.from_xyxy"):
         roi = UserROI.from_xyxy(0, 0, 10, 10)
     assert roi.is_bbox
+
+
+# ---------------------------------------------------------------------------
+# ROI.is_empty
+# ---------------------------------------------------------------------------
+
+
+def test_roi_is_empty_true_for_empty_polygon():
+    """An empty geometry reports is_empty True."""
+    roi = UserROI(geometry=Polygon())
+    assert roi.is_empty is True
+
+
+def test_roi_is_empty_false_for_real_geometry():
+    """A geometry with spatial extent reports is_empty False."""
+    roi = UserROI.from_bbox(0, 0, 10, 10)
+    assert roi.is_empty is False
+
+
+# ---------------------------------------------------------------------------
+# ROI.to_centroid
+# ---------------------------------------------------------------------------
+
+
+def test_roi_to_centroid_geometric_centroid():
+    """to_centroid() returns the geometric centroid by default."""
+    roi = UserROI.from_bbox(0, 0, 10, 10)
+    c = roi.to_centroid()
+    assert isinstance(c, UserCentroid)
+    assert c.x == pytest.approx(5.0)
+    assert c.y == pytest.approx(5.0)
+    assert not c.is_empty
+
+
+def test_roi_to_centroid_representative_point():
+    """representative=True uses representative_point (inside concave shapes)."""
+    # A U-shape whose geometric centroid falls *outside* the polygon.
+    u = Polygon([(0, 0), (10, 0), (10, 10), (7, 10), (7, 3), (3, 3), (3, 10), (0, 10)])
+    roi = UserROI(geometry=u)
+
+    centroid = roi.to_centroid(representative=False)
+    assert not u.contains(Point(centroid.x, centroid.y))
+
+    rep = roi.to_centroid(representative=True)
+    expected = u.representative_point()
+    assert rep.x == pytest.approx(expected.x)
+    assert rep.y == pytest.approx(expected.y)
+    assert u.contains(Point(rep.x, rep.y))
+
+
+def test_roi_to_centroid_empty_returns_nan():
+    """Empty geometry yields a degenerate (NaN) centroid by default."""
+    roi = UserROI(geometry=Polygon())
+    c = roi.to_centroid()
+    assert isinstance(c, UserCentroid)
+    assert np.isnan(c.x)
+    assert np.isnan(c.y)
+    assert c.is_empty
+
+
+def test_roi_to_centroid_empty_error_on_empty_raises():
+    """error_on_empty raises instead of returning a NaN centroid."""
+    roi = UserROI(geometry=Polygon())
+    with pytest.raises(ValueError, match="empty ROI geometry"):
+        roi.to_centroid(error_on_empty=True)
+
+
+def test_roi_to_centroid_predicted_carries_score_and_metadata():
+    """Predicted ROI -> PredictedCentroid with score + propagated metadata."""
+    track = Track(name="t1")
+    ident = Identity(name="animal_7")
+    sk = Skeleton(["a", "b", "c"])
+    inst = Instance.from_numpy(
+        np.array([[0, 0], [10, 0], [5, 10]], dtype=float), skeleton=sk
+    )
+    roi = PredictedROI(
+        geometry=box(0, 0, 10, 10),
+        score=0.85,
+        track=track,
+        tracking_score=0.7,
+        identity=ident,
+        identity_score=0.4,
+        instance=inst,
+        category="mouse",
+        name="m7",
+        source="manual",
+    )
+    c = roi.to_centroid()
+    assert isinstance(c, PredictedCentroid)
+    assert c.score == pytest.approx(0.85)
+    assert c.track is track
+    assert c.tracking_score == pytest.approx(0.7)
+    assert c.identity is ident
+    assert c.identity_score == pytest.approx(0.4)
+    assert c.instance is inst
+    assert c.category == "mouse"
+    assert c.name == "m7"
+    assert c.source == "manual"
+
+
+# ---------------------------------------------------------------------------
+# ROI.to_bbox
+# ---------------------------------------------------------------------------
+
+
+def test_roi_to_bbox_axis_aligned():
+    """Axis-aligned to_bbox() returns the geometry bounds with angle 0."""
+    roi = UserROI.from_bbox(2, 3, 6, 4)  # xywh -> bounds (2,3,8,7)
+    b = roi.to_bbox()
+    assert isinstance(b, UserBoundingBox)
+    assert (b.x1, b.y1, b.x2, b.y2) == pytest.approx((2.0, 3.0, 8.0, 7.0))
+    assert b.angle == pytest.approx(0.0)
+
+
+def test_roi_to_bbox_scalar_padding():
+    """Scalar padding inflates the box outward on both axes."""
+    roi = UserROI.from_bbox(0, 0, 10, 10)  # bounds (0,0,10,10)
+    b = roi.to_bbox(padding=2.0)
+    assert (b.x1, b.y1, b.x2, b.y2) == pytest.approx((-2.0, -2.0, 12.0, 12.0))
+
+
+def test_roi_to_bbox_tuple_padding():
+    """Per-axis padding inflates width/height independently."""
+    roi = UserROI.from_bbox(0, 0, 10, 10)
+    b = roi.to_bbox(padding=(1.0, 3.0))
+    assert (b.x1, b.y1, b.x2, b.y2) == pytest.approx((-1.0, -3.0, 11.0, 13.0))
+
+
+def test_roi_to_bbox_rotated():
+    """rotated=True fits a minimum-area oriented box recovering w/h/angle."""
+    # Rectangle 6x2 centered at origin, rotated 30 degrees.
+    rect = rotate(box(-3, -1, 3, 1), 30, origin=(0, 0), use_radians=False)
+    roi = UserROI(geometry=rect)
+    b = roi.to_bbox(rotated=True)
+    assert b.width == pytest.approx(6.0, abs=1e-6)
+    assert b.height == pytest.approx(2.0, abs=1e-6)
+    assert b.angle == pytest.approx(np.radians(30.0), abs=1e-6)
+    assert b.x_center == pytest.approx(0.0, abs=1e-6)
+    assert b.y_center == pytest.approx(0.0, abs=1e-6)
+    # The reconstructed corners must reproduce the source rectangle (the
+    # consistency-with-BoundingBox.corners contract). Compare both corner sets
+    # lexicographically since ordering/winding may differ.
+    src = np.array(rect.exterior.coords[:4], dtype=float)
+    got = np.asarray(b.corners, dtype=float)
+    src = src[np.lexsort((src[:, 1], src[:, 0]))]
+    got = got[np.lexsort((got[:, 1], got[:, 0]))]
+    assert np.allclose(src, got, atol=1e-6)
+
+
+def test_roi_to_bbox_empty_returns_nan():
+    """Empty geometry yields a degenerate (NaN) box by default."""
+    roi = UserROI(geometry=Polygon())
+    b = roi.to_bbox()
+    assert b.is_empty
+    assert np.isnan(b.x1) and np.isnan(b.x2)
+    assert b.angle == pytest.approx(0.0)
+
+
+def test_roi_to_bbox_empty_error_on_empty_raises():
+    """error_on_empty raises instead of returning a NaN box."""
+    roi = UserROI(geometry=Polygon())
+    with pytest.raises(ValueError, match="empty ROI geometry"):
+        roi.to_bbox(error_on_empty=True)
+
+
+def test_roi_to_bbox_predicted_carries_score_and_metadata():
+    """Predicted ROI -> PredictedBoundingBox with score + metadata."""
+    track = Track(name="t1")
+    roi = PredictedROI(
+        geometry=box(0, 0, 10, 10),
+        score=0.6,
+        track=track,
+        tracking_score=0.9,
+        category="fly",
+        name="f1",
+        source="net",
+    )
+    b = roi.to_bbox()
+    assert isinstance(b, PredictedBoundingBox)
+    assert b.score == pytest.approx(0.6)
+    assert b.track is track
+    assert b.tracking_score == pytest.approx(0.9)
+    assert b.category == "fly"
+    assert b.name == "f1"
+    assert b.source == "net"
+
+
+# ---------------------------------------------------------------------------
+# _apply_padding
+# ---------------------------------------------------------------------------
+
+
+def test_apply_padding_scalar():
+    """Scalar padding expands all four edges equally."""
+    assert _apply_padding(0, 0, 10, 10, 2) == (-2, -2, 12, 12)
+
+
+def test_apply_padding_tuple():
+    """Tuple padding applies px to x edges and py to y edges."""
+    assert _apply_padding(0, 0, 10, 10, (1, 3)) == (-1, -3, 11, 13)
+
+
+def test_apply_padding_negative_shrinks():
+    """Negative padding shrinks the box and is not clamped."""
+    assert _apply_padding(0, 0, 10, 10, -1) == (1, 1, 9, 9)
+
+
+# ---------------------------------------------------------------------------
+# _pose_to_geometry
+# ---------------------------------------------------------------------------
+
+
+def test_pose_to_geometry_shapes_nodes_only():
+    """node_radius>0 buffers each visible node into circles."""
+    pts = np.array([[0, 0], [10, 0], [5, 10]], dtype=float)
+    geom = _pose_to_geometry(
+        pts, [(0, 1), (1, 2)], method="shapes", node_radius=1.0, edge_radius=0.0
+    )
+    assert not geom.is_empty
+    # Three disjoint disks -> MultiPolygon ~ 3 * pi * r^2.
+    assert geom.area == pytest.approx(3 * np.pi, abs=0.1)
+
+
+def test_pose_to_geometry_shapes_edges_only():
+    """edge_radius>0 buffers each fully-visible edge into a capsule."""
+    pts = np.array([[0, 0], [10, 0], [5, 10]], dtype=float)
+    geom = _pose_to_geometry(
+        pts, [(0, 1), (1, 2)], method="shapes", node_radius=0.0, edge_radius=1.0
+    )
+    assert not geom.is_empty
+    assert geom.geom_type in ("Polygon", "MultiPolygon")
+
+
+def test_pose_to_geometry_shapes_edge_skipped_when_endpoint_invisible():
+    """Edges with an occluded endpoint are not drawn (empty if no shapes)."""
+    pts = np.array([[0, 0], [np.nan, np.nan], [5, 10]], dtype=float)
+    # Both edges touch the occluded middle node -> no edge shapes produced.
+    geom = _pose_to_geometry(
+        pts, [(0, 1), (1, 2)], method="shapes", node_radius=0.0, edge_radius=1.0
+    )
+    assert geom.is_empty
+
+
+def test_pose_to_geometry_shapes_misconfig_raises():
+    """Both radii 0 is a misconfiguration: always raises."""
+    pts = np.array([[0, 0], [10, 0]], dtype=float)
+    with pytest.raises(ValueError, match="at least one of node_radius"):
+        _pose_to_geometry(
+            pts, [(0, 1)], method="shapes", node_radius=0.0, edge_radius=0.0
+        )
+
+
+def test_pose_to_geometry_shapes_misconfig_raises_even_with_no_points():
+    """Misconfig guard fires before the empty-points check."""
+    pts = np.array([[np.nan, np.nan]], dtype=float)
+    with pytest.raises(ValueError, match="at least one of node_radius"):
+        _pose_to_geometry(pts, [], method="shapes", node_radius=0.0, edge_radius=0.0)
+
+
+def test_pose_to_geometry_shapes_no_visible_points_empty():
+    """All-occluded points yield an empty Polygon for shapes."""
+    pts = np.array([[np.nan, np.nan], [np.nan, np.nan]], dtype=float)
+    geom = _pose_to_geometry(pts, [(0, 1)], method="shapes", node_radius=1.0)
+    assert geom.is_empty
+    assert isinstance(geom, Polygon)
+
+
+def test_pose_to_geometry_convex_hull_three_points():
+    """convex_hull of >=3 visible points is a filled polygon."""
+    pts = np.array([[0, 0], [10, 0], [5, 10]], dtype=float)
+    geom = _pose_to_geometry(pts, [], method="convex_hull")
+    assert isinstance(geom, Polygon)
+    assert geom.area == pytest.approx(50.0)
+
+
+def test_pose_to_geometry_convex_hull_one_point_is_point():
+    """convex_hull of a single visible point is a Point (degenerate)."""
+    pts = np.array([[5, 5], [np.nan, np.nan]], dtype=float)
+    geom = _pose_to_geometry(pts, [], method="convex_hull")
+    assert isinstance(geom, Point)
+
+
+def test_pose_to_geometry_convex_hull_with_radius_buffers():
+    """A radius buffers a degenerate hull into a Polygon."""
+    pts = np.array([[5, 5], [np.nan, np.nan]], dtype=float)
+    geom = _pose_to_geometry(pts, [], method="convex_hull", radius=2.0)
+    assert isinstance(geom, Polygon)
+    assert geom.area == pytest.approx(np.pi * 4, abs=0.2)
+
+
+def test_pose_to_geometry_convex_hull_no_visible_points_empty():
+    """All-occluded points yield an empty Polygon for convex_hull."""
+    pts = np.array([[np.nan, np.nan]], dtype=float)
+    geom = _pose_to_geometry(pts, [], method="convex_hull")
+    assert geom.is_empty
+    assert isinstance(geom, Polygon)
+
+
+def test_pose_to_geometry_unknown_method_raises():
+    """An unrecognized method raises ValueError."""
+    pts = np.array([[0, 0], [10, 0]], dtype=float)
+    with pytest.raises(ValueError, match="Unknown method"):
+        _pose_to_geometry(pts, [(0, 1)], method="banana")
+
+
+# ---------------------------------------------------------------------------
+# _geometry_to_bbox_coords
+# ---------------------------------------------------------------------------
+
+
+def test_geometry_to_bbox_coords_axis_aligned():
+    """Axis-aligned bounds with angle 0."""
+    coords = _geometry_to_bbox_coords(box(0, 0, 4, 2), rotated=False)
+    assert coords == pytest.approx((0.0, 0.0, 4.0, 2.0, 0.0))
+
+
+def test_geometry_to_bbox_coords_empty():
+    """Empty geometry yields all-NaN coords with angle 0."""
+    x1, y1, x2, y2, angle = _geometry_to_bbox_coords(Polygon(), rotated=True)
+    assert np.isnan(x1) and np.isnan(y1) and np.isnan(x2) and np.isnan(y2)
+    assert angle == pytest.approx(0.0)
+
+
+def test_geometry_to_bbox_coords_rotated_recovers_box():
+    """Rotated MRR recovers width, height, center, and angle."""
+    rect = rotate(box(-3, -1, 3, 1), 30, origin=(0, 0), use_radians=False)
+    x1, y1, x2, y2, angle = _geometry_to_bbox_coords(rect, rotated=True)
+    assert (x2 - x1) == pytest.approx(6.0, abs=1e-6)
+    assert (y2 - y1) == pytest.approx(2.0, abs=1e-6)
+    assert (x1 + x2) / 2 == pytest.approx(0.0, abs=1e-6)
+    assert (y1 + y2) / 2 == pytest.approx(0.0, abs=1e-6)
+    assert angle == pytest.approx(np.radians(30.0), abs=1e-6)
+
+
+def test_geometry_to_bbox_coords_rotated_axis_aligned_preserves_area():
+    """Rotated fit of an axis-aligned box preserves area and center."""
+    x1, y1, x2, y2, _ = _geometry_to_bbox_coords(box(0, 0, 4, 2), rotated=True)
+    assert (x2 - x1) * (y2 - y1) == pytest.approx(8.0, abs=1e-6)
+    assert (x1 + x2) / 2 == pytest.approx(2.0, abs=1e-6)
+    assert (y1 + y2) / 2 == pytest.approx(1.0, abs=1e-6)
+
+
+def test_geometry_to_bbox_coords_rotated_degenerate_falls_back():
+    """A collinear geometry has a degenerate MRR; fall back to bounds, angle 0."""
+    line = LineString([(0, 0), (10, 0)])
+    coords = _geometry_to_bbox_coords(line, rotated=True)
+    assert coords == pytest.approx((0.0, 0.0, 10.0, 0.0, 0.0))
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: to_roi geometry rasterization consistency (via Centroid path)
+# ---------------------------------------------------------------------------
+
+
+def test_pose_to_geometry_then_rasterize_consistent():
+    """A shapes geometry rasterizes to a non-empty mask matching its extent."""
+    pts = np.array([[5, 5], [15, 5]], dtype=float)
+    geom = _pose_to_geometry(
+        pts, [(0, 1)], method="shapes", node_radius=0.0, edge_radius=3.0
+    )
+    roi = UserROI(geometry=geom)
+    mask = roi.to_mask(height=20, width=25)
+    assert mask.area > 0
+    # The mask centroid roughly tracks the segment midpoint (10, 5).
+    cy, cx = np.argwhere(mask.data).mean(axis=0)
+    assert cx == pytest.approx(10.0, abs=1.5)
+    assert cy == pytest.approx(5.0, abs=1.5)


### PR DESCRIPTION
Closes #529.

## Summary

Completes the **conversion matrix** so every spatial annotation modality —
pose (`Instance`), `Centroid`, `BoundingBox`, `SegmentationMask`, and `ROI` —
exposes the same verb set (`.to_centroid()`, `.to_bbox()`, `.to_mask()`,
`.to_roi()`), backed by the two geometry hubs that already exist: `ROI`
(Shapely) for vector ops and `SegmentationMask` for raster. **No new
rasterizer is written** — `to_mask()` is always `to_roi(...).to_mask(h, w)`, and
pose→vector is centralized in one private helper `roi._pose_to_geometry(...)`.

| from ↓ \ to → | Centroid | BoundingBox | SegmentationMask | ROI |
|---|---|---|---|---|
| **Pose** | `to_centroid(method, node, fallback)` | `to_bbox(mode, size, padding, rotated)` | `to_mask(h, w, **roi_kwargs)` | `to_roi(method, node_radius, edge_radius, radius)` |
| **Centroid** | — | `to_bbox(size, padding)` | `to_mask(h, w, radius)` | `to_roi(radius)` |
| **BoundingBox** | `to_centroid()` | `pad(padding)` | `to_mask(h, w)` | `to_roi()` |
| **SegmentationMask** | `to_centroid(method)` | `to_bbox(padding)` | — | `to_polygon()` / `to_roi()` |
| **ROI** | `to_centroid(representative)` | `to_bbox(padding, rotated)` | `to_mask(h, w)` | — |

The reverse into pose is `Centroid.to_pose(skeleton)`.

## Key changes

- **Pose → centroid:** new `geometric_median` method (Weiszfeld iteration, pure
  numpy — no scipy), an anchor `fallback` chain, and `error_on_empty`. The
  `source` tag vocabulary consumed by sleap-nn is preserved exactly
  (`center_of_mass`, `bbox_center`, `anchor:<node>`, `geometric_median`,
  `anchor:<node>-><fallback>`).
- **Pose → bbox / roi / mask:** `to_bbox` (tight / centered, padding, rotated
  via minimum-rotated-rectangle), `to_roi` (`shapes` = unioned buffered nodes
  and/or edge capsules; `convex_hull`), and `to_mask` via the shared geometry
  hub.
- **Centroid / BBox / Mask / ROI:** the new verbs above, plus
  `BoundingBox.pad`, `SegmentationMask.to_centroid` (`center_of_mass` /
  `bbox_center`, scale/offset-aware), and `to_bbox(padding)`.
- **Naming:** `Centroid.to_instance` / `from_instance` are renamed to `to_pose`
  / `from_pose`; the old names remain as thin **deprecated aliases** for
  back-compat.
- **Bug fix:** `SegmentationMask.to_polygon()` now returns a `PredictedROI`
  (with `score`) for predicted masks instead of silently downgrading to
  `UserROI`. A `to_roi()` alias delegates to it.
- **Return-type stable degenerate handling:** with no visible points / an empty
  mask / an exhausted anchor fallback, each `to_X()` returns an **empty instance
  of the target class** (NaN `Centroid`/`BoundingBox`, empty-`Polygon` `ROI`,
  all-background `SegmentationMask`) — never `None`. Pass `error_on_empty=True`
  to raise instead. A companion `is_empty` property is added to `Centroid`,
  `BoundingBox`, `ROI`, and `SegmentationMask`. `method="shapes"` with both
  radii `0` is a misconfiguration and always raises.
- **Batch conversion:** a single `LabeledFrame.convert(to, source, inplace, **kwargs)`
  (and `Labels.convert`) reaches every cell of the matrix through one entry
  point, forwarding kwargs to the per-object verb. `Labels.convert` guards lazy
  frames when `inplace=True` (in-place mutation on lazily-materialized frames
  would be silently lost).

## Example usage

```python
import sleap_io as sio

lf = labels[0]
# Top-down crops: anchor on the thorax, fall back to center-of-mass if occluded.
lf.convert(to="centroid", method="anchor", node="thorax", fallback="center_of_mass")
# Rasterize poses to masks by buffering nodes + edges.
lf.convert(to="mask", source="pose", node_radius=6, edge_radius=3, height=H, width=W)
# Fit padded detection boxes to masks, in place.
labels.convert(to="bbox", source="mask", padding=4, inplace=True)
```

## Metadata & variant propagation

Every conversion returns the `User*`/`Predicted*` variant matching the source
(carrying `score` on predicted paths) and propagates `track`, `tracking_score`,
`identity`, `identity_score`, `category`, `name`, `source`, and the
`instance=...` backref where a source `Instance` exists.

## Testing

- Full suite green: **4227 passed, 1 skipped**; `ruff check` + `ruff format`
  clean; docs doctests (`tests/test_docs.py`) pass.
- New conversion code is at ~100% line+branch coverage. New tests cover
  NaN/occluded-anchor handling, fallback (and fallback-exhausted → empty),
  `geometric_median` correctness incl. the iteration cap, degenerate → empty
  target vs `error_on_empty` raise, predicted→predicted variant + score +
  metadata propagation, `mask→polygon→mask` and `to_roi().to_mask() == to_mask()`
  round-trips, rotated-bbox corner reconstruction, anisotropic scale/offset
  centroids, the `shapes` both-radii-0 misconfiguration, and every `convert()`
  matrix path (incl. `inplace` routing and validation errors).

## Design decisions

- Burn-in uses Shapely `buffer` + `unary_union` (not skia): node → disc,
  edge → round-capped capsule; set a radius to `0` to drop that element.
- `radius` is the literal Shapely buffer; `method="shapes"` is used instead of
  "burn_in" (which sleap-nn reserves for an unrelated mask×crop op).
- A zero-area `convex_hull` (fewer than three visible points → `Point`/
  `LineString`) rasterizes to an all-background mask rather than leaking a
  `TypeError` from the low-level rasterizer.
- Raw-coordinate accessors (`Instance.bounding_box()`, `.centroid_xy`,
  `ROI.bounds`) are left untouched; the new `to_X()` are the object-returning
  supersets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)