### PR TITLE
feat(io): default save_embedding_vectors to False (off by default, like embed)

### DIFF
--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -168,7 +168,7 @@ def save_slp(
     progress_callback: Callable[[int, int], bool] | None = None,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
-    save_embedding_vectors: bool = True,
+    save_embedding_vectors: bool = False,
 ):
     """Save a SLEAP dataset to a `.slp` file.
 
@@ -216,12 +216,13 @@ def save_slp(
             file. This preserves additions from a newer sleap-io version across a
             load/save cycle. Default `False`. Best-effort (requires the source file
             to still exist and be readable HDF5). See `write_labels`.
-        save_embedding_vectors: If `True` (the default), write attached re-ID
-            appearance embeddings (the `/embeddings` group) to disk. If `False`,
-            skip the `/embeddings` group entirely -- appearance vectors are large
-            on disk, and a producer may want only the identity *links* persisted
-            while keeping the vectors in memory (e.g. to build identity
-            prototypes). Identity links (`/identity/links`) are written regardless.
+        save_embedding_vectors: If `False` (the default), skip the `/embeddings`
+            group entirely -- appearance vectors are large on disk, so only the
+            identity *links* are persisted by default (the vectors stay in memory,
+            e.g. to build identity prototypes). This mirrors `embed`, which is also
+            off by default for video frames. Set `True` to also write the
+            `/embeddings` group. Identity links (`/identity/links`) are written
+            regardless.
     """
     from sleap_io.io import slp
 

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -7044,7 +7044,7 @@ def _write_labels_lazy(
     verbose: bool = True,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
-    save_embedding_vectors: bool = True,
+    save_embedding_vectors: bool = False,
 ) -> None:
     """Write lazy Labels to SLP file using fast path.
 
@@ -7075,9 +7075,9 @@ def _write_labels_lazy(
         preserve_unknown: If `True`, top-level HDF5 datasets/groups in the source
             file not recognized by sleap-io are carried over into the saved file.
             See `write_labels`.
-        save_embedding_vectors: If `True` (the default), write attached re-ID
-            appearance embeddings (the `/embeddings` group). If `False`, skip them
-            while still writing identity links. See `write_labels`.
+        save_embedding_vectors: If `False` (the default), skip the `/embeddings`
+            group while still writing identity links. Set `True` to also write the
+            attached re-ID appearance embeddings. See `write_labels`.
 
     Raises:
         ValueError: If labels is not lazy.
@@ -7276,7 +7276,7 @@ def write_labels(
     progress_callback: Callable[[int, int], bool] | None = None,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
-    save_embedding_vectors: bool = True,
+    save_embedding_vectors: bool = False,
 ):
     """Write a SLEAP labels file.
 
@@ -7329,11 +7329,12 @@ def write_labels(
             version (which would otherwise drop them, since saving rebuilds the file
             from the in-memory model). Default `False`. Best-effort: requires the
             source file to still exist and be readable HDF5.
-        save_embedding_vectors: If `True` (the default), write attached re-ID appearance
-            embeddings (the `/embeddings` group). If `False`, skip them -- appearance
-            vectors are large on disk, so a producer may persist only the identity
-            *links* (`/identity/links`, always written) while keeping the vectors in
-            memory. Distinct from `embed`, which embeds *video frames*.
+        save_embedding_vectors: If `False` (the default), skip the `/embeddings`
+            group -- appearance vectors are large on disk, so only the identity
+            *links* (`/identity/links`, always written) are persisted by default,
+            keeping the vectors in memory. Set `True` to also write the attached
+            re-ID appearance embeddings. Off by default, mirroring `embed` (which
+            embeds *video frames*).
     """
     # Fast path for lazy labels (avoids materializing frames/instances)
     # Supported for simple embed modes: None, False, "source"

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1660,10 +1660,11 @@ class Labels:
                 frames.
             **kwargs: Additional format-specific arguments passed to the save function.
                 See `save_file` for format-specific options. For SLP this includes
-                `save_embedding_vectors` (default `True`): set `False` to persist
-                identity *links* but skip the large re-ID appearance `/embeddings`
-                vectors (kept in memory). Note this is distinct from `embed`, which
-                embeds *video frames*.
+                `save_embedding_vectors` (default `False`, like `embed`): identity
+                *links* are always persisted, but the large re-ID appearance
+                `/embeddings` vectors are skipped unless this is set `True` (they
+                stay in memory). Note this is distinct from `embed`, which embeds
+                *video frames*.
         """
         from pathlib import Path
 

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -91,7 +91,7 @@ def _make_identity_slp(path: Path, *, with_embeddings: bool = False) -> Labels:
         skeletons=[skeleton],
         identities=[id_a, id_b],
     )
