### PR TITLE
feat(skeleton): infer left/right symmetries from node names

### DIFF
--- a/docs/model/poses.md
+++ b/docs/model/poses.md
@@ -93,6 +93,7 @@ can review them before applying, since a wrong guess would silently corrupt flip
 augmentation:
 
 ```pycon
+>>> import sleap_io as sio
 >>> skel = sio.Skeleton(["nose", "eye_L", "eye_R", "ear_L", "ear_R"])
 >>> skel.infer_symmetries_by_name()
 [(1, 2), (3, 4)]

--- a/docs/model/poses.md
+++ b/docs/model/poses.md
@@ -85,6 +85,27 @@ indices.
 
 ```
 
+When a skeleton is imported without symmetry metadata (common for formats that
+don't store it) but its node names encode laterality, you can infer the pairs
+from names instead of adding them one by one. `infer_symmetries_by_name` is
+**non-mutating** -- it returns suggested `(left_index, right_index)` pairs so you
+can review them before applying, since a wrong guess would silently corrupt flip
+augmentation:
+
+```pycon
+>>> skel = sio.Skeleton(["nose", "eye_L", "eye_R", "ear_L", "ear_R"])
+>>> skel.infer_symmetries_by_name()
+[(1, 2), (3, 4)]
+>>> skel.add_symmetries(skel.infer_symmetries_by_name())  # apply if they look right
+>>> print(skel.symmetry_names)
+
+```
+
+Names are matched by splitting on separators (`_`, `-`, `.`, space), camelCase
+boundaries, and letter/digit boundaries, so `Ear_L`/`Ear_R`, `left_eye`/`right_eye`,
+`LeftPaw`/`RightPaw`, and `L1`/`R1` all pair up. Truly non-semantic pairings such
+as `L1`/`L2` cannot be inferred and must be declared with `add_symmetry`.
+
 ### Node, Edge, and Symmetry
 
 These are lightweight value types that you rarely need to construct directly --

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -122,7 +122,13 @@ __getattr__, __dir__, __all__ = lazy.attach(
         "model.labels_set": ["LabelsSet"],
         "model.matching": ["MatchResult"],
         "model.roi": ["AnnotationType", "ROI", "UserROI", "PredictedROI"],
-        "model.skeleton": ["Edge", "Node", "Skeleton", "Symmetry"],
+        "model.skeleton": [
+            "Edge",
+            "Node",
+            "Skeleton",
+            "Symmetry",
+            "infer_symmetry_pairs_by_name",
+        ],
         "model.suggestions": ["SuggestionFrame"],
         "model.video": ["Video"],
         # Transform module

--- a/sleap_io/model/skeleton.py
+++ b/sleap_io/model/skeleton.py
@@ -7,6 +7,7 @@ differently depending on the underlying pose model.
 
 from __future__ import annotations
 
+import re
 import typing
 from functools import lru_cache
 
@@ -478,6 +479,51 @@ class Skeleton:
         for symmetry in symmetries:
             self.add_symmetry(*symmetry)
 
+    def infer_symmetries_by_name(
+        self,
+        token_pairs: list[tuple[str, str]] | None = None,
+    ) -> list[tuple[int, int]]:
+        """Infer left/right symmetric node pairs from node names.
+
+        Useful when a skeleton has no symmetries defined (e.g. imported from a
+        format that does not carry symmetry metadata) but its node names encode
+        laterality, so that flip-dependent tooling (augmentation, QC) still
+        works. Names are matched by splitting on separators (`_`, `-`, `.`,
+        space), camelCase boundaries, and letter/digit boundaries, then pairing
+        nodes that share a stem but differ by a single left/right token. For
+        example, `Ear_L`/`Ear_R`, `left_eye`/`right_eye`, `LeftPaw`/`RightPaw`,
+        and `L1`/`R1` all pair up.
+
+        This is intentionally **non-mutating** and conservative: it returns
+        suggested pairs rather than writing them onto the skeleton, since a wrong
+        guess would silently corrupt flip augmentation. Apply the result
+        explicitly if desired, e.g.
+        `skel.add_symmetries(skel.infer_symmetries_by_name())`. Node names
+        without a delimited or camelCase/digit token boundary (e.g. `larm`) and
+        truly non-semantic pairings (e.g. `L1`/`L2`) cannot be inferred and must
+        be declared with `add_symmetry`.
+
+        Args:
+            token_pairs: List of `(left_token, right_token)` string pairs used to
+                recognize laterality, matched case-insensitively against whole
+                name segments. Defaults to `[("left", "right"), ("l", "r")]`.
+
+        Returns:
+            A list of `(left_index, right_index)` node-index pairs, ordered by
+            left index. Each node appears in at most one pair, and only stems
+            with exactly one left and one right member are paired (ambiguous
+            groups are skipped).
+
+        Example:
+            >>> skel = Skeleton(["nose", "eye_L", "eye_R", "ear_L", "ear_R"])
+            >>> skel.infer_symmetries_by_name()
+            [(1, 2), (3, 4)]
+            >>> skel.add_symmetries(skel.infer_symmetries_by_name())
+            >>> skel.symmetry_names
+            [('eye_L', 'eye_R'), ('ear_L', 'ear_R')]
+        """
+        return infer_symmetry_pairs_by_name(self.node_names, token_pairs=token_pairs)
+
     def rename_nodes(self, name_map: dict[NodeOrIndex, str] | list[str]):
         """Rename nodes in the skeleton.
 
@@ -820,3 +866,101 @@ def match_nodes_cached(
     inds_b = tuple([b_index_map[val] for val in a_arr[mask]])
 
     return inds_a, inds_b
+
+
+# Default left/right token pairs recognized by `infer_symmetry_pairs_by_name`.
+DEFAULT_LR_TOKENS: list[tuple[str, str]] = [("left", "right"), ("l", "r")]
+
+# Separators between name parts, and intra-part boundaries used to tokenize a
+# node name into whole segments so a left/right token can be matched exactly.
+_NAME_SEPARATORS = re.compile(r"[ _\-.]+")
+_SEGMENT_BOUNDARIES = [
+    re.compile(r"(?<=[a-z])(?=[A-Z])"),  # camelCase: ...aB... -> ...a B...
+    re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])"),  # acronym+word: ...ABc... -> ...A Bc...
+    re.compile(r"(?<=[A-Za-z])(?=[0-9])"),  # letter -> digit: ...a1... -> ...a 1...
+    re.compile(r"(?<=[0-9])(?=[A-Za-z])"),  # digit -> letter: ...1a... -> ...1 a...
+]
+
+
+def _split_name_segments(name: str) -> list[str]:
+    """Split a node name into lowercase segments for token matching.
+
+    Splits on separators (`_`, `-`, `.`, space), camelCase boundaries, and
+    letter/digit boundaries so that a left/right token can be recognized as a
+    whole segment. For example, `"frontLeftPaw"` -> `["front", "left", "paw"]`
+    and `"Ear_L"` -> `["ear", "l"]`.
+
+    Args:
+        name: The node name.
+
+    Returns:
+        The lowercased segments in order (empty if `name` has no content).
+    """
+    segments: list[str] = []
+    for chunk in _NAME_SEPARATORS.split(name):
+        if not chunk:
+            continue
+        for boundary in _SEGMENT_BOUNDARIES:
+            chunk = boundary.sub(" ", chunk)
+        segments.extend(seg.lower() for seg in chunk.split())
+    return segments
+
+
+def infer_symmetry_pairs_by_name(
+    node_names: list[str],
+    token_pairs: list[tuple[str, str]] | None = None,
+) -> list[tuple[int, int]]:
+    """Infer left/right symmetric node pairs from node names.
+
+    See `Skeleton.infer_symmetries_by_name` for the full description. This is the
+    underlying name-only implementation, exposed for callers that have a list of
+    node names but not a `Skeleton`.
+
+    Args:
+        node_names: Ordered node names (index = node index).
+        token_pairs: List of `(left_token, right_token)` pairs, matched
+            case-insensitively against whole name segments. Defaults to
+            `[("left", "right"), ("l", "r")]`.
+
+    Returns:
+        A list of `(left_index, right_index)` pairs ordered by left index. Each
+        node appears in at most one pair; only stems with exactly one left and
+        one right member are paired.
+    """
+    if token_pairs is None:
+        token_pairs = DEFAULT_LR_TOKENS
+
+    left_tokens = {left.lower() for left, _ in token_pairs}
+    right_tokens = {right.lower() for _, right in token_pairs}
+    # A token declared as both a left and a right marker is ambiguous; drop it.
+    ambiguous = left_tokens & right_tokens
+    left_tokens -= ambiguous
+    right_tokens -= ambiguous
+    side_tokens = left_tokens | right_tokens
+
+    # Group nodes by stem (name minus its single side token) and side.
+    groups: dict[str, dict[str, list[int]]] = {}
+    for idx, name in enumerate(node_names):
+        segments = _split_name_segments(name)
+        side_positions = [i for i, seg in enumerate(segments) if seg in side_tokens]
+        # Require exactly one side token: none = not a lateral node, more than one
+        # = ambiguous.
+        if len(side_positions) != 1:
+            continue
+        pos = side_positions[0]
+        side = "left" if segments[pos] in left_tokens else "right"
+        stem = "".join(segments[:pos] + segments[pos + 1 :])
+        # A bare side token (e.g. "L", "left") carries no landmark identity.
+        if not stem:
+            continue
+        bucket = groups.setdefault(stem, {"left": [], "right": []})
+        bucket[side].append(idx)
+
+    pairs: list[tuple[int, int]] = []
+    for bucket in groups.values():
+        # Only pair unambiguous 1:1 stems (exactly one left and one right member).
+        if len(bucket["left"]) == 1 and len(bucket["right"]) == 1:
+            pairs.append((bucket["left"][0], bucket["right"][0]))
+
+    pairs.sort(key=lambda pair: pair[0])
+    return pairs

--- a/tests/model/test_skeleton.py
+++ b/tests/model/test_skeleton.py
@@ -2,7 +2,13 @@
 
 import pytest
 
-from sleap_io.model.skeleton import Edge, Node, Skeleton, Symmetry
+from sleap_io.model.skeleton import (
+    Edge,
+    Node,
+    Skeleton,
+    Symmetry,
+    infer_symmetry_pairs_by_name,
+)
 
 
 def test_edge():
@@ -621,3 +627,126 @@ def test_skeleton_matches_symmetry_mismatch():
     )
 
     assert not skel1.matches(skel3, require_same_order=False)
+
+
+def test_infer_symmetries_by_name_suffix_and_prefix():
+    """Infer L/R pairs from delimited suffix and prefix tokens."""
+    skel = Skeleton(["nose", "eye_L", "eye_R", "L_ear", "R_ear"])
+    # (left_index, right_index), ordered by left index.
+    assert skel.infer_symmetries_by_name() == [(1, 2), (3, 4)]
+
+    # Full words too.
+    skel = Skeleton(["left_wing", "right_wing", "thorax"])
+    assert skel.infer_symmetries_by_name() == [(0, 1)]
+
+
+def test_infer_symmetries_by_name_module_function_matches_method():
+    """The module-level helper and the method agree."""
+    names = ["nose", "eye_L", "eye_R"]
+    # Skeleton() converts its node list in place, so pass a copy to keep `names`
+    # as strings for the module-level call below.
+    skel = Skeleton(list(names))
+    assert infer_symmetry_pairs_by_name(names) == skel.infer_symmetries_by_name()
+    assert infer_symmetry_pairs_by_name(names) == [(1, 2)]
+
+
+def test_infer_symmetries_by_name_camelcase():
+    """Infer pairs across camelCase boundaries (no separators)."""
+    assert infer_symmetry_pairs_by_name(["LeftEar", "RightEar"]) == [(0, 1)]
+    assert infer_symmetry_pairs_by_name(["earLeft", "earRight"]) == [(0, 1)]
+    # ALLCAPS acronym prefix + Word exercises the acronym boundary split.
+    assert infer_symmetry_pairs_by_name(["HINDLeftPaw", "HINDRightPaw"]) == [(0, 1)]
+
+
+def test_infer_symmetries_by_name_numeric_tokens():
+    """Infer pairs across letter/digit boundaries, e.g. L1/R1."""
+    assert infer_symmetry_pairs_by_name(["L1", "R1", "L2", "R2"]) == [(0, 1), (2, 3)]
+    # A digit in the middle exercises letter->digit and digit->letter splits.
+    assert infer_symmetry_pairs_by_name(["seg1Left", "seg1Right"]) == [(0, 1)]
+
+
+def test_infer_symmetries_by_name_embedded_and_lr_suffix():
+    """Infer pairs with a token embedded between stem parts, and bare l/r."""
+    assert infer_symmetry_pairs_by_name(["front_left_paw", "front_right_paw"]) == [
+        (0, 1)
+    ]
+    assert infer_symmetry_pairs_by_name(["frontLeftPaw", "frontRightPaw"]) == [(0, 1)]
+    assert infer_symmetry_pairs_by_name(["forelegL", "forelegR"]) == [(0, 1)]
+
+
+def test_infer_symmetries_by_name_returns_left_right_order():
+    """Each pair is (left_index, right_index), not sorted within the pair."""
+    names = ["right_a", "left_a", "right_b", "left_b"]
+    assert infer_symmetry_pairs_by_name(names) == [(1, 0), (3, 2)]
+
+
+def test_infer_symmetries_by_name_ignores_tokenless_names():
+    """Names without a whole L/R token segment are not paired."""
+    # "thorax"/"tail" contain the letters 'r'/'l' but not as a segment.
+    assert infer_symmetry_pairs_by_name(["nose", "thorax", "tail", "abdomen"]) == []
+    # A single side present without its partner yields nothing.
+    assert infer_symmetry_pairs_by_name(["eye_L", "nose"]) == []
+
+
+def test_infer_symmetries_by_name_bare_tokens_skipped():
+    """A bare side token has no stem/landmark identity, so it is skipped."""
+    assert infer_symmetry_pairs_by_name(["L", "R"]) == []
+    assert infer_symmetry_pairs_by_name(["left", "right"]) == []
+
+
+def test_infer_symmetries_by_name_non_semantic_not_inferred():
+    """Same-side names like L1/L2 cannot be inferred (must be declared)."""
+    assert infer_symmetry_pairs_by_name(["L1", "L2"]) == []
+
+
+def test_infer_symmetries_by_name_ambiguous_stem_skipped():
+    """A stem with more than one left (or right) member is ambiguous -> skipped."""
+    names = ["ear_left", "ear_right", "ear_l"]  # two 'left' members for stem "ear"
+    assert infer_symmetry_pairs_by_name(names) == []
+
+
+def test_infer_symmetries_by_name_multiple_tokens_skipped():
+    """A name carrying more than one side token is ambiguous -> skipped."""
+    assert infer_symmetry_pairs_by_name(["left_right_node", "middle"]) == []
+
+
+def test_infer_symmetries_by_name_stray_separators():
+    """Leading/trailing/repeated separators are tolerated."""
+    assert infer_symmetry_pairs_by_name(["ear_L_", "_ear_R"]) == [(0, 1)]
+
+
+def test_infer_symmetries_by_name_custom_tokens():
+    """Custom token pairs are honored; defaults then don't match."""
+    names = ["fin_top", "fin_bottom"]
+    assert infer_symmetry_pairs_by_name(names, token_pairs=[("top", "bottom")]) == [
+        (0, 1)
+    ]
+    # The method forwards token_pairs too (pass a copy; Skeleton() mutates it).
+    assert Skeleton(list(names)).infer_symmetries_by_name(
+        token_pairs=[("top", "bottom")]
+    ) == [(0, 1)]
+    # With the default L/R tokens, top/bottom are not recognized.
+    assert infer_symmetry_pairs_by_name(names) == []
+
+
+def test_infer_symmetries_by_name_ambiguous_token_config_skipped():
+    """A token declared as both left and right is dropped (no matches)."""
+    assert infer_symmetry_pairs_by_name(["l_a", "r_a"], token_pairs=[("l", "l")]) == []
+
+
+def test_infer_symmetries_by_name_empty():
+    """A skeleton with no nodes yields no pairs."""
+    assert Skeleton([]).infer_symmetries_by_name() == []
+
+
+def test_infer_symmetries_by_name_apply_is_idempotent():
+    """Inferred pairs can be applied via add_symmetries and are idempotent."""
+    skel = Skeleton(["nose", "eye_L", "eye_R", "ear_L", "ear_R"])
+    assert skel.symmetries == []
+
+    skel.add_symmetries(skel.infer_symmetries_by_name())
+    assert skel.symmetry_names == [("eye_L", "eye_R"), ("ear_L", "ear_R")]
+
+    # Applying again does not duplicate.
+    skel.add_symmetries(skel.infer_symmetries_by_name())
+    assert len(skel.symmetries) == 2


### PR DESCRIPTION
## Summary

Addresses #533. Adds a name-based left/right symmetry resolver at the skeleton
level so flip-dependent tooling works even when a skeleton has **no symmetries
defined** (common for formats imported without symmetry metadata). Both the
SLEAP Label-QC flip detector and sleap-nn flip augmentation read
`Skeleton.symmetries`; this gives a shared, robust way to populate it.

## Key Changes

- **`Skeleton.infer_symmetries_by_name(token_pairs=None)`** — returns suggested
  `(left_index, right_index)` pairs inferred from node names. **Non-mutating.**
- **`infer_symmetry_pairs_by_name(node_names, token_pairs=None)`** — module-level
  helper (also exported as `sleap_io.infer_symmetry_pairs_by_name`) for callers
  that have names but not a `Skeleton`.
- Matching segments names on separators (`_`, `-`, `.`, space), camelCase, and
  letter/digit boundaries, then pairs stems that differ by a single L/R token:
  `Ear_L`/`Ear_R`, `left_eye`/`right_eye`, `LeftPaw`/`RightPaw`, `L1`/`R1`,
  embedded tokens (`front_left_paw`), etc. Tokens are configurable via
  `token_pairs` (default `[("left", "right"), ("l", "r")]`).

## Example Usage

```python
import sleap_io as sio

skel = sio.Skeleton(["nose", "eye_L", "eye_R", "ear_L", "ear_R"])
skel.infer_symmetries_by_name()                        # [(1, 2), (3, 4)]
skel.add_symmetries(skel.infer_symmetries_by_name())   # apply after review
skel.symmetry_names                                    # [('eye_L', 'eye_R'), ('ear_L', 'ear_R')]
```

## API Changes

- New method `Skeleton.infer_symmetries_by_name()`.
- New function `sleap_io.infer_symmetry_pairs_by_name()`.
- No changes to existing APIs.

## Testing

- 16 new focused tests in `tests/model/test_skeleton.py`: delimiter/camelCase/
  numeric/embedded tokens, `(left, right)` ordering, tokenless names (no false
  positives on `thorax`/`tail`), bare tokens, ambiguous stems and ambiguous
  token config, custom tokens, stray separators, empty skeletons, and idempotent
  apply.
- New code is fully covered by the added tests; `ruff format` + `ruff check`
  clean.

## Design Decisions

- **Non-mutating on purpose.** Returns suggestions rather than writing guessed
  symmetries onto the skeleton — a wrong guess silently corrupts flip
  augmentation (mirrors the image but not the labels). Callers apply explicitly
  via `add_symmetries`.
- **Conservative matching.** A token is only recognized as a whole segment (it
  needs a delimiter or a camelCase/digit boundary), so letters inside words
  (`thorax`, `tail`) never false-match, and only unambiguous 1:1 stems are
  paired. Truly non-semantic pairings (`L1`/`L2`) are intentionally **not**
  inferred and must be declared with `add_symmetry`.
- **Shared source of truth.** Resolves to `Skeleton.symmetries`, which both the
  QC flip detector and sleap-nn flip augmentation already consume, so one
  populate step fixes both.

## Follow-ups (separate PRs, in `talmolab/sleap`)

- On opening a `.slp` whose skeleton has no symmetries but whose names suggest
  some, prompt the user to add the inferred pairs (uses this API).
- Replace the free-text symmetry cell in the skeleton editor with a node-name
  dropdown (also fixes an auto-create-phantom-node footgun).
