### PR TITLE
fix(io): set ImageSeries num_samples for pynwb 4 compatibility

### DIFF
--- a/sleap_io/io/nwb_annotations.py
+++ b/sleap_io/io/nwb_annotations.py
@@ -52,6 +52,31 @@ _PYNWB_ACCEPTS_NUM_SAMPLES = "num_samples" in {
 }
 
 
+def _with_num_samples(
+    kwargs: dict, num_samples: int, accepts_num_samples: bool
+) -> dict:
+    """Add ``num_samples`` to ImageSeries kwargs when the pynwb build accepts it.
+
+    pynwb >= 4 requires ``num_samples`` on an external-format ``ImageSeries`` that
+    uses rate-based timing, while pynwb < 4 does not accept the argument at all.
+    Isolating that version decision in a pure function keeps both branches
+    testable on any installed pynwb version.
+
+    Args:
+        kwargs: The base ``ImageSeries`` keyword arguments.
+        num_samples: Total frame count to record.
+        accepts_num_samples: Whether the installed pynwb accepts ``num_samples``
+            (typically ``_PYNWB_ACCEPTS_NUM_SAMPLES``).
+
+    Returns:
+        A new dict with ``num_samples`` added when ``accepts_num_samples`` is
+        ``True``, otherwise ``kwargs`` unchanged.
+    """
+    if accepts_num_samples:
+        return {**kwargs, "num_samples": num_samples}
+    return kwargs
+
+
 def sanitize_nwb_name(name: str) -> str:
     """Sanitize a name for use in NWB files.
 
@@ -350,9 +375,11 @@ def sleap_video_to_nwb_image_series(
         rate=fps,
         starting_frame=starting_frame,
     )
-    if _PYNWB_ACCEPTS_NUM_SAMPLES:
-        image_series_kwargs["num_samples"] = num_samples
-    image_series = ImageSeries(**image_series_kwargs)
+    image_series = ImageSeries(
+        **_with_num_samples(
+            image_series_kwargs, num_samples, _PYNWB_ACCEPTS_NUM_SAMPLES
+        )
+    )
 
     return image_series
 

--- a/sleap_io/io/nwb_annotations.py
+++ b/sleap_io/io/nwb_annotations.py
@@ -42,6 +42,15 @@ from sleap_io.io.utils import sanitize_filename
 from sleap_io.io.video_reading import ImageVideo, MediaVideo
 from sleap_io.io.video_writing import MJPEGFrameWriter
 
+# pynwb 4.0 requires ``num_samples`` for an external-format ``ImageSeries`` that
+# uses rate-based timing (its empty ``data`` cannot imply the frame count), while
+# pynwb < 4 does not accept the argument at all. Detect support from the docval so
+# the writer works across both without forcing a pynwb upgrade.
+_PYNWB_ACCEPTS_NUM_SAMPLES = "num_samples" in {
+    arg["name"]
+    for arg in getattr(ImageSeries.__init__, "__docval__", {}).get("args", [])
+}
+
 
 def sanitize_nwb_name(name: str) -> str:
     """Sanitize a name for use in NWB files.
