### PR TITLE
chore(release): Bump version to 0.9.0

### DIFF
--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -3,4 +3,4 @@
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release
 # version.
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
Bumps the package version from `0.8.0` to `0.9.0` ahead of the v0.9.0 release.

- Updates `sleap_io/version.py` (the single source of truth read dynamically by `pyproject.toml`).
- No other changes.

Release notes for v0.9.0 are drafted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DiaqkmRcp1L9yD8dx4jLj