-    save_slp(labels, str(path))
+    save_slp(labels, str(path), save_embedding_vectors=with_embeddings)
     return labels
 
 

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -1201,7 +1201,7 @@ def test_read_embeddings_skips_unknown_owner_type(tmp_path):
     labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[inst])])
     labels.update()
     path = str(tmp_path / "emb.slp")
-    save_slp(labels, path)
+    save_slp(labels, path, save_embedding_vectors=True)
 
     # Inject a row with an unsupported owner_type (99, not one of the OWNER_*).
     unknown_owner_type = 99
@@ -1248,7 +1248,7 @@ def test_mask_identity_and_embedding_round_trip(tmp_path):
     labels.update()
 
     path = str(tmp_path / "mask_ids.slp")
-    save_slp(labels, path)
+    save_slp(labels, path, save_embedding_vectors=True)
 
     with h5py.File(path, "r") as f:
         assert f["metadata"].attrs["format_id"] >= 2.5
@@ -1286,12 +1286,12 @@ def test_mask_identity_round_trip_lazy_save(tmp_path):
     labels.update()
 
     a = str(tmp_path / "a.slp")
-    save_slp(labels, a)
+    save_slp(labels, a, save_embedding_vectors=True)
     lazy = load_slp(a, lazy=True)
     assert lazy.is_lazy
 
     b = str(tmp_path / "b.slp")
-    save_slp(lazy, b)
+    save_slp(lazy, b, save_embedding_vectors=True)
     assert lazy.is_lazy  # fast path did not materialize
 
     reloaded = load_slp(b)
@@ -1317,7 +1317,7 @@ def test_centroid_identity_and_embedding_round_trip(tmp_path):
     labels.update()
 
     path = str(tmp_path / "centroid_ids.slp")
-    save_slp(labels, path)
+    save_slp(labels, path, save_embedding_vectors=True)
 
     with h5py.File(path, "r") as f:
         assert f["metadata"].attrs["format_id"] >= 2.5
@@ -1350,11 +1350,11 @@ def test_centroid_identity_round_trip_lazy_save(tmp_path):
     labels.update()
 
     a = str(tmp_path / "a.slp")
-    save_slp(labels, a)
+    save_slp(labels, a, save_embedding_vectors=True)
     lazy = load_slp(a, lazy=True)
     assert lazy.is_lazy
     b = str(tmp_path / "b.slp")
-    save_slp(lazy, b)
+    save_slp(lazy, b, save_embedding_vectors=True)
     assert lazy.is_lazy
 
     reloaded = load_slp(b)
@@ -1442,17 +1442,18 @@ def test_save_embedding_vectors_false_skips_embeddings_keeps_links(tmp_path):
     assert li.identity_embedding is None  # not persisted
 
 
-def test_save_embedding_vectors_default_writes_embeddings(tmp_path):
-    """Default save_embedding_vectors=True writes the /embeddings group."""
+def test_save_embedding_vectors_default_skips_embeddings(tmp_path):
+    """Default save_embedding_vectors=False skips /embeddings, keeps identity links."""
     labels = _labels_with_identity_and_embedding()
-    path = str(tmp_path / "with_emb.slp")
+    path = str(tmp_path / "no_emb.slp")
     save_slp(labels, path)
     with h5py.File(path, "r") as f:
-        assert "embeddings" in f
+        assert "embeddings" not in f
+        assert "links" in f["identity"]
 
     # Also reachable through Labels.save(...) via **kwargs.
     path2 = str(tmp_path / "via_save.slp")
-    labels.save(path2, save_embedding_vectors=False)
+    labels.save(path2)
     with h5py.File(path2, "r") as f:
         assert "embeddings" not in f
         assert "links" in f["identity"]
@@ -1493,7 +1494,7 @@ def test_embeddings_round_trip(tmp_path):
     labels.update()
 
     path = str(tmp_path / "embeddings.slp")