@@ -312,11 +321,18 @@ def sleap_video_to_nwb_image_series(
     if isinstance(filename, str):
         filename = [filename]
 
-    # Get video metadata
+    # Get video metadata. ``num_samples`` is the total frame count; on pynwb >= 4
+    # it is required for an external-format ImageSeries with rate-based timing.
     shape = sleap_video.shape
     if shape is not None:
+        num_samples = int(shape[0])
         height, width = shape[1:3]
     else:
+        # Shape is unavailable (e.g. the referenced file cannot be opened); fall
+        # back to the external-file count so ``num_samples`` is a valid positive
+        # int. The reader reconstructs the video from ``external_file`` alone, so
+        # this metadata does not affect round-trips.
+        num_samples = len(filename)
         height, width = 0, 0
 
     fps = sleap_video.fps if sleap_video.fps is not None else 30.0
@@ -324,7 +340,7 @@ def sleap_video_to_nwb_image_series(
     starting_frame = list(range(len(filename)))  # needs to match length of filenames
 
     # Create ImageSeries with external file reference
-    image_series = ImageSeries(
+    image_series_kwargs = dict(
         name=name,
         description=description,
         unit="NA",  # Standard for video data
@@ -334,6 +350,9 @@ def sleap_video_to_nwb_image_series(
         rate=fps,
         starting_frame=starting_frame,
     )
+    if _PYNWB_ACCEPTS_NUM_SAMPLES:
+        image_series_kwargs["num_samples"] = num_samples
+    image_series = ImageSeries(**image_series_kwargs)
 
     return image_series
 

--- a/tests/io/test_nwb_annotations.py
+++ b/tests/io/test_nwb_annotations.py
@@ -15,6 +15,7 @@ from sleap_io import Labels as SleapLabels
 from sleap_io import Skeleton as SleapSkeleton
 from sleap_io import Video as SleapVideo
 from sleap_io.io.nwb_annotations import (
+    _PYNWB_ACCEPTS_NUM_SAMPLES,
     MULTISUBJECTS_AVAILABLE,
     FrameInfo,
     FrameMap,
@@ -390,6 +391,29 @@ def test_video_roundtrip_media_video(centered_pair_low_quality_path):
 
     # Verify file path is preserved
     assert str(recovered_video.filename) == str(original_video.filename)
+
+
+@pytest.mark.skipif(
+    not _PYNWB_ACCEPTS_NUM_SAMPLES,
+    reason="pynwb < 4 does not accept num_samples on ImageSeries",
+)
+def test_image_series_num_samples_set_from_shape(centered_pair_low_quality_path):
+    """num_samples is set from the video frame count (pynwb >= 4 requires it)."""
+    original_video = SleapVideo.from_filename(centered_pair_low_quality_path)
+    image_series = sleap_video_to_nwb_image_series(original_video, name="test_media")
+    assert image_series.num_samples == original_video.shape[0]
+
+
+@pytest.mark.skipif(
+    not _PYNWB_ACCEPTS_NUM_SAMPLES,
+    reason="pynwb < 4 does not accept num_samples on ImageSeries",
+)
+def test_image_series_num_samples_falls_back_when_shape_unavailable():
+    """An unopenable video still gets a valid positive num_samples (external count)."""
+    video = SleapVideo.from_filename("does_not_exist.mp4")
+    image_series = sleap_video_to_nwb_image_series(video, name="missing")
+    assert video.shape is None
+    assert image_series.num_samples == 1
 
 
 def test_video_roundtrip_image_video(centered_pair_frame_paths):

--- a/tests/io/test_nwb_annotations.py
+++ b/tests/io/test_nwb_annotations.py
@@ -19,6 +19,7 @@ from sleap_io.io.nwb_annotations import (
     MULTISUBJECTS_AVAILABLE,
     FrameInfo,
     FrameMap,
+    _with_num_samples,
     create_nwb_to_slp_skeleton_map,
     create_nwb_to_slp_video_map,
     create_slp_to_nwb_skeleton_map,
@@ -414,6 +415,22 @@ def test_image_series_num_samples_falls_back_when_shape_unavailable():
     image_series = sleap_video_to_nwb_image_series(video, name="missing")
     assert video.shape is None
     assert image_series.num_samples == 1
+
+
+def test_with_num_samples_adds_when_accepted():
+    """The kwarg is added (without mutating the input) when pynwb accepts it."""
+    base = {"name": "v", "rate": 30.0}
+    out = _with_num_samples(base, 17, True)
+    assert out == {"name": "v", "rate": 30.0, "num_samples": 17}
+    assert "num_samples" not in base  # input untouched
+
+
+def test_with_num_samples_omitted_when_not_accepted():
+    """The kwarg is omitted for pynwb builds that do not accept it (< 4)."""
+    base = {"name": "v", "rate": 30.0}
+    out = _with_num_samples(base, 17, False)
+    assert out == base
+    assert "num_samples" not in out
 
 
 def test_video_roundtrip_image_video(centered_pair_frame_paths):


### PR DESCRIPTION
## Summary

pynwb **4.0** tightened validation: an external-format `ImageSeries` that uses rate-based timing now **requires `num_samples`**, because its empty `data` cannot be used to infer the frame count. Since `pynwb` is unpinned, CI resolves the latest pynwb (4.0.0) and **every NWB export / round-trip test fails**:

```
ValueError: ImageSeries 'video_0': num_samples should be set when format='external'
and rate is used for timing, because data is empty and its length cannot be used to
determine the number of frames.
```

Local dev environments on pynwb 3.x stayed green (3.x neither requires nor accepts the argument), which is why this slipped through. `main` itself is currently red from this same issue (26 NWB failures), independent of any code change.

## Fix

`sleap_video_to_nwb_image_series` now sets `num_samples`:

- From the video frame count (`Video.shape[0]`).
- Falling back to the external-file count when the video can't be opened (so `num_samples` is still a valid positive int). The reader rebuilds the video from `external_file` alone, so `num_samples` is metadata only and **round-trips are unaffected**.

To avoid forcing a pynwb major-version bump on existing users, the argument is passed **only when the installed pynwb accepts it**, detected from the `ImageSeries` docval:

```python
_PYNWB_ACCEPTS_NUM_SAMPLES = "num_samples" in {
    arg["name"]
    for arg in getattr(ImageSeries.__init__, "__docval__", {}).get("args", [])
}
```

So the writer works on **both pynwb < 4 (unchanged behavior) and pynwb >= 4 (now valid)**.

## Testing

- pynwb **4.0.0** (`uv run`): all previously-failing NWB tests pass — `tests/io/test_nwb_annotations.py` + `tests/io/test_nwb.py` (57 passed), plus the NWB cases in `tests/io/test_cli.py` and `tests/io/test_main.py`.
- pynwb **3.1.3** (local): `tests/io/test_nwb*` pass with the two new pynwb-4-only assertions skipped (55 passed, 2 skipped) — confirms 3.x behavior is preserved.
- Two new focused tests pin the behavior: `num_samples` is set from `shape[0]`, and the unopenable-video fallback yields a valid positive count. Both are guarded with `@pytest.mark.skipif(not _PYNWB_ACCEPTS_NUM_SAMPLES, ...)`.
- `ruff check` + `ruff format --check` clean.

This unblocks CI on `main` and all open PRs (including #531).

🤖 Generated with [Claude Code](https://claude.com/claude-code)