### PR TITLE
feat: frame-spanning Event annotations (data model + Labels + SLP format 2.6) (#539)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -419,8 +419,8 @@ sio show labels.slp --json
 
 Emits a single machine-readable JSON document on stdout, designed for scripting
 and for LLM agents inspecting SLP files. JSON mode always includes all details
-(full skeleton definitions, per-video info, tracks, identities, and provenance),
-so the individual detail flags are not needed:
+(full skeleton definitions, per-video info, tracks, identities, frame-spanning
+events, and provenance), so the individual detail flags are not needed:
 
 ```json
 {
@@ -439,6 +439,8 @@ so the individual detail flags are not needed:
     "n_identities": 0,
     "n_masks": 0,
     "n_rois": 0,
+    "n_events": 0,
+    "n_event_types": 0,
     "n_instances_with_identity_embedding": null
   },
   "skeletons": [
@@ -464,6 +466,8 @@ so the individual detail flags are not needed:
   ],
   "tracks": [],
   "identities": [],
+  "event_types": [],
+  "events": [],
   "provenance": {}
 }
 ```
@@ -492,6 +496,12 @@ Notes:
   to compute it.
 - Embedded package details (`embedded`, `shape`, `embedded_frames`) require
   open video backends; pass `--open-videos` to populate them.
+- Frame-spanning [events](model/events.md) are reported when present. Each
+  `event_types` entry is `{"index", "name"}` (plus `"description"` / `"metadata"`
+  when set); each `events` entry is `{"index", "type", "video", "start_frame",
+  "end_frame", "subject", "target", "predicted"}`, where `subject` / `target` are
+  `null` or `{"kind": "track"|"identity", "name": ...}`, and predicted events add
+  `"score"` and `"has_framewise_scores"`.
 
 ### Standalone Video Files
 
@@ -573,6 +583,12 @@ sio convert spots.csv -o labels.slp --from trackmate
 **Input formats:** `slp`, `nwb`, `coco`, `labelstudio`, `alphatracker`, `jabs`, `dlc`, `dlc_project`, `csv`, `trackmate`, `ultralytics`, `leap`
 
 **Output formats:** `slp`, `nwb`, `coco`, `labelstudio`, `jabs`, `ultralytics`, `csv`, `analysis_h5`
+
+!!! note "Events are SLP-only"
+    Frame-spanning [events](model/events.md) and their event-type catalog are
+    only representable in the `slp` format. Converting an event-bearing file to any
+    other output format drops them, and `sio convert` prints a warning (to stderr)
+    saying how many events and event types were discarded.
 
 ### Format Detection
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -236,6 +236,49 @@ Identities persist into SLP format v2.5+ and `Instance3D` into v1.9+, so round-t
 !!! note "See also"
     [3D model](model/3d.md): `Camera`, `CameraGroup`, `RecordingSession`, `FrameGroup`, `InstanceGroup`, `Identity`, `Instance3D`.
 
+### Behavior segmentation with events (HITL)
+
+An [`Event`][sleap_io.Event] is the first frame-*spanning* annotation: a `(video, start_frame, end_frame, type)` interval for behavior bouts, stimulus epochs, review flags — anything with a temporal extent. Events live on `Labels.events` (not on a `LabeledFrame`), reference a [`Track`](model/poses.md) / [`Identity`](model/embedding.md) as `subject` / `target`, and draw their vocabulary from an [`EventType`][sleap_io.EventType] catalog. This is the data model for human-in-the-loop behavior segmentation: a model proposes `PredictedEvent`s and a human accepts/edits them as `UserEvent`s.
+
+```python title="events_hitl.py" linenums="1"
+import sleap_io as sio
+
+labels = sio.load_slp("session.slp")
+video = labels.videos[0]
+mouse1, mouse2 = labels.tracks[:2]
+
+# Define the ethogram once (a color is just conventional free-form metadata).
+attack = sio.EventType(name="attack", metadata={"color": "#e6194b"})
+
+# A model proposes bouts with framewise + scalar confidence (both optional).
+labels.events.append(
+    sio.PredictedEvent(
+        type=attack, video=video, start_frame=100, end_frame=140,   # inclusive
+        subject=mouse1, target=mouse2,                              # directed
+        scores=[0.6] * 41, score=0.74,
+    )
+)
+# A human accepts/edits it as ground truth (a bare string auto-promotes to an
+# EventType(name=...); target=None means non-directed / "self").
+labels.events.append(
+    sio.UserEvent(type="rear", video=video, start_frame=120, subject=mouse1)
+)
+
+# Query what is happening, when, and to whom.
+labels.get_events(type="attack", predicted=True)     # model proposals to review
+labels.events_at(video, 130)                         # events covering frame 130
+[e for e in labels.get_events(subject=mouse1) if e.is_directed]
+
+# Persists to SLP format 2.6+ (additive /event_types + /events groups).
+labels.save("session_scored.slp")
+scored = sio.load_slp("session_scored.slp")
+scored.events, scored.event_types
+```
+
+!!! note "See also"
+    - [Events model](model/events.md) — full API, frame convention, and SLP format details
+    - [Poses](model/poses.md) / [Embeddings](model/embedding.md) — the `Track` / `Identity` catalogs events reference
+
 ### Reading and writing GeoJSON ROIs
 
 ROIs are serializable to the `movement`-compatible GeoJSON format used by Shapely, GeoPandas, QGIS, and QuPath. Each ROI also implements the Python [`__geo_interface__`](https://gist.github.com/sgillies/2217756) protocol so it plugs straight into any `geopandas.GeoDataFrame`.

--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -118,6 +118,26 @@ file.slp
 │   ├── owner_type               # Dataset: uint8 (0=instance, 2=centroid, 3=mask, 4=bbox, 5=roi)
 │   └── owner_id                 # Dataset: int64 (global instance_id or per-modality list index)
 │
+├── /event_types/                # Group: frame-spanning event catalog (Format 2.6+, optional)
+│   ├── name                     # Dataset: vlen utf-8 str, one per event type (catalog order)
+│   ├── description              # Dataset: vlen utf-8 str (omitted if all descriptions empty)
+│   ├── meta_owner               # Dataset: int32 event-type index (EAV metadata; all three omitted if none)
+│   ├── meta_key                 # Dataset: vlen utf-8 str metadata key
+│   └── meta_val                 # Dataset: vlen utf-8 str metadata value
+│
+├── /events/                     # Group: frame-spanning event annotations (Format 2.6+, optional)
+│   ├── video                    # Dataset: int64 video index (-1 = none)
+│   ├── start_frame / end_frame  # Dataset: int64 inclusive interval bounds
+│   ├── type                     # Dataset: int64 index into /event_types (-1 = none)
+│   ├── subject_kind/target_kind # Dataset: int8 (0=none/self, 1=track, 2=identity)
+│   ├── subject_idx/target_idx   # Dataset: int64 index into tracks or identities (-1 = none)
+│   ├── is_predicted             # Dataset: bool (user vs predicted)
+│   ├── score                    # Dataset: float64 scalar confidence, NaN=unset (omitted if none set)
+│   ├── name / source            # Dataset: vlen utf-8 str free-text
+│   ├── scores                   # Dataset: float32 flat framewise traces, chunked+gzip (CSR; omitted if none)
+│   ├── score_offsets            # Dataset: int64 (n_events+1) CSR offsets into scores
+│   └── meta_owner/meta_key/meta_val  # Dataset: per-event EAV metadata (omitted if none)
+│
 └── /video{N}/                   # Group: Per-video embedded data (one per video)
     ├── /video                   # Dataset: Embedded image data
     │   ├── @format              # Attribute: "png", "jpg", or "hdf5"
@@ -158,6 +178,8 @@ file.slp
 | `sessions_json` | `bytes[]` | JSON array of recording sessions (optional) |
 | `identity/` | group | re-ID identity catalog: `name` dataset + optional `meta_owner`/`meta_key`/`meta_val` EAV metadata + per-detection `links` (Format 2.5+, optional) |
 | `embeddings/` | group | Per-detection re-ID embeddings: `vectors` `(N, D)` + `owner_type`/`owner_id` join columns (Format 2.5+, optional) |
+| `event_types/` | group | Frame-spanning event catalog: `name` dataset + optional `description` + `meta_*` EAV metadata (Format 2.6+, optional) |
+| `events/` | group | Frame-spanning event annotations: columnar per-field datasets + ragged CSR `scores`/`score_offsets` framewise traces (Format 2.6+, optional) |
 | `provenance_json` | `bytes` | JSON object of provenance metadata (optional) |
 
 ### Provenance storage and the 64 KB metadata limit
@@ -622,6 +644,36 @@ All vectors in a file share a single dimensionality `D`; a mix of dimensionaliti
 ### Optional Group
 
 The `/embeddings` group is only written when at least one detection carries an `identity_embedding` and embedding vectors are being persisted. Passing `save_slp(labels, path, save_embedding_vectors=False)` writes the identity `links` but skips the `/embeddings` group entirely, so the (potentially large) vectors are omitted while the identity assignments are kept. On read, a missing group means no detection receives an embedding.
+
+## Events
+
+Frame-spanning [`Event`][sleap_io.Event] annotations — behavior bouts, stimulus epochs, review flags, or any labeled time range — and their [`EventType`][sleap_io.EventType] catalog are stored in the optional `/event_types` and `/events` groups (Format 2.6+). Unlike every other annotation, an event has a *temporal extent* (an inclusive `[start_frame, end_frame]` interval) and lives on [`Labels.events`][sleap_io.Labels] rather than on any [`LabeledFrame`][sleap_io.LabeledFrame]. Bumps `format_id` to `2.6`; both groups are additive, so old readers ignore them and event-free files are byte-identical.
+
+### Catalog (`/event_types`)
+
+Mirrors `/identity`: a `name` string dataset (one per type, catalog order), an optional `description` string dataset (omitted when every description is empty), and an optional `meta_owner` / `meta_key` / `meta_val` EAV metadata table (omitted when no type carries metadata). [`Labels.event_types`][sleap_io.Labels] is the catalog, auto-collected and deduped by name from `labels.events` on save.
+
+### Annotations (`/events`)
+
+A columnar struct-of-arrays (one dataset per field, like `/bboxes`); row `i` of every dataset describes event `i`:
+
+| Dataset | Dtype | Description |
+|---------|-------|-------------|
+| `video` | `int64` | Index into the videos list (`-1` = none) |
+| `start_frame` / `end_frame` | `int64` | Inclusive interval bounds (stored `int64`, read defensively) |
+| `type` | `int64` | Index into `/event_types` (`-1` = none) |
+| `subject_kind` / `target_kind` | `int8` | Participant kind: `0`=none/self, `1`=track, `2`=identity |
+| `subject_idx` / `target_idx` | `int64` | Index into tracks (kind 1) or identities (kind 2) (`-1` = none) |
+| `is_predicted` | `bool` | User vs. predicted event |
+| `score` | `float64` | Scalar event-level confidence; NaN = unset. **Omitted** when no event sets one |
+| `name` / `source` | vlen `str` | Free-text |
+| `meta_owner` / `meta_key` / `meta_val` | mixed | Per-event EAV metadata (omitted when none) |
+
+Framewise `PredictedEvent.scores` traces are variable-length, so they are stored as a **ragged CSR pair** (the same idiom as mask RLE / ROI WKB): a flat `scores` (`float32`, chunked + gzip) dataset plus an `score_offsets` (`int64`, length `n_events + 1`) dataset. Event `i`'s trace is `scores[score_offsets[i]:score_offsets[i+1]]`; an event with no trace gets a zero-length slice. Both trace datasets are omitted entirely when no event has a framewise trace. The scalar `score` and the framewise `scores` are independent — a predictor may set either, both, or neither.
+
+### Optional Groups
+
+Both groups are only written when the [`Labels`][sleap_io.Labels] object has events / event types; every column is presence-guarded so unused features cost zero bytes. On read, missing groups default to empty `events` / `event_types` lists.
 
 ## Suggestions
 

--- a/docs/model/events.md
+++ b/docs/model/events.md
@@ -183,8 +183,11 @@ like tracks are collected from instances:
 `EventType` or a bare name), `frame_idx` (events whose span *covers* that frame), and
 `predicted`. [`events_at`][sleap_io.Labels.events_at] is the shorthand for "what is
 happening at this frame?". `copy()` and `merge()` carry events across too: merging
-concatenates events, dedupes the catalog by name, and rebinds each event's
-video / subject / target / type onto the merged catalogs.
+rebinds each event's video / subject / target / type onto the merged catalogs and
+dedupes the catalog by name. Events themselves are deduped by identity —
+`(video, start_frame, end_frame, type name, subject, target, predicted?)` — so
+re-merging the same source is idempotent (confidence scores are not part of the
+identity, so an exact re-merge keeps the first copy).
 
 ## SLP persistence
 

--- a/docs/model/events.md
+++ b/docs/model/events.md
@@ -1,0 +1,170 @@
+# Events
+
+An [`Event`][sleap_io.Event] is the first sleap-io annotation with a **temporal extent**.
+Every other annotation type — [`Instance`](poses.md), [`Centroid`](centroids.md),
+[`BoundingBox`](boxes.md), [`SegmentationMask`](segmentation.md), `LabelImage`,
+[`ROI`](rois.md) — is strictly *per-frame* and lives on a single
+[`LabeledFrame`](labels.md). An `Event` instead spans a range of frames: a
+`(video, start_frame, end_frame, type)` interval. It models anything with a duration —
+behavior bouts, stimulus epochs, physiological events, feeding bouts, review flags.
+
+A behavior bout is just one kind of event, so the vocabulary is deliberately generic
+([`EventType`][sleap_io.EventType]) rather than behavior-specific.
+
+`Event` is abstract — use [`UserEvent`][sleap_io.UserEvent] (human-annotated) or
+[`PredictedEvent`][sleap_io.PredictedEvent] (model output).
+
+## Event types (the catalog)
+
+An [`EventType`][sleap_io.EventType] is a lightweight controlled-vocabulary entry — the
+"ethogram" for behavior, or any labeled span more generally. Like [`Track`](poses.md)
+and [`Identity`](embedding.md) it is name-matched across separately-loaded files and
+merges, and carries free-form string metadata (e.g. a UI color):
+
+```pycon
+>>> import sleap_io as sio
+>>> attack = sio.EventType(
+...     name="attack",
+...     description="One mouse attacks another.",
+...     metadata={"color": "#e6194b"},
+... )
+>>> print(attack.name)
+attack
+>>> print(attack.matches(sio.EventType(name="attack")))  # matched by name
+True
+
+```
+
+## Frame convention (inclusive)
+
+`start_frame` and `end_frame` are **both inclusive**: the event covers every frame in
+`[start_frame, end_frame]` and spans `end_frame - start_frame + 1` frames. Omitting
+`end_frame` yields an *instantaneous* single-frame event (`end_frame` is filled to
+`start_frame`):
+
+```pycon
+>>> import sleap_io as sio
+>>> video = sio.Video(filename="clip.mp4")
+>>> bout = sio.UserEvent(type="attack", video=video, start_frame=100, end_frame=140)
+>>> print(bout.n_frames)      # inclusive: 140 - 100 + 1
+41
+>>> print(bout.contains(140))  # inclusive at both ends
+True
+>>> print(bout.frames)         # a lazy range aligned to any framewise scores
+range(100, 141)
+>>> point = sio.UserEvent(type="light_on", video=video, start_frame=200)
+>>> print(point.is_instantaneous, point.end_frame)
+True 200
+
+```
+
+A string passed as `type` is auto-promoted to `EventType(name=...)`, so you do not have
+to build the catalog entry by hand for quick construction.
+
+## Participants: subject and target
+
+Each event optionally names up to two participants, each a [`Track`](poses.md) (a
+within-video trajectory) or an [`Identity`](embedding.md) (a cross-video animal):
+
+- `subject` — who the event is *about*. `None` means a frame-level event with no
+  individual (e.g. a stimulus epoch).
+- `target` — who the event is *directed at*. `None` means the event is non-directed /
+  individual (`"self"` in behavior-scoring terms).
+
+`is_directed` reports whether a `target` is set:
+
+```pycon
+>>> import sleap_io as sio
+>>> video = sio.Video(filename="clip.mp4")
+>>> mouse1, mouse2 = sio.Track(name="mouse1"), sio.Track(name="mouse2")
+>>> attack = sio.UserEvent(
+...     type="attack", video=video, start_frame=100, end_frame=140,
+...     subject=mouse1, target=mouse2,
+... )
+>>> print(attack.is_directed)
+True
+>>> rear = sio.UserEvent(type="rear", video=video, start_frame=50, subject=mouse1)
+>>> print(rear.is_directed)  # target is None -> non-directed ("self")
+False
+
+```
+
+## Overlapping events
+
+Events are a flat *set of intervals*, not a per-frame partition: they may overlap in
+time, even for the same subject. [`overlaps`][sleap_io.Event.overlaps] tests whether two
+events share a video and their inclusive spans intersect (events in different videos
+never overlap):
+
+```pycon
+>>> import sleap_io as sio
+>>> video = sio.Video(filename="clip.mp4")
+>>> a = sio.UserEvent(type="rear", video=video, start_frame=0, end_frame=10)
+>>> b = sio.UserEvent(type="freeze", video=video, start_frame=8, end_frame=20)
+>>> print(a.overlaps(b))
+True
+
+```
+
+## User vs. predicted events
+
+[`PredictedEvent`][sleap_io.PredictedEvent] adds two **independent, optional** confidence
+fields. A predictor sets whichever it produces (a framewise trace, an event-level scalar,
+both, or neither); neither is derived from the other:
+
+- `scores` — a framewise confidence trace of shape `(n_frames,)`, stored as `float32`
+  and aligned element-wise to `frames`.
+- `score` — a scalar event-level confidence.
+
+```pycon
+>>> import sleap_io as sio
+>>> video = sio.Video(filename="clip.mp4")
+>>> pred = sio.PredictedEvent(
+...     type="attack", video=video, start_frame=100, end_frame=104,
+...     scores=[0.6, 0.8, 0.9, 0.7, 0.5],  # per-frame, len == n_frames
+...     score=0.74,                         # event-level scalar
+... )
+>>> print(pred.is_predicted, pred.scores.dtype, len(pred.scores))
+True float32 5
+>>> user = sio.UserEvent(type="attack", video=video, start_frame=100, end_frame=104)
+>>> print(user.is_predicted)
+False
+
+```
+
+## Fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `type` | [`EventType`](#event-types-the-catalog) | Catalog entry; a bare string is auto-promoted |
+| `video` | [`Video`](video.md) | The video the event occurs in |
+| `start_frame` | `int` | First frame (inclusive) |
+| `end_frame` | `int \| None` | Last frame (inclusive); defaults to `start_frame` |
+| `subject` | [`Track`](poses.md) `\|` [`Identity`](embedding.md) `\| None` | Who the event is about |
+| `target` | [`Track`](poses.md) `\|` [`Identity`](embedding.md) `\| None` | Who the event is directed at (`None` = self) |
+| `name` | `str` | Human-readable name for this event instance |
+| `source` | `str` | Annotation source identifier |
+| `metadata` | `dict[str, str]` | Arbitrary string-keyed metadata |
+| `scores` | `np.ndarray \| None` | *(PredictedEvent)* framewise `(n_frames,)` trace, `float32` |
+| `score` | `float \| None` | *(PredictedEvent)* scalar event-level confidence |
+
+---
+
+!!! note "See also"
+
+    - **[Poses](poses.md)** and **[Embeddings](embedding.md)**: the `Track` and
+      `Identity` catalogs that events reference as participants.
+    - **[Labels & Frames](labels.md)**: the top-level container. Attaching events to
+      `Labels` and persisting them to the SLP format land in follow-up work.
+
+---
+
+## API reference
+
+::: sleap_io.EventType
+
+::: sleap_io.Event
+
+::: sleap_io.UserEvent
+
+::: sleap_io.PredictedEvent

--- a/docs/model/events.md
+++ b/docs/model/events.md
@@ -148,14 +148,73 @@ False
 | `scores` | `np.ndarray \| None` | *(PredictedEvent)* framewise `(n_frames,)` trace, `float32` |
 | `score` | `float \| None` | *(PredictedEvent)* scalar event-level confidence |
 
+## On `Labels`
+
+Events and their catalog live on the top-level container as two lists,
+[`Labels.events`][sleap_io.Labels] and `Labels.event_types` — siblings of `videos` /
+`tracks` / `suggestions`, **not** nested on any [`LabeledFrame`](labels.md) (an event
+may cover frames that carry no pose labels). Constructing a `Labels` auto-collects the
+catalog (deduped by name) and any `Track` / `Identity` used as a participant, exactly
+like tracks are collected from instances:
+
+```pycon
+>>> import sleap_io as sio
+>>> video = sio.Video(filename="clip.mp4")
+>>> mouse1, mouse2 = sio.Track(name="mouse1"), sio.Track(name="mouse2")
+>>> labels = sio.Labels(
+...     videos=[video],
+...     tracks=[mouse1, mouse2],
+...     events=[
+...         sio.UserEvent(type="attack", video=video, start_frame=100,
+...                       end_frame=140, subject=mouse1, target=mouse2),
+...         sio.UserEvent(type="rear", video=video, start_frame=120, subject=mouse2),
+...     ],
+... )
+>>> [et.name for et in labels.event_types]   # catalog auto-collected from events
+['attack', 'rear']
+>>> len(labels.get_events(type="attack"))
+1
+>>> len(labels.events_at(video, 130))        # events whose span covers frame 130
+1
+
+```
+
+[`get_events`][sleap_io.Labels.get_events] filters by `video`, `subject`, `type` (an
+`EventType` or a bare name), `frame_idx` (events whose span *covers* that frame), and
+`predicted`. [`events_at`][sleap_io.Labels.events_at] is the shorthand for "what is
+happening at this frame?". `copy()` and `merge()` carry events across too: merging
+concatenates events, dedupes the catalog by name, and rebinds each event's
+video / subject / target / type onto the merged catalogs.
+
+## SLP persistence
+
+Events persist to SLP in **format 2.6+** via two additive, presence-guarded HDF5 groups
+(older readers ignore them; event-free files are byte-identical):
+
+- `/event_types` — the catalog (a `name` string dataset, an optional `description`, and
+  an optional entity-attribute-value `meta_*` table), mirroring `/identity`.
+- `/events` — a columnar struct-of-arrays (one dataset per field, like `/bboxes`) plus a
+  ragged CSR pair (`scores` flat float32 + `score_offsets`) for the optional framewise
+  `PredictedEvent.scores`. Participants are stored as a `(kind, idx)` pair
+  (`0`=none/self, `1`=track, `2`=identity). The scalar `score` column and both trace
+  datasets are written only when some event uses them, so unused features cost zero
+  bytes.
+
+```python
+labels.save("behavior.slp")            # writes /event_types + /events (format 2.6)
+loaded = sio.load_slp("behavior.slp")  # events + catalog fully reconstructed
+loaded.events, loaded.event_types
+```
+
 ---
 
 !!! note "See also"
 
     - **[Poses](poses.md)** and **[Embeddings](embedding.md)**: the `Track` and
       `Identity` catalogs that events reference as participants.
-    - **[Labels & Frames](labels.md)**: the top-level container. Attaching events to
-      `Labels` and persisting them to the SLP format land in follow-up work.
+    - **[Labels & Frames](labels.md)**: the top-level container holding
+      `labels.events` / `labels.event_types` and the `get_events()` / `events_at()`
+      queries.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
       - ROIs: model/rois.md
       - Segmentation: model/segmentation.md
       - Embeddings: model/embedding.md
+      - Events: model/events.md
     - Formats:
       - formats/index.md
       - SLP Format: formats/slp.md

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -90,6 +90,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             "RecordingSession",
         ],
         "model.embedding": ["Embedding"],