-    save_slp(labels, path)
+    save_slp(labels, path, save_embedding_vectors=True)
 
     with h5py.File(path, "r") as f:
         assert f["metadata"].attrs["format_id"] >= 2.5
@@ -1547,7 +1548,7 @@ def test_embeddings_inconsistent_dim_raises(tmp_path):
     labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[i0, i1])])
 
     with pytest.raises(ValueError, match="inconsistent dimensions"):
-        save_slp(labels, str(tmp_path / "bad.slp"))
+        save_slp(labels, str(tmp_path / "bad.slp"), save_embedding_vectors=True)
 
 
 def test_bbox_identity_and_embedding_round_trip(tmp_path):
@@ -1568,7 +1569,7 @@ def test_bbox_identity_and_embedding_round_trip(tmp_path):
     labels.update()
 
     path = str(tmp_path / "bbox_ids.slp")
-    save_slp(labels, path)
+    save_slp(labels, path, save_embedding_vectors=True)
     with h5py.File(path, "r") as f:
         links = f["identity"]["links"][:]
         assert set(links["owner_type"].tolist()) == {OWNER_BBOX}
@@ -1599,7 +1600,7 @@ def test_roi_identity_and_embedding_round_trip(tmp_path):
     labels.update()
 
     path = str(tmp_path / "roi_ids.slp")
-    save_slp(labels, path)
+    save_slp(labels, path, save_embedding_vectors=True)
     with h5py.File(path, "r") as f:
         links = f["identity"]["links"][:]
         assert set(links["owner_type"].tolist()) == {OWNER_ROI}

--- a/tests/io/test_slp_lazy.py
+++ b/tests/io/test_slp_lazy.py
@@ -1727,7 +1727,7 @@ def test_lazy_embeddings_round_trip(tmp_path):
     labels.update()
 
     path = str(tmp_path / "lazy_embeddings.slp")
-    sio.save_slp(labels, path)
+    sio.save_slp(labels, path, save_embedding_vectors=True)
 
     lazy = sio.load_slp(path, lazy=True)
     assert lazy.is_lazy
@@ -1791,13 +1791,13 @@ def test_lazy_save_persists_identities_and_embeddings(tmp_path):
 
     # Save eagerly, then load lazily.
     a = str(tmp_path / "a.slp")
-    sio.save_slp(labels, a)
+    sio.save_slp(labels, a, save_embedding_vectors=True)
     lazy = sio.load_slp(a, lazy=True)
     assert lazy.is_lazy
 
     # Save the LAZY labels (exercises the fast-path writer) and reload eagerly.
     b = str(tmp_path / "b.slp")
-    sio.save_slp(lazy, b)
+    sio.save_slp(lazy, b, save_embedding_vectors=True)
 
     # The fast path must not have materialized: lazy labels stay lazy after save.
     assert lazy.is_lazy


### PR DESCRIPTION
## Summary

Re-ID appearance vectors are large on disk, so `save_slp` / `Labels.save` / `write_labels` now default `save_embedding_vectors=False`: by default only the identity **links** (`/identity/links`, always written) are persisted, and the `/embeddings` vectors group is skipped. Pass `save_embedding_vectors=True` to also write the vectors.

This mirrors `embed` for video frames (also off by default) and matches how sleap-nn wants to use it — persist identity assignments cheaply, opt into the large vectors only when needed (e.g. to rebuild prototypes). Closes the remaining decision from #525 §4 ("embedding save opt-out, off by default").

## API change

- `save_slp(..., save_embedding_vectors=False)` (was `True`); same for `Labels.save(..., save_embedding_vectors=...)` (via `**kwargs`) and the internal `write_labels`/`_write_labels_lazy`.
- Identity links are unaffected — always written when identities are present.

```python
labels.save("out.slp")                              # identity links only (no /embeddings)
labels.save("out.slp", save_embedding_vectors=True) # also writes /embeddings vectors
```

## Testing

- The embedding **round-trip** tests now opt in with `save_embedding_vectors=True` (they specifically verify the vectors persist).
- `test_save_embedding_vectors_default_writes_embeddings` is inverted → `test_save_embedding_vectors_default_skips_embeddings` (asserts a plain save omits `/embeddings` while `/identity/links` is written).
- Full suite green: **4202 passed, 3 skipped**; `ruff check` + `ruff format` clean.

Follow-up to #535 (the identity/embedding data-model simplification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qxz9EqU9Q59xbW86HfoEra