+        "model.event": ["Event", "EventType", "UserEvent", "PredictedEvent"],
         "model.identity": ["Identity"],
         "model.instance": [
             "Instance",

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from sleap_io.model.event import Event, EventType
+    from sleap_io.model.identity import Identity
     from sleap_io.model.label_image import LabelImage
 
 import numpy as np
@@ -32,7 +34,8 @@ from rich.table import Table
 from sleap_io.io import main as io_main
 from sleap_io.io._remote import _is_url, _redact_url
 from sleap_io.io.video_reading import HDF5Video
-from sleap_io.model.instance import Instance, PredictedInstance
+from sleap_io.model.event import PredictedEvent
+from sleap_io.model.instance import Instance, PredictedInstance, Track
 from sleap_io.model.labels import Labels
 from sleap_io.model.skeleton import Skeleton
 from sleap_io.model.video import Video
@@ -932,6 +935,11 @@ def _print_header(path: Path, labels: Labels) -> None:
     n_rois = len(labels.rois)
     if n_rois > 0:
         stats_parts.append(f"[bold]{n_rois}[/] ROI{'s' if n_rois != 1 else ''}")
+
+    # Frame-spanning events - only shown when present (pose-only files have none).
+    n_events = len(labels.events)
+    if n_events > 0:
+        stats_parts.append(f"[bold]{n_events}[/] event{'s' if n_events != 1 else ''}")
 
     header_lines.append("")
     header_lines.append(" | ".join(stats_parts))
@@ -2040,6 +2048,42 @@ def _print_frames_summary(labels: Labels) -> None:
         )
 
 
+def _build_event_type_dict(et: "EventType", index: int) -> dict:
+    """Build a JSON-serializable summary of an event type for ``show --json``."""
+    d: dict[str, Any] = {"index": index, "name": et.name}
+    if et.description:
+        d["description"] = et.description
+    if et.metadata:
+        d["metadata"] = dict(et.metadata)
+    return d
+
+
+def _event_participant_json(participant: "Track | Identity | None") -> dict | None:
+    """Represent an event subject/target (`Track` / `Identity` / None) for JSON."""
+    if participant is None:
+        return None
+    kind = "track" if isinstance(participant, Track) else "identity"
+    return {"kind": kind, "name": participant.name}
+
+
+def _build_event_dict(ev: "Event", index: int, video_idx: dict[int, int]) -> dict:
+    """Build a JSON-serializable summary of a single event for ``show --json``."""
+    d: dict[str, Any] = {
+        "index": index,
+        "type": ev.type.name if ev.type is not None else None,
+        "video": video_idx.get(id(ev.video)),
+        "start_frame": ev.start_frame,
+        "end_frame": ev.end_frame,
+        "subject": _event_participant_json(ev.subject),
+        "target": _event_participant_json(ev.target),
+        "predicted": ev.is_predicted,
+    }
+    if isinstance(ev, PredictedEvent):
+        d["score"] = ev.score
+        d["has_framewise_scores"] = ev.scores is not None
+    return d
+
+
 def _build_labels_json(
     path: Path,
     labels: Labels,
@@ -2077,6 +2121,10 @@ def _build_labels_json(
             if inst.identity_embedding is not None
         )
 
+    # Map each video to its catalog index (by object identity) so events can cite
+    # their video by index without an O(n) list search per event.
+    video_idx = {id(v): i for i, v in enumerate(labels.videos)}
+
     payload: dict[str, Any] = {
         "path": str(path.resolve()),
         "name": path.name,
@@ -2093,6 +2141,8 @@ def _build_labels_json(
             "n_identities": len(labels.identities),
             "n_masks": len(labels.masks),
             "n_rois": len(labels.rois),
+            "n_events": len(labels.events),
+            "n_event_types": len(labels.event_types),
             "n_instances_with_identity_embedding": n_with_embeddings,
         },
         "skeletons": [
@@ -2109,6 +2159,12 @@ def _build_labels_json(
         "identities": [
             {"index": i, "name": ident.name}
             for i, ident in enumerate(labels.identities)
+        ],
+        "event_types": [
+            _build_event_type_dict(et, i) for i, et in enumerate(labels.event_types)
+        ],
+        "events": [
+            _build_event_dict(ev, i, video_idx) for i, ev in enumerate(labels.events)
         ],
         "provenance": dict(labels.provenance),
     }
@@ -2672,6 +2728,18 @@ def convert(
     # Prepare output directory for ultralytics
     if resolved_output_format == "ultralytics":
         output_path.mkdir(parents=True, exist_ok=True)
+
+    # Warn when frame-spanning events would be silently dropped: only SLP persists
+    # events / event types, so any other target discards them.
+    if resolved_output_format != "slp" and (labels.events or labels.event_types):
+        n_ev = len(labels.events)
+        n_et = len(labels.event_types)
+        click.echo(
+            f"Warning: {n_ev} event{'s' if n_ev != 1 else ''} and "
+            f"{n_et} event type{'s' if n_et != 1 else ''} will be dropped "
+            f"('{resolved_output_format}' cannot represent events).",
+            err=True,
+        )
 
     # Save the output file
     try:

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -7541,6 +7541,12 @@ def _write_labels_lazy(
     else:
         reference_mode = VideoReferenceMode.EMBED
 
+    # Collect event catalog + participants (including each event's own video)
+    # before write_videos / write_tracks so event videos/tracks/identities land in
+    # the written catalogs (events live on top-level lists, not the lazy store, so
+    # this is identical to the eager path).
+    labels._collect_events()
+
     # Write videos metadata (uses labels.videos which may have been modified)
     write_videos(
         labels_path,
@@ -7554,10 +7560,6 @@ def _write_labels_lazy(
     write_video_crops(labels_path, labels)
 
     # Write other metadata
-    # Collect event catalog + participants before write_tracks so event tracks/
-    # identities land in the written catalogs (events live on top-level lists, not
-    # the lazy store, so this is identical to the eager path).
-    labels._collect_events()
     write_tracks(labels_path, labels.tracks)
     # Persist identities + per-detection identity links + embeddings directly from
     # the lazy store, mirroring the eager writer (write_identities /
@@ -7847,6 +7849,14 @@ def write_labels(
                 (video_map.get(video, video), frame_idx) for video, frame_idx in embed
             ]
 
+    # Auto-collect event catalog entries + participants (event types into
+    # labels.event_types, subject/target tracks/identities into labels.tracks/
+    # labels.identities, and the event's own video into labels.videos) BEFORE the
+    # original-videos snapshot and embedding, so an event-only video is embedded and
+    # remapped like any other and every event reference is persisted (a post-hoc
+    # `labels.events.append(...)` is not dropped). Mutates labels (eager path).
+    labels._collect_events()
+
     # Store original videos before embedding modifies them
     # We need to make a copy of the actual video objects, not just the list
     original_videos = [v for v in labels.videos] if embed else None
@@ -7881,11 +7891,6 @@ def write_labels(
     # Emit virtual crop records (after videos_json so indices line up). Omitted
     # entirely when no video is cropped (uncropped files stay byte-identical).
     write_video_crops(labels_path, labels)
-    # Auto-collect event catalog entries + participants (event types into
-    # labels.event_types, subject/target tracks/identities into labels.tracks/
-    # labels.identities) BEFORE write_tracks / write_identities so a post-hoc
-    # `labels.events.append(...)` is fully persisted. Mutates labels (eager path).
-    labels._collect_events()
     write_tracks(labels_path, labels.tracks)
     # Auto-collect any detection identity not yet registered in the catalog
     # (object-identity deduped) so post-hoc `inst.identity` / `mask.identity`

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -29,6 +29,16 @@ Format version history:
             owner_type/owner_id join columns; vectors chunked so whole rows stay
             within a chunk). The owner_type column reuses the shared OWNER_* codes
             across both. All additive, read on group presence.
+    - 2.6: Added frame-spanning events. The /event_types group holds the event
+            catalog (a native `name` string dataset + an optional `description`
+            dataset + an optional entity-attribute-value metadata table:
+            meta_owner/meta_key/meta_val), mirroring /identity. The /events group
+            holds the interval annotations as a columnar struct-of-arrays (video,
+            start_frame/end_frame inclusive int64, type, subject/target kind+idx,
+            is_predicted, score, name, source, per-event EAV metadata) plus a ragged
+            CSR pair (scores flat float32 + score_offsets int64) for optional
+            framewise PredictedEvent.scores traces. Every column is presence-guarded;
+            both groups additive, read on group presence.
 """
 
 from __future__ import annotations
@@ -72,6 +82,7 @@ from sleap_io.model.camera import (
     RecordingSession,
 )
 from sleap_io.model.embedding import Embedding
+from sleap_io.model.event import Event, EventType, PredictedEvent, UserEvent
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import (
     Instance,
@@ -1729,6 +1740,400 @@ def write_identities(labels_path: str, identities: list[Identity]) -> None:
             )
 
 
+def read_event_types(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> list[EventType]:
+    """Read the event-type catalog from a SLEAP labels file.
+
+    Event types are stored in the optional ``/event_types`` group (SLP format 2.6+)
+    as a native ``name`` string dataset plus an optional ``description`` string
+    dataset (omitted when every type's description is empty) and an optional
+    entity-attribute-value metadata table (``meta_owner`` / ``meta_key`` /
+    ``meta_val``, omitted when no type carries metadata). Absent in older files, in
+    which case an empty list is returned. Mirrors `read_identities`.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from.
+
+    Returns:
+        A list of `EventType` objects in catalog order.
+    """
+    cm = (
+        nullcontext(_hdf5_file)
+        if _hdf5_file is not None
+        else h5py.File(labels_path, "r")
+    )
+    with cm as f:
+        if "event_types" not in f or "name" not in f["event_types"]:
+            return []
+        group = f["event_types"]
+        names = [
+            n.decode() if isinstance(n, bytes) else str(n) for n in group["name"][:]
+        ]
+        if "description" in group:
+            descriptions = [
+                d.decode() if isinstance(d, bytes) else str(d)
+                for d in group["description"][:]
+            ]
+        else:
+            descriptions = ["" for _ in names]
+        metadata: list[dict[str, str]] = [{} for _ in names]
+        if "meta_owner" in group:
+            owners = group["meta_owner"][:]
+            keys = group["meta_key"][:]
+            vals = group["meta_val"][:]
+            for owner, key, val in zip(owners, keys, vals):
+                k = key.decode() if isinstance(key, bytes) else str(key)
+                v = val.decode() if isinstance(val, bytes) else str(val)
+                metadata[int(owner)][k] = v
+    return [
+        EventType(name=name, description=desc, metadata=meta)
+        for name, desc, meta in zip(names, descriptions, metadata)
+    ]
+
+
+def write_event_types(labels_path: str, event_types: list[EventType]) -> None:
+    """Write the event-type catalog to a SLEAP labels file.
+
+    Creates the ``/event_types`` group (SLP format 2.6+) holding a native ``name``
+    string dataset (one per event type), plus a ``description`` string dataset only
+    when any type has a non-empty description, plus -- only when any type carries
+    metadata -- a columnar entity-attribute-value metadata table (``meta_owner`` /
+    ``meta_key`` / ``meta_val``). No-op if there are no event types. Mirrors
+    `write_identities`.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        event_types: A list of `EventType` objects to store, in catalog order.
+    """
+    if not event_types:
+        return
+
+    str_dtype = h5py.string_dtype(encoding="utf-8")
+    names = np.array([et.name for et in event_types], dtype=object)
+    has_description = any(et.description for et in event_types)
+
+    meta_owner: list[int] = []
+    meta_key: list[str] = []
+    meta_val: list[str] = []
+    for idx, et in enumerate(event_types):
+        for key, value in et.metadata.items():
+            meta_owner.append(idx)
+            meta_key.append(str(key))
+            meta_val.append(str(value))
+
+    with h5py.File(labels_path, "a") as f:
+        group = f.require_group("event_types")
+        group.create_dataset("name", data=names, dtype=str_dtype, maxshape=(None,))
+        if has_description:
+            descriptions = np.array(
+                [et.description for et in event_types], dtype=object
+            )
+            group.create_dataset(
+                "description",
+                data=descriptions,
+                dtype=str_dtype,
+                maxshape=(None,),
+            )
+        if meta_owner:
+            group.create_dataset(
+                "meta_owner",
+                data=np.array(meta_owner, dtype="i4"),
+                maxshape=(None,),
+                compression="gzip",
+            )
+            group.create_dataset(
+                "meta_key",
+                data=np.array(meta_key, dtype=object),
+                dtype=str_dtype,
+                maxshape=(None,),
+                compression="gzip",
+            )
+            group.create_dataset(
+                "meta_val",
+                data=np.array(meta_val, dtype=object),
+                dtype=str_dtype,
+                maxshape=(None,),
+                compression="gzip",
+            )
+
+
+def read_events(
+    labels_path: str,
+    videos: list[Video],
+    event_types: list[EventType],
+    tracks: list[Track],
+    identities: list[Identity],
+    *,
+    _hdf5_file: h5py.File | None = None,
+) -> list[Event]:
+    """Read frame-spanning event annotations from a SLEAP labels file.
+
+    Events are stored in the optional ``/events`` group (SLP format 2.6+) as a
+    columnar struct-of-arrays (one dataset per column, mirroring ``/bboxes``) plus a
+    ragged CSR pair for the optional framewise `PredictedEvent.scores` traces (a flat
+    ``scores`` float32 dataset + an ``score_offsets`` int64 dataset of length
+    ``n_events + 1``; row ``i``'s trace is ``scores[off[i]:off[i+1]]``, a zero-length
+    slice meaning no trace). Absent in older files, in which case an empty list is
+    returned.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        videos: List of `Video` objects for relinking (indexed by the ``video``
+            column; ``-1`` means none).
+        event_types: List of `EventType` objects for relinking (indexed by the
+            ``type`` column; ``-1`` means none).
+        tracks: List of `Track` objects for relinking subject/target participants of
+            kind ``1``.
+        identities: List of `Identity` objects for relinking subject/target
+            participants of kind ``2``.
+        _hdf5_file: An already-open `h5py.File` handle to read from.
+
+    Returns:
+        A list of `Event` objects (``UserEvent`` / ``PredictedEvent``) in stored
+        order. Empty if no events are stored.
+    """
+    cm = (
+        nullcontext(_hdf5_file)
+        if _hdf5_file is not None
+        else h5py.File(labels_path, "r")
+    )
+    with cm as f:
+        if "events" not in f:
+            return []
+        grp = f["events"]
+        video_arr = grp["video"][:]
+        start_arr = grp["start_frame"][:]
+        end_arr = grp["end_frame"][:]
+        type_arr = grp["type"][:]
+        subject_kind_arr = grp["subject_kind"][:]
+        target_kind_arr = grp["target_kind"][:]
+        subject_idx_arr = grp["subject_idx"][:]
+        target_idx_arr = grp["target_idx"][:]
+        is_predicted_arr = grp["is_predicted"][:]
+        score_arr = grp["score"][:] if "score" in grp else None
+        name_arr = grp["name"][:]
+        source_arr = grp["source"][:]
+        scores_flat = grp["scores"][:] if "scores" in grp else None
+        score_offsets = grp["score_offsets"][:] if "score_offsets" in grp else None
+
+        n = len(video_arr)
+        # Reconstruct per-event metadata from the optional EAV table.
+        metadata: list[dict[str, str]] = [{} for _ in range(n)]
+        if "meta_owner" in grp:
+            owners = grp["meta_owner"][:]
+            keys = grp["meta_key"][:]
+            vals = grp["meta_val"][:]
+            for owner, key, val in zip(owners, keys, vals):
+                k = key.decode() if isinstance(key, bytes) else str(key)
+                v = val.decode() if isinstance(val, bytes) else str(val)
+                metadata[int(owner)][k] = v
+
+    def _participant(kind: int, idx: int):
+        if kind == 1 and 0 <= idx < len(tracks):
+            return tracks[idx]
+        if kind == 2 and 0 <= idx < len(identities):
+            return identities[idx]
+        return None
+
+    events: list[Event] = []
+    for i in range(n):
+        video_idx = int(video_arr[i])
+        video = videos[video_idx] if 0 <= video_idx < len(videos) else None
+
+        type_idx = int(type_arr[i])
+        if 0 <= type_idx < len(event_types):
+            event_type = event_types[type_idx]
+        else:
+            # Defensive: an event with no catalog entry (should not happen, since
+            # the catalog is auto-collected on save). Fall back to an empty type so
+            # the (required) ``Event.type`` validator still passes.
+            event_type = EventType(name="")
+
+        subject = _participant(int(subject_kind_arr[i]), int(subject_idx_arr[i]))
+        target = _participant(int(target_kind_arr[i]), int(target_idx_arr[i]))
+
+        nm = name_arr[i]
+        name = nm.decode() if isinstance(nm, bytes) else str(nm)
+        src = source_arr[i]
+        source = src.decode() if isinstance(src, bytes) else str(src)
+
+        kwargs = dict(
+            type=event_type,
+            video=video,
+            start_frame=int(start_arr[i]),
+            end_frame=int(end_arr[i]),
+            subject=subject,
+            target=target,
+            name=name,
+            source=source,
+            metadata=metadata[i],
+        )
+
+        if bool(is_predicted_arr[i]):
+            scores = None
+            if scores_flat is not None and score_offsets is not None:
+                lo = int(score_offsets[i])
+                hi = int(score_offsets[i + 1])
+                if hi > lo:
+                    scores = np.asarray(scores_flat[lo:hi], dtype=np.float32)
+            score = None
+            if score_arr is not None:
+                s = float(score_arr[i])
+                if not np.isnan(s):
+                    score = s
+            events.append(PredictedEvent(scores=scores, score=score, **kwargs))
+        else:
+            events.append(UserEvent(**kwargs))
+
+    return events
+
+
+def write_events(
+    labels_path: str,
+    events: list[Event],
+    videos: list[Video],
+    event_types: list[EventType],
+    tracks: list[Track],
+    identities: list[Identity],
+) -> None:
+    """Write frame-spanning event annotations to a SLEAP labels file.
+
+    Creates the ``/events`` group (SLP format 2.6+) as a columnar struct-of-arrays
+    (one dataset per column, built vectorized in a single pass, mirroring
+    `write_bboxes`) plus, only when at least one event carries a framewise
+    `PredictedEvent.scores` trace, a ragged CSR pair (a flat float32 ``scores``
+    dataset + an int64 ``score_offsets`` dataset of length ``n_events + 1``). All
+    columns are presence-guarded so unused features cost zero bytes: the scalar
+    ``score`` column is omitted when no event sets a scalar score, both trace
+    datasets are omitted when no event has a framewise trace, and the whole group is
+    omitted (this function returns early) when there are no events.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        events: A list of `Event` objects to write.
+        videos: List of `Video` objects for index mapping.
+        event_types: List of `EventType` objects for index mapping (the ``type``
+            column).
+        tracks: List of `Track` objects for subject/target index mapping (kind 1).
+        identities: List of `Identity` objects for subject/target index mapping
+            (kind 2).
+    """
+    if not events:
+        return
+
+    n = len(events)
+    video_id = {id(v): i for i, v in enumerate(videos)}
+    type_id = {id(et): i for i, et in enumerate(event_types)}
+    track_id = {id(t): i for i, t in enumerate(tracks)}
+    identity_id = {id(idn): i for i, idn in enumerate(identities)}
+
+    def _kind_idx(participant) -> tuple[int, int]:
+        if isinstance(participant, Track):
+            return 1, track_id.get(id(participant), -1)
+        if isinstance(participant, Identity):
+            return 2, identity_id.get(id(participant), -1)
+        return 0, -1
+
+    video_arr = np.empty(n, dtype=np.int64)
+    start_arr = np.empty(n, dtype=np.int64)
+    end_arr = np.empty(n, dtype=np.int64)
+    type_arr = np.empty(n, dtype=np.int64)
+    subject_kind_arr = np.zeros(n, dtype=np.int8)
+    target_kind_arr = np.zeros(n, dtype=np.int8)
+    subject_idx_arr = np.full(n, -1, dtype=np.int64)
+    target_idx_arr = np.full(n, -1, dtype=np.int64)
+    is_predicted_arr = np.zeros(n, dtype=bool)
+    score_arr = np.full(n, np.nan, dtype=np.float64)
+    names: list[str] = []
+    sources: list[str] = []
+
+    score_chunks: list[np.ndarray] = []
+    score_lengths = np.zeros(n, dtype=np.int64)
+
+    meta_owner: list[int] = []
+    meta_key: list[str] = []
+    meta_val: list[str] = []
+
+    any_scalar_score = False
+    for i, ev in enumerate(events):
+        video_arr[i] = video_id.get(id(ev.video), -1)
+        start_arr[i] = ev.start_frame
+        end_arr[i] = ev.end_frame
+        type_arr[i] = type_id.get(id(ev.type), -1) if ev.type is not None else -1
+
+        subject_kind_arr[i], subject_idx_arr[i] = _kind_idx(ev.subject)
+        target_kind_arr[i], target_idx_arr[i] = _kind_idx(ev.target)
+
+        is_predicted = isinstance(ev, PredictedEvent)
+        is_predicted_arr[i] = is_predicted
+        if is_predicted and ev.score is not None:
+            score_arr[i] = ev.score
+            any_scalar_score = True
+        if is_predicted and ev.scores is not None:
+            trace = np.asarray(ev.scores, dtype=np.float32)
+            score_chunks.append(trace)
+            score_lengths[i] = trace.shape[0]
+
+        names.append(ev.name)
+        sources.append(ev.source)
+        for key, value in ev.metadata.items():
+            meta_owner.append(i)
+            meta_key.append(str(key))
+            meta_val.append(str(value))
+
+    str_dt = h5py.special_dtype(vlen=str)
+    with h5py.File(labels_path, "a") as f:
+        grp = f.create_group("events")
+        grp.create_dataset("video", data=video_arr)
+        grp.create_dataset("start_frame", data=start_arr)
+        grp.create_dataset("end_frame", data=end_arr)
+        grp.create_dataset("type", data=type_arr)
+        grp.create_dataset("subject_kind", data=subject_kind_arr)
+        grp.create_dataset("target_kind", data=target_kind_arr)
+        grp.create_dataset("subject_idx", data=subject_idx_arr)
+        grp.create_dataset("target_idx", data=target_idx_arr)
+        grp.create_dataset("is_predicted", data=is_predicted_arr)
+        grp.create_dataset("name", data=names, dtype=str_dt)
+        grp.create_dataset("source", data=sources, dtype=str_dt)
+        # Presence-guarded: scalar scores only when at least one event sets one.
+        if any_scalar_score:
+            grp.create_dataset("score", data=score_arr)
+        # Presence-guarded ragged CSR: framewise traces only when at least one
+        # event has one. score_offsets = cumsum of per-event trace lengths.
+        if score_chunks:
+            scores_flat = np.concatenate(score_chunks)
+            score_offsets = np.zeros(n + 1, dtype=np.int64)
+            np.cumsum(score_lengths, out=score_offsets[1:])
+            grp.create_dataset(
+                "scores",
+                data=scores_flat,
+                dtype=np.float32,
+                chunks=True,
+                compression="gzip",
+                compression_opts=1,
+            )
+            grp.create_dataset("score_offsets", data=score_offsets)
+        # Presence-guarded EAV metadata table.
+        if meta_owner:
+            grp.create_dataset(
+                "meta_owner", data=np.array(meta_owner, dtype="i4"), compression="gzip"
+            )
+            grp.create_dataset(
+                "meta_key",
+                data=np.array(meta_key, dtype=object),
+                dtype=str_dt,
+                compression="gzip",
+            )
+            grp.create_dataset(
+                "meta_val",
+                data=np.array(meta_val, dtype=object),
+                dtype=str_dt,
+                compression="gzip",
+            )
+
+
 def read_identity_links(
     labels_path: str, *, _hdf5_file: h5py.File | None = None
 ) -> dict[int, dict[int, tuple[int, float | None]]]:
@@ -2719,6 +3124,14 @@ def write_metadata(labels_path: str, labels: Labels):
         )
     if has_identity_data:
         format_id = max(format_id, 2.5)
+
+    # Bump for frame-spanning events (new in 2.6): the /event_types catalog and the
+    # columnar /events group (+ ragged CSR framewise scores). Purely additive (each
+    # is a separate group read with a presence check), so the bump only applies when
+    # there is event data to persist. Works for lazy Labels too, since events and
+    # event_types live on top-level lists (not the lazy store).
+    if labels.events or labels.event_types:
+        format_id = max(format_id, 2.6)
 
     with h5py.File(labels_path, "a") as f:
         # Bump for chunked label image format (new in 2.2)
@@ -3840,6 +4253,12 @@ def _read_labels_lazy_from_open_file(
     skeletons = read_skeletons(labels_path, _hdf5_file=f)
     tracks = read_tracks(labels_path, _hdf5_file=f)
     identities = read_identities(labels_path, _hdf5_file=f)
+    # Frame-spanning events + catalog (SLP 2.6+). Top-level lists (not the lazy
+    # store), read eagerly like tracks/identities/suggestions.
+    event_types = read_event_types(labels_path, _hdf5_file=f)
+    events = read_events(
+        labels_path, videos, event_types, tracks, identities, _hdf5_file=f
+    )
     # Identity links: instance owners ride on the lazy store (keyed by global
     # instance_id) and attach at materialization time; mask owners attach eagerly
     # to the masks read below.
@@ -4004,6 +4423,8 @@ def _read_labels_lazy_from_open_file(
         suggestions=suggestions,
         sessions=sessions,
         provenance=provenance,
+        event_types=event_types,
+        events=events,
         lazy_store=lazy_store,
     )
 
@@ -6695,6 +7116,12 @@ def _read_labels_from_open_file(
         )
 
     identities = read_identities(labels_path, _hdf5_file=f)
+    # Frame-spanning events + catalog (SLP 2.6+). Top-level lists, read eagerly like
+    # tracks/identities/suggestions; absent groups yield empty lists.
+    event_types = read_event_types(labels_path, _hdf5_file=f)
+    events = read_events(
+        labels_path, videos, event_types, tracks, identities, _hdf5_file=f
+    )
     # Attach identity links (SLP format 2.5+). Additive: when the dataset is absent
     # (older files) these are empty mappings and a no-op. The global instances list
     # is ordered by instance_id, so it indexes directly; mask owners are attached
@@ -6843,6 +7270,8 @@ def _read_labels_from_open_file(
         suggestions=suggestions,
         sessions=sessions,
         provenance=provenance,
+        event_types=event_types,
+        events=events,
         rois=undist_rois,
     )
     labels.provenance["filename"] = labels_path
@@ -6937,6 +7366,11 @@ _KNOWN_TOPLEVEL_HDF5_NAMES = frozenset(
         # columnar appearance vectors.
         "identity",
         "embeddings",
+        # Frame-spanning event subsystem groups (SLP 2.6+): /event_types holds the
+        # catalog (name + optional description + EAV metadata); /events holds the
+        # columnar interval annotations plus the ragged CSR framewise scores.
+        "event_types",
+        "events",
         "provenance_json",
         "frames",
         "instances",
@@ -7120,6 +7554,10 @@ def _write_labels_lazy(
     write_video_crops(labels_path, labels)
 
     # Write other metadata
+    # Collect event catalog + participants before write_tracks so event tracks/
+    # identities land in the written catalogs (events live on top-level lists, not
+    # the lazy store, so this is identical to the eager path).
+    labels._collect_events()
     write_tracks(labels_path, labels.tracks)
     # Persist identities + per-detection identity links + embeddings directly from
     # the lazy store, mirroring the eager writer (write_identities /
@@ -7163,6 +7601,17 @@ def _write_labels_lazy(
         _add_owner_embedding_groups(embedding_entries, lazy_bboxes, OWNER_BBOX)
         _add_owner_embedding_groups(embedding_entries, lazy_rois, OWNER_ROI)
         _write_embedding_groups(labels_path, embedding_entries)
+    # Frame-spanning events + their catalog (SLP 2.6+). Events live on top-level
+    # lists, so the writers are identical to the eager path.
+    write_event_types(labels_path, labels.event_types)
+    write_events(
+        labels_path,
+        labels.events,
+        labels.videos,
+        labels.event_types,
+        labels.tracks,
+        labels.identities,
+    )
     write_suggestions(labels_path, labels.suggestions, labels.videos)
     # For sessions, pass empty list since we don't have materialized frames
     # (consistent with lazy load behavior)
@@ -7432,6 +7881,11 @@ def write_labels(
     # Emit virtual crop records (after videos_json so indices line up). Omitted
     # entirely when no video is cropped (uncropped files stay byte-identical).
     write_video_crops(labels_path, labels)
+    # Auto-collect event catalog entries + participants (event types into
+    # labels.event_types, subject/target tracks/identities into labels.tracks/
+    # labels.identities) BEFORE write_tracks / write_identities so a post-hoc
+    # `labels.events.append(...)` is fully persisted. Mutates labels (eager path).
+    labels._collect_events()
     write_tracks(labels_path, labels.tracks)
     # Auto-collect any detection identity not yet registered in the catalog
     # (object-identity deduped) so post-hoc `inst.identity` / `mask.identity`
@@ -7440,6 +7894,17 @@ def write_labels(
     labels._collect_identities()
     write_identities(labels_path, labels.identities)
     write_identity_links(labels_path, labels)
+    # Frame-spanning events + their catalog (SLP 2.6+). Additive groups; omitted
+    # entirely when there are no events / event types (files stay byte-identical).
+    write_event_types(labels_path, labels.event_types)
+    write_events(
+        labels_path,
+        labels.events,
+        labels.videos,
+        labels.event_types,
+        labels.tracks,
+        labels.identities,
+    )
     # Identity links always persist; the (large) appearance vectors are gated by
     # save_embedding_vectors so a producer can keep them in memory but off disk.
     if save_embedding_vectors:

--- a/sleap_io/model/event.py
+++ b/sleap_io/model/event.py
@@ -1,0 +1,308 @@
+"""Data structures for frame-spanning event annotations.
+
+Unlike every other annotation in sleap-io (`Instance`, `Centroid`, `BoundingBox`,
+`SegmentationMask`, `LabelImage`, `ROI`), which are strictly per-frame and live on a
+single `LabeledFrame`, an `Event` is the first annotation with a *temporal extent*: a
+``(video, start_frame, end_frame, type)`` interval. Events model anything with a
+duration -- behavior bouts, stimulus epochs, physiological events, feeding bouts,
+review flags -- and are stored on ``Labels.events`` rather than on any one frame.
+
+The class hierarchy mirrors the detection-modality pattern:
+    - `EventType` -- a catalog / controlled-vocabulary entry (the "ethogram"),
+      lightweight and name-matched like `Track` / `Identity`.
+    - `Event` -- abstract base carrying the interval, participants, and metadata.
+    - `UserEvent` -- a human-annotated event (ground truth).
+    - `PredictedEvent` -- a model-predicted event with optional confidence score(s).
+
+Frame convention:
+    ``start_frame`` and ``end_frame`` are both **inclusive** -- an event covers every
+    frame in ``[start_frame, end_frame]`` and spans ``end_frame - start_frame + 1``
+    frames. An event with ``end_frame == start_frame`` (or ``end_frame=None``, which is
+    filled to ``start_frame``) is *instantaneous* (a single frame).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from attrs import define, field
+from attrs.validators import instance_of
+
+if TYPE_CHECKING:
+    from sleap_io.model.identity import Identity
+    from sleap_io.model.instance import Track
+    from sleap_io.model.video import Video
+
+
+@define(eq=False)
+class EventType:
+    """A type of event in the catalog (controlled vocabulary).
+
+    A lightweight catalog object like `Track` / `Identity`: it is referenced by
+    `Event`s and matched across separately-loaded files and merges by ``name``.
+    Examples: a behavior (``"attack"``, ``"rear"``), a stimulus (``"light_on"``), a
+    physiological event (``"seizure"``), or any labeled span.
+
+    Attributes:
+        name: Human-readable name for this event type (e.g. ``"attack"``). Not
+            required to be unique, but ``name`` is how event types are matched across
+            files and merges.
+        description: Optional longer human-readable description of what this event
+            type represents. Empty by default.
+        metadata: Arbitrary string-keyed, string-valued metadata (e.g.
+            ``{"color": "#e6194b", "directed": "true"}``). Empty by default.
+
+    Notes:
+        `EventType` objects use object-identity equality (``eq=False``), matching
+        `Track` / `Identity`. Use `matches()` (default ``method="name"``) to compare
+        event types across files, where Python object identity is not meaningful.
+    """
+
+    name: str = field(default="", validator=instance_of(str))
+    description: str = field(default="", validator=instance_of(str))
+    metadata: dict[str, str] = field(factory=dict, validator=instance_of(dict))
+
+    def matches(self, other: "EventType", method: str = "name") -> bool:
+        """Check if this event type matches another event type.
+
+        Args:
+            other: Another event type to compare with.
+            method: Matching method:
+
+                - ``"name"`` (default): match by the `name` attribute, which
+                  survives serialization and cross-file merges.
+                - ``"identity"``: match by Python object identity (same object).
+
+        Returns:
+            True if the event types match according to the specified method.
+
+        Raises:
+            ValueError: If `method` is not one of the supported values.
+        """
+        if method == "name":
+            return self.name == other.name
+        elif method == "identity":
+            return self is other
+        else:
+            raise ValueError(f"Unknown matching method: {method}")
+
+    def __repr__(self) -> str:
+        """Return a readable string representation."""
+        return f'EventType(name="{self.name}")'
+
+
+def _as_event_type(value: "EventType | str") -> "EventType":
+    """Coerce a bare string into an `EventType`, passing `EventType`s through.
+
+    A string ``"attack"`` is auto-promoted to ``EventType(name="attack")`` so
+    ``UserEvent(type="attack", ...)`` works without constructing the catalog entry by
+    hand. `Labels` collection later dedupes these by name onto a canonical catalog.
+
+    Args:
+        value: An `EventType` or a bare string name.
+
+    Returns:
+        An `EventType`.
+    """
+    if isinstance(value, str):
+        return EventType(name=value)
+    return value
+
+
+def _as_scores(value: "np.ndarray | None") -> "np.ndarray | None":
+    """Coerce a framewise score trace to a 1-D ``float32`` array (or ``None``).
+
+    Args:
+        value: A 1-D array-like of per-frame scores, or ``None`` for no trace.
+
+    Returns:
+        A 1-D ``float32`` ``np.ndarray``, or ``None`` if ``value`` is ``None``.
+
+    Raises:
+        ValueError: If ``value`` is not 1-dimensional.
+    """
+    if value is None:
+        return None
+    arr = np.asarray(value, dtype=np.float32)
+    if arr.ndim != 1:
+        raise ValueError(
+            f"Framewise event scores must be 1-dimensional, got shape {arr.shape}."
+        )
+    return arr
+
+
+@define(eq=False)
+class Event:
+    """A labeled event spanning a range of frames in a video.
+
+    A frame-spanning annotation for anything with a temporal extent: behavior bouts,
+    stimulus epochs, physiological events, review flags, etc. Unlike per-frame
+    annotations, events live on ``Labels.events`` (not on a single `LabeledFrame`),
+    since an event may cover frames that carry no pose labels.
+
+    The interval is **inclusive** on both ends: the event covers every frame in
+    ``[start_frame, end_frame]``. ``end_frame`` defaults to ``start_frame`` (an
+    instantaneous, single-frame event) when not given.
+
+    Participants are optional and each may be a `Track` (a within-video trajectory) or
+    an `Identity` (a cross-video animal):
+
+    - ``subject`` -- who the event is *about*. ``None`` means a frame-level event with
+      no individual (e.g. a stimulus epoch).
+    - ``target`` -- who the event is *directed at*. ``None`` means the event is
+      non-directed / individual (``"self"`` in behavior-scoring terms).
+
+    Attributes:
+        type: The `EventType` catalog entry for this event. A bare string is
+            auto-promoted to ``EventType(name=...)``.
+        video: The `Video` the event occurs in.
+        start_frame: First frame of the event (inclusive).
+        end_frame: Last frame of the event (inclusive). Defaults to ``start_frame``
+            (an instantaneous event) when ``None``. Must be ``>= start_frame``.
+        subject: Optional `Track` or `Identity` the event is about. ``None`` means a
+            frame-level event with no individual.
+        target: Optional `Track` or `Identity` the event is directed at. ``None`` means
+            a non-directed / individual event (``"self"``).
+        name: Optional human-readable name for this specific event instance.
+        source: Annotation source identifier.
+        metadata: Arbitrary string-keyed, string-valued metadata. Empty by default.
+
+    Notes:
+        Events use object-identity equality (two `Event` objects are only equal if they
+        are the same object in memory).
+
+        This class is abstract. Use `UserEvent` or `PredictedEvent` instead.
+    """
+
+    type: "EventType" = field(
+        converter=_as_event_type, validator=instance_of(EventType)
+    )
+    video: "Video" = field()
+    start_frame: int = field(converter=int)
+    end_frame: "int | None" = field(default=None)
+    subject: "Track | Identity | None" = field(default=None)
+    target: "Track | Identity | None" = field(default=None)
+    name: str = field(default="", validator=instance_of(str))
+    source: str = field(default="", validator=instance_of(str))
+    metadata: dict[str, str] = field(factory=dict, validator=instance_of(dict))
+
+    def __attrs_post_init__(self):
+        """Guard abstract instantiation, fill ``end_frame``, and validate the span."""
+        if type(self) is Event:
+            raise TypeError("Event is abstract. Use UserEvent or PredictedEvent.")
+        if self.end_frame is None:
+            self.end_frame = self.start_frame
+        else:
+            self.end_frame = int(self.end_frame)
+        if self.end_frame < self.start_frame:
+            raise ValueError(
+                "Expected end_frame >= start_frame, got "
+                f"start_frame={self.start_frame}, end_frame={self.end_frame}."
+            )
+
+    @property
+    def is_predicted(self) -> bool:
+        """Whether this event is a prediction."""
+        return isinstance(self, PredictedEvent)
+
+    @property
+    def is_directed(self) -> bool:
+        """Whether this event is directed at a `target` (vs. non-directed / self)."""
+        return self.target is not None
+
+    @property
+    def is_instantaneous(self) -> bool:
+        """Whether this event spans a single frame (``start_frame == end_frame``)."""
+        return self.end_frame == self.start_frame
+
+    @property
+    def n_frames(self) -> int:
+        """Number of frames spanned (inclusive: ``end_frame - start_frame + 1``)."""
+        return self.end_frame - self.start_frame + 1
+
+    @property
+    def frames(self) -> range:
+        """The inclusive range of frame indices covered by this event.
+
+        Returns:
+            A ``range(start_frame, end_frame + 1)``. Its length equals `n_frames` and,
+            for a `PredictedEvent`, aligns element-wise with a framewise `scores` trace.
+            Returned lazily as a ``range`` (not a materialized array) so events spanning
+            hundreds of thousands of frames stay cheap.
+        """
+        return range(self.start_frame, self.end_frame + 1)
+
+    def contains(self, frame_idx: int) -> bool:
+        """Whether a frame index falls within this event's inclusive span.
+
+        Args:
+            frame_idx: A frame index to test.
+
+        Returns:
+            True if ``start_frame <= frame_idx <= end_frame``.
+        """
+        return self.start_frame <= frame_idx <= self.end_frame
+
+    def overlaps(self, other: "Event") -> bool:
+        """Whether this event overlaps another in the same video.
+
+        Two events overlap when they occur in the same `Video` (compared by object
+        identity) and their inclusive frame spans intersect. Events in different videos
+        never overlap, regardless of their frame indices.
+
+        Args:
+            other: Another event to test against.
+
+        Returns:
+            True if both events share a video and their spans intersect.
+        """
+        if self.video is not other.video:
+            return False
+        return (
+            self.start_frame <= other.end_frame and other.start_frame <= self.end_frame
+        )
+
+
+@define(eq=False)
+class UserEvent(Event):
+    """A human-annotated event (ground truth).
+
+    Inherits all fields from `Event`. Has no additional fields.
+
+    See `Event` for attribute documentation.
+    """
+
+    pass
+
+
+@define(eq=False)
+class PredictedEvent(Event):
+    """A model-predicted event.
+
+    Adds two independent, optional confidence fields. A predictor sets whichever it
+    produces (a framewise trace, an event-level scalar, both, or neither); neither is
+    derived from the other.
+
+    Attributes:
+        scores: Optional framewise confidence trace of shape ``(n_frames,)``, aligned
+            element-wise to `frames` (i.e. ``[start_frame, end_frame]``). Stored as
+            ``float32``. Validated to have length `n_frames` when set. ``None`` if the
+            predictor produced no per-frame trace.
+        score: Optional scalar event-level confidence. ``None`` if unset. **Not**
+            derived from `scores`.
+
+    See `Event` for other attribute documentation.
+    """
+
+    scores: "np.ndarray | None" = field(default=None, converter=_as_scores, repr=False)
+    score: "float | None" = field(default=None)
+
+    def __attrs_post_init__(self):
+        """Validate the framewise `scores` length against `n_frames`."""
+        super().__attrs_post_init__()
+        if self.scores is not None and len(self.scores) != self.n_frames:
+            raise ValueError(
+                "Framewise event scores must have length n_frames "
+                f"({self.n_frames}), got {len(self.scores)}."
+            )

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1031,12 +1031,13 @@ class Labels:
         """Register every event's `EventType` in ``self.event_types`` by name.
 
         Deduplicates the catalog by `EventType.name`: the first entry seen for a
-        given name is canonical, and every subsequent event carrying a distinct
-        same-named `EventType` object (e.g. from the string auto-promotion in the
-        `Event` constructor) is rebound to that canonical entry. This keeps a clean
-        one-entry-per-name catalog while letting callers pass either shared
-        `EventType` objects or bare strings. Mutates ``self.event_types`` and, when
-        rebinding, ``event.type``.
+        given name is canonical, and every subsequent same-named `EventType` object
+        -- whether discovered from an event's ``type`` (e.g. the string auto-promotion
+        in the `Event` constructor) or passed directly in ``event_types=`` -- is
+        collapsed onto that canonical entry, with each event's ``type`` rebound to it.
+        This keeps a clean one-entry-per-name catalog while letting callers pass
+        either shared `EventType` objects or bare strings. Mutates ``self.event_types``
+        and, when rebinding, ``event.type``.
         """
         by_name: dict[str, EventType] = {}
         for et in self.event_types:
@@ -1045,10 +1046,14 @@ class Labels:
             et = ev.type
             canonical = by_name.get(et.name)
             if canonical is None:
-                self.event_types.append(et)
                 by_name[et.name] = et
             elif canonical is not et:
                 ev.type = canonical
+        # Rebuild the catalog from the name-deduped map. This preserves first-seen
+        # order while collapsing every duplicate-named entry -- both event-discovered
+        # ones and any duplicates passed directly in ``event_types=`` -- onto a single
+        # canonical entry per name, matching the name-dedup the merge path performs.
+        self.event_types[:] = list(by_name.values())
 
     def append(self, lf: LabeledFrame, update: bool = True):
         """Append a labeled frame to the labels.

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -1014,6 +1014,11 @@ class Labels:
         """
         self._collect_event_types()
         for ev in self.events:
+            # An event may reference a video that carries no pose labels and so is
+            # not otherwise in the catalog; collect it (like suggestion videos in
+            # `update`) so its reference is not dropped (written as -1) on save.
+            if ev.video is not None and ev.video not in self.videos:
+                self.videos.append(ev.video)
             for participant in (ev.subject, ev.target):
                 if isinstance(participant, Track):
                     if participant not in self.tracks:
@@ -2729,6 +2734,11 @@ class Labels:
         for sf in self.suggestions:
             if sf.video in video_map:
                 sf.video = video_map[sf.video]
+
+        # Update frame-spanning events (video is a required field on every event).
+        for ev in self.events:
+            if ev.video in video_map:
+                ev.video = video_map[ev.video]
 
         # Update the list of videos.
         self.videos = [video_map.get(video, video) for video in self.videos]

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -3731,6 +3731,15 @@ class Labels:
             This method modifies the Labels object in place. The merge is designed to
             handle common workflows like merging predictions back into a project.
 
+            Frame-spanning events (``other.events``) are carried across too, with each
+            event's video / subject / target / type rerouted onto this object's merged
+            catalogs. Events are deduped by identity -- ``(video, start_frame,
+            end_frame, type name, subject, target, predicted?)`` -- so re-merging the
+            same source is idempotent (confidence scores are not part of the identity).
+            As a side effect, ``other``'s own event catalogs are normalized first (a
+            no-op unless events were appended to ``other`` post-hoc without an
+            intervening ``update()``).
+
             Provenance tracking: Each merge operation appends a record to
             ``self.provenance["merge_history"]`` containing:
 
@@ -3743,6 +3752,19 @@ class Labels:
             - ``result``: Merge statistics (frames_merged, instances_added, conflicts)
         """
         self._check_not_lazy("merge")
+
+        # Normalize the source's own event catalogs before building the merge maps.
+        # ``_collect_events`` registers each event's video / subject / target / type
+        # into ``other``'s videos / tracks / identities / event_types. It is a no-op
+        # when ``other`` was built via the constructor, loaded, or saved (all of which
+        # already collect), and only completes catalogs for a ``Labels`` that had
+        # events appended post-hoc without an intervening ``update()``. Doing it here
+        # means event-referenced videos/tracks/identities flow through the same
+        # matchers as everything else (Steps 2/3/3b), so they dedupe onto ``self``'s
+        # equivalents instead of landing as orphan duplicate catalog entries bound to
+        # the wrong object.
+        other._collect_events()
+
         from datetime import datetime
         from pathlib import Path
 
@@ -4197,15 +4219,20 @@ class Labels:
                     )
                     self.suggestions.append(new_suggestion)
 
-            # Step 5b: Merge events. Each incoming event is deep-copied (so the
-            # source Labels is never mutated) with its references rerouted onto this
-            # object's merged catalogs via a shared ``deepcopy`` memo: video (through
-            # ``video_map``), subject/target ``Track``s (``track_map``) and
-            # ``Identity``s (``identity_map``), and ``type`` (``event_type_map``).
-            # Events are a flat set of intervals with no per-frame identity, so they
-            # are concatenated wholesale (no dedup). ``other``'s participants/types
-            # were registered on it at construction, so every reference is in the
-            # memo; any stragglers are swept by the ``_collect_events`` below.
+            # Step 5b: Merge events. Each incoming event is deep-copied with its
+            # references rerouted onto this object's merged catalogs via a shared
+            # ``deepcopy`` memo: video (through ``video_map``), subject/target
+            # ``Track``s (``track_map``) and ``Identity``s (``identity_map``), and
+            # ``type`` (``event_type_map``). ``other._collect_events()`` at the top of
+            # merge guarantees every event reference is in ``other``'s catalogs and so
+            # in the memo, remapped onto ``self``'s canonical objects.
+            #
+            # Events have no per-frame slot to merge into, but they do carry a natural
+            # identity -- (video, start_frame, end_frame, type name, subject, target,
+            # predicted?) -- so the merge is idempotent: an incoming event whose
+            # identity already exists on ``self`` is skipped (mirroring the
+            # SuggestionFrame dedup in Step 5). Confidence scores are deliberately not
+            # part of the identity, so an exact re-merge keeps the first copy.
             if other.events:
                 event_memo: dict[int, Any] = {}
                 for other_video_obj, mapped in video_map.items():
@@ -4214,8 +4241,28 @@ class Labels:
                     event_memo[id(other_track_obj)] = mapped
                 event_memo.update(identity_map)
                 event_memo.update(event_type_map)
+
+                def _event_identity(ev: Event) -> tuple:
+                    # Keyed on the remapped (canonical) video/participant objects, so
+                    # object identity is a valid comparison across self + incoming.
+                    return (
+                        id(ev.video),
+                        ev.start_frame,
+                        ev.end_frame,
+                        ev.type.name if ev.type is not None else None,
+                        id(ev.subject),
+                        id(ev.target),
+                        ev.is_predicted,
+                    )
+
+                existing_keys = {_event_identity(ev) for ev in self.events}
                 for other_event in other.events:
-                    self.events.append(deepcopy(other_event, event_memo))
+                    new_event = deepcopy(other_event, event_memo)
+                    key = _event_identity(new_event)
+                    if key in existing_keys:
+                        continue
+                    existing_keys.add(key)
+                    self.events.append(new_event)
                 # Canonicalize any references that fell outside the memo.
                 self._collect_events()
 

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -22,6 +22,7 @@ from attrs import define, field
 
 from sleap_io.io.utils import sanitize_filename
 from sleap_io.model.camera import RecordingSession
+from sleap_io.model.event import Event, EventType
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, PredictedInstance, Track
 from sleap_io.model.labeled_frame import (
@@ -74,6 +75,13 @@ class Labels:
         tracks: A list of `Track`s that are associated with this dataset.
         identities: A list of `Identity`s for ground-truth animal identification,
             persistent across sessions and videos.
+        event_types: A list of `EventType`s -- the catalog / controlled vocabulary
+            (the "ethogram") referenced by `events`. Name-matched across files, like
+            `tracks` / `identities`.
+        events: A list of `Event`s -- frame-spanning interval annotations (behavior
+            bouts, stimulus epochs, review flags, ...). Unlike the per-frame
+            annotations these are stored here, not on individual `LabeledFrame`s,
+            since an event may cover frames that carry no pose labels.
         suggestions: A list of `SuggestionFrame`s that are associated with this dataset.
         sessions: A list of `RecordingSession`s that are associated with this dataset.
         provenance: Dictionary of metadata about where the dataset came from.
@@ -128,6 +136,14 @@ class Labels:
     suggestions: list[SuggestionFrame] = field(factory=list)
     sessions: list[RecordingSession] = field(factory=list)
     provenance: dict[str, Any] = field(factory=dict)
+
+    # Frame-spanning event annotations and their catalog (controlled vocabulary).
+    # Unlike per-frame annotations these are NOT stored on `LabeledFrame`s -- an
+    # event may cover frames with no pose labels -- so they live here as top-level
+    # lists, siblings of `videos` / `tracks` / `suggestions`. Keyword-only so the
+    # positional constructor signature is unchanged.
+    event_types: list[EventType] = field(factory=list, kw_only=True)
+    events: list[Event] = field(factory=list, kw_only=True)
 
     # Static ROIs: ROIs not tied to any specific frame (e.g., arena boundaries).
     # Accepted via constructor with alias="rois" for backward compatibility.
@@ -519,6 +535,9 @@ class Labels:
         # Collect multi-view identities bound only on InstanceGroups (sessions).
         self._collect_session_identities()
 
+        # Register event catalog entries and participants referenced by events.
+        self._collect_events()
+
         for sf in self.suggestions:
             if sf.video not in self.videos:
                 self.videos.append(sf.video)
@@ -862,6 +881,24 @@ class Labels:
                     deepcopy(lf) for lf in self.labeled_frames._supplementary
                 ]
 
+            # Deep-copy the event catalog and events, remapping each event's
+            # references (video / subject / target / type) onto the copied catalog
+            # objects. A shared ``deepcopy`` memo seeded with id(old)->new for every
+            # video / track / identity / event-type makes each event's fields point
+            # at the copies, preserving the object-sharing the eager path gets for
+            # free from ``deepcopy(self)``.
+            memo: dict[int, Any] = {}
+            for old_obj, new_obj in zip(self.videos, new_videos):
+                memo[id(old_obj)] = new_obj
+            for old_obj, new_obj in zip(self.tracks, new_tracks):
+                memo[id(old_obj)] = new_obj
+            for old_obj, new_obj in zip(self.identities, new_identities):
+                memo[id(old_obj)] = new_obj
+            new_event_types = [deepcopy(et) for et in self.event_types]
+            for old_obj, new_obj in zip(self.event_types, new_event_types):
+                memo[id(old_obj)] = new_obj
+            new_events = [deepcopy(ev, memo) for ev in self.events]
+
             labels_copy = Labels(
                 labeled_frames=new_lazy_frames,
                 videos=new_videos,
@@ -871,6 +908,8 @@ class Labels:
                 suggestions=[deepcopy(s) for s in self.suggestions],
                 sessions=[deepcopy(s) for s in self.sessions],
                 provenance=dict(self.provenance),
+                event_types=new_event_types,
+                events=new_events,
                 lazy_store=new_store,
             )
         else:
@@ -960,6 +999,51 @@ class Labels:
                     identity = instance_group.identity
                     if identity is not None and identity not in self.identities:
                         self.identities.append(identity)
+
+    def _collect_events(self):
+        """Register catalog entries and participants referenced by `events`.
+
+        Sweeps ``self.events`` and ensures every referenced `EventType` is in
+        ``self.event_types`` (deduped by name, canonicalizing each event's ``type``
+        onto the first catalog entry of that name) and every `Track` / `Identity`
+        used as an event ``subject`` / ``target`` is registered in ``self.tracks`` /
+        ``self.identities``. Mirrors `_collect_annotation_tracks` /
+        `_collect_identities`: called from `update()` (build path) and again at save
+        time so post-hoc ``labels.events.append(...)`` assignments are not dropped.
+        Idempotent and a cheap no-op when there are no events.
+        """
+        self._collect_event_types()
+        for ev in self.events:
+            for participant in (ev.subject, ev.target):
+                if isinstance(participant, Track):
+                    if participant not in self.tracks:
+                        self.tracks.append(participant)
+                elif isinstance(participant, Identity):
+                    if participant not in self.identities:
+                        self.identities.append(participant)
+
+    def _collect_event_types(self):
+        """Register every event's `EventType` in ``self.event_types`` by name.
+
+        Deduplicates the catalog by `EventType.name`: the first entry seen for a
+        given name is canonical, and every subsequent event carrying a distinct
+        same-named `EventType` object (e.g. from the string auto-promotion in the
+        `Event` constructor) is rebound to that canonical entry. This keeps a clean
+        one-entry-per-name catalog while letting callers pass either shared
+        `EventType` objects or bare strings. Mutates ``self.event_types`` and, when
+        rebinding, ``event.type``.
+        """
+        by_name: dict[str, EventType] = {}
+        for et in self.event_types:
+            by_name.setdefault(et.name, et)
+        for ev in self.events:
+            et = ev.type
+            canonical = by_name.get(et.name)
+            if canonical is None:
+                self.event_types.append(et)
+                by_name[et.name] = et
+            elif canonical is not et:
+                ev.type = canonical
 
     def append(self, lf: LabeledFrame, update: bool = True):
         """Append a labeled frame to the labels.
@@ -2321,6 +2405,74 @@ class Labels:
         if predicted is not None:
             results = [li for li in results if li.is_predicted == predicted]
         return results
+
+    def get_events(
+        self,
+        video: "Video | None" = None,
+        subject: "Track | Identity | None" = None,
+        type: "EventType | str | None" = None,
+        frame_idx: int | None = None,
+        predicted: bool | None = None,
+    ) -> list[Event]:
+        """Query frame-spanning events by video, subject, type, frame, or kind.
+
+        Unlike the per-frame ``get_*`` accessors, events are frame-spanning, so the
+        ``frame_idx`` filter matches every event whose inclusive span *covers* that
+        frame (``event.contains(frame_idx)``), not events "on" a single frame.
+
+        Args:
+            video: If specified, only return events for this video. A foreign
+                `Video` instance or filename is resolved via `match_video`.
+            subject: If specified, only return events with this `Track` or
+                `Identity` as their ``subject`` (object-identity comparison).
+            type: If specified, only return events of this type. Matched by name,
+                so either an `EventType` or a bare string name works.
+            frame_idx: If specified, only return events whose span covers this
+                frame index.
+            predicted: If ``True``, only return `PredictedEvent`s. If ``False``,
+                only `UserEvent`s. If ``None`` (default), return both.
+
+        Returns:
+            A list of matching events.
+        """
+        video = self._resolve_video(video)
+        results = list(self.events)
+        if video is not None:
+            results = [ev for ev in results if ev.video is video]
+        if frame_idx is not None:
+            results = [ev for ev in results if ev.contains(frame_idx)]
+        if subject is not None:
+            results = [ev for ev in results if ev.subject is subject]
+        if type is not None:
+            type_name = type.name if isinstance(type, EventType) else type
+            results = [ev for ev in results if ev.type.name == type_name]
+        if predicted is not None:
+            results = [ev for ev in results if ev.is_predicted == predicted]
+        return results
+
+    def events_at(
+        self,
+        video: "Video",
+        frame_idx: int,
+        subject: "Track | Identity | None" = None,
+    ) -> list[Event]:
+        """Return all events covering a given frame in a video.
+
+        Convenience wrapper over `get_events` for the common "what is happening at
+        this frame?" query: returns every event whose inclusive span covers
+        ``frame_idx`` in ``video``, optionally restricted to one ``subject``.
+
+        Args:
+            video: The video to query. A foreign `Video` instance or filename is
+                resolved via `match_video`.
+            frame_idx: The frame index to look up.
+            subject: If specified, only return events with this `Track` or
+                `Identity` as their ``subject`` (object-identity comparison).
+
+        Returns:
+            A list of events covering ``frame_idx`` in ``video``.
+        """
+        return self.get_events(video=video, frame_idx=frame_idx, subject=subject)
 
     def rename_nodes(
         self,
@@ -3863,6 +4015,23 @@ class Labels:
 
                 identity_map[id(other_identity)] = matched_identity
 
+            # Step 3c: Match and merge event types (dedupe by name). Mirrors the
+            # identity merge: the same event type across files collapses to one
+            # canonical catalog entry. ``event_type_map`` (keyed by the source
+            # type's object id) reroutes each incoming event's ``type`` onto the
+            # canonical entry in Step 5b.
+            event_type_map: dict[int, EventType] = {}
+            for other_event_type in other.event_types:
+                matched_event_type = None
+                for self_event_type in self.event_types:
+                    if self_event_type.matches(other_event_type):
+                        matched_event_type = self_event_type
+                        break
+                if matched_event_type is None:
+                    self.event_types.append(other_event_type)
+                    matched_event_type = other_event_type
+                event_type_map[id(other_event_type)] = matched_event_type
+
             # Step 4: Merge frames
             total_frames = len(other.labeled_frames)
 
@@ -4017,6 +4186,28 @@ class Labels:
                         video=mapped_video, frame_idx=other_suggestion.frame_idx
                     )
                     self.suggestions.append(new_suggestion)
+
+            # Step 5b: Merge events. Each incoming event is deep-copied (so the
+            # source Labels is never mutated) with its references rerouted onto this
+            # object's merged catalogs via a shared ``deepcopy`` memo: video (through
+            # ``video_map``), subject/target ``Track``s (``track_map``) and
+            # ``Identity``s (``identity_map``), and ``type`` (``event_type_map``).
+            # Events are a flat set of intervals with no per-frame identity, so they
+            # are concatenated wholesale (no dedup). ``other``'s participants/types
+            # were registered on it at construction, so every reference is in the
+            # memo; any stragglers are swept by the ``_collect_events`` below.
+            if other.events:
+                event_memo: dict[int, Any] = {}
+                for other_video_obj, mapped in video_map.items():
+                    event_memo[id(other_video_obj)] = mapped
+                for other_track_obj, mapped in track_map.items():
+                    event_memo[id(other_track_obj)] = mapped
+                event_memo.update(identity_map)
+                event_memo.update(event_type_map)
+                for other_event in other.events:
+                    self.events.append(deepcopy(other_event, event_memo))
+                # Canonicalize any references that fell outside the memo.
+                self._collect_events()
 
             # Update merge record
             merge_record["result"] = {

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -37,8 +37,9 @@ from sleap_io.io.cli import (
     cli,
 )
 from sleap_io.model.embedding import Embedding
+from sleap_io.model.event import EventType, PredictedEvent, UserEvent
 from sleap_io.model.identity import Identity
-from sleap_io.model.instance import Instance, PredictedInstance
+from sleap_io.model.instance import Instance, PredictedInstance, Track
 from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
 from sleap_io.model.mask import PredictedSegmentationMask, UserSegmentationMask
@@ -92,6 +93,43 @@ def _make_identity_slp(path: Path, *, with_embeddings: bool = False) -> Labels:
         identities=[id_a, id_b],
     )
     save_slp(labels, str(path), save_embedding_vectors=with_embeddings)
+    return labels
+
+
+def _make_event_slp(path: Path) -> Labels:
+    """Write a minimal .slp carrying frame-spanning events + a pose instance.
+
+    One labeled frame with a single instance (so pose exporters succeed) plus a
+    directed `UserEvent` (Track subject/target), a scalar-scored `PredictedEvent`
+    (Identity subject), and an `EventType` carrying metadata.
+    """
+    skeleton = Skeleton(["head", "tail"])
+    video = Video(filename="dummy.mp4", backend_metadata={"shape": (40, 64, 64, 3)})
+    m1, m2 = Track(name="m1"), Track(name="m2")
+    id_a = Identity(name="mouseA")
+    attack = EventType(name="attack", description="one attacks", metadata={"c": "#f00"})
+    inst = Instance.from_numpy(np.array([[10, 10], [20, 20]]), skeleton=skeleton)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst])
+    labels = Labels(
+        labeled_frames=[lf],
+        videos=[video],
+        skeletons=[skeleton],
+        tracks=[m1, m2],
+        events=[
+            UserEvent(
+                type=attack,
+                video=video,
+                start_frame=10,
+                end_frame=20,
+                subject=m1,
+                target=m2,
+            ),
+            PredictedEvent(
+                type="rear", video=video, start_frame=5, subject=id_a, score=0.9
+            ),
+        ],
+    )
+    save_slp(labels, str(path))
     return labels
 
 
@@ -797,6 +835,90 @@ def test_show_json_identities_and_embeddings(tmp_path):
     # Lazy loading skips the embedding scan and reports null (unknown).
     lazy = _invoke_json(["show", str(slp_path), "--json", "--no-open-videos"])
     assert lazy["stats"]["n_instances_with_identity_embedding"] is None
+
+
+def test_show_json_events(tmp_path):
+    """`sio show --json` reports events and event types (parity with identities)."""
+    slp_path = tmp_path / "events.slp"
+    _make_event_slp(slp_path)
+
+    data = _invoke_json(["show", str(slp_path), "--json", "--no-open-videos"])
+    assert data["stats"]["n_events"] == 2
+    assert data["stats"]["n_event_types"] == 2
+
+    assert [et["name"] for et in data["event_types"]] == ["attack", "rear"]
+    # Non-empty description / metadata are surfaced.
+    attack_type = data["event_types"][0]
+    assert attack_type["description"] == "one attacks"
+    assert attack_type["metadata"] == {"c": "#f00"}
+
+    user_ev, pred_ev = data["events"]
+    assert user_ev == {
+        "index": 0,
+        "type": "attack",
+        "video": 0,
+        "start_frame": 10,
+        "end_frame": 20,
+        "subject": {"kind": "track", "name": "m1"},
+        "target": {"kind": "track", "name": "m2"},
+        "predicted": False,
+    }
+    assert pred_ev["predicted"] is True
+    assert pred_ev["subject"] == {"kind": "identity", "name": "mouseA"}
+    assert pred_ev["target"] is None
+    assert pred_ev["score"] == pytest.approx(0.9)
+    assert pred_ev["has_framewise_scores"] is False
+
+
+def test_show_json_events_absent(tmp_path):
+    """A pose-only file reports zero events and empty event arrays (no crash)."""
+    data = _invoke_json(
+        ["show", str(_data_path("slp/typical.slp")), "--json", "--no-open-videos"]
+    )
+    assert data["stats"]["n_events"] == 0
+    assert data["stats"]["n_event_types"] == 0
+    assert data["events"] == []
+    assert data["event_types"] == []
+
+
+def test_show_reports_events(tmp_path):
+    """`sio show` shows an events chip in the header when events are present."""
+    slp_path = tmp_path / "events.slp"
+    _make_event_slp(slp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["show", str(slp_path), "--no-open-videos"])
+    assert result.exit_code == 0, result.output
+    assert "2 events" in _strip_ansi(result.output)
+
+
+def test_convert_warns_when_dropping_events(tmp_path):
+    """Converting an event file to a non-SLP format warns that events are dropped."""
+    src = tmp_path / "events.slp"
+    _make_event_slp(src)
+    out = tmp_path / "out.csv"
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["convert", str(src), "-o", str(out), "--to", "csv"])
+    assert result.exit_code == 0, result.output
+    text = _strip_ansi(result.output)
+    assert "2 events and 2 event types will be dropped" in text
+    assert "'csv' cannot represent events" in text
+
+
+def test_convert_slp_to_slp_preserves_events_no_warning(tmp_path):
+    """SLP->SLP conversion keeps events and issues no drop warning."""
+    src = tmp_path / "events.slp"
+    _make_event_slp(src)
+    out = tmp_path / "out.slp"
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["convert", str(src), "-o", str(out), "--to", "slp"])
+    assert result.exit_code == 0, result.output
+    assert "will be dropped" not in _strip_ansi(result.output)
+    reloaded = load_slp(str(out))
+    assert len(reloaded.events) == 2
+    assert len(reloaded.event_types) == 2
 
 
 def test_show_json_embedded_pkg():

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -10746,3 +10746,62 @@ def test_slp_event_mixed_scalar_score(tmp_path):
     assert by_type["a"].score == pytest.approx(0.5) and by_type["a"].scores is None
     assert by_type["b"].score is None
     np.testing.assert_allclose(by_type["b"].scores, [0.1, 0.2, 0.3])
+
+
+def test_slp_event_only_video_roundtrip(tmp_path):
+    """A video referenced only by an event is persisted, not dropped to None."""
+    video = Video(filename="clip.mp4")
+    labels = Labels(
+        events=[UserEvent(type="stim", video=video, start_frame=5, end_frame=9)]
+    )
+    # Collected into the catalog at construction (not on any frame/suggestion).
+    assert video in labels.videos
+    path = tmp_path / "eventvid.slp"
+    save_slp(labels, path)
+    loaded = load_slp(path)
+    assert loaded.events[0].video is not None
+    assert loaded.events[0].video in loaded.videos
+
+
+def test_slp_event_only_video_roundtrip_lazy(tmp_path):
+    """An event-only video appended to a lazy Labels survives the lazy save path."""
+    base = Labels(videos=[Video(filename="base.mp4")])
+    path = tmp_path / "base.slp"
+    save_slp(base, path)
+
+    lazy = load_slp(path, lazy=True)
+    extra = Video(filename="extra.mp4")
+    lazy.events.append(UserEvent(type="x", video=extra, start_frame=0, end_frame=2))
+    path2 = tmp_path / "with_event.slp"
+    save_slp(lazy, path2)
+
+    loaded = load_slp(path2)
+    assert len(loaded.events) == 1
+    ev = loaded.events[0]
+    assert ev.video is not None and ev.video in loaded.videos
+    assert str(ev.video.filename).endswith("extra.mp4")
+
+
+def test_slp_event_video_survives_embed(tmp_path):
+    """event.video is remapped to the embedded video on save_slp(embed=True).
+
+    ``embed_videos`` swaps each source video for a new embedded one via
+    ``Labels.replace_videos``; without remapping ``event.video`` there, the event's
+    video would strand and serialize to the ``-1`` sentinel (silent data loss).
+    """
+    video = Video.from_filename("tests/data/videos/small_robot_3_frame.mp4")
+    lf = LabeledFrame(video=video, frame_idx=0)
+    labels = Labels(
+        labeled_frames=[lf],
+        videos=[video],
+        events=[UserEvent(type="attack", video=video, start_frame=0, end_frame=0)],
+    )
+    out = tmp_path / "embedded.pkg.slp"
+    save_slp(labels, out, embed=True)
+
+    loaded = load_slp(out)
+    assert len(loaded.events) == 1
+    ev = loaded.events[0]
+    # The video reference survives and points at the (embedded) catalog video.
+    assert ev.video is not None
+    assert ev.video in loaded.videos

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -77,6 +77,8 @@ from sleap_io.io.slp import (
     read_bboxes,
     read_centroids,
     read_embeddings,
+    read_event_types,
+    read_events,
     read_identities,
     read_identity_links,
     read_instances,
@@ -100,6 +102,8 @@ from sleap_io.io.slp import (
     video_to_dict,
     write_bboxes,
     write_centroids,
+    write_event_types,
+    write_events,
     write_identities,
     write_labels,
     write_lfs,
@@ -120,6 +124,7 @@ from sleap_io.io.video_reading import (
 from sleap_io.model.bbox import PredictedBoundingBox, UserBoundingBox
 from sleap_io.model.centroid import PredictedCentroid, UserCentroid
 from sleap_io.model.embedding import Embedding
+from sleap_io.model.event import EventType, PredictedEvent, UserEvent
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance3D, PredictedInstance3D
 from sleap_io.model.label_image import LabelImage, PredictedLabelImage, UserLabelImage
@@ -10378,3 +10383,366 @@ def test_save_prefer_metadata_grayscale_flip_consistent(tmp_path, small_robot_pa
     # The flip survives and shape/grayscale agree off metadata.
     assert rec_video.backend_metadata["shape"][-1] == 1
     assert rec_video.grayscale is True
+
+
+# --- Frame-spanning events (SLP 2.6+) --------------------------------------
+
+
+def _event_labels():
+    """Build a Labels exercising every event feature for round-trip tests."""
+    video = Video(filename="clip.mp4")
+    m1, m2 = Track(name="mouse1"), Track(name="mouse2")
+    idA = Identity(name="mouseA")
+    attack = EventType(
+        name="attack",
+        description="one mouse attacks another",
+        metadata={"color": "#e6194b"},
+    )
+    events = [
+        UserEvent(
+            type=attack,
+            video=video,
+            start_frame=10,
+            end_frame=20,
+            subject=m1,
+            target=m2,
+            name="bout1",
+            source="hand",
+            metadata={"scorer": "alice"},
+        ),
+        UserEvent(type="rear", video=video, start_frame=15, subject=m1),
+        PredictedEvent(
+            type="freeze",
+            video=video,
+            start_frame=5,
+            end_frame=9,
+            scores=[0.1, 0.2, 0.3, 0.4, 0.5],
+            score=0.7,
+            subject=idA,
+        ),
+        PredictedEvent(
+            type="freeze", video=video, start_frame=30, end_frame=32, score=0.9
+        ),
+        UserEvent(type="light_on", video=video, start_frame=0, end_frame=100),
+    ]
+    return Labels(videos=[video], tracks=[m1, m2], events=events)
+
+
+def test_slp_event_roundtrip(tmp_path):
+    """Events + their catalog round-trip through SLP with all fields intact."""
+    labels = _event_labels()
+    path = tmp_path / "events.slp"
+    save_slp(labels, path)
+
+    loaded = load_slp(path)
+    assert len(loaded.events) == 5
+    assert sorted(et.name for et in loaded.event_types) == [
+        "attack",
+        "freeze",
+        "light_on",
+        "rear",
+    ]
+    by_type = {}
+    for ev in loaded.events:
+        by_type.setdefault(ev.type.name, []).append(ev)
+
+    a = by_type["attack"][0]
+    assert (a.start_frame, a.end_frame) == (10, 20)
+    assert a.subject.name == "mouse1" and a.target.name == "mouse2"
+    assert a.subject in loaded.tracks and a.target in loaded.tracks
+    assert a.name == "bout1" and a.source == "hand"
+    assert a.metadata == {"scorer": "alice"}
+    assert not a.is_predicted
+    # EventType description + metadata round-trip via /event_types.
+    assert a.type.description == "one mouse attacks another"
+    assert a.type.metadata == {"color": "#e6194b"}
+    # Catalog entry is shared (canonicalized), not duplicated.
+    assert a.type in loaded.event_types
+
+    r = by_type["rear"][0]
+    assert r.is_instantaneous and r.start_frame == 15 and r.subject.name == "mouse1"
+
+    lo = by_type["light_on"][0]
+    assert lo.subject is None and lo.target is None
+    assert (lo.start_frame, lo.end_frame) == (0, 100)
+    assert lo.video in loaded.videos
+
+
+def test_slp_event_predicted_scores(tmp_path):
+    """Framewise scores (float32 CSR) and the scalar score round-trip independently."""
+    labels = _event_labels()
+    path = tmp_path / "events.slp"
+    save_slp(labels, path)
+    loaded = load_slp(path)
+
+    freezes = [ev for ev in loaded.events if ev.type.name == "freeze"]
+    with_trace = [ev for ev in freezes if ev.scores is not None]
+    scalar_only = [ev for ev in freezes if ev.scores is None]
+    assert len(with_trace) == 1 and len(scalar_only) == 1
+
+    ft = with_trace[0]
+    assert ft.is_predicted and ft.scores.dtype == np.float32
+    np.testing.assert_allclose(ft.scores, [0.1, 0.2, 0.3, 0.4, 0.5])
+    assert ft.score == pytest.approx(0.7)
+    assert ft.subject.name == "mouseA" and ft.subject in loaded.identities
+
+    assert scalar_only[0].score == pytest.approx(0.9)
+    assert scalar_only[0].scores is None
+
+
+def test_slp_event_format_version(tmp_path):
+    """Events bump the SLP format_id to 2.6."""
+    labels = _event_labels()
+    path = tmp_path / "events.slp"
+    save_slp(labels, path)
+    with h5py.File(path, "r") as f:
+        assert float(f["metadata"].attrs["format_id"]) == pytest.approx(2.6)
+
+
+def test_slp_event_no_events_omits_groups(tmp_path):
+    """A Labels with no events writes neither group and stays below format 2.6."""
+    labels = Labels(videos=[Video(filename="clip.mp4")])
+    path = tmp_path / "noev.slp"
+    save_slp(labels, path)
+    with h5py.File(path, "r") as f:
+        assert "events" not in f and "event_types" not in f
+        assert float(f["metadata"].attrs["format_id"]) < 2.6
+    loaded = load_slp(path)
+    assert loaded.events == [] and loaded.event_types == []
+
+
+def test_slp_event_user_only_presence_guards(tmp_path):
+    """User-only events omit the score column and both framewise-trace datasets."""
+    video = Video(filename="clip.mp4")
+    labels = Labels(
+        videos=[video],
+        events=[UserEvent(type="rear", video=video, start_frame=1, end_frame=3)],
+    )
+    path = tmp_path / "useronly.slp"
+    save_slp(labels, path)
+    with h5py.File(path, "r") as f:
+        keys = set(f["events"].keys())
+        assert "score" not in keys
+        assert "scores" not in keys and "score_offsets" not in keys
+        assert "meta_owner" not in keys  # no per-event metadata
+    loaded = load_slp(path)
+    assert len(loaded.events) == 1 and not loaded.events[0].is_predicted
+
+
+def test_slp_event_scalar_score_only(tmp_path):
+    """A predicted event with a scalar score but no trace omits the trace datasets."""
+    video = Video(filename="clip.mp4")
+    labels = Labels(
+        videos=[video],
+        events=[
+            PredictedEvent(type="x", video=video, start_frame=0, end_frame=4, score=0.5)
+        ],
+    )
+    path = tmp_path / "scalar.slp"
+    save_slp(labels, path)
+    with h5py.File(path, "r") as f:
+        keys = set(f["events"].keys())
+        assert "score" in keys
+        assert "scores" not in keys and "score_offsets" not in keys
+    loaded = load_slp(path)
+    assert loaded.events[0].score == pytest.approx(0.5)
+    assert loaded.events[0].scores is None
+
+
+def test_slp_event_type_description_omitted_when_empty(tmp_path):
+    """The /event_types description dataset is omitted when no type describes itself."""
+    video = Video(filename="clip.mp4")
+    labels = Labels(
+        videos=[video],
+        events=[UserEvent(type="rear", video=video, start_frame=0)],
+    )
+    path = tmp_path / "nodesc.slp"
+    save_slp(labels, path)
+    with h5py.File(path, "r") as f:
+        assert "description" not in f["event_types"]
+    loaded = load_slp(path)
+    assert loaded.event_types[0].description == ""
+
+
+def test_slp_event_large_frame_indices(tmp_path):
+    """int64-range frame indices survive the round-trip (data reaches frame 587,937)."""
+    video = Video(filename="clip.mp4")
+    labels = Labels(
+        videos=[video],
+        events=[
+            UserEvent(type="x", video=video, start_frame=587_000, end_frame=587_937)
+        ],
+    )
+    path = tmp_path / "big.slp"
+    save_slp(labels, path)
+    loaded = load_slp(path)
+    ev = loaded.events[0]
+    assert ev.start_frame == 587_000 and ev.end_frame == 587_937
+    assert ev.n_frames == 938
+
+
+def test_slp_event_lazy_roundtrip(tmp_path):
+    """Events round-trip through the lazy read/write fast path."""
+    labels = _event_labels()
+    path = tmp_path / "events.slp"
+    save_slp(labels, path)
+
+    lazy = load_slp(path, lazy=True)
+    assert lazy.is_lazy
+    assert len(lazy.events) == 5
+    assert sorted(et.name for et in lazy.event_types) == [
+        "attack",
+        "freeze",
+        "light_on",
+        "rear",
+    ]
+
+    path2 = tmp_path / "events_lazy.slp"
+    save_slp(lazy, path2)
+    reloaded = load_slp(path2)
+    assert len(reloaded.events) == 5
+    ft = [
+        ev
+        for ev in reloaded.events
+        if ev.type.name == "freeze" and ev.scores is not None
+    ]
+    assert len(ft) == 1
+    np.testing.assert_allclose(ft[0].scores, [0.1, 0.2, 0.3, 0.4, 0.5])
+
+
+def test_slp_event_lazy_copy_preserves_events(tmp_path):
+    """Copying a lazy Labels deep-copies events with references remapped."""
+    labels = _event_labels()
+    path = tmp_path / "events.slp"
+    save_slp(labels, path)
+    lazy = load_slp(path, lazy=True)
+
+    lc = lazy.copy()
+    assert len(lc.events) == 5
+    for ev in lc.events:
+        assert ev.type in lc.event_types
+        assert ev.video in lc.videos
+        if ev.subject is not None:
+            assert ev.subject in lc.tracks or ev.subject in lc.identities
+
+
+def test_slp_event_backward_compat(slp_typical):
+    """An SLP written before format 2.6 loads with empty event lists."""
+    loaded = load_slp(slp_typical)
+    assert loaded.events == []
+    assert loaded.event_types == []
+
+
+def test_read_events_type_index_none_fallback(tmp_path):
+    """Serialize an event whose type is not in the catalog.
+
+    The type resolves to ``-1`` and reads back as a blank ``EventType`` (the
+    documented ``-1 = none`` value).
+    """
+    video = Video(filename="clip.mp4")
+    orphan_type = EventType(name="orphan")
+    ev = UserEvent(type=orphan_type, video=video, start_frame=0, end_frame=2)
+    path = tmp_path / "orphan.slp"
+    # Write with an EMPTY event_types list so the type resolves to index -1.
+    write_events(str(path), [ev], [video], [], [], [])
+    loaded = read_events(str(path), [video], [], [], [])
+    assert len(loaded) == 1
+    assert isinstance(loaded[0].type, EventType)
+    assert loaded[0].type.name == ""
+
+
+def test_write_read_event_types_direct(tmp_path):
+    """write_event_types / read_event_types round-trip the catalog directly."""
+    path = tmp_path / "cat.slp"
+    types = [
+        EventType(name="attack", description="d", metadata={"color": "#fff"}),
+        EventType(name="rear"),
+    ]
+    write_event_types(str(path), types)
+    loaded = read_event_types(str(path))
+    assert [et.name for et in loaded] == ["attack", "rear"]
+    assert loaded[0].description == "d" and loaded[0].metadata == {"color": "#fff"}
+    assert loaded[1].description == "" and loaded[1].metadata == {}
+
+
+def test_write_events_empty_is_noop(tmp_path):
+    """write_events / write_event_types are no-ops on empty input."""
+    path = tmp_path / "empty.slp"
+    # Seed a file so the append-mode writers have something to open.
+    write_event_types(str(path), [EventType(name="x")])
+    write_events(str(path), [], [], [], [], [])
+    with h5py.File(path, "r") as f:
+        assert "events" not in f
+    assert read_events(str(path), [], [], [], []) == []
+
+
+def test_read_event_types_absent(tmp_path):
+    """read_event_types / read_events return empty lists when the groups are absent."""
+    video = Video(filename="clip.mp4")
+    labels = Labels(videos=[video])
+    path = tmp_path / "plain.slp"
+    save_slp(labels, path)
+    assert read_event_types(str(path)) == []
+    assert read_events(str(path), [video], [], [], []) == []
+
+
+def test_slp_event_predicted_trace_without_scalar_score(tmp_path):
+    """A predicted event with a framewise trace but no scalar score round-trips.
+
+    The scalar ``score`` column is omitted and reads back as ``None``.
+    """
+    video = Video(filename="clip.mp4")
+    labels = Labels(
+        videos=[video],
+        events=[
+            PredictedEvent(
+                type="freeze",
+                video=video,
+                start_frame=0,
+                end_frame=2,
+                scores=[0.1, 0.2, 0.3],
+            )
+        ],
+    )
+    path = tmp_path / "traceonly.slp"
+    save_slp(labels, path)
+    with h5py.File(path, "r") as f:
+        assert "score" not in f["events"]  # no scalar score anywhere
+        assert "scores" in f["events"]  # framewise trace present
+    loaded = load_slp(path)
+    ev = loaded.events[0]
+    assert ev.is_predicted and ev.score is None
+    np.testing.assert_allclose(ev.scores, [0.1, 0.2, 0.3])
+
+
+def test_slp_event_mixed_scalar_score(tmp_path):
+    """Unset scalar scores are stored as NaN and read back as ``None``.
+
+    Exercises the mixed case where some predicted events set a scalar score and
+    others do not.
+    """
+    video = Video(filename="clip.mp4")
+    labels = Labels(
+        videos=[video],
+        events=[
+            PredictedEvent(
+                type="a", video=video, start_frame=0, end_frame=1, score=0.5
+            ),
+            PredictedEvent(
+                type="b",
+                video=video,
+                start_frame=2,
+                end_frame=4,
+                scores=[0.1, 0.2, 0.3],
+            ),
+        ],
+    )
+    path = tmp_path / "mixed.slp"
+    save_slp(labels, path)
+    with h5py.File(path, "r") as f:
+        assert "score" in f["events"]  # at least one scalar score -> column present
+    loaded = load_slp(path)
+    by_type = {ev.type.name: ev for ev in loaded.events}
+    assert by_type["a"].score == pytest.approx(0.5) and by_type["a"].scores is None
+    assert by_type["b"].score is None
+    np.testing.assert_allclose(by_type["b"].scores, [0.1, 0.2, 0.3])

--- a/tests/model/test_event.py
+++ b/tests/model/test_event.py
@@ -1,0 +1,337 @@
+"""Tests for the frame-spanning Event data model."""
+
+import numpy as np
+import pytest
+
+from sleap_io.model.event import (
+    Event,
+    EventType,
+    PredictedEvent,
+    UserEvent,
+)
+from sleap_io.model.identity import Identity
+from sleap_io.model.instance import Track
+
+# --- EventType ---------------------------------------------------------------
+
+
+def test_event_type_defaults():
+    """EventType has empty name/description and an empty metadata dict."""
+    et = EventType()
+    assert et.name == ""
+    assert et.description == ""
+    assert et.metadata == {}
+
+
+def test_event_type_fields():
+    """EventType stores name, description, and metadata."""
+    et = EventType(
+        name="attack",
+        description="One mouse attacks another.",
+        metadata={"color": "#e6194b"},
+    )
+    assert et.name == "attack"
+    assert et.description == "One mouse attacks another."
+    assert et.metadata == {"color": "#e6194b"}
+
+
+def test_event_type_identity_equality():
+    """Two EventTypes with the same name are not equal (object-identity eq)."""
+    a = EventType(name="rear")
+    b = EventType(name="rear")
+    assert a is not b
+    assert a != b
+    assert a == a
+
+
+def test_event_type_matches():
+    """matches() supports name (default), identity, and rejects unknown methods."""
+    a = EventType(name="rear")
+    b = EventType(name="rear")
+    c = EventType(name="freeze")
+    assert a.matches(b)  # default method="name"
+    assert a.matches(b, method="name")
+    assert not a.matches(c)
+    assert a.matches(a, method="identity")
+    assert not a.matches(b, method="identity")
+    with pytest.raises(ValueError, match="Unknown matching method"):
+        a.matches(b, method="bogus")
+
+
+def test_event_type_repr():
+    """EventType has a compact repr showing only the name."""
+    assert repr(EventType(name="attack")) == 'EventType(name="attack")'
+
+
+def test_event_type_validators():
+    """EventType validates field types."""
+    with pytest.raises(TypeError):
+        EventType(name=5)
+    with pytest.raises(TypeError):
+        EventType(description=5)
+    with pytest.raises(TypeError):
+        EventType(metadata="notadict")
+
+
+# --- Event (abstract base) ---------------------------------------------------
+
+
+def test_event_abstract():
+    """Event cannot be instantiated directly."""
+    with pytest.raises(TypeError, match="Event is abstract"):
+        Event(type="attack", video="v", start_frame=0)
+
+
+def test_event_type_auto_promotion():
+    """A bare-string type is auto-promoted to an EventType(name=...)."""
+    e = UserEvent(type="attack", video="v", start_frame=0)
+    assert isinstance(e.type, EventType)
+    assert e.type.name == "attack"
+
+
+def test_event_type_object_passthrough():
+    """An EventType object passed as type is stored as-is (not copied)."""
+    et = EventType(name="rear")
+    e = UserEvent(type=et, video="v", start_frame=0)
+    assert e.type is et
+
+
+def test_event_type_invalid():
+    """A non-string, non-EventType type is rejected by the validator."""
+    with pytest.raises(TypeError):
+        UserEvent(type=5, video="v", start_frame=0)
+
+
+def test_event_defaults():
+    """Event defaults: end_frame=start_frame, no participants, empty metadata."""
+    e = UserEvent(type="rear", video="v", start_frame=10)
+    assert e.end_frame == 10
+    assert e.subject is None
+    assert e.target is None
+    assert e.name == ""
+    assert e.source == ""
+    assert e.metadata == {}
+
+
+def test_event_end_frame_fill():
+    """Omitting end_frame yields an instantaneous single-frame event."""
+    e = UserEvent(type="rear", video="v", start_frame=42)
+    assert e.end_frame == 42
+    assert e.is_instantaneous
+    assert e.n_frames == 1
+    assert list(e.frames) == [42]
+
+
+def test_event_span():
+    """A multi-frame span reports the right length, frames, and containment."""
+    e = UserEvent(type="rear", video="v", start_frame=5, end_frame=9)
+    assert e.end_frame == 9
+    assert not e.is_instantaneous
+    assert e.n_frames == 5
+    assert list(e.frames) == [5, 6, 7, 8, 9]
+    assert e.frames == range(5, 10)
+    # Inclusive containment at both ends.
+    assert e.contains(5)
+    assert e.contains(9)
+    assert e.contains(7)
+    assert not e.contains(4)
+    assert not e.contains(10)
+
+
+def test_event_end_before_start():
+    """end_frame < start_frame is rejected."""
+    with pytest.raises(ValueError, match="end_frame >= start_frame"):
+        UserEvent(type="rear", video="v", start_frame=10, end_frame=3)
+
+
+def test_event_frame_indices_coerced_to_int():
+    """Numpy integer frame indices are coerced to Python ints."""
+    e = UserEvent(
+        type="rear",
+        video="v",
+        start_frame=np.int64(5),
+        end_frame=np.int64(9),
+    )
+    assert isinstance(e.start_frame, int)
+    assert isinstance(e.end_frame, int)
+    assert e.n_frames == 5
+
+
+def test_event_large_frame_indices():
+    """Frame indices well beyond int16/int32 are handled (int64 range)."""
+    e = UserEvent(type="rear", video="v", start_frame=587_000, end_frame=587_937)
+    assert e.n_frames == 938
+    assert e.contains(587_937)
+
+
+def test_event_directedness():
+    """is_directed reflects whether a target is set."""
+    m1, m2 = Track(name="mouse1"), Track(name="mouse2")
+    directed = UserEvent(
+        type="attack", video="v", start_frame=0, end_frame=2, subject=m1, target=m2
+    )
+    assert directed.is_directed
+    assert directed.subject is m1
+    assert directed.target is m2
+
+    non_directed = UserEvent(type="rear", video="v", start_frame=0, subject=m1)
+    assert not non_directed.is_directed
+    assert non_directed.target is None
+
+
+def test_event_participants_track_or_identity():
+    """subject/target accept either a Track or an Identity."""
+    track = Track(name="mouse1")
+    ident = Identity(name="mouse_A")
+    e = UserEvent(type="attack", video="v", start_frame=0, subject=ident, target=track)
+    assert e.subject is ident
+    assert e.target is track
+
+
+def test_event_overlaps_same_video():
+    """Events in the same video overlap iff their inclusive spans intersect."""
+    video = object()
+    a = UserEvent(type="x", video=video, start_frame=0, end_frame=10)
+    touching = UserEvent(type="x", video=video, start_frame=10, end_frame=20)
+    disjoint = UserEvent(type="x", video=video, start_frame=11, end_frame=20)
+    contained = UserEvent(type="x", video=video, start_frame=3, end_frame=4)
+
+    assert a.overlaps(touching)  # share frame 10
+    assert touching.overlaps(a)  # symmetric
+    assert not a.overlaps(disjoint)
+    assert a.overlaps(contained)
+
+
+def test_event_overlaps_different_video():
+    """Events in different videos never overlap, even at the same frames."""
+    a = UserEvent(type="x", video=object(), start_frame=0, end_frame=10)
+    b = UserEvent(type="x", video=object(), start_frame=0, end_frame=10)
+    assert not a.overlaps(b)
+
+
+def test_event_identity_equality():
+    """Events use object-identity equality."""
+    a = UserEvent(type="x", video="v", start_frame=0, end_frame=5)
+    b = UserEvent(type="x", video="v", start_frame=0, end_frame=5)
+    assert a is not b
+    assert a != b
+    assert a == a
+
+
+def test_event_metadata_and_strings():
+    """name/source/metadata are stored and validated."""
+    e = UserEvent(
+        type="x",
+        video="v",
+        start_frame=0,
+        name="bout_1",
+        source="hand_scored",
+        metadata={"scorer": "alice"},
+    )
+    assert e.name == "bout_1"
+    assert e.source == "hand_scored"
+    assert e.metadata == {"scorer": "alice"}
+    with pytest.raises(TypeError):
+        UserEvent(type="x", video="v", start_frame=0, name=5)
+    with pytest.raises(TypeError):
+        UserEvent(type="x", video="v", start_frame=0, metadata="notadict")
+
+
+# --- UserEvent / PredictedEvent ----------------------------------------------
+
+
+def test_user_event_not_predicted():
+    """UserEvent is not a prediction and carries no score fields."""
+    e = UserEvent(type="x", video="v", start_frame=0)
+    assert not e.is_predicted
+    assert not hasattr(e, "score")
+    assert not hasattr(e, "scores")
+
+
+def test_predicted_event_is_predicted():
+    """PredictedEvent reports is_predicted True."""
+    e = PredictedEvent(type="x", video="v", start_frame=0)
+    assert e.is_predicted
+
+
+def test_predicted_event_scores_none_by_default():
+    """Both score fields default to None and are independent."""
+    e = PredictedEvent(type="x", video="v", start_frame=0, end_frame=5)
+    assert e.scores is None
+    assert e.score is None
+
+
+def test_predicted_event_framewise_scores():
+    """Framewise scores are stored as a float32 array aligned to frames."""
+    e = PredictedEvent(
+        type="x",
+        video="v",
+        start_frame=0,
+        end_frame=4,
+        scores=[0.1, 0.2, 0.3, 0.4, 0.5],
+    )
+    assert isinstance(e.scores, np.ndarray)
+    assert e.scores.dtype == np.float32
+    assert len(e.scores) == e.n_frames == 5
+    np.testing.assert_allclose(e.scores, [0.1, 0.2, 0.3, 0.4, 0.5], atol=1e-6)
+    # Framewise trace aligns element-wise with the frame range.
+    assert len(e.scores) == len(e.frames)
+
+
+def test_predicted_event_scalar_score():
+    """A scalar event-level score is stored independently of any trace."""
+    e = PredictedEvent(type="x", video="v", start_frame=0, end_frame=4, score=0.9)
+    assert e.score == pytest.approx(0.9)
+    assert e.scores is None
+
+
+def test_predicted_event_both_scores():
+    """A predictor may set both the scalar and the framewise scores."""
+    e = PredictedEvent(
+        type="x",
+        video="v",
+        start_frame=0,
+        end_frame=2,
+        scores=[0.5, 0.6, 0.7],
+        score=0.6,
+    )
+    assert e.score == pytest.approx(0.6)
+    assert len(e.scores) == 3
+
+
+def test_predicted_event_scores_length_mismatch():
+    """Framewise scores must have length n_frames."""
+    with pytest.raises(ValueError, match="length n_frames"):
+        PredictedEvent(
+            type="x", video="v", start_frame=0, end_frame=4, scores=[0.1, 0.2]
+        )
+
+
+def test_predicted_event_scores_not_1d():
+    """Framewise scores must be 1-dimensional."""
+    with pytest.raises(ValueError, match="1-dimensional"):
+        PredictedEvent(
+            type="x",
+            video="v",
+            start_frame=0,
+            end_frame=1,
+            scores=[[0.1, 0.2], [0.3, 0.4]],
+        )
+
+
+def test_predicted_event_instantaneous_scores():
+    """An instantaneous predicted event accepts a length-1 framewise trace."""
+    e = PredictedEvent(type="x", video="v", start_frame=7, scores=[0.8])
+    assert e.n_frames == 1
+    assert len(e.scores) == 1
+    assert e.scores.dtype == np.float32
+
+
+def test_top_level_exports():
+    """Event classes are importable from the package root."""
+    import sleap_io as sio
+
+    assert sio.Event is Event
+    assert sio.EventType is EventType
+    assert sio.UserEvent is UserEvent
+    assert sio.PredictedEvent is PredictedEvent

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -9269,3 +9269,17 @@ def test_labels_replace_videos_remaps_events():
     labels.replace_videos(video_map={old: new})
     assert labels.events[0].video is new
     assert labels.videos == [new]
+
+
+def test_labels_merge_event_only_video():
+    """Merging a Labels whose event references an event-only video keeps the video."""
+    from sleap_io.model.event import UserEvent
+
+    la = Labels(videos=[Video(filename="a.mp4")])
+    vb = Video(filename="b.mp4")
+    lb = Labels(events=[UserEvent(type="x", video=vb, start_frame=0, end_frame=2)])
+    la.merge(lb)
+    assert len(la.events) == 1
+    ev = la.events[0]
+    assert ev.video is not None
+    assert ev.video in la.videos

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -9242,3 +9242,30 @@ def test_labels_merge_events():
     rear = la.get_events(type="rear")[0]
     assert rear.is_predicted
     assert_allclose(rear.scores, [0.1, 0.2, 0.3])
+
+
+def test_labels_collect_event_video():
+    """Constructing Labels collects an event's video into labels.videos."""
+    from sleap_io.model.event import UserEvent
+
+    v = Video(filename="clip.mp4")
+    # Video is referenced only by an event (no labeled frame / suggestion / videos=).
+    labels = Labels(
+        events=[UserEvent(type="stim", video=v, start_frame=5, end_frame=9)]
+    )
+    assert v in labels.videos
+
+
+def test_labels_replace_videos_remaps_events():
+    """replace_videos remaps event.video references onto the new videos."""
+    from sleap_io.model.event import UserEvent
+
+    old = Video(filename="old.mp4")
+    new = Video(filename="new.mp4")
+    labels = Labels(
+        videos=[old],
+        events=[UserEvent(type="x", video=old, start_frame=0, end_frame=2)],
+    )
+    labels.replace_videos(video_map={old: new})
+    assert labels.events[0].video is new
+    assert labels.videos == [new]

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -9069,3 +9069,176 @@ def test_labels_convert_lazy_read_only_allowed(slp_typical):
 
     results = lazy.convert("centroid", source="pose")
     assert isinstance(results, list)
+
+
+# --- Frame-spanning events -------------------------------------------------
+
+
+def test_labels_events_collection():
+    """Constructing Labels collects event types (name-dedup) and participants."""
+    from sleap_io.model.event import EventType, PredictedEvent, UserEvent
+
+    v = Video(filename="clip.mp4")
+    m1, m2 = Track(name="mouse1"), Track(name="mouse2")
+    idA = Identity(name="mouseA")
+    # Two separate string-typed "attack" events -> one catalog entry, rebound.
+    e1 = UserEvent(
+        type="attack", video=v, start_frame=0, end_frame=5, subject=m1, target=m2
+    )
+    e2 = UserEvent(type="attack", video=v, start_frame=10, subject=m2)
+    e3 = PredictedEvent(type="rear", video=v, start_frame=3, subject=idA)
+    labels = Labels(videos=[v], events=[e1, e2, e3])
+
+    assert sorted(et.name for et in labels.event_types) == ["attack", "rear"]
+    # Name-dedup rebinds both "attack" events to the canonical EventType.
+    assert e1.type is e2.type
+    assert isinstance(e1.type, EventType)
+    # Participants collected into the catalogs.
+    assert m1 in labels.tracks and m2 in labels.tracks
+    assert idA in labels.identities
+
+
+def test_labels_events_collection_preserves_existing_catalog():
+    """A pre-supplied event_types entry is the canonical one events bind to."""
+    from sleap_io.model.event import EventType, UserEvent
+
+    v = Video(filename="clip.mp4")
+    canonical = EventType(name="attack", description="canonical")
+    e = UserEvent(type="attack", video=v, start_frame=0)  # distinct EventType object
+    labels = Labels(videos=[v], event_types=[canonical], events=[e])
+    assert len(labels.event_types) == 1
+    assert e.type is canonical
+
+
+def test_labels_get_events():
+    """get_events filters by video, subject, type, frame span, and predicted."""
+    from sleap_io.model.event import PredictedEvent, UserEvent
+
+    v = Video(filename="clip.mp4")
+    m1, m2 = Track(name="mouse1"), Track(name="mouse2")
+    e1 = UserEvent(type="attack", video=v, start_frame=10, end_frame=20, subject=m1)
+    e2 = UserEvent(type="attack", video=v, start_frame=30, end_frame=40, subject=m2)
+    e3 = UserEvent(type="rear", video=v, start_frame=15, subject=m1)
+    e4 = PredictedEvent(type="freeze", video=v, start_frame=12, end_frame=18)
+    labels = Labels(videos=[v], tracks=[m1, m2], events=[e1, e2, e3, e4])
+
+    assert len(labels.get_events()) == 4
+    assert set(labels.get_events(type="attack")) == {e1, e2}
+    # type accepts an EventType too (matched by name).
+    attack_type = next(et for et in labels.event_types if et.name == "attack")
+    assert set(labels.get_events(type=attack_type)) == {e1, e2}
+    assert set(labels.get_events(subject=m1)) == {e1, e3}
+    assert labels.get_events(predicted=True) == [e4]
+    assert set(labels.get_events(predicted=False)) == {e1, e2, e3}
+    assert len(labels.get_events(video=v)) == 4
+    # frame_idx matches events whose inclusive span covers the frame.
+    assert set(labels.get_events(frame_idx=15)) == {e1, e3, e4}
+    assert labels.get_events(frame_idx=35) == [e2]
+    assert labels.get_events(frame_idx=100) == []
+
+
+def test_labels_events_at():
+    """events_at returns events covering a frame, optionally by subject."""
+    from sleap_io.model.event import UserEvent
+
+    v = Video(filename="clip.mp4")
+    m1 = Track(name="mouse1")
+    e1 = UserEvent(type="attack", video=v, start_frame=10, end_frame=20, subject=m1)
+    e2 = UserEvent(type="light_on", video=v, start_frame=0, end_frame=100)
+    labels = Labels(videos=[v], tracks=[m1], events=[e1, e2])
+
+    assert set(labels.events_at(v, 15)) == {e1, e2}
+    assert labels.events_at(v, 15, subject=m1) == [e1]
+    assert labels.events_at(v, 50) == [e2]
+
+
+def test_labels_copy_events_eager():
+    """copy() deep-copies events with references remapped onto the copied catalogs."""
+    from sleap_io.model.event import PredictedEvent, UserEvent
+
+    v = Video(filename="clip.mp4")
+    m1 = Track(name="mouse1")
+    idA = Identity(name="mouseA")
+    e1 = UserEvent(type="attack", video=v, start_frame=0, end_frame=5, subject=m1)
+    e2 = PredictedEvent(
+        type="freeze",
+        video=v,
+        start_frame=1,
+        end_frame=3,
+        scores=[0.1, 0.2, 0.3],
+        subject=idA,
+    )
+    labels = Labels(videos=[v], tracks=[m1], events=[e1, e2])
+
+    lc = labels.copy()
+    assert len(lc.events) == 2
+    ce1 = lc.events[0]
+    # Independent objects.
+    assert ce1 is not e1 and ce1.video is not v
+    # References remapped onto the copied catalogs.
+    assert ce1.video is lc.videos[0]
+    assert ce1.type in lc.event_types
+    assert ce1.subject in lc.tracks
+    ce2 = lc.events[1]
+    assert ce2.subject in lc.identities
+    assert_allclose(ce2.scores, [0.1, 0.2, 0.3])
+
+
+def test_labels_merge_events():
+    """Merge concatenates events, dedupes types by name, and rebinds references."""
+    from sleap_io.model.event import PredictedEvent, UserEvent
+
+    v1 = Video(filename="clip.mp4")
+    m1a = Track(name="mouse1")
+    la = Labels(
+        videos=[v1],
+        tracks=[m1a],
+        events=[
+            UserEvent(type="attack", video=v1, start_frame=0, end_frame=5, subject=m1a)
+        ],
+    )
+    v2 = Video(filename="clip.mp4")
+    m1b = Track(name="mouse1")
+    idB = Identity(name="mouseB")
+    lb = Labels(
+        videos=[v2],
+        tracks=[m1b],
+        identities=[idB],
+        events=[
+            UserEvent(
+                type="attack", video=v2, start_frame=10, end_frame=15, subject=m1b
+            ),
+            PredictedEvent(
+                type="rear",
+                video=v2,
+                start_frame=20,
+                end_frame=22,
+                subject=idB,
+                scores=[0.1, 0.2, 0.3],
+            ),
+        ],
+    )
+
+    res = la.merge(lb, video="basename", track="name")
+    assert res.successful
+    assert len(la.events) == 3
+    # Event types deduped by name.
+    assert sorted(et.name for et in la.event_types) == ["attack", "rear"]
+    # Every merged event references la's canonical catalogs.
+    for ev in la.events:
+        assert ev.type in la.event_types
+        assert ev.video in la.videos
+    attacks = la.get_events(type="attack")
+    assert len(attacks) == 2
+    assert attacks[0].type is attacks[1].type
+    # Name-merged track: incoming "attack" subject now references la's canonical track.
+    assert all(ev.subject in la.tracks for ev in attacks)
+    # Identity participant collected into la.
+    assert any(i.name == "mouseB" for i in la.identities)
+    # Source labels not mutated.
+    assert lb.events[0].video is v2
+    assert len(lb.events) == 2
+    # Predicted event scores preserved through the merge deep-copy.
+    rear = la.get_events(type="rear")[0]
+    assert rear.is_predicted
+    assert_allclose(rear.scores, [0.1, 0.2, 0.3])

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -13,16 +13,19 @@ from shapely.geometry import box
 import sleap_io
 from sleap_io import (
     Embedding,
+    EventType,
     FrameGroup,
     Identity,
     Instance,
     InstanceGroup,
     LabeledFrame,
+    PredictedEvent,
     PredictedInstance,
     RecordingSession,
     Skeleton,
     SuggestionFrame,
     Track,
+    UserEvent,
     Video,
     load_slp,
     save_slp,
@@ -9076,8 +9079,6 @@ def test_labels_convert_lazy_read_only_allowed(slp_typical):
 
 def test_labels_events_collection():
     """Constructing Labels collects event types (name-dedup) and participants."""
-    from sleap_io.model.event import EventType, PredictedEvent, UserEvent
-
     v = Video(filename="clip.mp4")
     m1, m2 = Track(name="mouse1"), Track(name="mouse2")
     idA = Identity(name="mouseA")
@@ -9100,8 +9101,6 @@ def test_labels_events_collection():
 
 def test_labels_events_collection_preserves_existing_catalog():
     """A pre-supplied event_types entry is the canonical one events bind to."""
-    from sleap_io.model.event import EventType, UserEvent
-
     v = Video(filename="clip.mp4")
     canonical = EventType(name="attack", description="canonical")
     e = UserEvent(type="attack", video=v, start_frame=0)  # distinct EventType object
@@ -9112,8 +9111,6 @@ def test_labels_events_collection_preserves_existing_catalog():
 
 def test_labels_get_events():
     """get_events filters by video, subject, type, frame span, and predicted."""
-    from sleap_io.model.event import PredictedEvent, UserEvent
-
     v = Video(filename="clip.mp4")
     m1, m2 = Track(name="mouse1"), Track(name="mouse2")
     e1 = UserEvent(type="attack", video=v, start_frame=10, end_frame=20, subject=m1)
@@ -9139,8 +9136,6 @@ def test_labels_get_events():
 
 def test_labels_events_at():
     """events_at returns events covering a frame, optionally by subject."""
-    from sleap_io.model.event import UserEvent
-
     v = Video(filename="clip.mp4")
     m1 = Track(name="mouse1")
     e1 = UserEvent(type="attack", video=v, start_frame=10, end_frame=20, subject=m1)
@@ -9154,8 +9149,6 @@ def test_labels_events_at():
 
 def test_labels_copy_events_eager():
     """copy() deep-copies events with references remapped onto the copied catalogs."""
-    from sleap_io.model.event import PredictedEvent, UserEvent
-
     v = Video(filename="clip.mp4")
     m1 = Track(name="mouse1")
     idA = Identity(name="mouseA")
@@ -9186,8 +9179,6 @@ def test_labels_copy_events_eager():
 
 def test_labels_merge_events():
     """Merge concatenates events, dedupes types by name, and rebinds references."""
-    from sleap_io.model.event import PredictedEvent, UserEvent
-
     v1 = Video(filename="clip.mp4")
     m1a = Track(name="mouse1")
     la = Labels(
@@ -9246,8 +9237,6 @@ def test_labels_merge_events():
 
 def test_labels_collect_event_video():
     """Constructing Labels collects an event's video into labels.videos."""
-    from sleap_io.model.event import UserEvent
-
     v = Video(filename="clip.mp4")
     # Video is referenced only by an event (no labeled frame / suggestion / videos=).
     labels = Labels(
@@ -9258,8 +9247,6 @@ def test_labels_collect_event_video():
 
 def test_labels_replace_videos_remaps_events():
     """replace_videos remaps event.video references onto the new videos."""
-    from sleap_io.model.event import UserEvent
-
     old = Video(filename="old.mp4")
     new = Video(filename="new.mp4")
     labels = Labels(
@@ -9273,8 +9260,6 @@ def test_labels_replace_videos_remaps_events():
 
 def test_labels_merge_event_only_video():
     """Merging a Labels whose event references an event-only video keeps the video."""
-    from sleap_io.model.event import UserEvent
-
     la = Labels(videos=[Video(filename="a.mp4")])
     vb = Video(filename="b.mp4")
     lb = Labels(events=[UserEvent(type="x", video=vb, start_frame=0, end_frame=2)])
@@ -9283,3 +9268,105 @@ def test_labels_merge_event_only_video():
     ev = la.events[0]
     assert ev.video is not None
     assert ev.video in la.videos
+
+
+def test_labels_merge_events_idempotent():
+    """Re-merging the same source is idempotent: identical events are not duplicated."""
+
+    def make():
+        v = Video(filename="clip.mp4")
+        m = Track(name="m1")
+        return Labels(
+            videos=[v],
+            tracks=[m],
+            events=[
+                UserEvent(type="attack", video=v, start_frame=0, end_frame=5, subject=m)
+            ],
+        )
+
+    la = make()
+    for _ in range(3):
+        la.merge(make(), video="basename", track="name")
+    # The same (video, span, type, subject, target, predicted?) event collapses.
+    assert len(la.events) == 1
+    assert len(la.event_types) == 1
+    assert len(la.videos) == 1
+    assert len(la.tracks) == 1
+
+
+def test_labels_merge_events_distinct_not_deduped():
+    """A genuinely different event still merges alongside an existing one."""
+    v1 = Video(filename="clip.mp4")
+    la = Labels(
+        videos=[v1],
+        events=[UserEvent(type="attack", video=v1, start_frame=0, end_frame=5)],
+    )
+    v2 = Video(filename="clip.mp4")
+    lb = Labels(
+        videos=[v2],
+        events=[UserEvent(type="attack", video=v2, start_frame=10, end_frame=15)],
+    )
+    la.merge(lb, video="basename")
+    # Same type/video but a different span -> a distinct event, kept.
+    assert len(la.events) == 2
+    assert len(la.event_types) == 1
+    assert {(e.start_frame, e.end_frame) for e in la.events} == {(0, 5), (10, 15)}
+
+
+def test_labels_merge_events_user_vs_predicted_not_deduped():
+    """A user and a predicted event with the same span are distinct identities."""
+    v1 = Video(filename="clip.mp4")
+    la = Labels(
+        videos=[v1],
+        events=[UserEvent(type="attack", video=v1, start_frame=0, end_frame=5)],
+    )
+    v2 = Video(filename="clip.mp4")
+    lb = Labels(
+        videos=[v2],
+        events=[PredictedEvent(type="attack", video=v2, start_frame=0, end_frame=5)],
+    )
+    la.merge(lb, video="basename")
+    assert len(la.events) == 2
+    assert {e.is_predicted for e in la.events} == {False, True}
+
+
+def test_labels_merge_events_post_hoc_participants_not_duplicated():
+    """Events appended post-hoc (no update) route participants through the matchers.
+
+    ``merge`` normalizes ``other``'s event catalogs first, so an event's video and
+    subject dedupe onto ``self``'s equivalents instead of landing as orphan copies.
+    """
+    vA = Video(filename="shared.mp4")
+    tA = Track(name="mouse1")
+    la = Labels(videos=[vA], tracks=[tA])
+
+    lb = Labels()  # empty; event appended WITHOUT update()/save()
+    vB = Video(filename="shared.mp4")
+    tB = Track(name="mouse1")
+    lb.events.append(
+        UserEvent(type="attack", video=vB, start_frame=0, end_frame=3, subject=tB)
+    )
+
+    la.merge(lb, video="basename", track="name")
+    assert len(la.videos) == 1  # not duplicated to two "shared.mp4"
+    assert len(la.tracks) == 1
+    ev = la.events[0]
+    assert ev.video is la.videos[0]
+    assert ev.subject is la.tracks[0]
+
+
+def test_labels_merge_events_does_not_mutate_clean_source():
+    """A source normalized at construction is not mutated by merge."""
+    v = Video(filename="clip.mp4")
+    src = Labels(
+        videos=[v],
+        events=[UserEvent(type="attack", video=v, start_frame=0, end_frame=5)],
+    )
+    before = (len(src.events), len(src.videos), src.events[0].video, src.events[0].type)
+    Labels().merge(src, video="basename")
+    assert (
+        len(src.events),
+        len(src.videos),
+        src.events[0].video,
+        src.events[0].type,
+    ) == before

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -9370,3 +9370,19 @@ def test_labels_merge_events_does_not_mutate_clean_source():
         src.events[0].video,
         src.events[0].type,
     ) == before
+
+
+def test_labels_event_types_dedup_pre_supplied_duplicates():
+    """Duplicate-named event_types passed directly collapse to one canonical entry."""
+    v = Video(filename="clip.mp4")
+    d1 = EventType(name="groom", description="first")
+    d2 = EventType(name="groom", description="second")
+    labels = Labels(
+        videos=[v],
+        event_types=[d1, d2],
+        events=[UserEvent(type=d1, video=v, start_frame=0, end_frame=1)],
+    )
+    # Both same-named entries collapse to the first-seen one.
+    assert [et.name for et in labels.event_types] == ["groom"]
+    assert labels.event_types[0] is d1
+    assert labels.events[0].type is d1


### PR DESCRIPTION
## Summary

Implements #539 **in full** — the frame-spanning `Event` annotation, end to end: data
model, `Labels` integration, SLP serialization, docs, and tests, in one PR. `Event` is
the first sleap-io annotation with a *temporal extent* (a `(video, start_frame,
end_frame, type)` interval) — every existing annotation (`Instance`, `Centroid`,
`BoundingBox`, `SegmentationMask`, `LabelImage`, `ROI`) is strictly per-frame. Events
model anything with a duration: behavior bouts (HITL behavior-segmentation), stimulus
epochs, physiological events, feeding bouts, review flags.

## Key changes

### Data model — `sleap_io/model/event.py`
- **`EventType`** — lightweight, name-matched catalog entry (the "ethogram"), following
  the `Track` / `Identity` pattern (`@define(eq=False)`, `name` / `description` /
  `metadata`, `matches()`).
- **`Event`** — abstract base carrying the interval, `subject` / `target` participants
  (`Track | Identity | None`), and metadata. Guards abstract instantiation, fills
  `end_frame`→`start_frame` when omitted, validates `end_frame >= start_frame`.
  **Inclusive** frame convention. Properties `is_predicted` / `is_directed` /
  `is_instantaneous` / `n_frames` / `frames`; methods `contains()` / `overlaps()`.
- **`UserEvent` / `PredictedEvent`** — human-vs-model split. `PredictedEvent` adds two
  independent optional fields: `scores` (framewise `(n_frames,)` `float32` trace) and
  `score` (scalar); neither is derived from the other.

### `Labels` integration
- New top-level lists **`Labels.events`** and **`Labels.event_types`** (kw_only), siblings
  of `videos` / `tracks` / `suggestions` — *not* on `LabeledFrame` (events may cover
  unlabeled frames).
- **Auto-collection**: registers referenced `EventType`s (deduped by name, canonicalizing
  each event's `type`), subject/target `Track` / `Identity`, and each event's `video`
  into the respective catalogs — at construction and at save time.
- **Accessors**: `get_events(video, subject, type, frame_idx, predicted)` (`frame_idx`
  matches events whose span *covers* the frame) and `events_at(video, frame_idx, subject)`.
- **`copy()`** (eager + lazy) and **`merge()`** carry events across, remapping every
  reference onto the copied/merged catalogs. `merge()` dedupes `event_types` by name and
  dedupes events by identity — `(video, start/end frame, type name, subject, target,
  predicted?)` — so re-merging the same source is **idempotent**; it normalizes `other`'s
  own event catalogs first so post-hoc-appended participants route through the matchers
  onto the target's catalogs instead of duplicating.
- Constructing/saving also dedupes duplicate-named `event_types` passed directly in
  `event_types=` (not just event-discovered ones), keeping a clean one-entry-per-name
  catalog.

### SLP serialization — format `2.6` (additive, presence-guarded)
- **`/event_types`** — catalog group (`name` + optional `description` + EAV `meta_*`),
  mirroring `/identity`.
- **`/events`** — columnar struct-of-arrays (one dataset per field, like `/bboxes`):
  `video`, `start_frame`/`end_frame` (int64, inclusive), `type`, `subject_kind`/
  `target_kind` (int8: 0=none/self, 1=track, 2=identity), `subject_idx`/`target_idx`,
  `is_predicted`, `score` (float64, NaN=unset), `name`/`source`, per-event EAV metadata —
  plus a **ragged CSR pair** (`scores` flat float32 + `score_offsets`) for optional
  framewise traces. The scalar `score` column, both trace datasets, and the metadata
  table are each omitted when unused; the whole group is omitted when there are no events,
  so event-free files stay byte-identical.
- Wired into the eager **and** lazy read/write paths; registered in
  `_KNOWN_TOPLEVEL_HDF5_NAMES`; `format_id` bumped to 2.6 only when events are present;
  format-version-history docstring updated.

### CLI — `sio show` / `sio convert`
- **`sio show --json`** reports `stats.n_events` / `n_event_types` plus top-level
  `events` / `event_types` arrays (type, video index, span, subject/target `kind`+`name`,
  `predicted`, `score`, `has_framewise_scores`) — parity with the `identities` treatment.
  The human `sio show` header gains an events chip.
- **`sio convert`** warns (to stderr) when a non-SLP target would silently drop events;
  SLP→SLP round-trips them.

### Docs
- `docs/model/events.md` — full model reference (frame convention, participants,
  overlap, Labels attachment, SLP persistence, merge dedup/idempotency).
- `docs/examples.md` — a HITL behavior-segmentation example.
- `docs/formats/slp.md` — the `/event_types` + `/events` groups and format 2.6.
- `docs/cli.md` — events in the `sio show --json` schema and the `sio convert` warning.

## Example

```python
import sleap_io as sio

labels = sio.load_slp("session.slp")
video, (m1, m2) = labels.videos[0], labels.tracks[:2]
attack = sio.EventType(name="attack", metadata={"color": "#e6194b"})

# Model proposal (framewise + scalar confidence, both optional/independent)
labels.events.append(sio.PredictedEvent(
    type=attack, video=video, start_frame=100, end_frame=140,   # inclusive
    subject=m1, target=m2, scores=[0.6]*41, score=0.74))
# Human ground truth (bare string auto-promotes; target=None => non-directed)
labels.events.append(sio.UserEvent(type="rear", video=video, start_frame=120, subject=m1))

labels.get_events(type="attack", predicted=True)   # proposals to review
labels.events_at(video, 130)                        # events covering frame 130
labels.save("scored.slp")                           # /event_types + /events (format 2.6)
```

## Design decisions (per the issue's "leans")

Keep the `EventType` catalog (strings auto-promote) · union `subject`/`target` fields ·
inclusive `[start_frame, end_frame]` · defer `from_predicted` · field name `type`.

## Testing

- **Model** (`test_event.py`): 32 tests, 100% line + branch coverage of `event.py`.
- **Labels** (`test_labels.py`): collection (name-dedup + rebind, participants, video),
  `get_events` / `events_at`, `copy`, `merge` (idempotent identity-dedup,
  post-hoc-participant routing, source-not-mutated, distinct/user-vs-predicted kept),
  pre-supplied `event_types` dedup, `replace_videos` remap.
- **SLP** (`test_slp.py`): round-trip (eager + lazy), framewise/scalar scores, presence
  guards, format 2.6, backward-compat (pre-2.6 → empty), the `-1 = none` type sentinel,
  event-only-video round-trip, and `event.video` surviving `embed=True`.
- **CLI** (`test_cli.py`): `show --json` events/event_types (Track + Identity
  participants), events-absent parity, header events chip, `convert` drop-warning, and
  SLP→SLP preserves-with-no-warning.
- Full `tests/` suite green; all doc code blocks execute; ruff clean; CI passing across
  macOS / Ubuntu / Windows on Python 3.10 and 3.13.

An adversarial multi-agent review (SLP / merge-copy / compat lenses, each finding
independently verified) caught and this PR fixes two silent-data-loss bugs where
`event.video` was dropped to `None` — for event-only videos and on the `embed=True` /
`apply_crops()` path — both now covered by regression tests.

A follow-up multi-agent review (merge / CLI / lazy / save-mutation lenses) surfaced and
this PR now also fixes: **non-idempotent event merges** (events duplicated on re-merge),
**post-hoc-appended participants duplicated on merge**, and the **CLI being event-blind**
(`show` and `--json` omitted events). The save-time collection was confirmed consistent
with the existing `_collect_identities` pattern, and the lazy/streaming paths were
verified clean.

Closes #539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DiaqkmRcp1L9yD8dx4jLj

