### PR TITLE
feat(model,io,cli): first-class Category (class membership) mirroring Identity

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -419,8 +419,9 @@ sio show labels.slp --json
 
 Emits a single machine-readable JSON document on stdout, designed for scripting
 and for LLM agents inspecting SLP files. JSON mode always includes all details
-(full skeleton definitions, per-video info, tracks, identities, frame-spanning
-events, and provenance), so the individual detail flags are not needed:
+(full skeleton definitions, per-video info, tracks, identities, categories,
+frame-spanning events, and provenance), so the individual detail flags are not
+needed:
 
 ```json
 {
@@ -437,11 +438,13 @@ events, and provenance), so the individual detail flags are not needed:
     "n_skeletons": 1,
     "n_tracks": 0,
     "n_identities": 0,
+    "n_categories": 0,
     "n_masks": 0,
     "n_rois": 0,
     "n_events": 0,
     "n_event_types": 0,
-    "n_instances_with_identity_embedding": null
+    "n_instances_with_identity_embedding": null,
+    "n_instances_with_category_embedding": null
   },
   "skeletons": [
     {
@@ -466,6 +469,7 @@ events, and provenance), so the individual detail flags are not needed:
   ],
   "tracks": [],
   "identities": [],
+  "categories": [],
   "event_types": [],
   "events": [],
   "provenance": {}
@@ -491,9 +495,13 @@ Notes:
 
 - Output is strict JSON: NaN/Infinity are converted to `null`, so it parses
   with any standard JSON library (`sio show x.slp --json | jq .stats`).
-- `stats.n_instances_with_identity_embedding` is `null` when lazy loading is
+- `stats.n_instances_with_identity_embedding` and
+  `stats.n_instances_with_category_embedding` are `null` when lazy loading is
   active (counting would require materializing all frames); pass `--no-lazy`
-  to compute it.
+  to compute them.
+- [Categories](model/category.md) are reported alongside identities:
+  `stats.n_categories` counts the catalog and each `categories` entry is
+  `{"index", "name"}` (parallel to `identities`).
 - Embedded package details (`embedded`, `shape`, `embedded_frames`) require
   open video backends; pass `--open-videos` to populate them.
 - Frame-spanning [events](model/events.md) are reported when present. Each
@@ -1171,6 +1179,8 @@ Merged 2 files:
 | `--skeleton` | `structure` | Skeleton matching method |
 | `--video` | `auto` | Video matching method |
 | `--track` | `identity` | Track matching method |
+| `--identity` | `name` | Global identity catalog dedup method (`name`, `identity`) |
+| `--category` | `name` | Global category catalog dedup method (`name`, `identity`) |
 | `--frame` | `auto` | Frame merge strategy |
 | `--instance` | `spatial` | Instance matching method |
 | `--embed` | (none) | Embed frames in output (`user`, `all`, `suggestions`, `source`) |
@@ -1260,6 +1270,25 @@ For frame strategies that pair instances (`auto`, `update_tracks`), how to match
 ```bash
 # Use IoU for instance matching
 sio merge base.slp other.slp -o merged.slp --instance iou
+```
+
+#### Catalog Deduplication (`--identity`, `--category`)
+
+How to dedupe the global [identity](model/3d.md#identity) and
+[category](model/category.md) catalogs when combining files. Both default to
+`name` (the key that survives serialization and cross-file merges):
+
+| Method | Behavior |
+|--------|----------|
+| `name` | Merge catalog entries with identical `name` into one (default) |
+| `identity` | Match only by Python object identity (keep same-named entries from different files distinct) |
+
+```bash
+# Merge two classified files, collapsing same-named categories into one catalog
+sio merge a.slp b.slp -o merged.slp --category name
+
+# Keep every file's identities distinct (no name-based dedup)
+sio merge a.slp b.slp -o merged.slp --identity identity
 ```
 
 ### Common Scenarios
@@ -1980,7 +2009,7 @@ sio render --images frames/ --overlay masks.tif -o output.mp4
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--color-by` | auto | Color scheme: `auto`, `track`, `instance`, `node` |
+| `--color-by` | auto | Color scheme: `auto`, `track`, `instance`, `node`, `identity`, `category` |
 | `--palette` | standard | Color palette (standard, tableau10, distinct, glasbey, rainbow, etc.) |
 | `--marker-shape` | circle | Node marker: `circle`, `square`, `diamond`, `triangle`, `cross` |
 | `--marker-size` | 4.0 | Node marker radius in pixels |
@@ -1988,6 +2017,19 @@ sio render --images frames/ --overlay masks.tif -o output.mp4
 | `--alpha` | 1.0 | Pose overlay transparency (0.0-1.0) |
 | `--no-nodes` | false | Hide node markers |
 | `--no-edges` | false | Hide skeleton edges |
+
+!!! tip "Coloring by identity or category"
+    `--color-by identity` colors each detection by its global
+    [`Identity`](model/3d.md#identity), and `--color-by category` colors it by its
+    [`Category`](model/category.md) — each gets one palette color per its index in
+    `Labels.identities` / `Labels.categories` order (the same plumbing as
+    `--color-by track`). Detections with no identity/category fall back to the first
+    palette color. Both are explicit-only (never chosen by `auto`).
+
+    ```bash
+    # Color instances by their classified category (e.g. female_fly vs male_fly)
+    sio render classified.slp --color-by category -o by_category.mp4
+    ```
 
 #### Overlay Options
 

--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -113,10 +113,21 @@ file.slp
 │   └── links                    # Dataset: structured (owner_type, owner_id, identity_idx, identity_score)
 │                                 #   one row per detection that has an identity
 │
+├── /categories/                 # Group: class/category catalog (Format 2.7+, optional)
+│   ├── name                     # Dataset: vlen utf-8 str, one per category (catalog order)
+│   ├── meta_owner               # Dataset: int32 category index (EAV metadata; all three omitted if none)
+│   ├── meta_key                 # Dataset: vlen utf-8 str metadata key
+│   ├── meta_val                 # Dataset: vlen utf-8 str metadata value
+│   └── links                    # Dataset: structured (owner_type, owner_id, category_idx, category_score)
+│                                 #   one row per detection that has a category
+│
 ├── /embeddings/                 # Group: per-detection re-ID embeddings (Format 2.5+, optional)
 │   ├── vectors                  # Dataset: float (N, D), chunked + gzip (all rows share D)
 │   ├── owner_type               # Dataset: uint8 (0=instance, 2=centroid, 3=mask, 4=bbox, 5=roi)
-│   └── owner_id                 # Dataset: int64 (global instance_id or per-modality list index)
+│   ├── owner_id                 # Dataset: int64 (global instance_id or per-modality list index)
+│   ├── category_vectors         # Dataset: float (M, D'), parallel category embeddings (Format 2.7+, optional)
+│   ├── category_owner_type      # Dataset: uint8 category-embedding join (Format 2.7+, optional)
+│   └── category_owner_id        # Dataset: int64 category-embedding join (Format 2.7+, optional)
 │
 ├── /event_types/                # Group: frame-spanning event catalog (Format 2.6+, optional)
 │   ├── name                     # Dataset: vlen utf-8 str, one per event type (catalog order)
@@ -177,7 +188,8 @@ file.slp
 | `suggestions_json` | `bytes[]` | JSON array of suggested frames (optional) |
 | `sessions_json` | `bytes[]` | JSON array of recording sessions (optional) |
 | `identity/` | group | re-ID identity catalog: `name` dataset + optional `meta_owner`/`meta_key`/`meta_val` EAV metadata + per-detection `links` (Format 2.5+, optional) |
-| `embeddings/` | group | Per-detection re-ID embeddings: `vectors` `(N, D)` + `owner_type`/`owner_id` join columns (Format 2.5+, optional) |
+| `categories/` | group | class/category catalog: `name` dataset + optional `meta_owner`/`meta_key`/`meta_val` EAV metadata + per-detection `links` (Format 2.7+, optional) |
+| `embeddings/` | group | Per-detection re-ID embeddings: `vectors` `(N, D)` + `owner_type`/`owner_id` join columns; plus optional parallel `category_vectors` `(M, D')` + `category_owner_type`/`category_owner_id` for category embeddings (Format 2.5+; category datasets 2.7+, optional) |
 | `event_types/` | group | Frame-spanning event catalog: `name` dataset + optional `description` + `meta_*` EAV metadata (Format 2.6+, optional) |
 | `events/` | group | Frame-spanning event annotations: columnar per-field datasets + ragged CSR `scores`/`score_offsets` framewise traces (Format 2.6+, optional) |
 | `provenance_json` | `bytes` | JSON object of provenance metadata (optional) |
@@ -627,6 +639,52 @@ The index corresponds to the position in `/identity/name`.
 
 The `/identity` group is only written when the [`Labels`][sleap_io.Labels] object contains identities. On read, a missing group defaults to an empty catalog.
 
+## Categories
+
+[`Category`][sleap_io.Category] objects name the **class** a detection belongs to (e.g. `"female_fly"`, `"fur_shaved"`), assigned by classification or re-ID. A `Category` has exactly two fields: a human-readable `name` (a `string`, not required to be unique) and a free-form `metadata` mapping of string keys to string values. Categories are matched by `name` by default (see [`Category.matches`][sleap_io.Category.matches]), so two detections labeled `"female_fly"` refer to the same class across separately loaded files and merges.
+
+[`Labels.categories`][sleap_io.Labels] is the catalog of these objects — a list, like [`Labels.identities`][sleap_io.Labels] — auto-collected in first-seen order from the detections and instance groups on save. The `/categories` group is a **fully self-contained mirror of `/identity`** (its own catalog, EAV metadata, and per-detection `links`), introduced at **Format 2.7** (additive; older readers ignore it and category-free files are byte-identical).
+
+!!! note "Legacy `category` string"
+    Older files stored a free-form class label on ROI / bounding-box / centroid / mask annotations (the `roi_categories` / `mask_categories` / bbox / centroid `category` datasets). Those remain unchanged; the new `/categories` catalog is the first-class promotion of that concept and is written separately. See [Categories](../model/category.md).
+
+### Catalog (`/categories/name`)
+
+The `name` dataset holds one variable-length UTF-8 string per category, in catalog order:
+
+```python
+f["/categories/name"][:]  # ["female_fly", "male_fly"]
+```
+
+### Metadata (`/categories/meta_owner`, `/categories/meta_key`, `/categories/meta_val`)
+
+Free-form per-category metadata is stored as an entity-attribute-value (EAV) table, exactly like `/identity`: three parallel datasets with one row per `(category, key, value)` triple.
+
+| Dataset | Type | Description |
+|---------|------|-------------|
+| `meta_owner` | `int32` | Index of the owning category in `/categories/name` |
+| `meta_key` | vlen `str` | Metadata key |
+| `meta_val` | vlen `str` | Metadata value |
+
+All three datasets are omitted entirely when no category carries any metadata.
+
+### Per-Detection Linking (`/categories/links`)
+
+Per-detection category assignments are stored in the `/categories/links` structured dataset, with one row per detection that carries a category. Each row joins a detection — identified by an `owner_type`/`owner_id` pair (the same join scheme as `/identity/links` and `/embeddings`) — to an entry in the category catalog:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `owner_type` | `uint8` | Detection modality code (shared `OWNER_*` codes: `0`=instance, `2`=centroid, `3`=mask, `4`=bbox, `5`=roi) |
+| `owner_id` | `int64` | Per-owner-type positional id (same enumeration as `/identity/links`: global instance id for instance owners, or global per-modality list index for centroid / mask / bbox / ROI owners; static ROIs follow frame ROIs) |
+| `category_idx` | `int32` | Index into `/categories/name` |
+| `category_score` | `float32` | Category-assignment score (NaN if unrecorded) |
+
+This is additive: old readers ignore the group, and detections without a category simply have no row. Each detection also carries a single `category_embedding` slot; those vectors, when present, live alongside identity vectors in the `/embeddings` group as parallel `category_*` datasets — see [Embeddings](#embeddings).
+
+### Optional Group
+
+The `/categories` group is only written when the [`Labels`][sleap_io.Labels] object contains categories. On read, a missing group defaults to an empty catalog.
+
 ## Embeddings
 
 Per-detection appearance / re-identification [`Embedding`][sleap_io.Embedding] vectors are stored in the optional `/embeddings` group (Format 2.5+). An `Embedding` is a bare value object wrapping a single 1-D feature `vector` of shape `(D,)` (its `dim` property returns `D`); each detection — an instance, [`Centroid`][sleap_io.Centroid], [`BoundingBox`][sleap_io.BoundingBox], [`SegmentationMask`][sleap_io.SegmentationMask], or [`ROI`][sleap_io.ROI] — carries at most one, in its `identity_embedding` slot.
@@ -639,11 +697,23 @@ The group is a single columnar struct-of-arrays. Row `i` of all three datasets d
 | `owner_type` | `(N,)` | `uint8` | Detection modality code (shared `OWNER_*` codes: `0`=instance, `2`=centroid, `3`=mask, `4`=bbox, `5`=roi) |
 | `owner_id` | `(N,)` | `int64` | Per-owner-type positional id: the global instance id for instance owners, or the global per-modality list index for centroid / mask / bbox / ROI owners (matching `write_lfs` / `write_masks` / `write_centroids` / `write_bboxes` / `write_rois`; static ROIs follow frame ROIs) |
 
-All vectors in a file share a single dimensionality `D`; a mix of dimensionalities is rejected at write time. The `owner_type`/`owner_id` join is identical to the one used by `/identity/links`, so a detection's identity link and its embedding are matched by the same pair.
+All identity vectors in a file share a single dimensionality `D`; a mix of dimensionalities is rejected at write time. The `owner_type`/`owner_id` join is identical to the one used by `/identity/links`, so a detection's identity link and its embedding are matched by the same pair.
+
+### Category embeddings (parallel datasets, Format 2.7+)
+
+Each detection can also carry a `category_embedding` (the appearance vector its class was predicted from). These are stored in the **same `/embeddings` group** as a set of **parallel, independent datasets**, added at Format 2.7:
+
+| Dataset | Shape | Dtype | Description |
+|---------|-------|-------|-------------|
+| `category_vectors` | `(M, D')` | float | Stacked category embedding vectors, chunked + gzip-compressed |
+| `category_owner_type` | `(M,)` | `uint8` | Detection modality code (same shared `OWNER_*` codes) |
+| `category_owner_id` | `(M,)` | `int64` | Same per-owner-type positional id join as the identity columns |
+
+Category vectors are kept **independent** of the identity `vectors`/`owner_type`/`owner_id` datasets rather than sharing one table, so the two embedding kinds need **not** share dimensionality (`D` may differ from `D'`). A file with only identity embeddings has no `category_*` datasets and stays byte-identical to a pre-2.7 file. On read, absent `category_*` datasets simply mean no detection receives a category embedding.
 
 ### Optional Group
 
-The `/embeddings` group is only written when at least one detection carries an `identity_embedding` and embedding vectors are being persisted. Passing `save_slp(labels, path, save_embedding_vectors=False)` writes the identity `links` but skips the `/embeddings` group entirely, so the (potentially large) vectors are omitted while the identity assignments are kept. On read, a missing group means no detection receives an embedding.
+The `/embeddings` group is only written when at least one detection carries an `identity_embedding` or a `category_embedding` and embedding vectors are being persisted. Passing `save_slp(labels, path, save_embedding_vectors=False)` writes the identity and category `links` but skips the `/embeddings` group entirely, so the (potentially large) vectors are omitted while the identity/category assignments are kept. On read, a missing group means no detection receives an embedding.
 
 ## Events
 
@@ -1497,7 +1567,7 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 - Triggered automatically when any mask records a `from_predicted` link; otherwise the format stays at whatever other state drives `format_id`
 - Backward compatible: the column is always written but reads are gated on its presence, so files written before 2.4 (which lack the column) load `from_predicted` as `None`
 
-### Format 2.5 (Current)
+### Format 2.5
 
 **Re-ID identity subsystem: identity catalog, per-detection links, and appearance embeddings.**
 
@@ -1508,6 +1578,27 @@ Minor handling improvements for tracking_score (no schema change from 1.2).
 - New optional `/embeddings` group holding per-detection appearance / re-ID vectors as a single columnar struct-of-arrays: `vectors` `(N, D)` float (chunked so whole rows stay within a chunk, gzip-compressed; all vectors share one `D`) plus the `owner_type`/`owner_id` join columns (see [Embeddings](#embeddings)). Persists the single `identity_embedding` slot on each instance, `SegmentationMask`, `Centroid`, `BoundingBox`, or `ROI`; large float vectors live in gzipped numeric datasets, never in JSON
 - Triggered automatically when any detection carries an [`Identity`][sleap_io.Identity] or an embedding; identity- and embedding-free files stay at `format_id <= 2.4`. Pass `save_slp(..., save_embedding_vectors=False)` to write the identity `links` but skip the (large) `/embeddings` group
 - Backward compatible: reads are gated on group presence, so older readers ignore both groups
+
+### Format 2.6
+
+**Frame-spanning events: event catalog and interval annotations.**
+
+- New optional `/event_types` group (a `name` string dataset + optional `description` + `meta_*` EAV metadata) and `/events` group (a columnar struct-of-arrays plus a ragged CSR `scores`/`score_offsets` pair for optional framewise `PredictedEvent.scores`) — see [Events](#events)
+- An [`Event`][sleap_io.Event] has a *temporal extent* (an inclusive `[start_frame, end_frame]` interval) and lives on [`Labels.events`][sleap_io.Labels] rather than a `LabeledFrame`; participants are stored as `(kind, idx)` pairs referencing tracks or identities
+- Triggered automatically when the file has any events / event types; event-free files stay at `format_id <= 2.5`
+- Backward compatible: reads are gated on group presence, so older readers ignore both groups
+
+### Format 2.7 (Current)
+
+**Class/category subsystem: category catalog, per-detection links, and category appearance embeddings.**
+
+- New optional `/categories` group (see [Categories](#categories)), a fully self-contained mirror of `/identity`:
+    - `name` — one variable-length UTF-8 string per [`Category`][sleap_io.Category], in catalog order
+    - `meta_owner` / `meta_key` / `meta_val` — an entity-attribute-value table of per-category `metadata`, all three omitted when no category carries metadata
+    - `links` — a structured dataset (`owner_type`, `owner_id`, `category_idx`, `category_score`) with one row per detection that carries a category, using the same shared `OWNER_*` join codes as `/identity/links`
+- Category appearance vectors (the `category_embedding` slot on each instance, `SegmentationMask`, `Centroid`, `BoundingBox`, or `ROI`) live in the **same `/embeddings` group** as **parallel, independent** datasets — `category_vectors` `(M, D')` plus `category_owner_type` / `category_owner_id` — kept separate from the identity `vectors` datasets so the two embedding kinds need not share dimensionality (see [Embeddings](#category-embeddings-parallel-datasets-format-27))
+- Triggered automatically when any detection carries a [`Category`][sleap_io.Category] or a category embedding; category-free files stay at `format_id <= 2.6`. Pass `save_slp(..., save_embedding_vectors=False)` to write the category `links` but skip the (large) category vectors
+- Backward compatible and byte-identical for unused features: the `/categories` group and the `category_*` embedding datasets are only written when present, so identity-only files stay unchanged
 
 ## Browser-side compatibility (h5wasm / sleap-io.js)
 

--- a/docs/model/category.md
+++ b/docs/model/category.md
@@ -1,0 +1,227 @@
+# Categories
+
+A [`Category`][sleap_io.Category] names the **class** an individual belongs to — a group of
+detections that share some attribute, typically assigned by a classifier or retrieved via
+re-ID (e.g. `"female_fly"`, `"male_fly"`, `"fur_shaved"`, `"mouse"`). It is the third grouping
+axis alongside `Track` and `Identity`:
+
+| Concept | Scope | Question it answers |
+| --- | --- | --- |
+| [`Track`](poses.md) | within one video | *which trajectory* is this over time? (ephemeral) |
+| [`Identity`](3d.md#identity) | across videos / sessions | *which specific individual* is this? (persistent) |
+| [`Category`](category.md) | across individuals | *which class* does this belong to? (classification / re-ID) |
+
+Where an `Identity` names one specific animal, a `Category` names a *set* of animals that share a
+property. Many individuals map to one category.
+
+## The `Category` class
+
+A `Category` has exactly two fields — the same shape as [`Identity`][sleap_io.Identity] and
+[`Track`](poses.md):
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `str` | Human-readable class name (e.g. `"female_fly"`). Not required to be unique, but `name` is how categories are matched across separately-loaded files and merges. |
+| `metadata` | `dict[str, str]` | Arbitrary string-keyed, string-valued metadata (e.g. `{"color": "#e6194b", "supercategory": "insect"}`). Empty by default. |
+
+```pycon
+>>> import sleap_io as sio
+>>> female = sio.Category(name="female_fly", metadata={"color": "#e6194b"})
+>>> male = sio.Category(name="male_fly")
+>>> print(female.name)
+female_fly
+
+```
+
+Like `Track` and `Identity`, `Category` uses **object-identity equality** (`eq=False`), so two
+`Category` objects with the same `name` are distinct objects but still *match* by name — the key
+that survives serialization and cross-file merges. Compare with `matches()` (default
+`method="name"`); pass `method="identity"` to instead require the same Python object:
+
+```pycon
+>>> import sleap_io as sio
+>>> a1 = sio.Category(name="female_fly")
+>>> a2 = sio.Category(name="female_fly")
+>>> print(a1.matches(a2))  # same name -> same class
+True
+>>> print(a1.matches(a2, method="identity"))  # distinct objects -> no match
+False
+
+```
+
+!!! note "No dedicated color"
+    There is no `color` field on a `Category`. If a visualization color is desired, store it as a
+    conventional metadata entry such as `metadata["color"] = "#e6194b"`; it persists like any other
+    metadata key. Coloring *by category* uses the palette index into `Labels.categories` order
+    (identical to color-by-identity), not a per-category color.
+
+## Per-detection slots
+
+Every detection modality — [`Instance`](poses.md), [`Centroid`](centroids.md),
+[`SegmentationMask`](segmentation.md), [`BoundingBox`](boxes.md), [`ROI`](rois.md) — carries a
+trio of category slots, mirroring the identity trio (`identity` / `identity_score` /
+`identity_embedding`):
+
+| Slot | Type | Description |
+| --- | --- | --- |
+| `category` | `Category \| None` | The assigned class. |
+| `category_score` | `float \| None` | Classification / assignment confidence. |
+| `category_embedding` | [`Embedding`](embedding.md) `\| None` | The appearance vector the class was predicted from. |
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "tail"])
+>>> female = sio.Category(name="female_fly")
+>>> inst = sio.Instance.from_numpy(
+...     np.array([[0, 1], [2, 3]]),
+...     skeleton=skeleton,
+...     category=female,
+...     category_score=0.97,
+...     category_embedding=sio.Embedding(np.ones(64, dtype="float32")),
+... )
+>>> print(inst.category.name, inst.category_score, inst.category_embedding.dim)
+female_fly 0.97 64
+
+```
+
+The trio is propagated when converting between detection modalities (e.g.
+`Instance.to_centroid()`, `Centroid.to_bbox()`), exactly like the identity trio.
+
+### Promotion of the legacy `category` string
+
+Older code set a **free-form `category: str`** class label directly on bounding boxes, centroids,
+ROIs, and masks (the object-detection class, e.g. `category="mouse"`). That field is now the
+first-class `Category` slot, with a `str -> Category` converter so existing call sites keep
+working — the empty-string "unset" sentinel maps to `None`:
+
+```pycon
+>>> import sleap_io as sio
+>>> bbox = sio.UserBoundingBox(x1=0, y1=0, x2=10, y2=10, category="mouse")
+>>> print(bbox.category)  # promoted to a Category
+Category(name="mouse")
+>>> unset = sio.UserBoundingBox(x1=0, y1=0, x2=10, y2=10)
+>>> print(unset.category)  # "" / omitted -> None
+None
+
+```
+
+## The catalog: `Labels.categories`
+
+[`Labels.categories`][sleap_io.Labels] is the top-level catalog of `Category` objects — a list,
+like [`Labels.identities`][sleap_io.Labels] and [`Labels.tracks`][sleap_io.Labels] — auto-collected
+in first-seen order from the detections on save:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "tail"])
+>>> female = sio.Category(name="female_fly")
+>>> male = sio.Category(name="male_fly")
+>>> video = sio.Video(filename="clip.mp4", open_backend=False)
+>>> inst_f = sio.Instance.from_numpy(
+...     np.array([[0, 1], [2, 3]]), skeleton=skeleton, category=female
+... )
+>>> inst_m = sio.Instance.from_numpy(
+...     np.array([[4, 5], [6, 7]]), skeleton=skeleton, category=male
+... )
+>>> lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst_f, inst_m])
+>>> labels = sio.Labels(labeled_frames=[lf], categories=[female, male])
+>>> print([c.name for c in labels.categories])
+['female_fly', 'male_fly']
+
+```
+
+## Save / load round-trip
+
+The category catalog, the per-detection `category` / `category_score` links, and the
+`category_embedding` appearance vectors persist to SLP in **format 2.7+** (additive — older
+readers ignore them and category-free files round-trip unchanged):
+
+```pycon
+>>> import os
+>>> import tempfile
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "tail"])
+>>> female = sio.Category(name="female_fly")
+>>> inst = sio.Instance.from_numpy(
+...     np.array([[0, 1], [2, 3]]),
+...     skeleton=skeleton,
+...     category=female,
+...     category_embedding=sio.Embedding(np.ones(64, dtype="float32")),
+... )
+>>> video = sio.Video(filename="clip.mp4", open_backend=False)
+>>> lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
+>>> labels = sio.Labels(labeled_frames=[lf], categories=[female])
+>>> path = os.path.join(tempfile.mkdtemp(), "cats.slp")
+>>> sio.save_slp(labels, path, save_embedding_vectors=True)
+>>> loaded = sio.load_slp(path)
+>>> print([c.name for c in loaded.categories])
+['female_fly']
+>>> print(loaded[0][0].category.name, loaded[0][0].category_embedding.dim)
+female_fly 64
+
+```
+
+Pass `save_slp(..., save_embedding_vectors=False)` to persist the category *links* (which
+detection is which class) while skipping the large appearance vectors — the same gate used for
+identity embeddings. See [Formats → SLP](../formats/slp.md#categories) and
+[Embeddings](embedding.md).
+
+## Merging: deduping the catalog
+
+When merging files, the category catalog is deduped by a [`CategoryMatcher`][sleap_io.Labels.merge]
+— by default matching on `name`, so two files that both use `"female_fly"` collapse to a single
+catalog entry:
+
+```pycon
+>>> import numpy as np
+>>> import sleap_io as sio
+>>> skeleton = sio.Skeleton(["head", "tail"])
+>>> def make():
+...     female = sio.Category(name="female_fly")
+...     inst = sio.Instance.from_numpy(
+...         np.array([[0, 1], [2, 3]]), skeleton=skeleton, category=female
+...     )
+...     video = sio.Video(filename="clip.mp4", open_backend=False)
+...     lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])
+...     return sio.Labels(labeled_frames=[lf], categories=[female])
+...
+>>> base, other = make(), make()
+>>> _ = base.merge(other, category="name", frame="keep_both")
+>>> print([c.name for c in base.categories])  # same-named categories deduped
+['female_fly']
+
+```
+
+Pass `category="identity"` to instead require the same Python object (no name-based dedup). See
+[Merging](../merging.md).
+
+## Coloring by category
+
+`render_image` / `render_video` accept `color_by="category"`, which assigns one palette color per
+category by its index in `Labels.categories` order (identical plumbing to `color_by="identity"`).
+Detections without a category fall back to index 0:
+
+```python
+import sleap_io as sio
+
+labels = sio.load_slp("classified.slp")
+img = sio.render_image(labels[0], color_by="category")
+sio.render_video(labels, "by_category.mp4", color_by="category")
+```
+
+From the CLI:
+
+```bash
+sio render classified.slp --color-by category -o by_category.mp4
+```
+
+See [Rendering](../rendering.md) and the [CLI reference](../cli.md#sio-render).
+
+---
+
+## API reference
+
+::: sleap_io.Category

--- a/docs/model/index.md
+++ b/docs/model/index.md
@@ -79,6 +79,9 @@ classDiagram
         +Identity identity
         +float identity_score
         +Embedding identity_embedding
+        +Category category
+        +float category_score
+        +Embedding category_embedding
     }
     class PredictedInstance:::poses {
         +float score
@@ -135,6 +138,10 @@ classDiagram
         +Identity identity
     }
     class Identity:::threed {
+        +str name
+        +dict~str,str~ metadata
+    }
+    class Category:::labels {
         +str name
         +dict~str,str~ metadata
     }
@@ -233,6 +240,8 @@ classDiagram
     Instance3D --> Skeleton : uses
     Instance3D <|-- PredictedInstance3D
     Labels --> Identity
+    Labels --> Category
+    Instance --> Category
 
     Centroid <|-- UserCentroid
     Centroid <|-- PredictedCentroid
@@ -282,6 +291,7 @@ classDiagram
 | [`FrameGroup`](3d.md) | [3D](3d.md) | Matched labeled frames across views at one time point |
 | [`InstanceGroup`](3d.md) | [3D](3d.md) | Same animal matched across cameras, with optional 3D points |
 | [`Identity`](3d.md#identity) | [3D](3d.md) | Cross-session persistent animal identity (distinct from per-video `Track`) |
+| [`Category`](category.md) | [Categories](category.md) | Class/type a detection belongs to (e.g. `female_fly`), assigned by classification or re-ID |
 | [`Instance3D`](3d.md#instance3d) | [3D](3d.md) | Structured triangulated 3D keypoint storage |
 | [`PredictedInstance3D`](3d.md#instance3d) | [3D](3d.md) | Model-predicted 3D keypoints with per-point scores |
 | [`Centroid`](centroids.md) | [Centroids](centroids.md) | Abstract base centroid point annotation |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
       - ROIs: model/rois.md
       - Segmentation: model/segmentation.md
       - Embeddings: model/embedding.md
+      - Categories: model/category.md
       - Events: model/events.md
     - Formats:
       - formats/index.md

--- a/sleap_io/__init__.py
+++ b/sleap_io/__init__.py
@@ -89,6 +89,7 @@ __getattr__, __dir__, __all__ = lazy.attach(
             "InstanceGroup",
             "RecordingSession",
         ],
+        "model.category": ["Category"],
         "model.embedding": ["Embedding"],
         "model.event": ["Event", "EventType", "UserEvent", "PredictedEvent"],
         "model.identity": ["Identity"],

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -926,6 +926,13 @@ def _print_header(path: Path, labels: Labels) -> None:
             f"[bold]{n_identities}[/] identit{'ies' if n_identities != 1 else 'y'}"
         )
 
+    # Global categories - only shown when present (pose-only files have none).
+    n_categories = len(labels.categories)
+    if n_categories > 0:
+        stats_parts.append(
+            f"[bold]{n_categories}[/] categor{'ies' if n_categories != 1 else 'y'}"
+        )
+
     # Segmentation masks and ROIs - only shown when present to avoid cluttering
     # pose-only files.
     n_masks = len(labels.masks)
@@ -1659,8 +1666,9 @@ def _print_tracks_summary(labels: Labels) -> None:
 def _print_embeddings_summary(labels: Labels) -> None:
     """Print a per-detection re-ID embedding summary (inline).
 
-    Reports the number of instances carrying an ``identity_embedding``. Skipped for
-    lazy labels, since scanning instances would force a full materialization.
+    Reports the number of instances carrying an ``identity_embedding`` and/or a
+    ``category_embedding``. Skipped for lazy labels, since scanning instances would
+    force a full materialization.
     """
     # Iterating instances on lazy labels would force materialization; only
     # summarize embeddings when the labeled frames are readily available.
@@ -1673,14 +1681,28 @@ def _print_embeddings_summary(labels: Labels) -> None:
         for inst in lf.instances
         if inst.identity_embedding is not None
     )
-    if n_with_embeddings == 0:
+    n_with_category_embeddings = sum(
+        1
+        for lf in labels.labeled_frames
+        for inst in lf.instances
+        if inst.category_embedding is not None
+    )
+    if n_with_embeddings == 0 and n_with_category_embeddings == 0:
         return
 
     console.print()
-    console.print(
-        f"[bold]Embeddings[/] ({n_with_embeddings} instance"
-        f"{'s' if n_with_embeddings != 1 else ''} with an identity embedding)"
-    )
+    console.print("[bold]Embeddings[/]")
+    if n_with_embeddings > 0:
+        console.print(
+            f"  {n_with_embeddings} instance"
+            f"{'s' if n_with_embeddings != 1 else ''} with an identity embedding"
+        )
+    if n_with_category_embeddings > 0:
+        console.print(
+            f"  {n_with_category_embeddings} instance"
+            f"{'s' if n_with_category_embeddings != 1 else ''} "
+            f"with a category embedding"
+        )
 
 
 def _print_tracks_details(labels: Labels) -> None:
@@ -2100,7 +2122,7 @@ def _build_labels_json(
 
     Returns:
         JSON-serializable dict with file info, stats, skeletons, videos,
-        tracks, identities, and provenance.
+        tracks, identities, categories, and provenance.
     """
     file_size = path.stat().st_size if path.exists() else None
     is_pkg = _is_pkg_slp(path)
@@ -2121,6 +2143,18 @@ def _build_labels_json(
             if inst.identity_embedding is not None
         )
 
+    # Scanning instances for category embeddings would likewise force
+    # materialization of lazy labels; report null (unknown) in that case.
+    if labels.is_lazy:
+        n_with_category_embeddings = None
+    else:
+        n_with_category_embeddings = sum(
+            1
+            for lf in labels.labeled_frames
+            for inst in lf.instances
+            if inst.category_embedding is not None
+        )
+
     # Map each video to its catalog index (by object identity) so events can cite
     # their video by index without an O(n) list search per event.
     video_idx = {id(v): i for i, v in enumerate(labels.videos)}
@@ -2139,11 +2173,13 @@ def _build_labels_json(
             "n_skeletons": len(labels.skeletons),
             "n_tracks": len(labels.tracks),
             "n_identities": len(labels.identities),
+            "n_categories": len(labels.categories),
             "n_masks": len(labels.masks),
             "n_rois": len(labels.rois),
             "n_events": len(labels.events),
             "n_event_types": len(labels.event_types),
             "n_instances_with_identity_embedding": n_with_embeddings,
+            "n_instances_with_category_embedding": n_with_category_embeddings,
         },
         "skeletons": [
             _build_skeleton_dict(sk, i) for i, sk in enumerate(labels.skeletons)
@@ -2159,6 +2195,9 @@ def _build_labels_json(
         "identities": [
             {"index": i, "name": ident.name}
             for i, ident in enumerate(labels.identities)
+        ],
+        "categories": [
+            {"index": i, "name": cat.name} for i, cat in enumerate(labels.categories)
         ],
         "event_types": [
             _build_event_type_dict(et, i) for i, et in enumerate(labels.event_types)
@@ -3475,6 +3514,13 @@ def unsplit(
     help="Identity matching method for deduping the identity catalog.",
 )
 @click.option(
+    "--category",
+    type=click.Choice(["name", "identity"]),
+    default="name",
+    show_default=True,
+    help="Category matching method for deduping the category catalog.",
+)
+@click.option(
     "--frame",
     type=click.Choice(
         [
@@ -3515,6 +3561,7 @@ def merge(
     video: str,
     track: str,
     identity: str,
+    category: str,
     frame: str,
     instance: str,
     embed: str | None,
@@ -3567,6 +3614,10 @@ def merge(
       • name: Match identities by name [default]
       • identity: Match identities by object identity
 
+    [dim]Category:[/] How to dedupe the global category catalog
+      • name: Match categories by name [default]
+      • identity: Match categories by object identity
+
     [dim]Examples:[/]
 
         $ sio merge project.slp predictions.slp -o merged.slp
@@ -3612,9 +3663,10 @@ def merge(
 
     click.echo(f"  {initial_frames} frames, {initial_videos} videos")
 
-    # Select how the global identity catalog is deduped during merge ("uuid" or
-    # "name"), forwarded to Labels.merge() as the identity matcher method.
-    merge_identity_kwargs: dict = {"identity": identity}
+    # Select how the global identity and category catalogs are deduped during
+    # merge ("name" or "identity"), forwarded to Labels.merge() as the identity
+    # and category matcher methods.
+    merge_identity_kwargs: dict = {"identity": identity, "category": category}
 
     # Merge remaining files
     for input_file in expanded_files[1:]:
@@ -4072,10 +4124,11 @@ def filenames(
 # Appearance options
 @click.option(
     "--color-by",
-    type=click.Choice(["auto", "track", "instance", "node", "identity"]),
+    type=click.Choice(["auto", "track", "instance", "node", "identity", "category"]),
     default="auto",
     show_default=True,
-    help="Color scheme: auto (smart default), track, instance, node, or identity.",
+    help="Color scheme: auto (smart default), track, instance, node, identity, "
+    "or category.",
 )
 @click.option(
     "--palette",

--- a/sleap_io/io/cli.py
+++ b/sleap_io/io/cli.py
@@ -930,7 +930,8 @@ def _print_header(path: Path, labels: Labels) -> None:
     n_categories = len(labels.categories)
     if n_categories > 0:
         stats_parts.append(
-            f"[bold]{n_categories}[/] categor{'ies' if n_categories != 1 else 'y'}"
+            f"[bold]{n_categories}[/] "
+            f"{'categories' if n_categories != 1 else 'category'}"
         )
 
     # Segmentation masks and ROIs - only shown when present to avoid cluttering

--- a/sleap_io/io/coco.py
+++ b/sleap_io/io/coco.py
@@ -962,7 +962,7 @@ def convert_labels(
     for lf in labels.labeled_frames:
         for roi in lf.rois:
             # Get or create category
-            cat_name = roi.category if roi.category else "object"
+            cat_name = roi.category.name if roi.category else "object"
             if cat_name not in category_name_to_id:
                 category = {
                     "id": category_id_counter,
@@ -1015,7 +1015,7 @@ def convert_labels(
 
         # Export masks as COCO RLE annotations
         for seg_mask in lf.masks:
-            cat_name = seg_mask.category if seg_mask.category else "object"
+            cat_name = seg_mask.category.name if seg_mask.category else "object"
             if cat_name not in category_name_to_id:
                 category = {
                     "id": category_id_counter,
@@ -1070,7 +1070,7 @@ def convert_labels(
         for bbox_obj in lf.bboxes:
             if bbox_obj.instance is not None:
                 continue
-            cat_name = bbox_obj.category if bbox_obj.category else "object"
+            cat_name = bbox_obj.category.name if bbox_obj.category else "object"
             if cat_name not in category_name_to_id:
                 category = {
                     "id": category_id_counter,

--- a/sleap_io/io/jabs.py
+++ b/sleap_io/io/jabs.py
@@ -372,7 +372,11 @@ def convert_labels(all_labels: Labels, video: Video) -> dict:
 
     # Extract static objects from ROIs
     for roi in all_labels.rois:
-        if roi.category in ("arena", "anchor") and roi.source == "jabs":
+        if (
+            roi.category is not None
+            and roi.category.name in ("arena", "anchor")
+            and roi.source == "jabs"
+        ):
             coords = _roi_to_static_object_coords(roi)
             if coords is not None:
                 static_objects[roi.name] = coords

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -39,6 +39,19 @@ Format version history:
             CSR pair (scores flat float32 + score_offsets int64) for optional
             framewise PredictedEvent.scores traces. Every column is presence-guarded;
             both groups additive, read on group presence.
+    - 2.7: Added the class/category subsystem, mirroring identity. The /categories
+            group is a fully self-contained mirror of /identity: a native `name`
+            string dataset + an optional entity-attribute-value metadata table
+            (meta_owner/meta_key/meta_val) forming the category catalog, plus a
+            per-detection `links` dataset (owner_type, owner_id, category_idx,
+            category_score) joining a detection to a catalog entry. Category
+            appearance vectors live in the SAME /embeddings group as sibling
+            parallel datasets (category_vectors (M, D) + category_owner_type /
+            category_owner_id join columns), independent of the identity
+            vectors/owner_type/owner_id datasets so the two embedding kinds need
+            not share dimensionality D. Identity-only files stay byte-identical
+            (no category_* datasets, no /categories group written). All additive,
+            read on group presence.
 """
 
 from __future__ import annotations
@@ -81,6 +94,7 @@ from sleap_io.model.camera import (
     InstanceGroup,
     RecordingSession,
 )
+from sleap_io.model.category import Category
 from sleap_io.model.embedding import Embedding
 from sleap_io.model.event import Event, EventType, PredictedEvent, UserEvent
 from sleap_io.model.identity import Identity
@@ -1740,6 +1754,103 @@ def write_identities(labels_path: str, identities: list[Identity]) -> None:
             )
 
 
+def read_categories(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> list[Category]:
+    """Read the category catalog from a SLEAP labels file.
+
+    Categories are stored in the optional ``/categories`` group (SLP format 2.7+)
+    as a native ``name`` string dataset plus an optional entity-attribute-value
+    metadata table (``meta_owner`` / ``meta_key`` / ``meta_val``, omitted when no
+    category carries metadata). This is a fully self-contained mirror of the
+    ``/identity`` catalog (`read_identities`). Absent in older files, in which case
+    an empty list is returned.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from.
+
+    Returns:
+        A list of `Category` objects in catalog order.
+    """
+    cm = (
+        nullcontext(_hdf5_file)
+        if _hdf5_file is not None
+        else h5py.File(labels_path, "r")
+    )
+    with cm as f:
+        if "categories" not in f or "name" not in f["categories"]:
+            return []
+        group = f["categories"]
+        names = [
+            n.decode() if isinstance(n, bytes) else str(n) for n in group["name"][:]
+        ]
+        metadata: list[dict[str, str]] = [{} for _ in names]
+        if "meta_owner" in group:
+            owners = group["meta_owner"][:]
+            keys = group["meta_key"][:]
+            vals = group["meta_val"][:]
+            for owner, key, val in zip(owners, keys, vals):
+                k = key.decode() if isinstance(key, bytes) else str(key)
+                v = val.decode() if isinstance(val, bytes) else str(val)
+                metadata[int(owner)][k] = v
+    return [Category(name=name, metadata=meta) for name, meta in zip(names, metadata)]
+
+
+def write_categories(labels_path: str, categories: list[Category]) -> None:
+    """Write the category catalog to a SLEAP labels file.
+
+    Creates the ``/categories`` group (SLP format 2.7+) holding a native ``name``
+    string dataset (one per category) plus, only when any category carries
+    metadata, a columnar entity-attribute-value metadata table
+    (``meta_owner`` / ``meta_key`` / ``meta_val``). A fully self-contained mirror
+    of `write_identities`. No-op if there are no categories.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        categories: A list of `Category` objects to store, in catalog order.
+    """
+    if not categories:
+        return
+
+    str_dtype = h5py.string_dtype(encoding="utf-8")
+    names = np.array([cat.name for cat in categories], dtype=object)
+
+    meta_owner: list[int] = []
+    meta_key: list[str] = []
+    meta_val: list[str] = []
+    for idx, cat in enumerate(categories):
+        for key, value in cat.metadata.items():
+            meta_owner.append(idx)
+            meta_key.append(str(key))
+            meta_val.append(str(value))
+
+    with h5py.File(labels_path, "a") as f:
+        group = f.require_group("categories")
+        group.create_dataset("name", data=names, dtype=str_dtype, maxshape=(None,))
+        if meta_owner:
+            group.create_dataset(
+                "meta_owner",
+                data=np.array(meta_owner, dtype="i4"),
+                maxshape=(None,),
+                compression="gzip",
+            )
+            group.create_dataset(
+                "meta_key",
+                data=np.array(meta_key, dtype=object),
+                dtype=str_dtype,
+                maxshape=(None,),
+                compression="gzip",
+            )
+            group.create_dataset(
+                "meta_val",
+                data=np.array(meta_val, dtype=object),
+                dtype=str_dtype,
+                maxshape=(None,),
+                compression="gzip",
+            )
+
+
 def read_event_types(
     labels_path: str, *, _hdf5_file: h5py.File | None = None
 ) -> list[EventType]:
@@ -2340,6 +2451,215 @@ def _identity_link_rows_from_store(
     return rows
 
 
+def read_category_links(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> dict[int, dict[int, tuple[int, float | None]]]:
+    """Read per-detection category links from a SLEAP labels file.
+
+    Links are stored in the optional ``/categories/links`` dataset (SLP format
+    2.7+), a structured array of ``(owner_type, owner_id, category_idx,
+    category_score)`` rows joining a detection -- identified by ``owner_type`` (one
+    of the ``OWNER_*`` codes) and ``owner_id`` -- to an index into the file's
+    category catalog. A fully self-contained mirror of `read_identity_links`.
+    ``owner_id`` is the per-owner-type positional id (e.g. the global
+    ``instance_id`` assigned by `write_lfs` for instance owners), mirroring the
+    ``/embeddings`` join. The dataset is absent in older files, in which case an
+    empty mapping is returned.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from.
+
+    Returns:
+        A dict mapping each ``owner_type`` to a ``{owner_id: (category_idx,
+        category_score)}`` mapping. ``category_score`` is ``None`` when it was not
+        recorded (stored as NaN). Empty for older files.
+    """
+    cm = (
+        nullcontext(_hdf5_file)
+        if _hdf5_file is not None
+        else h5py.File(labels_path, "r")
+    )
+    with cm as f:
+        if "categories" not in f or "links" not in f["categories"]:
+            return {}
+        data = f["categories"]["links"][:]
+    result: dict[int, dict[int, tuple[int, float | None]]] = {}
+    for row in data:
+        owner_type = int(row["owner_type"])
+        score = float(row["category_score"])
+        result.setdefault(owner_type, {})[int(row["owner_id"])] = (
+            int(row["category_idx"]),
+            None if np.isnan(score) else score,
+        )
+    return result
+
+
+def _write_category_link_rows(
+    labels_path: str, rows: list[tuple[int, int, int, float]]
+) -> None:
+    """Write ``(owner_type, owner_id, category_idx, category_score)`` rows.
+
+    Shared dataset-writing core for the per-detection category link, mirroring
+    `_write_identity_link_rows`. The rows can be built either by iterating a
+    `Labels` (the eager path, see `write_category_links`) or from a lazy store dict
+    (the lazy save path), keeping the on-disk ``/categories/links`` layout identical
+    for both.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        rows: A list of ``(owner_type, owner_id, category_idx, category_score)``
+            tuples. ``category_score`` is a float (NaN encodes an unrecorded score).
+            An empty list is a no-op (no dataset is created).
+    """
+    if not rows:
+        return
+
+    category_link_dtype = np.dtype(
+        [
+            ("owner_type", "u1"),
+            ("owner_id", "i8"),
+            ("category_idx", "i4"),
+            ("category_score", "f4"),
+        ]
+    )
+    arr = np.array(rows, dtype=category_link_dtype)
+    with h5py.File(labels_path, "a") as f:
+        group = f.require_group("categories")
+        group.create_dataset("links", data=arr, maxshape=(None,))
+
+
+def write_category_links(labels_path: str, labels: Labels) -> None:
+    """Write per-detection category links to a SLEAP labels file.
+
+    Creates the ``/categories/links`` dataset (SLP format 2.7+) as a structured
+    array of ``(owner_type, owner_id, category_idx, category_score)`` rows for every
+    detection carrying a `Category` registered in ``labels.categories``. Instance,
+    mask, centroid, bbox, and ROI owners are written (``OWNER_*``). A fully
+    self-contained mirror of `write_identity_links`.
+
+    The instance ``owner_id`` matches the global id assigned by `write_lfs`, and the
+    mask / centroid / bbox / ROI ``owner_id`` matches the global per-modality list
+    index assigned by `write_masks` / `write_centroids` / `write_bboxes` /
+    `write_rois` (each enumeration order over frames then the modality; ROIs append
+    static ROIs after frame ROIs), so the link is resolved by joining on that id at
+    read time. Category is resolved to a catalog index by object identity (a single
+    ``id()``-keyed lookup), so the pass stays O(number of detections).
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        labels: A `Labels` object to store the category links for.
+    """
+    if not labels.categories:
+        return
+
+    id_to_idx = {id(cat): i for i, cat in enumerate(labels.categories)}
+    rows = []
+    instance_id = 0
+    masks: list = []
+    centroids: list = []
+    bboxes: list = []
+    rois: list = []
+    for lf in labels:
+        for inst in lf:
+            category = getattr(inst, "category", None)
+            if category is not None:
+                idx = id_to_idx.get(id(category))
+                if idx is not None:
+                    score = inst.category_score
+                    rows.append(
+                        (
+                            OWNER_INSTANCE,
+                            instance_id,
+                            idx,
+                            float("nan") if score is None else float(score),
+                        )
+                    )
+            instance_id += 1
+        masks.extend(lf.masks)
+        centroids.extend(lf.centroids)
+        bboxes.extend(lf.bboxes)
+        rois.extend(lf.rois)
+    # Static ROIs are appended after frame ROIs (matching write_labels' all_rois).
+    rois.extend(labels.static_rois)
+
+    rows.extend(_category_link_rows_for_owner(masks, id_to_idx, OWNER_MASK))
+    rows.extend(_category_link_rows_for_owner(centroids, id_to_idx, OWNER_CENTROID))
+    rows.extend(_category_link_rows_for_owner(bboxes, id_to_idx, OWNER_BBOX))
+    rows.extend(_category_link_rows_for_owner(rois, id_to_idx, OWNER_ROI))
+    _write_category_link_rows(labels_path, rows)
+
+
+def _category_link_rows_for_owner(
+    anns: list, id_to_idx: dict[int, int], owner_type: int
+) -> list[tuple[int, int, int, float]]:
+    """Build category-link rows for an ordered annotation list under one owner type.
+
+    Annotations join on their global per-modality list index (the same enumeration
+    as the modality's writer, e.g. `write_masks` / `write_centroids`), so ``anns``
+    must be supplied in that exact order. Category is resolved to a catalog index by
+    object identity. Mirrors `_identity_link_rows_for_owner`.
+
+    Args:
+        anns: The ordered global annotation list for one modality.
+        id_to_idx: Mapping from a `Category`'s object id to its catalog index.
+        owner_type: The ``OWNER_*`` code for this modality (e.g. ``OWNER_MASK``).
+
+    Returns:
+        A list of ``(owner_type, owner_id, category_idx, category_score)`` tuples.
+    """
+    rows = []
+    for owner_id, ann in enumerate(anns):
+        category = getattr(ann, "category", None)
+        if category is None:
+            continue
+        idx = id_to_idx.get(id(category))
+        if idx is None:
+            continue
+        score = ann.category_score
+        rows.append(
+            (
+                owner_type,
+                owner_id,
+                idx,
+                float("nan") if score is None else float(score),
+            )
+        )
+    return rows
+
+
+def _category_link_rows_from_store(
+    store: "LazyDataStore",
+) -> list[tuple[int, int, int, float]]:
+    """Build ``/categories/links`` rows from a lazy store without materializing.
+
+    The lazy store already holds the per-instance category links keyed by the
+    global ``instance_id`` (the same id space written by the fast path), so the
+    rows can be emitted directly as ``OWNER_INSTANCE`` owners without rebuilding
+    `Instance` objects. Rows are sorted by ``instance_id`` for deterministic
+    output. Mirrors `_identity_link_rows_from_store`.
+
+    Args:
+        store: The `LazyDataStore` backing a lazy `Labels`.
+
+    Returns:
+        A list of ``(owner_type, owner_id, category_idx, category_score)`` tuples
+        matching the format expected by `_write_category_link_rows`.
+    """
+    rows = []
+    for instance_id in sorted(store._instance_categories):
+        category_idx, score = store._instance_categories[instance_id]
+        rows.append(
+            (
+                OWNER_INSTANCE,
+                int(instance_id),
+                int(category_idx),
+                float("nan") if score is None else float(score),
+            )
+        )
+    return rows
+
+
 # Owner-type codes for the owner_type join column shared by the /embeddings group
 # and the /identity/links dataset. Both subsystems join a detection to a per-row
 # payload via an (owner_type, owner_id) pair, so they share one code set: this
@@ -2372,38 +2692,94 @@ def read_embeddings(
         mapping. Rows with an unsupported owner type are skipped with a warning.
         Empty for older files.
     """
-    supported = (OWNER_INSTANCE, OWNER_CENTROID, OWNER_MASK, OWNER_BBOX, OWNER_ROI)
-    by_owner: dict[int, dict[int, Embedding]] = {}
-
     cm = (
         nullcontext(_hdf5_file)
         if _hdf5_file is not None
         else h5py.File(labels_path, "r")
     )
     with cm as f:
-        if "embeddings" not in f:
-            return by_owner
-        group = f["embeddings"]
-        vectors = group["vectors"][:]
-        owner_type = group["owner_type"][:]
-        owner_id = group["owner_id"][:]
-        unknown_owner_types: set[int] = set()
-        for i in range(len(vectors)):
-            otype = int(owner_type[i])
-            if otype not in supported:
-                unknown_owner_types.add(otype)
-                continue
-            by_owner.setdefault(otype, {})[int(owner_id[i])] = Embedding(
-                vector=vectors[i]
-            )
-        if unknown_owner_types:
-            warnings.warn(
-                "Skipped /embeddings rows with unsupported owner_type(s) "
-                f"{sorted(unknown_owner_types)}: instance, mask, centroid, bbox, "
-                "and ROI embeddings are attached on read. These vectors were "
-                "written by a newer sleap-io and are ignored here.",
-                stacklevel=2,
-            )
+        if "embeddings" not in f or "vectors" not in f["embeddings"]:
+            return {}
+        return _read_embedding_datasets(
+            f["embeddings"], ("vectors", "owner_type", "owner_id")
+        )
+
+
+def read_category_embeddings(
+    labels_path: str, *, _hdf5_file: h5py.File | None = None
+) -> dict[int, dict[int, "Embedding"]]:
+    """Read per-detection category (classification) embeddings from a SLP file.
+
+    Category embeddings are stored in the SAME optional ``/embeddings`` group (SLP
+    format 2.7+) as sibling parallel datasets: the stacked ``category_vectors``
+    ``(M, D)`` plus the ``category_owner_type`` / ``category_owner_id`` join
+    columns. These are independent of the identity ``vectors`` datasets read by
+    `read_embeddings` (the two embedding kinds need not share dimensionality D).
+    Absent in older files (or when no category embedding was written), in which
+    case an empty mapping is returned.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        _hdf5_file: An already-open `h5py.File` handle to read from.
+
+    Returns:
+        A dict mapping each supported ``owner_type`` to a ``{owner_id: Embedding}``
+        mapping. Rows with an unsupported owner type are skipped with a warning.
+        Empty for older files.
+    """
+    cm = (
+        nullcontext(_hdf5_file)
+        if _hdf5_file is not None
+        else h5py.File(labels_path, "r")
+    )
+    with cm as f:
+        if "embeddings" not in f or "category_vectors" not in f["embeddings"]:
+            return {}
+        return _read_embedding_datasets(
+            f["embeddings"],
+            ("category_vectors", "category_owner_type", "category_owner_id"),
+        )
+
+
+def _read_embedding_datasets(
+    group: h5py.Group, dataset_names: tuple[str, str, str]
+) -> dict[int, dict[int, "Embedding"]]:
+    """Read one ``(vectors, owner_type, owner_id)`` triple into an owner-keyed map.
+
+    Shared reader core for the identity (`read_embeddings`) and category
+    (`read_category_embeddings`) parallel dataset triples within the ``/embeddings``
+    group. Row ``i`` of all three datasets describes the same detection; the
+    returned `Embedding` vectors are views onto the one loaded vectors array.
+
+    Args:
+        group: The open ``/embeddings`` HDF5 group.
+        dataset_names: The ``(vectors, owner_type, owner_id)`` dataset names to read.
+
+    Returns:
+        A dict mapping each supported ``owner_type`` to a ``{owner_id: Embedding}``
+        mapping. Rows with an unsupported owner type are skipped with a warning.
+    """
+    supported = (OWNER_INSTANCE, OWNER_CENTROID, OWNER_MASK, OWNER_BBOX, OWNER_ROI)
+    by_owner: dict[int, dict[int, Embedding]] = {}
+    vectors_name, owner_type_name, owner_id_name = dataset_names
+    vectors = group[vectors_name][:]
+    owner_type = group[owner_type_name][:]
+    owner_id = group[owner_id_name][:]
+    unknown_owner_types: set[int] = set()
+    for i in range(len(vectors)):
+        otype = int(owner_type[i])
+        if otype not in supported:
+            unknown_owner_types.add(otype)
+            continue
+        by_owner.setdefault(otype, {})[int(owner_id[i])] = Embedding(vector=vectors[i])
+    if unknown_owner_types:
+        warnings.warn(
+            f"Skipped /embeddings '{vectors_name}' rows with unsupported "
+            f"owner_type(s) {sorted(unknown_owner_types)}: instance, mask, centroid, "
+            "bbox, and ROI embeddings are attached on read. These vectors were "
+            "written by a newer sleap-io and are ignored here.",
+            stacklevel=2,
+        )
     return by_owner
 
 
@@ -2440,6 +2816,40 @@ def _attach_identity_and_embeddings(
             ann.identity_embedding = emb
 
 
+def _attach_category_and_embeddings(
+    anns: list,
+    categories: list[Category],
+    category_map: dict[int, tuple[int, float | None]],
+    category_embedding_map: dict[int, "Embedding"],
+) -> None:
+    """Attach per-annotation category links + embedding by global-list index.
+
+    Category mirror of `_attach_identity_and_embeddings`, shared by the eager and
+    lazy read paths for any detection modality (e.g. masks, centroids). ``anns``
+    must be in the global per-modality list index order (as returned by
+    `read_masks` / `read_centroids`), which is the id space the owner rows were
+    written against.
+
+    Args:
+        anns: The ordered global annotation list for one modality.
+        categories: The category catalog (links resolve by catalog index).
+        category_map: ``{owner_id: (category_idx, category_score)}`` from
+            `read_category_links` for this modality's owner type.
+        category_embedding_map: ``{owner_id: Embedding}`` from
+            `read_category_embeddings` for this modality's owner type.
+    """
+    for owner_id, ann in enumerate(anns):
+        link = category_map.get(owner_id)
+        if link is not None:
+            category_idx, category_score = link
+            if 0 <= category_idx < len(categories):
+                ann.category = categories[category_idx]
+                ann.category_score = category_score
+        emb = category_embedding_map.get(owner_id)
+        if emb is not None:
+            ann.category_embedding = emb
+
+
 def write_embeddings(labels_path: str, labels: Labels) -> None:
     """Write per-detection re-ID embeddings to a SLEAP labels file.
 
@@ -2461,6 +2871,39 @@ def write_embeddings(labels_path: str, labels: Labels) -> None:
     """
     entries = _embedding_groups_from_labels(labels)
     _write_embedding_groups(labels_path, entries)
+
+
+# Parallel category-embedding dataset names within the shared /embeddings group
+# (SLP 2.7+). Sibling to the identity vectors/owner_type/owner_id datasets so the
+# two embedding kinds are independent and need not share dimensionality D.
+_CATEGORY_EMBEDDING_DATASETS = (
+    "category_vectors",
+    "category_owner_type",
+    "category_owner_id",
+)
+
+
+def write_category_embeddings(labels_path: str, labels: Labels) -> None:
+    """Write per-detection category (classification) embeddings to a SLP file.
+
+    Creates sibling ``category_vectors`` / ``category_owner_type`` /
+    ``category_owner_id`` datasets in the SAME ``/embeddings`` group (SLP format
+    2.7+), independent of the identity ``vectors`` datasets so the two embedding
+    kinds need not share dimensionality D. Category mirror of `write_embeddings`;
+    the owner_id join spaces match `write_lfs` / `write_masks` / `write_centroids`
+    / `write_bboxes` / `write_rois` exactly as identity does. Purely additive: a
+    file with no category embeddings never gains the ``category_*`` datasets.
+
+    Args:
+        labels_path: A string path to the SLEAP labels file.
+        labels: A `Labels` object to store the category embeddings for.
+
+    Raises:
+        ValueError: If the category embedding vectors do not all share the same
+            dimensionality.
+    """
+    entries = _category_embedding_groups_from_labels(labels)
+    _write_embedding_groups(labels_path, entries, _CATEGORY_EMBEDDING_DATASETS)
 
 
 def _embedding_groups_from_labels(labels: Labels) -> list:
@@ -2503,21 +2946,70 @@ def _embedding_groups_from_labels(labels: Labels) -> list:
     return entries
 
 
-def _add_owner_embedding_groups(entries: list, anns: list, owner_type: int) -> None:
+def _category_embedding_groups_from_labels(labels: Labels) -> list:
+    """Collect per-detection category embeddings by iterating a `Labels`.
+
+    Category mirror of `_embedding_groups_from_labels`, reading the
+    ``category_embedding`` slot on each detection. Join spaces are identical
+    (per-instance global ``instance_id``; per-mask / per-centroid / per-bbox /
+    per-ROI global per-modality list index; static ROIs follow frame ROIs).
+
+    Args:
+        labels: A `Labels` object to collect detection category embeddings from.
+
+    Returns:
+        A list of ``(owner_type, owner_id, Embedding)`` tuples for the
+        ``category_*`` datasets.
+    """
+    entries: list = []
+
+    instance_id = 0
+    masks: list = []
+    centroids: list = []
+    bboxes: list = []
+    rois: list = []
+    for lf in labels:
+        for inst in lf:
+            emb = getattr(inst, "category_embedding", None)
+            if emb is not None:
+                entries.append((OWNER_INSTANCE, instance_id, emb))
+            instance_id += 1
+        masks.extend(lf.masks)
+        centroids.extend(lf.centroids)
+        bboxes.extend(lf.bboxes)
+        rois.extend(lf.rois)
+    rois.extend(labels.static_rois)
+
+    _add_owner_embedding_groups(entries, masks, OWNER_MASK, attr="category_embedding")
+    _add_owner_embedding_groups(
+        entries, centroids, OWNER_CENTROID, attr="category_embedding"
+    )
+    _add_owner_embedding_groups(entries, bboxes, OWNER_BBOX, attr="category_embedding")
+    _add_owner_embedding_groups(entries, rois, OWNER_ROI, attr="category_embedding")
+    return entries
+
+
+def _add_owner_embedding_groups(
+    entries: list, anns: list, owner_type: int, attr: str = "identity_embedding"
+) -> None:
     """Append per-annotation embedding entries to ``entries`` (shared eager/lazy).
 
     Annotations join on their global per-modality list index (the same enumeration
     as the modality's writer, e.g. `write_masks` / `write_centroids`), so ``anns``
-    must be supplied in that exact order.
+    must be supplied in that exact order. The ``attr`` parameter selects which
+    embedding slot to read (``identity_embedding`` by default, or
+    ``category_embedding`` for the parallel category vectors dataset).
 
     Args:
         entries: The ``[(owner_type, owner_id, Embedding), ...]`` accumulator to
             extend in place.
         anns: The ordered global annotation list for one modality.
         owner_type: The ``OWNER_*`` code for this modality (e.g. ``OWNER_MASK``).
+        attr: The detection attribute holding the `Embedding` to collect
+            (``identity_embedding`` or ``category_embedding``).
     """
     for owner_id, ann in enumerate(anns):
-        emb = getattr(ann, "identity_embedding", None)
+        emb = getattr(ann, attr, None)
         if emb is not None:
             entries.append((owner_type, owner_id, emb))
 
@@ -2545,7 +3037,37 @@ def _embedding_groups_from_store(store: "LazyDataStore") -> list:
     return entries
 
 
-def _write_embedding_groups(labels_path: str, entries: list) -> None:
+def _category_embedding_groups_from_store(store: "LazyDataStore") -> list:
+    """Collect per-detection category embeddings from a lazy store.
+
+    Category mirror of `_embedding_groups_from_store`, reading the store's
+    per-instance category embedding dict keyed by the global ``instance_id``.
+    Entries are sorted by ``instance_id`` for deterministic output.
+
+    Args:
+        store: The `LazyDataStore` backing a lazy `Labels`.
+
+    Returns:
+        A list of ``(owner_type, owner_id, Embedding)`` tuples for the
+        ``category_*`` datasets.
+    """
+    entries: list = []
+    for instance_id in sorted(store._instance_category_embeddings):
+        entries.append(
+            (
+                OWNER_INSTANCE,
+                int(instance_id),
+                store._instance_category_embeddings[instance_id],
+            )
+        )
+    return entries
+
+
+def _write_embedding_groups(
+    labels_path: str,
+    entries: list,
+    dataset_names: tuple[str, str, str] = ("vectors", "owner_type", "owner_id"),
+) -> None:
     """Write per-detection embeddings to the ``/embeddings`` group of a SLP file.
 
     Shared dataset-writing core for both the eager (`Labels`-driven) and lazy
@@ -2555,11 +3077,19 @@ def _write_embedding_groups(labels_path: str, entries: list) -> None:
     parallel datasets so more per-embedding attributes can be added later without
     re-laying-out ``vectors``. Purely additive: old readers ignore the group.
 
+    The ``dataset_names`` parameter selects the ``(vectors, owner_type, owner_id)``
+    dataset names within the shared ``/embeddings`` group. Identity vectors use the
+    default names; category vectors use the parallel sibling names
+    ``("category_vectors", "category_owner_type", "category_owner_id")`` (SLP 2.7+),
+    so the two embedding kinds are independent and need not share dimensionality D.
+
     Args:
         labels_path: A string path to the SLEAP labels file.
         entries: A list of ``(owner_type, owner_id, Embedding)`` tuples as produced
-            by `_embedding_groups_from_labels` or `_embedding_groups_from_store`. An
-            empty list is a no-op.
+            by `_embedding_groups_from_labels` or `_embedding_groups_from_store` (or
+            their category counterparts). An empty list is a no-op.
+        dataset_names: The ``(vectors, owner_type, owner_id)`` dataset names to
+            create within ``/embeddings``.
 
     Raises:
         ValueError: If the embedding vectors do not all share the same
@@ -2568,11 +3098,13 @@ def _write_embedding_groups(labels_path: str, entries: list) -> None:
     if not entries:
         return
 
+    vectors_name, owner_type_name, owner_id_name = dataset_names
     dims = {emb.dim for _, _, emb in entries}
     if len(dims) > 1:
         raise ValueError(
             f"Embedding vectors have inconsistent dimensions {sorted(dims)}; all "
-            "vectors must share D to store in the columnar /embeddings dataset."
+            f"vectors must share D to store in the columnar /embeddings "
+            f"'{vectors_name}' dataset."
         )
     vectors = np.stack([emb.vector for _, _, emb in entries])
     owner_type = np.array([otype for otype, _, _ in entries], dtype="u1")
@@ -2586,17 +3118,17 @@ def _write_embedding_groups(labels_path: str, entries: list) -> None:
     with h5py.File(labels_path, "a") as f:
         group = f.require_group("embeddings")
         group.create_dataset(
-            "vectors",
+            vectors_name,
             data=vectors,
             maxshape=(None, d),
             chunks=(chunk_rows, d),
             compression="gzip",
         )
         group.create_dataset(
-            "owner_type", data=owner_type, maxshape=(None,), compression="gzip"
+            owner_type_name, data=owner_type, maxshape=(None,), compression="gzip"
         )
         group.create_dataset(
-            "owner_id", data=owner_id, maxshape=(None,), compression="gzip"
+            owner_id_name, data=owner_id, maxshape=(None,), compression="gzip"
         )
 
 
@@ -3104,6 +3636,16 @@ def write_metadata(labels_path: str, labels: Labels):
                 for d in lazy_dets
             )
         )
+        has_category_data = (
+            bool(labels.categories)
+            or bool(store._instance_categories)
+            or bool(store._instance_category_embeddings)
+            or any(
+                getattr(d, "category", None) is not None
+                or getattr(d, "category_embedding", None) is not None
+                for d in lazy_dets
+            )
+        )
     else:
         dets = [
             d for lf in labels for d in (*lf.masks, *lf.centroids, *lf.bboxes, *lf.rois)
@@ -3122,6 +3664,20 @@ def write_metadata(labels_path: str, labels: Labels):
                 for d in dets
             )
         )
+        has_category_data = (
+            bool(labels.categories)
+            or any(
+                getattr(inst, "category", None) is not None
+                or getattr(inst, "category_embedding", None) is not None
+                for lf in labels
+                for inst in lf
+            )
+            or any(
+                getattr(d, "category", None) is not None
+                or getattr(d, "category_embedding", None) is not None
+                for d in dets
+            )
+        )
     if has_identity_data:
         format_id = max(format_id, 2.5)
 
@@ -3132,6 +3688,14 @@ def write_metadata(labels_path: str, labels: Labels):
     # event_types live on top-level lists (not the lazy store).
     if labels.events or labels.event_types:
         format_id = max(format_id, 2.6)
+
+    # Bump for the class/category subsystem (new in 2.7): the /categories catalog +
+    # per-detection category links, and the parallel category_* appearance datasets
+    # in /embeddings. Purely additive (each is a separate dataset/group read with a
+    # presence check), so the bump only applies when there is category data to
+    # persist (computed above alongside has_identity_data for both eager and lazy).
+    if has_category_data:
+        format_id = max(format_id, 2.7)
 
     with h5py.File(labels_path, "a") as f:
         # Bump for chunked label image format (new in 2.2)
@@ -4253,6 +4817,9 @@ def _read_labels_lazy_from_open_file(
     skeletons = read_skeletons(labels_path, _hdf5_file=f)
     tracks = read_tracks(labels_path, _hdf5_file=f)
     identities = read_identities(labels_path, _hdf5_file=f)
+    # Class/category catalog (SLP 2.7+). Self-contained mirror of /identity; a
+    # top-level list read eagerly like identities.
+    categories = read_categories(labels_path, _hdf5_file=f)
     # Frame-spanning events + catalog (SLP 2.6+). Top-level lists (not the lazy
     # store), read eagerly like tracks/identities/suggestions.
     event_types = read_event_types(labels_path, _hdf5_file=f)
@@ -4268,6 +4835,13 @@ def _read_labels_lazy_from_open_file(
     centroid_identity_map = identity_links.get(OWNER_CENTROID, {})
     bbox_identity_map = identity_links.get(OWNER_BBOX, {})
     roi_identity_map = identity_links.get(OWNER_ROI, {})
+    # Category links (SLP 2.7+): same owner-keyed split as identity links.
+    category_links = read_category_links(labels_path, _hdf5_file=f)
+    instance_categories = category_links.get(OWNER_INSTANCE, {})
+    mask_category_map = category_links.get(OWNER_MASK, {})
+    centroid_category_map = category_links.get(OWNER_CENTROID, {})
+    bbox_category_map = category_links.get(OWNER_BBOX, {})
+    roi_category_map = category_links.get(OWNER_ROI, {})
     # Embeddings: per-instance embeddings ride on the lazy store; mask/centroid/
     # bbox/ROI embeddings attach to those (eagerly-read) annotations below.
     embeddings_by_owner = read_embeddings(labels_path, _hdf5_file=f)
@@ -4276,6 +4850,15 @@ def _read_labels_lazy_from_open_file(
     centroid_embedding_map = embeddings_by_owner.get(OWNER_CENTROID, {})
     bbox_embedding_map = embeddings_by_owner.get(OWNER_BBOX, {})
     roi_embedding_map = embeddings_by_owner.get(OWNER_ROI, {})
+    # Category embeddings (SLP 2.7+): parallel category_* datasets in /embeddings.
+    category_embeddings_by_owner = read_category_embeddings(labels_path, _hdf5_file=f)
+    instance_category_embeddings = category_embeddings_by_owner.get(OWNER_INSTANCE, {})
+    mask_category_embedding_map = category_embeddings_by_owner.get(OWNER_MASK, {})
+    centroid_category_embedding_map = category_embeddings_by_owner.get(
+        OWNER_CENTROID, {}
+    )
+    bbox_category_embedding_map = category_embeddings_by_owner.get(OWNER_BBOX, {})
+    roi_category_embedding_map = category_embeddings_by_owner.get(OWNER_ROI, {})
     suggestions = read_suggestions(labels_path, videos, _hdf5_file=f)
     metadata = read_metadata(labels_path, _hdf5_file=f)
     provenance = read_provenance(labels_path, metadata, _hdf5_file=f)
@@ -4303,6 +4886,9 @@ def _read_labels_lazy_from_open_file(
         identities=identities,
         instance_identities=instance_identities,
         instance_embeddings=instance_embeddings,
+        categories=categories,
+        instance_categories=instance_categories,
+        instance_category_embeddings=instance_category_embeddings,
     )
 
     # Create LazyFrameList
@@ -4318,12 +4904,24 @@ def _read_labels_lazy_from_open_file(
         roi_identity_map,
         roi_embedding_map,
     )
+    _attach_category_and_embeddings(
+        [r for r, _v, _f in roi_tuples],
+        categories,
+        roi_category_map,
+        roi_category_embedding_map,
+    )
     mask_tuples = read_masks(labels_path, videos, tracks, _hdf5_file=f)
     _attach_identity_and_embeddings(
         [m for m, _v, _f in mask_tuples],
         identities,
         mask_identity_map,
         mask_embedding_map,
+    )
+    _attach_category_and_embeddings(
+        [m for m, _v, _f in mask_tuples],
+        categories,
+        mask_category_map,
+        mask_category_embedding_map,
     )
     bbox_tuples = read_bboxes(labels_path, videos, tracks, _hdf5_file=f)
     _attach_identity_and_embeddings(
@@ -4332,12 +4930,24 @@ def _read_labels_lazy_from_open_file(
         bbox_identity_map,
         bbox_embedding_map,
     )
+    _attach_category_and_embeddings(
+        [b for b, _v, _f in bbox_tuples],
+        categories,
+        bbox_category_map,
+        bbox_category_embedding_map,
+    )
     centroid_tuples = read_centroids(labels_path, videos, tracks, _hdf5_file=f)
     _attach_identity_and_embeddings(
         [c for c, _v, _f in centroid_tuples],
         identities,
         centroid_identity_map,
         centroid_embedding_map,
+    )
+    _attach_category_and_embeddings(
+        [c for c, _v, _f in centroid_tuples],
+        categories,
+        centroid_category_map,
+        centroid_category_embedding_map,
     )
     li_tuples, li_file = read_label_images(
         labels_path,
@@ -4420,6 +5030,7 @@ def _read_labels_lazy_from_open_file(
         skeletons=skeletons,
         tracks=tracks,
         identities=identities,
+        categories=categories,
         suggestions=suggestions,
         sessions=sessions,
         provenance=provenance,
@@ -4658,7 +5269,7 @@ def write_rois(
             )
         )
 
-        categories.append(roi.category)
+        categories.append(roi.category.name if roi.category else "")
         names.append(roi.name)
         sources.append(roi.source)
 
@@ -4945,7 +5556,7 @@ def write_bboxes(
             bbox.tracking_score if bbox.tracking_score is not None else float("nan")
         )
 
-        categories.append(bbox.category)
+        categories.append(bbox.category.name if bbox.category else "")
         names.append(bbox.name)
         sources.append(bbox.source)
 
@@ -5150,7 +5761,7 @@ def write_centroids(
             else float("nan")
         )
 
-        categories.append(centroid.category)
+        categories.append(centroid.category.name if centroid.category else "")
         names.append(centroid.name)
         sources.append(centroid.source)
 
@@ -5498,7 +6109,7 @@ def write_masks(
             )
         )
 
-        categories.append(mask.category)
+        categories.append(mask.category.name if mask.category else "")
         names.append(mask.name)
         sources.append(mask.source)
 
@@ -7116,6 +7727,9 @@ def _read_labels_from_open_file(
         )
 
     identities = read_identities(labels_path, _hdf5_file=f)
+    # Class/category catalog (SLP 2.7+). Self-contained mirror of /identity; a
+    # top-level list read eagerly like identities.
+    categories = read_categories(labels_path, _hdf5_file=f)
     # Frame-spanning events + catalog (SLP 2.6+). Top-level lists, read eagerly like
     # tracks/identities/suggestions; absent groups yield empty lists.
     event_types = read_event_types(labels_path, _hdf5_file=f)
@@ -7137,6 +7751,19 @@ def _read_labels_from_open_file(
             instances[inst_id].identity = identities[identity_idx]
             instances[inst_id].identity_score = identity_score
 
+    # Attach category links (SLP format 2.7+). Self-contained mirror of the identity
+    # links above; absent /categories group -> empty mappings and a no-op.
+    category_links = read_category_links(labels_path, _hdf5_file=f)
+    instance_category_map = category_links.get(OWNER_INSTANCE, {})
+    mask_category_map = category_links.get(OWNER_MASK, {})
+    centroid_category_map = category_links.get(OWNER_CENTROID, {})
+    bbox_category_map = category_links.get(OWNER_BBOX, {})
+    roi_category_map = category_links.get(OWNER_ROI, {})
+    for inst_id, (category_idx, category_score) in instance_category_map.items():
+        if 0 <= inst_id < len(instances) and 0 <= category_idx < len(categories):
+            instances[inst_id].category = categories[category_idx]
+            instances[inst_id].category_score = category_score
+
     # Attach appearance / re-ID embeddings (SLP format 2.5+). Additive: absent
     # /embeddings group -> empty mappings and a no-op. Mask/centroid/bbox/ROI
     # embeddings are attached after their respective read_* calls.
@@ -7148,6 +7775,19 @@ def _read_labels_from_open_file(
     centroid_embedding_map = embeddings_by_owner.get(OWNER_CENTROID, {})
     bbox_embedding_map = embeddings_by_owner.get(OWNER_BBOX, {})
     roi_embedding_map = embeddings_by_owner.get(OWNER_ROI, {})
+
+    # Attach category embeddings (SLP format 2.7+): parallel category_* datasets in
+    # /embeddings. Absent -> empty mappings and a no-op.
+    category_embeddings_by_owner = read_category_embeddings(labels_path, _hdf5_file=f)
+    for inst_id, emb in category_embeddings_by_owner.get(OWNER_INSTANCE, {}).items():
+        if 0 <= inst_id < len(instances):
+            instances[inst_id].category_embedding = emb
+    mask_category_embedding_map = category_embeddings_by_owner.get(OWNER_MASK, {})
+    centroid_category_embedding_map = category_embeddings_by_owner.get(
+        OWNER_CENTROID, {}
+    )
+    bbox_category_embedding_map = category_embeddings_by_owner.get(OWNER_BBOX, {})
+    roi_category_embedding_map = category_embeddings_by_owner.get(OWNER_ROI, {})
 
     sessions = read_sessions(
         labels_path, videos, labeled_frames, identities=identities, _hdf5_file=f
@@ -7161,6 +7801,12 @@ def _read_labels_from_open_file(
         roi_identity_map,
         roi_embedding_map,
     )
+    _attach_category_and_embeddings(
+        [r for r, _v, _f in roi_tuples],
+        categories,
+        roi_category_map,
+        roi_category_embedding_map,
+    )
     mask_tuples = read_masks(labels_path, videos, tracks, instances, _hdf5_file=f)
     # Attach per-mask identity links + embeddings (SLP format 2.5+/2.6+). Masks
     # are returned in global mask-list index order, the same id space written by
@@ -7171,6 +7817,12 @@ def _read_labels_from_open_file(
         mask_identity_map,
         mask_embedding_map,
     )
+    _attach_category_and_embeddings(
+        [m for m, _v, _f in mask_tuples],
+        categories,
+        mask_category_map,
+        mask_category_embedding_map,
+    )
     bbox_tuples = read_bboxes(labels_path, videos, tracks, instances, _hdf5_file=f)
     # Attach per-bbox identity links + embeddings (global bbox-list index).
     _attach_identity_and_embeddings(
@@ -7178,6 +7830,12 @@ def _read_labels_from_open_file(
         identities,
         bbox_identity_map,
         bbox_embedding_map,
+    )
+    _attach_category_and_embeddings(
+        [b for b, _v, _f in bbox_tuples],
+        categories,
+        bbox_category_map,
+        bbox_category_embedding_map,
     )
     centroid_tuples = read_centroids(
         labels_path, videos, tracks, instances, _hdf5_file=f
@@ -7188,6 +7846,12 @@ def _read_labels_from_open_file(
         identities,
         centroid_identity_map,
         centroid_embedding_map,
+    )
+    _attach_category_and_embeddings(
+        [c for c, _v, _f in centroid_tuples],
+        categories,
+        centroid_category_map,
+        centroid_category_embedding_map,
     )
     li_tuples, _li_file = read_label_images(
         labels_path,
@@ -7267,6 +7931,7 @@ def _read_labels_from_open_file(
         skeletons=skeletons,
         tracks=tracks,
         identities=identities,
+        categories=categories,
         suggestions=suggestions,
         sessions=sessions,
         provenance=provenance,
@@ -7363,9 +8028,12 @@ _KNOWN_TOPLEVEL_HDF5_NAMES = frozenset(
         "sessions_json",
         # Re-ID identity subsystem groups (SLP 2.5+): /identity holds the catalog
         # (name + EAV metadata) and per-detection links; /embeddings holds the
-        # columnar appearance vectors.
+        # columnar appearance vectors. Class/category subsystem (SLP 2.7+):
+        # /categories mirrors /identity (catalog + links); category appearance
+        # vectors are parallel datasets inside the same /embeddings group.
         "identity",
         "embeddings",
+        "categories",
         # Frame-spanning event subsystem groups (SLP 2.6+): /event_types holds the
         # catalog (name + optional description + EAV metadata); /events holds the
         # columnar interval annotations plus the ragged CSR framewise scores.
@@ -7594,6 +8262,24 @@ def _write_labels_lazy(
     )
     identity_rows.extend(_identity_link_rows_for_owner(lazy_rois, id_to_idx, OWNER_ROI))
     _write_identity_link_rows(labels_path, identity_rows)
+    # Class/category catalog + per-detection category links (SLP 2.7+). Self-
+    # contained mirror of the identity block above, driven by the store dicts.
+    write_categories(labels_path, lazy_store.categories)
+    cat_id_to_idx = {id(cat): i for i, cat in enumerate(lazy_store.categories)}
+    category_rows = _category_link_rows_from_store(lazy_store)
+    category_rows.extend(
+        _category_link_rows_for_owner(lazy_masks, cat_id_to_idx, OWNER_MASK)
+    )
+    category_rows.extend(
+        _category_link_rows_for_owner(lazy_centroids, cat_id_to_idx, OWNER_CENTROID)
+    )
+    category_rows.extend(
+        _category_link_rows_for_owner(lazy_bboxes, cat_id_to_idx, OWNER_BBOX)
+    )
+    category_rows.extend(
+        _category_link_rows_for_owner(lazy_rois, cat_id_to_idx, OWNER_ROI)
+    )
+    _write_category_link_rows(labels_path, category_rows)
     # Identity links always persist; the appearance vectors are gated by
     # save_embedding_vectors (mirrors the eager path).
     if save_embedding_vectors:
@@ -7603,6 +8289,35 @@ def _write_labels_lazy(
         _add_owner_embedding_groups(embedding_entries, lazy_bboxes, OWNER_BBOX)
         _add_owner_embedding_groups(embedding_entries, lazy_rois, OWNER_ROI)
         _write_embedding_groups(labels_path, embedding_entries)
+        # Category appearance vectors: parallel category_* datasets in /embeddings.
+        category_embedding_entries = _category_embedding_groups_from_store(lazy_store)
+        _add_owner_embedding_groups(
+            category_embedding_entries,
+            lazy_masks,
+            OWNER_MASK,
+            attr="category_embedding",
+        )
+        _add_owner_embedding_groups(
+            category_embedding_entries,
+            lazy_centroids,
+            OWNER_CENTROID,
+            attr="category_embedding",
+        )
+        _add_owner_embedding_groups(
+            category_embedding_entries,
+            lazy_bboxes,
+            OWNER_BBOX,
+            attr="category_embedding",
+        )
+        _add_owner_embedding_groups(
+            category_embedding_entries,
+            lazy_rois,
+            OWNER_ROI,
+            attr="category_embedding",
+        )
+        _write_embedding_groups(
+            labels_path, category_embedding_entries, _CATEGORY_EMBEDDING_DATASETS
+        )
     # Frame-spanning events + their catalog (SLP 2.6+). Events live on top-level
     # lists, so the writers are identical to the eager path.
     write_event_types(labels_path, labels.event_types)
@@ -7899,6 +8614,13 @@ def write_labels(
     labels._collect_identities()
     write_identities(labels_path, labels.identities)
     write_identity_links(labels_path, labels)
+    # Auto-collect any detection category not yet registered in the catalog
+    # (object-identity deduped), mirroring _collect_identities, then persist the
+    # /categories catalog + per-detection links (SLP 2.7+). Additive: omitted
+    # entirely when there are no categories (files stay byte-identical).
+    labels._collect_categories()
+    write_categories(labels_path, labels.categories)
+    write_category_links(labels_path, labels)
     # Frame-spanning events + their catalog (SLP 2.6+). Additive groups; omitted
     # entirely when there are no events / event types (files stay byte-identical).
     write_event_types(labels_path, labels.event_types)
@@ -7914,6 +8636,8 @@ def write_labels(
     # save_embedding_vectors so a producer can keep them in memory but off disk.
     if save_embedding_vectors:
         write_embeddings(labels_path, labels)
+        # Category appearance vectors: parallel category_* datasets in /embeddings.
+        write_category_embeddings(labels_path, labels)
     write_suggestions(labels_path, labels.suggestions, labels.videos)
     write_sessions(
         labels_path,

--- a/sleap_io/io/slp_lazy.py
+++ b/sleap_io/io/slp_lazy.py
@@ -15,6 +15,7 @@ import attrs
 import numpy as np
 
 if TYPE_CHECKING:
+    from sleap_io.model.category import Category
     from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, PredictedInstance, Track
     from sleap_io.model.labeled_frame import LabeledFrame
@@ -95,6 +96,19 @@ class LazyDataStore:
         factory=dict, repr=False, alias="instance_embeddings"
     )
 
+    # Global category catalog and per-instance category links (format 2.7+).
+    # ``categories`` are canonical objects shared with Labels.categories;
+    # ``_instance_categories`` maps global instance_id -> (category_idx, score).
+    categories: list["Category"] = attrs.field(factory=list, repr=False)
+    _instance_categories: dict = attrs.field(
+        factory=dict, repr=False, alias="instance_categories"
+    )
+    # Per-instance category (classification) embeddings (format 2.7+):
+    # instance_id -> Embedding.
+    _instance_category_embeddings: dict = attrs.field(
+        factory=dict, repr=False, alias="instance_category_embeddings"
+    )
+
     def __attrs_post_init__(self) -> None:
         """Validate index bounds on construction."""
         self.validate()
@@ -173,6 +187,9 @@ class LazyDataStore:
             identities=self.identities,  # Share references (canonical objects)
             instance_identities=dict(self._instance_identities),
             instance_embeddings=dict(self._instance_embeddings),
+            categories=self.categories,  # Share references (canonical objects)
+            instance_categories=dict(self._instance_categories),
+            instance_category_embeddings=dict(self._instance_category_embeddings),
             format_id=self.format_id,
             source_path=self._source_path,
             negative_frames=self._negative_frames.copy(),
@@ -322,6 +339,21 @@ class LazyDataStore:
         # immutable.
         identity_embedding = self._instance_embeddings.get(instance_id)
 
+        # Resolve the optional per-instance global category (format 2.7+). Joined on
+        # the global instance_id, mirroring identity; absent for older files.
+        category = None
+        category_score = None
+        if self._instance_categories:
+            entry = self._instance_categories.get(instance_id)
+            if entry is not None:
+                category_idx, cat_score = entry
+                if 0 <= category_idx < len(self.categories):
+                    category = self.categories[category_idx]
+                    category_score = cat_score
+
+        # Resolve the optional per-instance classification embedding (format 2.7+).
+        category_embedding = self._instance_category_embeddings.get(instance_id)
+
         if instance_type == InstanceType.USER:
             pts_data = self.points_data[point_id_start:point_id_end]
             points_array = self._make_points_array(pts_data, skeleton)
@@ -336,6 +368,9 @@ class LazyDataStore:
                 identity=identity,
                 identity_score=identity_score,
                 identity_embedding=identity_embedding,
+                category=category,
+                category_score=category_score,
+                category_embedding=category_embedding,
             )
         else:  # PREDICTED
             pts_data = self.pred_points_data[point_id_start:point_id_end]
@@ -352,6 +387,9 @@ class LazyDataStore:
                 identity=identity,
                 identity_score=identity_score,
                 identity_embedding=identity_embedding,
+                category=category,
+                category_score=category_score,
+                category_embedding=category_embedding,
             )
 
     def _make_points_array(

--- a/sleap_io/io/ultralytics.py
+++ b/sleap_io/io/ultralytics.py
@@ -528,7 +528,7 @@ def _build_class_names_from_rois(rois: list[ROI]) -> dict[int, str]:
     Returns:
         A dictionary mapping integer class IDs to category name strings.
     """
-    categories = sorted({roi.category for roi in rois if roi.category})
+    categories = sorted({roi.category.name for roi in rois if roi.category})
     if not categories:
         return {0: "object"}
     return {i: name for i, name in enumerate(categories)}
@@ -543,7 +543,7 @@ def _build_class_names_from_bboxes(bboxes: list[BoundingBox]) -> dict[int, str]:
     Returns:
         A dictionary mapping integer class IDs to category name strings.
     """
-    categories = sorted({bbox.category for bbox in bboxes if bbox.category})
+    categories = sorted({bbox.category.name for bbox in bboxes if bbox.category})
     if not categories:
         return {0: "object"}
     return {i: name for i, name in enumerate(categories)}
@@ -1067,7 +1067,7 @@ def write_roi_label_file(
 
     with open(label_path, "w") as f:
         for roi in exploded_rois:
-            class_id = name_to_id.get(roi.category, 0)
+            class_id = name_to_id.get(roi.category.name, 0) if roi.category else 0
 
             if not roi.is_bbox:
                 # Write segmentation polygon
@@ -1125,7 +1125,7 @@ def write_bbox_label_file(
 
     with open(label_path, "w") as f:
         for bbox in bboxes:
-            class_id = name_to_id.get(bbox.category, 0)
+            class_id = name_to_id.get(bbox.category.name, 0) if bbox.category else 0
 
             # Normalize center coordinates and dimensions
             x_center_norm = bbox.x_center / width_px

--- a/sleap_io/model/bbox.py
+++ b/sleap_io/model/bbox.py
@@ -18,7 +18,10 @@ from typing import TYPE_CHECKING
 import attrs
 import numpy as np
 
+from sleap_io.model.category import to_category
+
 if TYPE_CHECKING:
+    from sleap_io.model.category import Category
     from sleap_io.model.centroid import Centroid
     from sleap_io.model.embedding import Embedding
     from sleap_io.model.identity import Identity
@@ -51,11 +54,17 @@ class BoundingBox:
             Kept separate from `tracking_score` (short-term tracklet vs long-term
             identity).
         instance: Optional linked pose instance.
-        category: Class label (e.g., "mouse", "fly").
+        category: Optional `Category` (class label, e.g. ``"mouse"``, ``"fly"``)
+            for this box. Promoted from the legacy free-form string; ``None`` if
+            unset. Mirrors `Instance.category`.
         name: Human-readable name.
         source: Annotation source identifier.
         identity_embedding: Optional `Embedding` describing this detection's
             appearance for re-identification. ``None`` by default.
+        category_score: Score associated with the `category` assignment (e.g. the
+            classifier confidence). ``None`` if unassigned or assigned manually.
+        category_embedding: Optional `Embedding` describing this detection's
+            appearance for classification. ``None`` by default.
 
     Notes:
         Bounding boxes use identity-based equality (two BoundingBox objects are
@@ -75,10 +84,12 @@ class BoundingBox:
     identity: "Identity | None" = attrs.field(default=None)
     identity_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
-    category: str = attrs.field(default="")
+    category: "Category | None" = attrs.field(default=None, converter=to_category)
     name: str = attrs.field(default="")
     source: str = attrs.field(default="")
     identity_embedding: "Embedding | None" = attrs.field(default=None, repr=False)
+    category_score: float | None = attrs.field(default=None)
+    category_embedding: "Embedding | None" = attrs.field(default=None, repr=False)
 
     # Private: deferred instance index for lazy loading.
     _instance_idx: int = attrs.field(default=-1, repr=False, eq=False, init=False)
@@ -295,6 +306,8 @@ class BoundingBox:
             geometry=geom,
             name=self.name,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             source=self.source,
             track=self.track,
             tracking_score=self.tracking_score,
@@ -360,6 +373,8 @@ class BoundingBox:
             identity_embedding=self.identity_embedding,
             instance=self.instance,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             name=self.name,
             source=self.source,
         )
@@ -400,6 +415,8 @@ class BoundingBox:
             identity_embedding=self.identity_embedding,
             instance=self.instance,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             name=self.name,
             source=self.source,
         )

--- a/sleap_io/model/camera.py
+++ b/sleap_io/model/camera.py
@@ -7,6 +7,7 @@ import numpy as np
 from attrs import define, field
 from attrs.validators import instance_of
 
+from sleap_io.model.category import Category
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, Instance3D
 from sleap_io.model.labeled_frame import LabeledFrame
@@ -455,6 +456,8 @@ class InstanceGroup:
         points: Optional 3D points for the `InstanceGroup`. Delegates to
             `instance_3d.points` if present.
         identity: Optional `Identity` for this group (which animal).
+        category: Optional `Category` for this group (which class). Mirrors
+            `identity` but groups by class rather than individual.
         metadata: Dictionary of metadata.
     """
 
@@ -466,6 +469,7 @@ class InstanceGroup:
     )
     _instance_3d: "Instance3D | None" = field(default=None)
     identity: "Identity | None" = field(default=None)
+    category: "Category | None" = field(default=None)
     metadata: dict = field(factory=dict, validator=instance_of(dict))
 
     @property
@@ -538,6 +542,8 @@ class InstanceGroup:
         parts = [f"InstanceGroup(n_cameras={n_cams}, has_3d={has_3d}"]
         if self.identity is not None:
             parts.append(f', identity="{self.identity.name}"')
+        if self.category is not None:
+            parts.append(f', category="{self.category.name}"')
         parts.append(")")
         return "".join(parts)
 

--- a/sleap_io/model/category.py
+++ b/sleap_io/model/category.py
@@ -1,0 +1,98 @@
+"""Category data structure for ground-truth class membership of detections."""
+
+from __future__ import annotations
+
+from attrs import define, field
+from attrs.validators import instance_of
+
+
+@define(eq=False)
+class Category:
+    """Ground-truth class membership of a detection (e.g. species, sex, condition).
+
+    Where `Track` is an ephemeral temporal trajectory within a single video and
+    `Identity` names a specific individual across videos, `Category` names the
+    *class* an individual belongs to -- a group of individuals that share some
+    attribute, typically assigned by classification or retrieved via re-ID (e.g.
+    ``"female_fly"``, ``"fur_shaved"``, ``"mouse"``). The per-detection binding is
+    stored on ``Instance.category`` (and the analogous slot on the other detection
+    modalities), alongside an optional ``category_score`` (assignment confidence)
+    and ``category_embedding`` (the appearance vector it was classified from).
+
+    Attributes:
+        name: Human-readable name for this category (e.g., ``"female_fly"``). Not
+            required to be unique, but ``name`` is how categories are matched
+            across separately-loaded files and merges.
+        metadata: Arbitrary string-keyed, string-valued metadata (e.g.
+            ``{"color": "#e6194b", "supercategory": "insect"}``). Empty by default.
+
+    Notes:
+        `Category` objects use object-identity equality (``eq=False``), matching
+        `Track` and `Identity`. Use `matches()` (default ``method="name"``) to
+        compare categories across files, where Python object identity is not
+        meaningful.
+    """
+
+    name: str = field(default="", validator=instance_of(str))
+    metadata: dict[str, str] = field(factory=dict, validator=instance_of(dict))
+
+    def matches(self, other: "Category", method: str = "name") -> bool:
+        """Check if this category matches another category.
+
+        Args:
+            other: Another category to compare with.
+            method: Matching method:
+
+                - ``"name"`` (default): match by the `name` attribute, which
+                  survives serialization and cross-file merges.
+                - ``"identity"``: match by Python object identity (same object).
+
+        Returns:
+            True if the categories match according to the specified method.
+
+        Raises:
+            ValueError: If `method` is not one of the supported values.
+        """
+        if method == "name":
+            return self.name == other.name
+        elif method == "identity":
+            return self is other
+        else:
+            raise ValueError(f"Unknown matching method: {method}")
+
+    def __repr__(self) -> str:
+        """Return a readable string representation."""
+        return f'Category(name="{self.name}")'
+
+
+def to_category(value: "Category | str | None") -> "Category | None":
+    """Coerce a category-like value to a `Category` (or ``None``).
+
+    Promotes the legacy free-form ``category: str`` field (the object-detection
+    class label) to a first-class `Category`, keeping existing ``category="mouse"``
+    call sites working:
+
+    - ``None`` or the empty string ``""`` (the old "unset" sentinel) -> ``None``.
+    - a non-empty ``str`` -> ``Category(name=value)``.
+    - an existing `Category` -> returned unchanged.
+
+    Args:
+        value: A `Category`, a class-label string, ``""``, or ``None``.
+
+    Returns:
+        A `Category`, or ``None`` if the input was ``None`` / ``""``.
+
+    Raises:
+        TypeError: If `value` is not a `Category`, `str`, or ``None``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, Category):
+        return value
+    if isinstance(value, str):
+        if value == "":
+            return None
+        return Category(name=value)
+    raise TypeError(
+        f"category must be a Category, str, or None, got {type(value).__name__}."
+    )

--- a/sleap_io/model/centroid.py
+++ b/sleap_io/model/centroid.py
@@ -20,8 +20,11 @@ from typing import TYPE_CHECKING
 import attrs
 import numpy as np
 
+from sleap_io.model.category import to_category
+
 if TYPE_CHECKING:
     from sleap_io.model.bbox import BoundingBox
+    from sleap_io.model.category import Category
     from sleap_io.model.embedding import Embedding
     from sleap_io.model.identity import Identity
     from sleap_io.model.instance import Instance, PredictedInstance, Track
@@ -117,12 +120,18 @@ class Centroid:
             Kept separate from `tracking_score` (short-term tracklet vs long-term
             identity).
         instance: Optional linked pose instance.
-        category: Class label (e.g., ``"lysosome"``, ``"cell"``).
+        category: Optional `Category` (class label, e.g. ``"lysosome"``,
+            ``"cell"``) for this centroid. Promoted from the legacy free-form
+            string; ``None`` if unset. Mirrors `Instance.category`.
         name: Human-readable name (e.g., ``"ID43008"``).
         source: How the centroid was computed (e.g., ``"center_of_mass"``,
             ``"trackmate"``).
         identity_embedding: Optional `Embedding` describing this detection's
             appearance for re-identification. ``None`` by default.
+        category_score: Score associated with the `category` assignment (e.g. the
+            classifier confidence). ``None`` if unassigned or assigned manually.
+        category_embedding: Optional `Embedding` describing this detection's
+            appearance for classification. ``None`` by default.
 
     Notes:
         Centroids use identity-based equality (two Centroid objects are only
@@ -140,10 +149,12 @@ class Centroid:
     identity: "Identity | None" = attrs.field(default=None)
     identity_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
-    category: str = attrs.field(default="")
+    category: "Category | None" = attrs.field(default=None, converter=to_category)
     name: str = attrs.field(default="")
     source: str = attrs.field(default="")
     identity_embedding: "Embedding | None" = attrs.field(default=None, repr=False)
+    category_score: float | None = attrs.field(default=None)
+    category_embedding: "Embedding | None" = attrs.field(default=None, repr=False)
 
     # Private: deferred instance index for lazy loading.
     _instance_idx: int = attrs.field(default=-1, repr=False, eq=False, init=False)
@@ -219,6 +230,9 @@ class Centroid:
                 identity=self.identity,
                 identity_score=self.identity_score,
                 identity_embedding=self.identity_embedding,
+                category=self.category,
+                category_score=self.category_score,
+                category_embedding=self.category_embedding,
             )
         else:
             return Instance.from_numpy(
@@ -229,6 +243,9 @@ class Centroid:
                 identity=self.identity,
                 identity_score=self.identity_score,
                 identity_embedding=self.identity_embedding,
+                category=self.category,
+                category_score=self.category_score,
+                category_embedding=self.category_embedding,
             )
 
     def to_instance(
@@ -376,6 +393,9 @@ class Centroid:
             identity=instance.identity,
             identity_score=instance.identity_score,
             identity_embedding=instance.identity_embedding,
+            category=instance.category,
+            category_score=instance.category_score,
+            category_embedding=instance.category_embedding,
             instance=instance,
             source=source,
         )
@@ -496,6 +516,8 @@ class Centroid:
             identity_embedding=self.identity_embedding,
             instance=self.instance,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             name=self.name,
             source=self.source,
         )
@@ -544,6 +566,8 @@ class Centroid:
             identity_embedding=self.identity_embedding,
             instance=self.instance,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             name=self.name,
             source=self.source,
         )
@@ -597,6 +621,8 @@ class Centroid:
                 identity_embedding=self.identity_embedding,
                 instance=self.instance,
                 category=self.category,
+                category_score=self.category_score,
+                category_embedding=self.category_embedding,
                 name=self.name,
                 source=self.source,
             )

--- a/sleap_io/model/instance.py
+++ b/sleap_io/model/instance.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import attrs
 import numpy as np
 
+from sleap_io.model.category import Category, to_category
 from sleap_io.model.embedding import Embedding
 from sleap_io.model.identity import Identity
 from sleap_io.model.skeleton import Node, Skeleton
@@ -429,6 +430,16 @@ class Instance:
         identity_embedding: An optional `Embedding` describing this instance's
             appearance for re-identification (e.g. a vector produced by a re-ID
             model). ``None`` by default.
+        category: An optional `Category` representing the *class* this instance
+            belongs to (e.g. ``"female_fly"``, ``"fur_shaved"``), typically
+            assigned by classification or re-ID. Mirrors `identity` but groups by
+            class rather than individual. `None` if no category is assigned.
+        category_score: The score associated with the `category` assignment (e.g.
+            the classifier confidence). `None` if the instance has no category or
+            the category was assigned manually.
+        category_embedding: An optional `Embedding` describing this instance's
+            appearance for classification (the vector the `category` was
+            classified from). ``None`` by default.
     """
 
     points: PointsArray = attrs.field(eq=attrs.cmp_using(eq=np.array_equal))
@@ -437,8 +448,11 @@ class Instance:
     tracking_score: float | None = None
     identity: Identity | None = None
     identity_score: float | None = None
+    category: Category | None = attrs.field(default=None, converter=to_category)
+    category_score: float | None = None
     from_predicted: "PredictedInstance | None" = None
     identity_embedding: Embedding | None = attrs.field(default=None, repr=False)
+    category_embedding: Embedding | None = attrs.field(default=None, repr=False)
 
     @classmethod
     def empty(
@@ -448,7 +462,10 @@ class Instance:
         tracking_score: float | None = None,
         identity: Identity | None = None,
         identity_score: float | None = None,
+        category: Category | None = None,
+        category_score: float | None = None,
         identity_embedding: Embedding | None = None,
+        category_embedding: Embedding | None = None,
         from_predicted: "PredictedInstance | None" = None,
     ) -> "Instance":
         """Create an empty instance with no points.
@@ -463,7 +480,11 @@ class Instance:
                 track or if the track was assigned manually.
             identity: An optional global `Identity` for this instance.
             identity_score: The score associated with the `identity` assignment.
+            category: An optional `Category` (class) for this instance.
+            category_score: The score associated with the `category` assignment.
             identity_embedding: An optional re-ID `Embedding` for this instance.
+            category_embedding: An optional classification `Embedding` for this
+                instance.
             from_predicted: The `PredictedInstance` (if any) that this instance was
                 initialized from. This is used with human-in-the-loop workflows.
 
@@ -480,7 +501,10 @@ class Instance:
             tracking_score=tracking_score,
             identity=identity,
             identity_score=identity_score,
+            category=category,
+            category_score=category_score,
             identity_embedding=identity_embedding,
+            category_embedding=category_embedding,
             from_predicted=from_predicted,
         )
 
@@ -510,7 +534,10 @@ class Instance:
         tracking_score: float | None = None,
         identity: Identity | None = None,
         identity_score: float | None = None,
+        category: Category | None = None,
+        category_score: float | None = None,
         identity_embedding: Embedding | None = None,
+        category_embedding: Embedding | None = None,
         from_predicted: "PredictedInstance | None" = None,
     ) -> "Instance":
         """Create an instance object from a numpy array.
@@ -538,7 +565,11 @@ class Instance:
                 track or if the track was assigned manually.
             identity: An optional global `Identity` for this instance.
             identity_score: The score associated with the `identity` assignment.
+            category: An optional `Category` (class) for this instance.
+            category_score: The score associated with the `category` assignment.
             identity_embedding: An optional re-ID `Embedding` for this instance.
+            category_embedding: An optional classification `Embedding` for this
+                instance.
             from_predicted: The `PredictedInstance` (if any) that this instance was
                 initialized from. This is used with human-in-the-loop workflows.
 
@@ -552,7 +583,10 @@ class Instance:
             tracking_score=tracking_score,
             identity=identity,
             identity_score=identity_score,
+            category=category,
+            category_score=category_score,
             identity_embedding=identity_embedding,
+            category_embedding=category_embedding,
             from_predicted=from_predicted,
         )
 
@@ -620,7 +654,8 @@ class Instance:
         Delegates to ``Centroid.from_pose()``. A ``PredictedInstance`` yields a
         ``PredictedCentroid`` carrying its ``score``; any other instance yields a
         ``UserCentroid``. Metadata (``track``, ``tracking_score``, ``identity``,
-        ``identity_score``, ``identity_embedding``, ``instance=self``) is
+        ``identity_score``, ``identity_embedding``, ``category``,
+        ``category_score``, ``category_embedding``, ``instance=self``) is
         propagated.
 
         Args:
@@ -670,7 +705,8 @@ class Instance:
         A ``PredictedInstance`` yields a ``PredictedBoundingBox`` carrying its
         ``score``; any other instance yields a ``UserBoundingBox``. Metadata
         (``track``, ``tracking_score``, ``identity``, ``identity_score``,
-        ``identity_embedding``, ``instance=self``) is propagated.
+        ``identity_embedding``, ``category``, ``category_score``,
+        ``category_embedding``, ``instance=self``) is propagated.
 
         Args:
             mode: ``"tight"`` to fit the visible points, or ``"centered"`` to
@@ -762,6 +798,9 @@ class Instance:
             identity=self.identity,
             identity_score=self.identity_score,
             identity_embedding=self.identity_embedding,
+            category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             instance=self,
         )
         if isinstance(self, PredictedInstance):
@@ -782,7 +821,8 @@ class Instance:
         A ``PredictedInstance`` yields a ``PredictedROI`` carrying its ``score``;
         any other instance yields a ``UserROI``. Metadata (``track``,
         ``tracking_score``, ``identity``, ``identity_score``,
-        ``identity_embedding``, ``instance=self``) is propagated.
+        ``identity_embedding``, ``category``, ``category_score``,
+        ``category_embedding``, ``instance=self``) is propagated.
 
         Args:
             method: ``"shapes"`` to union buffered node points and/or edge
@@ -839,6 +879,9 @@ class Instance:
             identity=self.identity,
             identity_score=self.identity_score,
             identity_embedding=self.identity_embedding,
+            category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             instance=self,
         )
         if isinstance(self, PredictedInstance):
@@ -892,6 +935,7 @@ class Instance:
                 tracking_score=self.tracking_score,
                 identity=self.identity,
                 identity_score=self.identity_score,
+                category=self.category,
                 instance=self,
             )
             if isinstance(self, PredictedInstance):
@@ -1191,6 +1235,11 @@ class PredictedInstance(Instance):
             `Instance.identity_score`).
         identity_embedding: An optional re-ID `Embedding` (see
             `Instance.identity_embedding`).
+        category: An optional `Category` (class) (see `Instance.category`).
+        category_score: The score associated with the `category` assignment (see
+            `Instance.category_score`).
+        category_embedding: An optional classification `Embedding` (see
+            `Instance.category_embedding`).
     """
 
     points: PredictedPointsArray = attrs.field(eq=attrs.cmp_using(eq=np.array_equal))
@@ -1200,8 +1249,11 @@ class PredictedInstance(Instance):
     tracking_score: float | None = 0
     identity: Identity | None = None
     identity_score: float | None = None
+    category: Category | None = attrs.field(default=None, converter=to_category)
+    category_score: float | None = None
     from_predicted: "PredictedInstance | None" = None
     identity_embedding: Embedding | None = attrs.field(default=None, repr=False)
+    category_embedding: Embedding | None = attrs.field(default=None, repr=False)
 
     def __repr__(self) -> str:
         """Return a readable representation of the instance."""
@@ -1228,7 +1280,10 @@ class PredictedInstance(Instance):
         tracking_score: float | None = None,
         identity: Identity | None = None,
         identity_score: float | None = None,
+        category: Category | None = None,
+        category_score: float | None = None,
         identity_embedding: Embedding | None = None,
+        category_embedding: Embedding | None = None,
         from_predicted: "PredictedInstance | None" = None,
     ) -> "PredictedInstance":
         """Create an empty instance with no points."""
@@ -1243,7 +1298,10 @@ class PredictedInstance(Instance):
             tracking_score=tracking_score,
             identity=identity,
             identity_score=identity_score,
+            category=category,
+            category_score=category_score,
             identity_embedding=identity_embedding,
+            category_embedding=category_embedding,
             from_predicted=from_predicted,
         )
 
@@ -1275,7 +1333,10 @@ class PredictedInstance(Instance):
         tracking_score: float | None = None,
         identity: Identity | None = None,
         identity_score: float | None = None,
+        category: Category | None = None,
+        category_score: float | None = None,
         identity_embedding: Embedding | None = None,
+        category_embedding: Embedding | None = None,
         from_predicted: "PredictedInstance | None" = None,
     ) -> "PredictedInstance":
         """Create a predicted instance object from a numpy array."""
@@ -1291,7 +1352,10 @@ class PredictedInstance(Instance):
             tracking_score=tracking_score,
             identity=identity,
             identity_score=identity_score,
+            category=category,
+            category_score=category_score,
             identity_embedding=identity_embedding,
+            category_embedding=category_embedding,
             from_predicted=from_predicted,
         )
 

--- a/sleap_io/model/label_image.py
+++ b/sleap_io/model/label_image.py
@@ -507,7 +507,7 @@ class LabelImage:
             data[mask.data] = label_id
             objects[label_id] = LabelImage.Info(
                 track=mask.track,
-                category=mask.category,
+                category=mask.category.name if mask.category else "",
                 name=mask.name,
                 instance=mask.instance,
             )

--- a/sleap_io/model/labels.py
+++ b/sleap_io/model/labels.py
@@ -22,6 +22,7 @@ from attrs import define, field
 
 from sleap_io.io.utils import sanitize_filename
 from sleap_io.model.camera import RecordingSession
+from sleap_io.model.category import Category
 from sleap_io.model.event import Event, EventType
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, PredictedInstance, Track
@@ -42,6 +43,7 @@ if TYPE_CHECKING:
     from sleap_io.model.labels_set import LabelsSet
     from sleap_io.model.mask import SegmentationMask
     from sleap_io.model.matching import (
+        CategoryMatcher,
         IdentityMatcher,
         InstanceMatcher,
         MatchResult,
@@ -75,6 +77,9 @@ class Labels:
         tracks: A list of `Track`s that are associated with this dataset.
         identities: A list of `Identity`s for ground-truth animal identification,
             persistent across sessions and videos.
+        categories: A list of `Category`s grouping detections by class/type (e.g.
+            `female_fly`, `fur_shaved`). Name-matched across files, like
+            `tracks` / `identities`.
         event_types: A list of `EventType`s -- the catalog / controlled vocabulary
             (the "ethogram") referenced by `events`. Name-matched across files, like
             `tracks` / `identities`.
@@ -144,6 +149,11 @@ class Labels:
     # positional constructor signature is unchanged.
     event_types: list[EventType] = field(factory=list, kw_only=True)
     events: list[Event] = field(factory=list, kw_only=True)
+
+    # Global `Category` catalog grouping detections by class/type (e.g.
+    # `female_fly`, `fur_shaved`). Keyword-only so the positional constructor
+    # signature is unchanged (mirrors `identities`, kept out of the positional block).
+    categories: list[Category] = field(factory=list, kw_only=True)
 
     # Static ROIs: ROIs not tied to any specific frame (e.g., arena boundaries).
     # Accepted via constructor with alias="rois" for backward compatibility.
@@ -528,12 +538,17 @@ class Labels:
                 if inst.identity is not None and inst.identity not in self.identities:
                     self.identities.append(inst.identity)
 
+                if inst.category is not None and inst.category not in self.categories:
+                    self.categories.append(inst.category)
+
             # Collect tracks and identities from nested annotations
             self._collect_annotation_tracks(lf)
             self._collect_annotation_identities(lf)
+            self._collect_annotation_categories(lf)
 
         # Collect multi-view identities bound only on InstanceGroups (sessions).
         self._collect_session_identities()
+        self._collect_session_categories()
 
         # Register event catalog entries and participants referenced by events.
         self._collect_events()
@@ -863,12 +878,20 @@ class Labels:
             # deep-copying preserves index alignment while keeping the catalog
             # independent.
             new_identities = [deepcopy(i) for i in self.identities]
+            # Categories are a name-matched catalog like identities; deep-copy to
+            # keep the copied catalog independent. Not event participants, so they
+            # are NOT seeded into the event memo below.
+            new_categories = [deepcopy(c) for c in self.categories]
 
             # Update store references
             new_store.videos = new_videos
             new_store.skeletons = new_skeletons
             new_store.tracks = new_tracks
             new_store.identities = new_identities
+            # Categories are index-referenced by the store's per-instance maps (like
+            # identities), so point the store at the copied catalog to keep
+            # materialized detections referencing the independent copies.
+            new_store.categories = new_categories
 
             # Annotations are stored on the lazy store's per-frame dicts
             # and will be attached to frames when they are materialized.
@@ -910,6 +933,7 @@ class Labels:
                 provenance=dict(self.provenance),
                 event_types=new_event_types,
                 events=new_events,
+                categories=new_categories,
                 lazy_store=new_store,
             )
         else:
@@ -956,6 +980,19 @@ class Labels:
             if ann.identity is not None and ann.identity not in self.identities:
                 self.identities.append(ann.identity)
 
+    def _collect_annotation_categories(self, lf: LabeledFrame):
+        """Collect categories from non-instance annotations on a frame.
+
+        Mirrors `_collect_annotation_identities` for the global `Category` catalog.
+        `SegmentationMask`, `Centroid`, `BoundingBox`, and `ROI` carry a `category`;
+        deduped by object identity (``not in``), matching the instance-category
+        collection in update/append/extend. Static ROIs (not frame-bound) are swept
+        by the save-time `_collect_categories`.
+        """
+        for ann in (*lf.masks, *lf.centroids, *lf.bboxes, *lf.rois):
+            if ann.category is not None and ann.category not in self.categories:
+                self.categories.append(ann.category)
+
     def _collect_identities(self):
         """Register every detection's `Identity` in the catalog.
 
@@ -982,6 +1019,30 @@ class Labels:
             register(roi.identity)
         self._collect_session_identities()
 
+    def _collect_categories(self):
+        """Register every detection's `Category` in the catalog.
+
+        Save-time sweep mirroring `_collect_identities`: an ``id()``-keyed set for
+        O(number of detections) dedup, sweeping instances + (masks, centroids,
+        bboxes, rois) + static ROIs, then session categories. Mutates
+        ``self.categories`` (eager labels only).
+        """
+        seen: set[int] = {id(cat) for cat in self.categories}
+
+        def register(category: "Category | None") -> None:
+            if category is not None and id(category) not in seen:
+                seen.add(id(category))
+                self.categories.append(category)
+
+        for lf in self.labeled_frames:
+            for inst in lf:
+                register(inst.category)
+            for ann in (*lf.masks, *lf.centroids, *lf.bboxes, *lf.rois):
+                register(ann.category)
+        for roi in self.static_rois:
+            register(roi.category)
+        self._collect_session_categories()
+
     def _collect_session_identities(self):
         """Collect multi-view identities bound only on `InstanceGroup`s.
 
@@ -999,6 +1060,24 @@ class Labels:
                     identity = instance_group.identity
                     if identity is not None and identity not in self.identities:
                         self.identities.append(identity)
+
+    def _collect_session_categories(self):
+        """Collect multi-view categories bound only on `InstanceGroup`s.
+
+        A multi-view category may be attached to an `InstanceGroup`
+        (``session.frame_groups[*].instance_groups[*].category``) without ever
+        appearing on a per-instance ``Instance.category``. Those categories would
+        otherwise be dropped on save, so collect them into ``self.categories``.
+
+        Deduped by object identity (``not in``), mirroring
+        `_collect_session_identities`. Cheap no-op for labels without sessions.
+        """
+        for session in self.sessions:
+            for frame_group in session.frame_groups.values():
+                for instance_group in frame_group.instance_groups:
+                    category = instance_group.category
+                    if category is not None and category not in self.categories:
+                        self.categories.append(category)
 
     def _collect_events(self):
         """Register catalog entries and participants referenced by `events`.
@@ -1083,9 +1162,14 @@ class Labels:
                 if inst.identity is not None and inst.identity not in self.identities:
                     self.identities.append(inst.identity)
 
+                if inst.category is not None and inst.category not in self.categories:
+                    self.categories.append(inst.category)
+
             self._collect_annotation_tracks(lf)
             self._collect_annotation_identities(lf)
+            self._collect_annotation_categories(lf)
             self._collect_session_identities()
+            self._collect_session_categories()
 
     def extend(self, lfs: list[LabeledFrame], update: bool = True):
         """Append labeled frames to the labels.
@@ -1119,10 +1203,18 @@ class Labels:
                     ):
                         self.identities.append(inst.identity)
 
+                    if (
+                        inst.category is not None
+                        and inst.category not in self.categories
+                    ):
+                        self.categories.append(inst.category)
+
                 self._collect_annotation_tracks(lf)
                 self._collect_annotation_identities(lf)
+                self._collect_annotation_categories(lf)
 
             self._collect_session_identities()
+            self._collect_session_categories()
 
     def _append_indexed(self, lf: LabeledFrame, update: bool = True) -> None:
         """Append a labeled frame while keeping the frame index warm.
@@ -2140,7 +2232,11 @@ class Labels:
         else:
             results = list(self.rois)
         if category is not None:
-            results = [r for r in results if r.category == category]
+            results = [
+                r
+                for r in results
+                if r.category is not None and r.category.name == category
+            ]
         if track is not None:
             results = [r for r in results if r.track is track]
         if instance is not None:
@@ -2201,7 +2297,11 @@ class Labels:
         else:
             results = list(self.masks)
         if category is not None:
-            results = [r for r in results if r.category == category]
+            results = [
+                r
+                for r in results
+                if r.category is not None and r.category.name == category
+            ]
         if track is not None:
             results = [r for r in results if r.track is track]
         if instance is not None:
@@ -2267,7 +2367,11 @@ class Labels:
         else:
             results = list(self.bboxes)
         if category is not None:
-            results = [b for b in results if b.category == category]
+            results = [
+                b
+                for b in results
+                if b.category is not None and b.category.name == category
+            ]
         if track is not None:
             results = [b for b in results if b.track is track]
         if instance is not None:
@@ -2332,7 +2436,11 @@ class Labels:
         else:
             results = list(self.centroids)
         if category is not None:
-            results = [c for c in results if c.category == category]
+            results = [
+                c
+                for c in results
+                if c.category is not None and c.category.name == category
+            ]
         if track is not None:
             results = [c for c in results if c.track is track]
         if instance is not None:
@@ -3674,6 +3782,7 @@ class Labels:
         video: "str | VideoMatcher | None" = None,
         track: "str | TrackMatcher | None" = None,
         identity: "str | IdentityMatcher | None" = None,
+        category: "str | CategoryMatcher | None" = None,
         frame: str = "auto",
         instance: "str | InstanceMatcher | None" = None,
         validate: bool = True,
@@ -3705,6 +3814,12 @@ class Labels:
                 dedupes the identity catalog by `name` so the same animal across
                 files collapses to one canonical `Identity`. Pass an
                 `IdentityMatcher` with method "identity" to dedupe by object
+                identity instead.
+            category: Global `Category` catalog matching method. Can be a string
+                ("name") or a CategoryMatcher object. Default is "name", which
+                dedupes the category catalog by `name` so the same class across
+                files collapses to one canonical `Category`. Pass a
+                `CategoryMatcher` with method "identity" to dedupe by object
                 identity instead.
             frame: Frame merge strategy. One of "auto", "keep_original",
                 "keep_new", "keep_both", "update_tracks", "replace_predictions".
@@ -3775,7 +3890,9 @@ class Labels:
 
         import sleap_io
         from sleap_io.model.matching import (
+            NAME_CATEGORY_MATCHER,
             NAME_IDENTITY_MATCHER,
+            CategoryMatcher,
             ConflictResolution,
             ErrorMode,
             IdentityMatcher,
@@ -4052,6 +4169,32 @@ class Labels:
 
                 identity_map[id(other_identity)] = matched_identity
 
+            # Step 3b-cat: Match and merge categories (dedupe by name). Mirrors the
+            # identity merge: the same class across files maps to a single canonical
+            # catalog object. ``category_map`` (keyed by the source category's object
+            # id, since `Category` is ``eq=False``) is threaded into ``_map_instance``
+            # so per-instance categories point at the deduped catalog entry.
+            if isinstance(category, CategoryMatcher):
+                category_matcher = category
+            elif isinstance(category, str):
+                category_matcher = CategoryMatcher(method=category)
+            else:
+                category_matcher = NAME_CATEGORY_MATCHER
+            category_map: dict[int, Category] = {}
+            for other_category in other.categories:
+                matched_category = None
+                for self_category in self.categories:
+                    if category_matcher.match(self_category, other_category):
+                        matched_category = self_category
+                        break
+
+                if matched_category is None:
+                    # Add new category if no match.
+                    self.categories.append(other_category)
+                    matched_category = other_category
+
+                category_map[id(other_category)] = matched_category
+
             # Step 3c: Match and merge event types (dedupe by name). Mirrors the
             # identity merge: the same event type across files collapses to one
             # canonical catalog entry. ``event_type_map`` (keyed by the source
@@ -4111,6 +4254,7 @@ class Labels:
                             skeleton_map,
                             track_map,
                             identity_map=identity_map,
+                            category_map=category_map,
                             memo=instance_memo,
                         )
                         new_frame.instances.append(new_inst)
@@ -4151,6 +4295,7 @@ class Labels:
                                 skeleton_map,
                                 track_map,
                                 identity_map=identity_map,
+                                category_map=category_map,
                                 memo=instance_memo,
                             )
                             remapped_instances.append(remapped_inst)
@@ -4442,6 +4587,7 @@ class Labels:
         skeleton_map: dict[Skeleton, Skeleton],
         track_map: dict[Track, Track],
         identity_map: dict[int, Identity] | None = None,
+        category_map: dict[int, Category] | None = None,
         memo: dict[int, Instance | PredictedInstance] | None = None,
     ) -> Instance | PredictedInstance:
         """Map an instance to use mapped skeleton, track, and identity.
@@ -4455,6 +4601,12 @@ class Labels:
                 provided, the instance's identity is resolved through this map so
                 that the same animal across files points at a single catalog object.
                 The instance's ``identity_score`` and ``identity_embedding`` are
+                always copied.
+            category_map: Optional mapping from the source `Category`'s object id to
+                the canonical (deduped) `Category` in the merged catalog. When
+                provided, the instance's category is resolved through this map so
+                that the same class across files points at a single catalog object.
+                The instance's ``category_score`` and ``category_embedding`` are
                 always copied.
             memo: Optional mapping from the id of the source instance to the new
                 instance, mutated in place. Used to repair ``from_predicted``
@@ -4486,6 +4638,15 @@ class Labels:
             if (instance.identity is not None and identity_map)
             else instance.identity
         )
+        # Resolve the category through the catalog dedup map (keyed by the source
+        # category's object id, since `Category` is ``eq=False``) so the same class
+        # across merged files maps to one canonical Category. Falls back to the
+        # instance's own category when no map/category is present.
+        mapped_category = (
+            category_map.get(id(instance.category), instance.category)
+            if (instance.category is not None and category_map)
+            else instance.category
+        )
 
         # Reorder points by node name when the source order differs from the mapped
         # skeleton's order, otherwise the per-node coordinates/scores would be carried
@@ -4513,6 +4674,9 @@ class Labels:
                 identity=mapped_identity,
                 identity_score=instance.identity_score,
                 identity_embedding=instance.identity_embedding,
+                category=mapped_category,
+                category_score=instance.category_score,
+                category_embedding=instance.category_embedding,
             )
         else:
             new_instance = Instance(
@@ -4524,6 +4688,9 @@ class Labels:
                 identity=mapped_identity,
                 identity_score=instance.identity_score,
                 identity_embedding=instance.identity_embedding,
+                category=mapped_category,
+                category_score=instance.category_score,
+                category_embedding=instance.category_embedding,
             )
         if memo is not None:
             memo[id(instance)] = new_instance

--- a/sleap_io/model/mask.py
+++ b/sleap_io/model/mask.py
@@ -30,6 +30,8 @@ from typing import TYPE_CHECKING
 import attrs
 import numpy as np
 
+from sleap_io.model.category import to_category
+
 if TYPE_CHECKING:
     if sys.version_info >= (3, 11):
         from typing import Self
@@ -37,6 +39,7 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
     from sleap_io.model.bbox import BoundingBox
+    from sleap_io.model.category import Category
     from sleap_io.model.centroid import Centroid
     from sleap_io.model.embedding import Embedding
     from sleap_io.model.identity import Identity
@@ -125,7 +128,9 @@ class SegmentationMask:
         height: Height of the mask in pixels.
         width: Width of the mask in pixels.
         name: Optional human-readable name for this mask.
-        category: Optional category label (e.g., class name for detection).
+        category: Optional `Category` (class label, e.g. class name for
+            detection) for this mask. Promoted from the legacy free-form string;
+            ``None`` if unset. Mirrors `Instance.category`.
         source: Optional string indicating the source of this annotation.
         track: Optional `Track` this mask is associated with.
         tracking_score: Confidence of the track identity assignment. ``None``
@@ -146,6 +151,10 @@ class SegmentationMask:
         offset: Origin ``(x, y)`` of the mask in image pixel coordinates.
         identity_embedding: Optional `Embedding` describing this detection's
             appearance for re-identification. ``None`` by default.
+        category_score: Score associated with the `category` assignment (e.g. the
+            classifier confidence). ``None`` if unassigned or assigned manually.
+        category_embedding: Optional `Embedding` describing this detection's
+            appearance for classification. ``None`` by default.
 
     Notes:
         Masks use identity-based equality (two mask objects are only equal if they
@@ -159,7 +168,7 @@ class SegmentationMask:
     height: int = attrs.field()
     width: int = attrs.field()
     name: str = attrs.field(default="")
-    category: str = attrs.field(default="")
+    category: "Category | None" = attrs.field(default=None, converter=to_category)
     source: str = attrs.field(default="")
     track: "Track | None" = attrs.field(default=None)
     tracking_score: float | None = attrs.field(default=None)
@@ -170,6 +179,8 @@ class SegmentationMask:
     scale: tuple[float, float] = attrs.field(default=(1.0, 1.0))
     offset: tuple[float, float] = attrs.field(default=(0.0, 0.0))
     identity_embedding: "Embedding | None" = attrs.field(default=None, repr=False)
+    category_score: float | None = attrs.field(default=None)
+    category_embedding: "Embedding | None" = attrs.field(default=None, repr=False)
 
     def __attrs_post_init__(self):
         """Validate that this class is not instantiated directly."""
@@ -219,6 +230,8 @@ class SegmentationMask:
         kwargs: dict = dict(
             name=self.name,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             source=self.source,
             track=self.track,
             tracking_score=self.tracking_score,
@@ -407,6 +420,8 @@ class SegmentationMask:
             identity_embedding=self.identity_embedding,
             instance=self.instance,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             name=self.name,
             source=self.source,
         )
@@ -471,6 +486,8 @@ class SegmentationMask:
             identity_embedding=self.identity_embedding,
             instance=self.instance,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             name=self.name,
             source=self.source,
         )
@@ -536,6 +553,8 @@ class SegmentationMask:
             geometry=geometry,
             name=self.name,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             source=self.source,
             track=self.track,
             tracking_score=self.tracking_score,
@@ -633,6 +652,8 @@ class PredictedSegmentationMask(SegmentationMask):
             width=self.width,
             name=self.name,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             source=self.source,
             track=self.track,
             tracking_score=self.tracking_score,

--- a/sleap_io/model/matching.py
+++ b/sleap_io/model/matching.py
@@ -9,6 +9,7 @@ Key features:
 - Instance matching: spatial proximity, track identity, and bounding box IoU
 - Track matching: by name or object identity
 - Identity matching: by name or object identity
+- Category matching: by name or object identity
 - Video matching: path, basename, content, and auto matching
 
 Video matching supports path-based, filename-based, content-based, and
@@ -23,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 import attrs
 import numpy as np
 
+from sleap_io.model.category import Category
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, Track
 from sleap_io.model.labeled_frame import LabeledFrame
@@ -82,6 +84,19 @@ class IdentityMatchMethod(str, Enum):
         NAME: Match identities by their `name` attribute, which survives
             serialization and cross-file merges (default).
         IDENTITY: Match identities by Python object identity (same object).
+    """
+
+    NAME = "name"
+    IDENTITY = "identity"
+
+
+class CategoryMatchMethod(str, Enum):
+    """Methods for matching categories.
+
+    Attributes:
+        NAME: Match categories by their `name` attribute, which survives
+            serialization and cross-file merges (default).
+        IDENTITY: Match categories by Python object identity (same object).
     """
 
     NAME = "name"
@@ -908,6 +923,27 @@ class IdentityMatcher:
 
 
 @attrs.define
+class CategoryMatcher:
+    """Matcher for comparing and matching categories.
+
+    Attributes:
+        method: The matching method to use. Can be a CategoryMatchMethod enum
+            value or a string that will be converted to the enum. Default is
+            NAME (matches by the category `name`, which survives serialization
+            and cross-file merges).
+    """
+
+    method: CategoryMatchMethod | str = attrs.field(
+        default=CategoryMatchMethod.NAME,
+        converter=lambda x: CategoryMatchMethod(x) if isinstance(x, str) else x,
+    )
+
+    def match(self, category1: Category, category2: Category) -> bool:
+        """Check if two categories match according to the configured method."""
+        return category1.matches(category2, method=self.method.value)
+
+
+@attrs.define
 class VideoMatcher:
     """Matcher for comparing and matching videos.
 
@@ -1272,6 +1308,8 @@ NAME_TRACK_MATCHER = TrackMatcher(method=TrackMatchMethod.NAME)
 IDENTITY_TRACK_MATCHER = TrackMatcher(method=TrackMatchMethod.IDENTITY)
 
 NAME_IDENTITY_MATCHER = IdentityMatcher(method=IdentityMatchMethod.NAME)
+
+NAME_CATEGORY_MATCHER = CategoryMatcher(method=CategoryMatchMethod.NAME)
 
 AUTO_VIDEO_MATCHER = VideoMatcher(method=VideoMatchMethod.AUTO)
 PATH_VIDEO_MATCHER = VideoMatcher(method=VideoMatchMethod.PATH, strict=True)

--- a/sleap_io/model/roi.py
+++ b/sleap_io/model/roi.py
@@ -15,11 +15,14 @@ from typing import TYPE_CHECKING
 import attrs
 import numpy as np
 
+from sleap_io.model.category import to_category
+
 if TYPE_CHECKING:
     from shapely.geometry import Polygon
     from shapely.geometry.base import BaseGeometry
 
     from sleap_io.model.bbox import BoundingBox
+    from sleap_io.model.category import Category
     from sleap_io.model.centroid import Centroid
     from sleap_io.model.embedding import Embedding
     from sleap_io.model.identity import Identity
@@ -56,7 +59,9 @@ class ROI:
     Attributes:
         geometry: A Shapely geometry object (e.g., `Polygon`, `box`, `Point`).
         name: Optional human-readable name for this ROI.
-        category: Optional category label (e.g., class name for detection).
+        category: Optional `Category` (class label, e.g. class name for
+            detection) for this ROI. Promoted from the legacy free-form string;
+            ``None`` if unset. Mirrors `Instance.category`.
         source: Optional string indicating the source of this annotation.
         video: Optional `Video` this ROI is associated with. Used for static ROIs
             that are not tied to any specific frame.
@@ -74,6 +79,10 @@ class ROI:
             SLP format (v1.6+) via instance index.
         identity_embedding: Optional `Embedding` describing this detection's
             appearance for re-identification. ``None`` by default.
+        category_score: Score associated with the `category` assignment (e.g. the
+            classifier confidence). ``None`` if unassigned or assigned manually.
+        category_embedding: Optional `Embedding` describing this detection's
+            appearance for classification. ``None`` by default.
 
     Notes:
         ROIs use identity-based equality (two ROI objects are only equal if they
@@ -94,7 +103,7 @@ class ROI:
             )
 
     name: str = attrs.field(default="")
-    category: str = attrs.field(default="")
+    category: "Category | None" = attrs.field(default=None, converter=to_category)
     source: str = attrs.field(default="")
     video: "Video | None" = attrs.field(default=None)
     track: "Track | None" = attrs.field(default=None)
@@ -103,6 +112,8 @@ class ROI:
     identity_score: float | None = attrs.field(default=None)
     instance: "Instance | None" = attrs.field(default=None)
     identity_embedding: "Embedding | None" = attrs.field(default=None, repr=False)
+    category_score: float | None = attrs.field(default=None)
+    category_embedding: "Embedding | None" = attrs.field(default=None, repr=False)
 
     # Private: deferred instance index for lazy loading. When ROIs are read
     # from a file without materialized instances (e.g., lazy mode), this stores
@@ -299,7 +310,7 @@ class ROI:
             "geometry": mapping(self.geometry),
             "properties": {
                 "name": self.name,
-                "category": self.category,
+                "category": self.category.name if self.category is not None else "",
                 "source": self.source,
             },
         }
@@ -329,6 +340,8 @@ class ROI:
         kwargs = dict(
             name=self.name,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             source=self.source,
             track=self.track,
             tracking_score=self.tracking_score,
@@ -389,6 +402,8 @@ class ROI:
             identity_embedding=self.identity_embedding,
             instance=self.instance,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             name=self.name,
             source=self.source,
         )
@@ -452,6 +467,8 @@ class ROI:
             identity_embedding=self.identity_embedding,
             instance=self.instance,
             category=self.category,
+            category_score=self.category_score,
+            category_embedding=self.category_embedding,
             name=self.name,
             source=self.source,
         )
@@ -482,6 +499,8 @@ class ROI:
                     geometry=geom,
                     name=self.name,
                     category=self.category,
+                    category_score=self.category_score,
+                    category_embedding=self.category_embedding,
                     source=self.source,
                     video=self.video,
                     track=self.track,

--- a/sleap_io/rendering/colors.py
+++ b/sleap_io/rendering/colors.py
@@ -166,7 +166,7 @@ PaletteName = Literal[
 ]
 
 # Type alias for color schemes
-ColorScheme = Literal["track", "instance", "node", "identity", "auto"]
+ColorScheme = Literal["track", "instance", "node", "identity", "category", "auto"]
 
 
 def get_palette(name: PaletteName | str, n_colors: int) -> list[tuple[int, int, int]]:
@@ -416,6 +416,8 @@ def build_color_map(
     palette: PaletteName | str = "standard",
     identity_indices: list[int] | None = None,
     n_identities: int = 0,
+    category_indices: list[int] | None = None,
+    n_categories: int = 0,
 ) -> dict[str, list[tuple[int, int, int]]]:
     """Build color mapping based on scheme.
 
@@ -429,6 +431,9 @@ def build_color_map(
         identity_indices: Global identity index for each instance (for identity
             coloring; a palette index into ``Labels.identities`` order).
         n_identities: Total number of identities (for identity coloring).
+        category_indices: Global category index for each instance (for category
+            coloring; a palette index into ``Labels.categories`` order).
+        n_categories: Total number of categories (for category coloring).
 
     Returns:
         Dictionary with 'instance_colors' and/or 'node_colors' lists.
@@ -458,6 +463,21 @@ def build_color_map(
         if identity_indices is not None:
             instance_colors = [
                 palette_colors[idx % len(palette_colors)] for idx in identity_indices
+            ]
+        else:
+            instance_colors = palette_colors[:n_instances]
+
+        colors["instance_colors"] = instance_colors
+
+    elif scheme == "category":
+        # Colors based on global category. Mirrors the identity scheme: one palette
+        # color per category index (in ``Labels.categories`` order).
+        n = max(n_categories, n_instances) if n_categories > 0 else n_instances
+        palette_colors = get_palette(palette, max(n, 1))
+
+        if category_indices is not None:
+            instance_colors = [
+                palette_colors[idx % len(palette_colors)] for idx in category_indices
             ]
         else:
             instance_colors = palette_colors[:n_instances]

--- a/sleap_io/rendering/core.py
+++ b/sleap_io/rendering/core.py
@@ -613,6 +613,40 @@ def _compute_identity_coloring(
     return identity_indices, len(catalog)
 
 
+def _compute_category_coloring(
+    instances: Iterable,
+    catalog: list | None,
+) -> tuple[list[int], int]:
+    """Compute per-instance category indices for the ``category`` color scheme.
+
+    Mirrors ``_compute_identity_coloring``. Each instance is mapped to a stable
+    index in the category catalog (the ``Labels.categories`` order when available,
+    otherwise discovered from the instances in encounter order). Instances without a
+    category map to index 0. Coloring is by palette index, exactly like the
+    ``identity`` scheme.
+
+    Args:
+        instances: Instances to color (order matches the rendered points).
+        catalog: Optional starting category catalog (e.g. ``labels.categories``).
+
+    Returns:
+        Tuple of ``(category_indices, n_categories)``.
+    """
+    catalog = list(catalog) if catalog else []
+    idmap = {id(cat): i for i, cat in enumerate(catalog)}
+    category_indices: list[int] = []
+    for inst in instances:
+        cat = getattr(inst, "category", None)
+        if cat is None:
+            category_indices.append(0)
+            continue
+        if id(cat) not in idmap:
+            idmap[id(cat)] = len(catalog)
+            catalog.append(cat)
+        category_indices.append(idmap[id(cat)])
+    return category_indices, len(catalog)
+
+
 def render_frame(
     frame: np.ndarray,
     instances_points: list[np.ndarray],
@@ -635,6 +669,9 @@ def render_frame(
     # Identity info for identity coloring
     identity_indices: list[int] | None = None,
     n_identities: int = 0,
+    # Category info for category coloring
+    category_indices: list[int] | None = None,
+    n_categories: int = 0,
     # Callbacks
     pre_render_callback: Callable[[RenderContext], None] | None = None,
     post_render_callback: Callable[[RenderContext], None] | None = None,
@@ -655,7 +692,8 @@ def render_frame(
         instances_points: List of (n_nodes, 2) arrays of keypoint coordinates.
         edge_inds: List of (src_idx, dst_idx) tuples for skeleton edges.
         node_names: List of node name strings.
-        color_by: Color scheme - 'track', 'instance', 'node', or 'identity'.
+        color_by: Color scheme - 'track', 'instance', 'node', 'identity', or
+            'category'.
         palette: Color palette name.
         marker_shape: Node marker shape.
         marker_size: Node marker radius in pixels.
@@ -669,6 +707,9 @@ def render_frame(
         identity_indices: Global identity index for each instance (for identity
             coloring; a palette index into ``Labels.identities`` order).
         n_identities: Total number of identities (for identity coloring).
+        category_indices: Global category index for each instance (for category
+            coloring; a palette index into ``Labels.categories`` order).
+        n_categories: Total number of categories (for category coloring).
         pre_render_callback: Called before poses are drawn.
         post_render_callback: Called after poses are drawn.
         per_instance_callback: Called after each instance is drawn.
@@ -713,6 +754,8 @@ def render_frame(
         palette=palette,
         identity_indices=identity_indices,
         n_identities=n_identities,
+        category_indices=category_indices,
+        n_categories=n_categories,
     )
 
     # Get drawing function for marker shape
@@ -933,8 +976,8 @@ def render_image(
               ``(0.25, 0.25, 0.75, 0.75)`` crops the center 50% of the frame.
               Detection is type-based: all values must be ``float`` and in range.
             - ``None``: No cropping (default).
-        color_by: Color scheme - 'track', 'instance', 'node', 'identity', or
-            'auto'.
+        color_by: Color scheme - 'track', 'instance', 'node', 'identity',
+            'category', or 'auto'.
         palette: Color palette name.
         marker_shape: Node marker shape.
         marker_size: Node marker radius in pixels.
@@ -1423,6 +1466,14 @@ def render_image(
         catalog = source.identities if isinstance(source, Labels) else None
         identity_indices, n_identities = _compute_identity_coloring(instances, catalog)
 
+    # Compute per-instance category indices when the resolved scheme is
+    # "category", mirroring the identity plumbing.
+    category_indices = None
+    n_categories = 0
+    if resolved_scheme == "category":
+        catalog = source.categories if isinstance(source, Labels) else None
+        category_indices, n_categories = _compute_category_coloring(instances, catalog)
+
     # Render
     rendered = render_frame(
         frame=render_image_data,
@@ -1442,6 +1493,8 @@ def render_image(
         n_tracks=n_tracks,
         identity_indices=identity_indices,
         n_identities=n_identities,
+        category_indices=category_indices,
+        n_categories=n_categories,
         pre_render_callback=pre_render_callback,
         post_render_callback=post_render_callback,
         per_instance_callback=per_instance_callback,
@@ -1555,8 +1608,8 @@ def render_video(
             - ``None``: No cropping (default).
         preset: Quality preset ('preview'=0.25x, 'draft'=0.5x, 'final'=1.0x).
         scale: Scale factor (overrides preset if both provided).
-        color_by: Color scheme - 'track', 'instance', 'node', 'identity', or
-            'auto'.
+        color_by: Color scheme - 'track', 'instance', 'node', 'identity',
+            'category', or 'auto'.
         palette: Color palette name.
         marker_shape: Node marker shape.
         marker_size: Node marker radius in pixels.
@@ -2002,6 +2055,12 @@ def render_video(
     if resolved_scheme == "identity":
         _identity_catalog = list(labels.identities) if labels is not None else []
 
+    # Category catalog for stable category coloring across frames (mirrors the
+    # identity index map). Only built when coloring by category.
+    _category_catalog: list | None = None
+    if resolved_scheme == "category":
+        _category_catalog = list(labels.categories) if labels is not None else []
+
     # Track-keyed palette for overlay (mask/ROI/bbox) coloring under
     # color_by="track", matching centroids/poses/trails (same `palette`).
     _overlay_palette_by_track: list[tuple[int, int, int]] = []
@@ -2182,6 +2241,9 @@ def render_video(
                     n_identities=(
                         len(_identity_catalog) if _identity_catalog is not None else 0
                     ),
+                    n_categories=(
+                        len(_category_catalog) if _category_catalog is not None else 0
+                    ),
                     pre_render_callback=pre_render_callback,
                     post_render_callback=post_render_callback,
                     per_instance_callback=None,
@@ -2214,6 +2276,14 @@ def render_video(
             if resolved_scheme == "identity":
                 identity_indices, n_identities = _compute_identity_coloring(
                     instances, _identity_catalog
+                )
+
+            # Get category indices when coloring by category
+            category_indices = None
+            n_categories = 0
+            if resolved_scheme == "category":
+                category_indices, n_categories = _compute_category_coloring(
+                    instances, _category_catalog
                 )
 
             # Build instance metadata
@@ -2287,6 +2357,8 @@ def render_video(
                 n_tracks=n_tracks,
                 identity_indices=identity_indices,
                 n_identities=n_identities,
+                category_indices=category_indices,
+                n_categories=n_categories,
                 pre_render_callback=pre_render_callback,
                 post_render_callback=post_render_callback,
                 per_instance_callback=per_instance_callback,

--- a/tests/io/test_cli.py
+++ b/tests/io/test_cli.py
@@ -36,6 +36,7 @@ from sleap_io.io.cli import (
     _run_subprocess_with_progress,
     cli,
 )
+from sleap_io.model.category import Category
 from sleap_io.model.embedding import Embedding
 from sleap_io.model.event import EventType, PredictedEvent, UserEvent
 from sleap_io.model.identity import Identity
@@ -91,6 +92,36 @@ def _make_identity_slp(path: Path, *, with_embeddings: bool = False) -> Labels:
         videos=[video],
         skeletons=[skeleton],
         identities=[id_a, id_b],
+    )
+    save_slp(labels, str(path), save_embedding_vectors=with_embeddings)
+    return labels
+
+
+def _make_category_slp(path: Path, *, with_embeddings: bool = False) -> Labels:
+    """Write a minimal 2-instance .slp carrying global categories.
+
+    Builds one labeled frame with two instances assigned to two `Category`
+    objects. When ``with_embeddings`` is set, the first instance also carries a
+    per-instance ``category_embedding``.
+    """
+    skeleton = Skeleton(["head", "tail"])
+    cat_a = Category(name="female_fly")
+    cat_b = Category(name="male_fly")
+    video = Video(filename="dummy.mp4", backend_metadata={"shape": (1, 64, 64, 3)})
+    inst_a = Instance.from_numpy(
+        np.array([[10, 10], [20, 20]]), skeleton=skeleton, category=cat_a
+    )
+    inst_b = Instance.from_numpy(
+        np.array([[30, 30], [40, 40]]), skeleton=skeleton, category=cat_b
+    )
+    if with_embeddings:
+        inst_a.category_embedding = Embedding(vector=np.ones(8, dtype="float32"))
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst_a, inst_b])
+    labels = Labels(
+        labeled_frames=[lf],
+        videos=[video],
+        skeletons=[skeleton],
+        categories=[cat_a, cat_b],
     )
     save_slp(labels, str(path), save_embedding_vectors=with_embeddings)
     return labels
@@ -236,7 +267,8 @@ def test_show_reports_embeddings(tmp_path):
     )
     assert result.exit_code == 0, result.output
     out = _strip_ansi(result.output)
-    assert "Embeddings (1 instance with an identity embedding)" in out
+    assert "Embeddings" in out
+    assert "1 instance with an identity embedding" in out
 
 
 def test_show_embeddings_skipped_when_absent(tmp_path):
@@ -251,6 +283,34 @@ def test_show_embeddings_skipped_when_absent(tmp_path):
     assert result.exit_code == 0, result.output
     out = _strip_ansi(result.output)
     assert "Embeddings" not in out
+
+
+def test_show_reports_categories(tmp_path):
+    """`sio show` reports the global category count in the header stats."""
+    slp_path = tmp_path / "cats.slp"
+    _make_category_slp(slp_path)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["show", str(slp_path), "--no-open-videos"])
+    assert result.exit_code == 0, result.output
+    out = _strip_ansi(result.output)
+    assert "2 categories" in out
+
+
+def test_show_reports_category_embeddings(tmp_path):
+    """`sio show --no-lazy` summarizes per-instance category embeddings."""
+    slp_path = tmp_path / "cats_emb.slp"
+    _make_category_slp(slp_path, with_embeddings=True)
+
+    runner = CliRunner()
+    # Embedding scan is skipped for lazy labels, so request eager loading.
+    result = runner.invoke(
+        cli, ["show", str(slp_path), "--no-lazy", "--no-open-videos"]
+    )
+    assert result.exit_code == 0, result.output
+    out = _strip_ansi(result.output)
+    assert "Embeddings" in out
+    assert "1 instance with a category embedding" in out
 
 
 def test_show_lf_zero_details():
@@ -835,6 +895,23 @@ def test_show_json_identities_and_embeddings(tmp_path):
     # Lazy loading skips the embedding scan and reports null (unknown).
     lazy = _invoke_json(["show", str(slp_path), "--json", "--no-open-videos"])
     assert lazy["stats"]["n_instances_with_identity_embedding"] is None
+
+
+def test_show_json_categories_and_embeddings(tmp_path):
+    """JSON output reports categories and the embedding count (eager only)."""
+    slp_path = tmp_path / "cats_emb.slp"
+    _make_category_slp(slp_path, with_embeddings=True)
+
+    data = _invoke_json(
+        ["show", str(slp_path), "--json", "--no-lazy", "--no-open-videos"]
+    )
+    assert data["stats"]["n_categories"] == 2
+    assert data["stats"]["n_instances_with_category_embedding"] == 1
+    assert [c["name"] for c in data["categories"]] == ["female_fly", "male_fly"]
+
+    # Lazy loading skips the embedding scan and reports null (unknown).
+    lazy = _invoke_json(["show", str(slp_path), "--json", "--no-open-videos"])
+    assert lazy["stats"]["n_instances_with_category_embedding"] is None
 
 
 def test_show_json_events(tmp_path):
@@ -4706,6 +4783,93 @@ def test_merge_help_lists_identity():
     assert "--identity" in _strip_ansi(result.output)
 
 
+@pytest.mark.parametrize("method", ["name", "identity"])
+def test_merge_category_option_accepted(method, tmp_path):
+    """`sio merge --category {name,identity}` is accepted and runs."""
+    a = tmp_path / "a.slp"
+    b = tmp_path / "b.slp"
+    _make_category_slp(a)
+    _make_category_slp(b)
+
+    runner = CliRunner()
+    merged_path = tmp_path / "merged.slp"
+    result = runner.invoke(
+        cli,
+        [
+            "merge",
+            str(a),
+            str(b),
+            "-o",
+            str(merged_path),
+            "--category",
+            method,
+            "--frame",
+            "keep_both",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    output = _strip_ansi(result.output)
+    assert "Merged 2 files:" in output
+    assert merged_path.exists()
+
+
+def test_merge_category_name_dedupes_catalog(tmp_path):
+    """`sio merge --category name` dedupes same-named categories across files."""
+    a = tmp_path / "a.slp"
+    b = tmp_path / "b.slp"
+    _make_category_slp(a)
+    _make_category_slp(b)
+
+    runner = CliRunner()
+    merged_path = tmp_path / "merged.slp"
+    result = runner.invoke(
+        cli,
+        [
+            "merge",
+            str(a),
+            str(b),
+            "-o",
+            str(merged_path),
+            "--category",
+            "name",
+            "--frame",
+            "keep_both",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # Both files carry the same two category names; name-dedup keeps exactly two.
+    merged = load_slp(str(merged_path))
+    assert sorted(c.name for c in merged.categories) == ["female_fly", "male_fly"]
+
+
+def test_merge_category_invalid_choice(tmp_path, slp_typical):
+    """An unsupported --category value is rejected by Click."""
+    runner = CliRunner()
+    merged_path = tmp_path / "merged.slp"
+    result = runner.invoke(
+        cli,
+        [
+            "merge",
+            slp_typical,
+            slp_typical,
+            "-o",
+            str(merged_path),
+            "--category",
+            "bogus",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "category" in _strip_ansi(result.output).lower()
+
+
+def test_merge_help_lists_category():
+    """`sio merge --help` documents the --category option."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["merge", "--help"])
+    assert result.exit_code == 0
+    assert "--category" in _strip_ansi(result.output)
+
+
 def test_merge_frame_strategies(tmp_path, slp_typical):
     """Test different frame strategies."""
     runner = CliRunner()
@@ -5541,6 +5705,46 @@ def test_render_color_by_identity_help_choice():
     result = runner.invoke(cli, ["render", "--help"])
     assert result.exit_code == 0
     assert "identity" in _strip_ansi(result.output)
+
+
+def test_render_color_by_category(tmp_path):
+    """`sio render --color-by category` is accepted and renders an image.
+
+    Each category is colored by its index in ``Labels.categories`` via the
+    palette (mirroring ``color_by="identity"``).
+    """
+    slp_path = tmp_path / "cats.slp"
+    _make_category_slp(slp_path)
+
+    output_path = tmp_path / "frame.png"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "render",
+            "-i",
+            str(slp_path),
+            "--lf",
+            "0",
+            "--background",
+            "black",
+            "--color-by",
+            "category",
+            "-o",
+            str(output_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Rendered:" in result.output
+    assert output_path.exists()
+
+
+def test_render_color_by_category_help_choice():
+    """`sio render --help` lists category as a --color-by choice."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["render", "--help"])
+    assert result.exit_code == 0
+    assert "category" in _strip_ansi(result.output)
 
 
 def test_render_crop_pixel(centered_pair, tmp_path):

--- a/tests/io/test_coco.py
+++ b/tests/io/test_coco.py
@@ -1921,7 +1921,7 @@ class TestCOCOROIMaskIO:
         # (annotation 3) both become masks; no ROIs.
         assert len(labels.rois) == 0
         assert len(labels.masks) == 2
-        masks_by_cat = {m.category: m for m in labels.masks}
+        masks_by_cat = {m.category.name: m for m in labels.masks}
         # Polygon annotation -> mask rasterized at the image resolution.
         plant_mask = masks_by_cat["plant"]
         assert plant_mask.height == 100
@@ -1934,7 +1934,7 @@ class TestCOCOROIMaskIO:
 
         # Bbox-only annotation -> BoundingBox (annotation 1)
         assert len(labels.bboxes) == 1
-        assert labels.bboxes[0].category == "animal"
+        assert labels.bboxes[0].category.name == "animal"
         x, y, w, h = labels.bboxes[0].xywh
         assert x == pytest.approx(10.0)
         assert y == pytest.approx(20.0)
@@ -1947,9 +1947,9 @@ class TestCOCOROIMaskIO:
             json_path, dataset_root=tmp_path, segmentation_format="roi"
         )
         assert len(labels_roi.rois) == 1
-        assert labels_roi.rois[0].category == "plant"
+        assert labels_roi.rois[0].category.name == "plant"
         assert len(labels_roi.masks) == 1
-        assert labels_roi.masks[0].category == "animal"
+        assert labels_roi.masks[0].category.name == "animal"
         assert len(labels_roi.bboxes) == 1
 
     def test_coco_category_preservation(self, tmp_path):
@@ -2106,7 +2106,7 @@ class TestCOCOROIMaskIO:
 
         assert len(labels.masks) == 1
         mask = labels.masks[0]
-        assert mask.category == "cell"
+        assert mask.category.name == "cell"
         assert mask.height == 5
         assert mask.width == 5
 
@@ -2150,7 +2150,7 @@ class TestCOCOROIMaskIO:
         assert len(labels.bboxes) == 1
         bbox = labels.bboxes[0]
         assert isinstance(bbox, UserBoundingBox)
-        assert bbox.category == "animal"
+        assert bbox.category.name == "animal"
         x, y, w, h = bbox.xywh
         assert x == pytest.approx(10.0)
         assert y == pytest.approx(20.0)
@@ -2190,7 +2190,7 @@ class TestCOCOROIMaskIO:
         assert len(labels.masks) == 1
         mask = labels.masks[0]
         assert isinstance(mask, UserSegmentationMask)
-        assert mask.category == "obj"
+        assert mask.category.name == "obj"
         assert mask.height == 100
         assert mask.width == 100
         # Mask bbox (in image coords) matches the polygon extent within a pixel.
@@ -2207,7 +2207,7 @@ class TestCOCOROIMaskIO:
         assert len(labels_roi.masks) == 0
         assert len(labels_roi.rois) == 1
         roi = labels_roi.rois[0]
-        assert roi.category == "obj"
+        assert roi.category.name == "obj"
         minx, miny, maxx, maxy = roi.bounds
         assert minx == pytest.approx(10.0)
         assert miny == pytest.approx(10.0)
@@ -2251,7 +2251,7 @@ class TestCOCOROIMaskIO:
         assert len(labels.bboxes) == 1
         bbox = labels.bboxes[0]
         assert isinstance(bbox, UserBoundingBox)
-        assert bbox.category == "animal"
+        assert bbox.category.name == "animal"
         x, y, w, h = bbox.xywh
         assert x == pytest.approx(2.0)
         assert y == pytest.approx(2.0)
@@ -2350,7 +2350,7 @@ def test_read_labels_keypoints_and_segmentation(tmp_path):
     assert len(labels.masks) == 1
     mask = labels.masks[0]
     assert isinstance(mask, UserSegmentationMask)
-    assert mask.category == "animal"
+    assert mask.category.name == "animal"
     assert mask.instance is instance
     assert mask.height == 100
     assert mask.width == 100
@@ -2365,7 +2365,7 @@ def test_read_labels_keypoints_and_segmentation(tmp_path):
     bbox = labels.bboxes[0]
     assert isinstance(bbox, UserBoundingBox)
     assert bbox.instance is instance
-    assert bbox.category == "animal"
+    assert bbox.category.name == "animal"
     bx, by, bw, bh = bbox.xywh
     assert bx == pytest.approx(10.0)
     assert by == pytest.approx(10.0)
@@ -2422,7 +2422,7 @@ def test_read_labels_keypoints_and_rle_segmentation(tmp_path):
     assert len(labels.masks) == 1
     mask = labels.masks[0]
     assert isinstance(mask, UserSegmentationMask)
-    assert mask.category == "animal"
+    assert mask.category.name == "animal"
     assert mask.height == 5
     assert mask.width == 5
     # Mask should be linked to the instance
@@ -2466,7 +2466,7 @@ def test_coco_polygon_mask_falls_back_to_roi_without_dims(tmp_path):
     labels = coco.read_labels(json_path, dataset_root=tmp_path)
     assert len(labels.masks) == 0
     assert len(labels.rois) == 1
-    assert labels.rois[0].category == "obj"
+    assert labels.rois[0].category.name == "obj"
 
 
 def test_coco_multipolygon_annotation_single_mask(tmp_path):
@@ -2561,7 +2561,7 @@ def test_coco_segmentation_load_file_and_slp_roundtrip(tmp_path):
     assert sum(len(lf.masks) for lf in labels.labeled_frames) == 1
     mask = labels.masks[0]
     assert isinstance(mask, UserSegmentationMask)
-    assert mask.category == "critter"
+    assert mask.category.name == "critter"
 
     # Round-trip through .slp preserves the mask, category, and area.
     slp_path = tmp_path / "seg.slp"
@@ -2569,7 +2569,7 @@ def test_coco_segmentation_load_file_and_slp_roundtrip(tmp_path):
     reloaded = sio.load_file(str(slp_path))
     rmasks = [m for lf in reloaded.labeled_frames for m in lf.masks]
     assert len(rmasks) == 1
-    assert rmasks[0].category == "critter"
+    assert rmasks[0].category.name == "critter"
     assert rmasks[0].area == mask.area
 
 
@@ -2654,16 +2654,16 @@ def test_coco_category_as_track(tmp_path):
     # Every mask's track name equals its category.
     for m in labels.masks:
         assert m.track is not None
-        assert m.track.name == m.category
+        assert m.track.name == m.category.name
     # The bbox-only annotation also gets its category track.
     assert len(labels.bboxes) == 1
     assert labels.bboxes[0].track is not None
-    assert labels.bboxes[0].track.name == labels.bboxes[0].category == "b"
+    assert labels.bboxes[0].track.name == labels.bboxes[0].category.name == "b"
     # The bbox and the masks of category "b" share the same Track object.
-    b_mask = next(m for m in labels.masks if m.category == "b")
+    b_mask = next(m for m in labels.masks if m.category.name == "b")
     assert labels.bboxes[0].track is b_mask.track
     # The two "a" masks (different frames) share the same Track object.
-    a_masks = [m for m in labels.masks if m.category == "a"]
+    a_masks = [m for m in labels.masks if m.category.name == "a"]
     assert len(a_masks) == 2
     assert a_masks[0].track is a_masks[1].track
 
@@ -2674,7 +2674,7 @@ def test_coco_category_as_track(tmp_path):
     assert {t.name for t in reloaded.tracks} == {"a", "b"}
     for m in reloaded.masks:
         assert m.track is not None
-        assert m.track.name == m.category
+        assert m.track.name == m.category.name
 
     # roi mode also assigns category tracks to the vector ROIs.
     roi_labels = coco.read_labels(
@@ -2686,7 +2686,7 @@ def test_coco_category_as_track(tmp_path):
     assert {t.name for t in roi_labels.tracks} == {"a", "b"}
     for r in roi_labels.rois:
         assert r.track is not None
-        assert r.track.name == r.category
+        assert r.track.name == r.category.name
 
     # Default (category_as_track=False) leaves masks and bboxes untracked.
     untracked = coco.read_labels(json_path, dataset_root=tmp_path)
@@ -2737,7 +2737,7 @@ def test_coco_detection_reads_as_bbox(tmp_path):
 
     for bbox in labels.bboxes:
         assert isinstance(bbox, UserBoundingBox)
-        assert bbox.category == "person"
+        assert bbox.category.name == "person"
 
     # Check first bbox coordinates
     x, y, w, h = labels.bboxes[0].xywh
@@ -2983,7 +2983,7 @@ def test_coco_mixed_bbox_and_instances(tmp_path):
     bbox = labels.bboxes[0]
     assert isinstance(bbox, UserBoundingBox)
     assert bbox.instance is instance
-    assert bbox.category == "animal"
+    assert bbox.category.name == "animal"
 
     x, y, w, h = bbox.xywh
     assert x == pytest.approx(20.0)

--- a/tests/io/test_geojson.py
+++ b/tests/io/test_geojson.py
@@ -53,7 +53,7 @@ def test_roundtrip_bbox(tmp_path):
     result = loaded[0]
     assert result.bounds == pytest.approx(roi.bounds)
     assert result.name == "my_box"
-    assert result.category == "det"
+    assert result.category.name == "det"
 
 
 def test_roundtrip_polygon(tmp_path):
@@ -96,7 +96,7 @@ def test_roundtrip_point(tmp_path):
     assert loaded[0].geometry.geom_type == "Point"
     assert loaded[0].geometry.x == pytest.approx(5)
     assert loaded[0].geometry.y == pytest.approx(10)
-    assert loaded[0].category == "anchor"
+    assert loaded[0].category.name == "anchor"
 
 
 def test_roundtrip_linestring(tmp_path):
@@ -128,7 +128,7 @@ def test_roundtrip_all_metadata(tmp_path):
 
     result = loaded[0]
     assert result.name == "full_meta"
-    assert result.category == "cat1"
+    assert result.category.name == "cat1"
     assert result.source == "model_v2"
 
 
@@ -185,7 +185,7 @@ def test_missing_properties_defaults(tmp_path):
     assert len(loaded) == 1
     roi = loaded[0]
     assert roi.name == ""
-    assert roi.category == ""
+    assert roi.category is None
     assert roi.source == ""
 
 

--- a/tests/io/test_jabs.py
+++ b/tests/io/test_jabs.py
@@ -133,7 +133,7 @@ def test_read_labels_static_objects_as_rois(jabs_real_data_v5):
     assert len(labels.rois) == 1
     roi = labels.rois[0]
     assert roi.name == "corners"
-    assert roi.category == "arena"
+    assert roi.category.name == "arena"
     assert roi.source == "jabs"
     assert roi.video == labels.videos[0]  # Static ROI keeps video reference
 
@@ -186,7 +186,7 @@ def test_static_object_to_roi_single_point():
     roi = _static_object_to_roi("lixit", coords, video)
 
     assert roi.name == "lixit"
-    assert roi.category == "anchor"
+    assert roi.category.name == "anchor"
     assert isinstance(roi.geometry, Point)
     assert roi.geometry.x == 100.0
     assert roi.geometry.y == 200.0

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -18,6 +18,7 @@ from PIL import Image
 from sleap_io import (
     Camera,
     CameraGroup,
+    Category,
     FrameGroup,
     Instance,
     InstanceGroup,
@@ -75,6 +76,9 @@ from sleap_io.io.slp import (
     prepare_frames_to_embed,
     process_and_embed_frames,
     read_bboxes,
+    read_categories,
+    read_category_embeddings,
+    read_category_links,
     read_centroids,
     read_embeddings,
     read_event_types,
@@ -101,6 +105,7 @@ from sleap_io.io.slp import (
     session_to_dict,
     video_to_dict,
     write_bboxes,
+    write_categories,
     write_centroids,
     write_event_types,
     write_events,
@@ -808,7 +813,7 @@ def test_lazy_write_preserves_static_roi_video(tmp_path):
     assert len(reread.static_rois) == 1
     assert reread.static_rois[0].video is not None
     assert reread.static_rois[0].video.filename == "v.mp4"
-    assert reread.static_rois[0].category == "arena"
+    assert reread.static_rois[0].category.name == "arena"
 
 
 def test_lazy_write_static_roi_without_video(tmp_path):
@@ -826,7 +831,7 @@ def test_lazy_write_static_roi_without_video(tmp_path):
     save_file(lazy, p2)
 
     reread = load_slp(p2)
-    by_category = {r.category: r for r in reread.static_rois}
+    by_category = {r.category.name: r for r in reread.static_rois}
     assert by_category["anchored"].video is reread.videos[0]
     assert by_category["orphan"].video is None
 
@@ -849,7 +854,7 @@ def test_lazy_write_preserves_static_roi_video_multi(tmp_path):
 
     reread = load_slp(p2)
     assert len(reread.static_rois) == 2
-    by_category = {r.category: r for r in reread.static_rois}
+    by_category = {r.category.name: r for r in reread.static_rois}
     assert by_category["arena_b"].video is reread.videos[1]
     assert by_category["arena_b"].video.filename == "b.mp4"
     assert by_category["arena_c"].video is reread.videos[2]
@@ -1616,6 +1621,241 @@ def test_roi_identity_and_embedding_round_trip(tmp_path):
     assert lr.identity is not None and lr.identity.name == "arena_A"
     assert lr.identity_score == pytest.approx(0.6)
     np.testing.assert_array_equal(lr.identity_embedding.vector, np.ones(3))
+
+
+def test_category_catalog_round_trip(tmp_path):
+    """Test the /categories catalog round-trips like /identity (name + metadata)."""
+    labels_path = str(tmp_path / "test.slp")
+
+    categories = [
+        Category(name="female_fly", metadata={"color": "#ff0000"}),
+        Category(name="male_fly"),
+        Category(name="fur_shaved", metadata={"color": "#00ff00", "cohort": "3"}),
+    ]
+
+    with h5py.File(labels_path, "w"):
+        pass  # Create empty file
+
+    write_categories(labels_path, categories)
+    loaded = read_categories(labels_path)
+
+    assert len(loaded) == 3
+    assert loaded[0].name == "female_fly"
+    assert loaded[0].metadata == {"color": "#ff0000"}
+    assert loaded[1].name == "male_fly"
+    assert loaded[1].metadata == {}  # no metadata stays empty
+    assert loaded[2].name == "fur_shaved"
+    assert loaded[2].metadata == {"color": "#00ff00", "cohort": "3"}
+
+
+def test_category_empty_round_trip(tmp_path):
+    """Test that an empty categories list doesn't create a dataset."""
+    labels_path = str(tmp_path / "test.slp")
+    with h5py.File(labels_path, "w"):
+        pass
+
+    write_categories(labels_path, [])
+    assert read_categories(labels_path) == []
+
+
+def test_per_instance_category_round_trip(tmp_path):
+    """Per-instance category links + the catalog round-trip through SLP (2.7)."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    cat_a = Category(name="female_fly", metadata={"cohort": "1"})
+    cat_b = Category(name="male_fly")
+    insts = [
+        Instance.from_numpy(
+            np.array([[0, 1], [2, 3]]), skel, category=cat_a, category_score=0.95
+        ),
+        PredictedInstance.from_numpy(
+            np.array([[4, 5], [6, 7]]), skel, score=0.8, category=cat_b
+        ),
+        Instance.from_numpy(np.array([[8, 9], [10, 11]]), skel),  # no category
+    ]
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=insts)])
+    labels.update()
+
+    path = str(tmp_path / "categories.slp")
+    save_slp(labels, path)
+
+    # Format bumped to 2.7 and the /categories group + links dataset are present.
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] == 2.7
+        assert "links" in f["categories"]
+        links = f["categories"]["links"][:]
+        assert "owner_type" in links.dtype.names
+        assert set(links["owner_type"].tolist()) == {OWNER_INSTANCE}
+
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)
+    assert li[0].category is not None
+    assert li[0].category.name == "female_fly"
+    assert li[0].category.metadata == {"cohort": "1"}
+    assert li[0].category_score == pytest.approx(0.95)
+    assert li[1].category is not None
+    assert li[1].category.name == "male_fly"
+    assert li[1].category_score is None  # not recorded -> None
+    assert li[2].category is None
+    # The two distinct loaded categories are shared with the catalog.
+    assert {c.name for c in loaded.categories} == {"female_fly", "male_fly"}
+    assert li[0].category is loaded.categories[loaded.categories.index(li[0].category)]
+
+
+def test_category_embedding_round_trip(tmp_path):
+    """Per-detection category embeddings round-trip via the parallel datasets."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    i0 = Instance.from_numpy(
+        np.array([[0, 1], [2, 3]]),
+        skel,
+        category="female_fly",
+        category_embedding=Embedding(np.arange(32, dtype=np.float64)),
+    )
+    i1 = PredictedInstance.from_numpy(
+        np.array([[4, 5], [6, 7]]),
+        skel,
+        score=0.8,
+        category="male_fly",
+        category_embedding=Embedding(np.full(32, 2.0, dtype=np.float64)),
+    )
+    i2 = Instance.from_numpy(np.array([[8, 9], [0, 1]]), skel)  # no embedding
+
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[i0, i1, i2])])
+    labels.update()
+
+    path = str(tmp_path / "category_embeddings.slp")
+    save_slp(labels, path, save_embedding_vectors=True)
+
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] == 2.7
+        # Category vectors live in the shared /embeddings group as parallel datasets.
+        assert set(f["embeddings"].keys()) == {
+            "category_vectors",
+            "category_owner_type",
+            "category_owner_id",
+        }
+        assert f["embeddings/category_vectors"].shape == (2, 32)
+        assert f["embeddings/category_vectors"].dtype == np.float64  # dtype preserved
+        assert set(f["embeddings/category_owner_type"][:].tolist()) == {OWNER_INSTANCE}
+
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)
+    assert li[0].category_embedding.dim == 32
+    assert li[0].category_embedding.vector.dtype == np.float64
+    np.testing.assert_array_equal(li[0].category_embedding.vector, np.arange(32))
+    np.testing.assert_array_equal(li[1].category_embedding.vector, np.full(32, 2.0))
+    # Sparse: instances without a category embedding stay None.
+    assert li[2].category_embedding is None
+
+
+def test_save_embedding_vectors_default_skips_category_embeddings(tmp_path):
+    """Default save_embedding_vectors=False drops category vectors, keeps links."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    inst = Instance.from_numpy(
+        np.array([[0, 1], [2, 3]]),
+        skel,
+        category="female_fly",
+        category_score=0.7,
+        category_embedding=Embedding(np.arange(16, dtype=np.float32)),
+    )
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[inst])])
+    labels.update()
+
+    path = str(tmp_path / "no_cat_emb.slp")
+    save_slp(labels, path)  # default save_embedding_vectors=False
+
+    with h5py.File(path, "r") as f:
+        assert "embeddings" not in f  # no vectors written at all
+        assert "links" in f["categories"]  # category link still persisted
+
+    # Vectors remain in memory on the original object (not mutated by save).
+    assert list(labels[0].instances)[0].category_embedding is not None
+
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)[0]
+    assert li.category is not None and li.category.name == "female_fly"
+    assert li.category_score == pytest.approx(0.7)
+    assert li.category_embedding is None  # not persisted
+
+
+def test_identity_and_category_embeddings_different_dims_round_trip(tmp_path):
+    """Identity + category embeddings with DIFFERENT dims both survive.
+
+    Validates the parallel-datasets design: category vectors live in sibling
+    datasets independent of identity vectors, so the two need not share D.
+    """
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    inst = Instance.from_numpy(
+        np.array([[0, 1], [2, 3]]),
+        skel,
+        identity=Identity(name="mouse_A"),
+        identity_embedding=Embedding(np.ones(128, dtype=np.float32)),
+        category="female_fly",
+        category_embedding=Embedding(np.arange(64, dtype=np.float32)),
+    )
+    labels = Labels([LabeledFrame(video=video, frame_idx=0, instances=[inst])])
+    labels.update()
+
+    path = str(tmp_path / "mixed_dims.slp")
+    save_slp(labels, path, save_embedding_vectors=True)
+
+    with h5py.File(path, "r") as f:
+        assert f["embeddings/vectors"].shape == (1, 128)
+        assert f["embeddings/category_vectors"].shape == (1, 64)
+
+    loaded = load_slp(path)
+    li = list(loaded[0].instances)[0]
+    assert li.identity_embedding.dim == 128
+    assert li.category_embedding.dim == 64
+    np.testing.assert_array_equal(li.identity_embedding.vector, np.ones(128))
+    np.testing.assert_array_equal(li.category_embedding.vector, np.arange(64))
+
+
+def test_no_category_keeps_low_format_and_no_group(tmp_path):
+    """Category-free labels stay additive (no /categories group, no 2.7 bump)."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    labels = Labels(
+        [
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[Instance.from_numpy(np.array([[0, 1], [2, 3]]), skel)],
+            )
+        ]
+    )
+    path = str(tmp_path / "no_category.slp")
+    save_slp(labels, path)
+
+    with h5py.File(path, "r") as f:
+        assert f["metadata"].attrs["format_id"] < 2.7
+        assert "categories" not in f
+
+    loaded = load_slp(path)
+    assert loaded.categories == []
+    assert list(loaded[0].instances)[0].category is None
+
+
+def test_pre_2_7_fixture_loads_with_empty_categories(slp_minimal):
+    """An existing pre-2.7 fixture (no categories) loads unchanged, categories []."""
+    with h5py.File(slp_minimal, "r") as f:
+        assert f["metadata"].attrs["format_id"] < 2.7
+        assert "categories" not in f
+
+    loaded = load_slp(slp_minimal)
+    assert loaded.categories == []
+    for lf in loaded:
+        for inst in lf.instances:
+            assert inst.category is None
+            assert inst.category_score is None
+            assert inst.category_embedding is None
+    # The category read helpers are no-ops on a pre-2.7 file.
+    assert read_categories(slp_minimal) == []
+    assert read_category_links(slp_minimal) == {}
+    assert read_category_embeddings(slp_minimal) == {}
 
 
 def test_make_frame_group_and_frame_group_to_dict(
@@ -5010,9 +5250,9 @@ def test_slp_roi_roundtrip(tmp_path):
     path = str(tmp_path / "test_rois.slp")
     save_slp(labels, path)
 
-    # Verify format_id is 1.5
+    # Verify format_id bumped to 2.7 (ROIs carry a `Category`, i.e. category data).
     format_id = read_hdf5_attrs(path, "metadata", "format_id")
-    assert format_id == 1.5
+    assert format_id == 2.7
 
     loaded = load_slp(path)
 
@@ -5020,7 +5260,7 @@ def test_slp_roi_roundtrip(tmp_path):
     assert len(loaded.rois) == 2
     roi_names = {r.name for r in loaded.rois}
     assert "bbox1" in roi_names
-    triangle = [r for r in loaded.rois if r.category == "arena"][0]
+    triangle = [r for r in loaded.rois if r.category.name == "arena"][0]
     assert triangle.track is loaded.tracks[0]
 
 
@@ -5111,14 +5351,14 @@ def test_slp_roi_wkb_roundtrip_geometry_types(tmp_path):
             category="multi",
         ),
     ]
-    original_wkb = {r.category: r.geometry.wkb for r in rois}
+    original_wkb = {r.category.name: r.geometry.wkb for r in rois}
 
     path = str(tmp_path / "roi_geom_types.slp")
     save_slp(Labels(videos=[video], skeletons=[skeleton], rois=rois), path)
     loaded = load_slp(path, open_videos=False)
 
     assert len(loaded.rois) == 3
-    by_cat = {r.category: r for r in loaded.rois}
+    by_cat = {r.category.name: r for r in loaded.rois}
     assert isinstance(by_cat["pred"], PredictedROI)
     assert by_cat["pred"].score == pytest.approx(0.85, abs=1e-5)
     assert isinstance(by_cat["user"], UserROI)
@@ -5178,7 +5418,7 @@ def test_slp_mask_roundtrip(tmp_path):
     assert m.height == 20
     assert m.width == 30
     assert m.name == "seg1"
-    assert m.category == "foreground"
+    assert m.category.name == "foreground"
 
     # Check mask data roundtrips correctly
     np.testing.assert_array_equal(m.data, mask_data)
@@ -5577,7 +5817,7 @@ def test_slp_bbox_roundtrip(tmp_path):
     assert b1.height == pytest.approx(80.0)
     assert b1.angle == pytest.approx(0.0)
     assert b1.name == "bbox1"
-    assert b1.category == "mouse"
+    assert b1.category.name == "mouse"
     assert b1.source == "manual"
     assert b1.track is None
 
@@ -5589,7 +5829,7 @@ def test_slp_bbox_roundtrip(tmp_path):
     assert b2.height == pytest.approx(30.0)
     assert b2.angle == pytest.approx(0.5)
     assert b2.name == "bbox2"
-    assert b2.category == "fly"
+    assert b2.category.name == "fly"
     assert b2.track is loaded.tracks[0]
 
     # Verify low-level read_bboxes works directly
@@ -5644,7 +5884,7 @@ def test_slp_predicted_bbox_roundtrip(tmp_path):
     b_user = loaded.bboxes[0]
     assert isinstance(b_user, UserBoundingBox)
     assert not isinstance(b_user, PredictedBoundingBox)
-    assert b_user.category == "cat"
+    assert b_user.category.name == "cat"
 
     b_pred = loaded.bboxes[1]
     assert isinstance(b_pred, PredictedBoundingBox)
@@ -5652,7 +5892,7 @@ def test_slp_predicted_bbox_roundtrip(tmp_path):
     assert b_pred.y_center == pytest.approx(200.0)
     assert b_pred.width == pytest.approx(50.0)
     assert b_pred.height == pytest.approx(60.0)
-    assert b_pred.category == "dog"
+    assert b_pred.category.name == "dog"
     assert b_pred.score == pytest.approx(0.95, abs=1e-5)
 
 
@@ -5743,7 +5983,7 @@ def test_slp_bbox_lazy_roundtrip(tmp_path):
 
     b2 = reloaded.bboxes[1]
     assert isinstance(b2, PredictedBoundingBox)
-    assert b2.category == "fly"
+    assert b2.category.name == "fly"
     assert b2.score == pytest.approx(0.85, abs=1e-5)
 
 
@@ -7361,7 +7601,7 @@ def test_slp_mask_instance_roundtrip(tmp_path):
     assert len(loaded.masks) == 1
     rm = loaded.masks[0]
     assert rm.instance is not None
-    assert rm.category == "cell"
+    assert rm.category.name == "cell"
     assert isinstance(rm, UserSegmentationMask)
 
 
@@ -7392,12 +7632,13 @@ def test_slp_predicted_mask_roundtrip(tmp_path):
     rm = loaded.masks[0]
     assert isinstance(rm, PredictedSegmentationMask)
     assert rm.score == pytest.approx(0.95, abs=1e-5)
-    assert rm.category == "cell"
+    assert rm.category.name == "cell"
     np.testing.assert_array_equal(rm.data, np.ones((5, 5), dtype=bool))
 
-    # Verify format_id bumped to 1.9
+    # Verify format_id bumped to 2.7: the mask carries a `Category` ("cell"), which
+    # is category data, so the class/category subsystem bump applies.
     format_id = read_hdf5_attrs(path, "metadata", "format_id")
-    assert format_id == 1.9
+    assert format_id == 2.7
 
 
 def test_slp_mask_from_predicted_persisted(tmp_path):
@@ -8137,7 +8378,7 @@ def test_slp_predicted_roi_roundtrip(tmp_path):
     rr = loaded.rois[0]
     assert isinstance(rr, PredictedROI)
     assert rr.score == pytest.approx(0.85, abs=1e-5)
-    assert rr.category == "arena"
+    assert rr.category.name == "arena"
 
 
 def test_slp_user_roi_roundtrip(tmp_path):
@@ -8258,7 +8499,7 @@ def test_slp_backward_compat_no_predicted_fields(tmp_path):
     rm = loaded.masks[0]
     # Pre-v1.9 files should read as UserSegmentationMask (default, not Predicted)
     assert type(rm) is UserSegmentationMask
-    assert rm.category == "cell"
+    assert rm.category.name == "cell"
     np.testing.assert_array_equal(rm.data, np.ones((5, 5), dtype=bool))
 
 
@@ -8311,17 +8552,17 @@ def test_slp_all_annotations_roundtrip(labels_all_annotations, tmp_path):
     # --- Metadata: name, category, source preserved ---
     for orig, reloaded in zip(labels.masks, loaded.masks):
         assert reloaded.name == orig.name
-        assert reloaded.category == orig.category
+        assert reloaded.category.name == orig.category.name
         assert reloaded.source == orig.source
 
     for orig, reloaded in zip(labels.rois, loaded.rois):
         assert reloaded.name == orig.name
-        assert reloaded.category == orig.category
+        assert reloaded.category.name == orig.category.name
         assert reloaded.source == orig.source
 
     for orig, reloaded in zip(labels.bboxes, loaded.bboxes):
         assert reloaded.name == orig.name
-        assert reloaded.category == orig.category
+        assert reloaded.category.name == orig.category.name
         assert reloaded.source == orig.source
 
     for orig, reloaded in zip(labels.label_images, loaded.label_images):
@@ -8430,7 +8671,7 @@ def test_slp_backward_compat_roi_json_attrs(tmp_path):
     roi = loaded.rois[0]
     # No is_predicted column → defaults to UserROI
     assert type(roi) is UserROI
-    assert roi.category == "arena"
+    assert roi.category.name == "arena"
     assert roi.name == "test_roi"
     assert roi.source == "manual"
     assert roi.geometry.bounds == circle.bounds
@@ -9400,7 +9641,7 @@ def test_slp_centroid_roundtrip(tmp_path):
     assert lc1.track is loaded.tracks[0]
     assert lc1.tracking_score == pytest.approx(0.8)
     assert lc1.name == "c1"
-    assert lc1.category == "cell"
+    assert lc1.category.name == "cell"
     assert lc1.source == "center_of_mass"
 
     lc2 = loaded.centroids[1]
@@ -9411,7 +9652,7 @@ def test_slp_centroid_roundtrip(tmp_path):
     assert lc2.score == pytest.approx(0.95)
     assert lc2.tracking_score is None
     assert lc2.name == "c2"
-    assert lc2.category == "lysosome"
+    assert lc2.category.name == "lysosome"
     assert lc2.source == "trackmate"
 
 

--- a/tests/io/test_slp_lazy.py
+++ b/tests/io/test_slp_lazy.py
@@ -1759,6 +1759,151 @@ def test_lazy_embeddings_round_trip(tmp_path):
     )
 
 
+def test_lazy_per_instance_category_round_trip(tmp_path):
+    """Per-instance categories materialize + copy correctly via the lazy loader."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    cat_a = sio.Category(name="female_fly", metadata={"cohort": "1"})
+    cat_b = sio.Category(name="male_fly")
+    insts = [
+        Instance.from_numpy(
+            np.array([[0, 1], [2, 3]]), skel, category=cat_a, category_score=0.95
+        ),
+        PredictedInstance.from_numpy(
+            np.array([[4, 5], [6, 7]]), skel, score=0.8, category=cat_b
+        ),
+        Instance.from_numpy(np.array([[8, 9], [10, 11]]), skel),  # no category
+    ]
+    labels = sio.Labels([LabeledFrame(video=video, frame_idx=0, instances=insts)])
+    labels.update()
+
+    path = str(tmp_path / "lazy_categories.slp")
+    sio.save_slp(labels, path)
+
+    lazy = sio.load_slp(path, lazy=True)
+    assert lazy.is_lazy
+    assert {c.name for c in lazy.categories} == {"female_fly", "male_fly"}
+
+    li = list(lazy[0].instances)
+    assert li[0].category is not None
+    assert li[0].category.name == "female_fly"
+    assert li[0].category.metadata == {"cohort": "1"}
+    assert li[0].category_score == pytest.approx(0.95)
+    assert li[1].category is not None
+    assert li[1].category.name == "male_fly"
+    assert li[1].category_score is None
+    assert li[2].category is None
+
+    # The materialized category is the canonical catalog object.
+    assert li[0].category in lazy.categories
+
+    # Lazy store copy preserves category wiring, the catalog, and consistency.
+    copied = lazy.copy()
+    cli = list(copied[0].instances)
+    assert cli[0].category is not None
+    assert cli[0].category.name == "female_fly"
+    assert {c.name for c in copied.categories} == {"female_fly", "male_fly"}
+    assert cli[0].category in copied.categories  # materialized inst -> catalog
+    assert copied.categories[0] is not lazy.categories[0]  # independent copy
+
+
+def test_lazy_category_embeddings_round_trip(tmp_path):
+    """Per-instance category embeddings materialize via the lazy loader."""
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+
+    i0 = Instance.from_numpy(
+        np.array([[0, 1], [2, 3]]),
+        skel,
+        category="female_fly",
+        category_embedding=sio.Embedding(np.arange(64, dtype=np.float32)),
+    )
+    i1 = Instance.from_numpy(np.array([[8, 9], [0, 1]]), skel)  # no embedding
+
+    labels = sio.Labels([LabeledFrame(video=video, frame_idx=0, instances=[i0, i1])])
+    labels.update()
+
+    path = str(tmp_path / "lazy_category_embeddings.slp")
+    sio.save_slp(labels, path, save_embedding_vectors=True)
+
+    lazy = sio.load_slp(path, lazy=True)
+    assert lazy.is_lazy
+    li = list(lazy[0].instances)
+    assert li[0].category_embedding is not None
+    assert li[0].category_embedding.dim == 64
+    np.testing.assert_array_equal(
+        li[0].category_embedding.vector, np.arange(64, dtype=np.float32)
+    )
+    assert li[1].category_embedding is None
+
+    # Lazy store copy preserves category embeddings.
+    cli = list(lazy.copy()[0].instances)
+    assert cli[0].category_embedding.dim == 64
+    np.testing.assert_array_equal(
+        cli[0].category_embedding.vector, np.arange(64, dtype=np.float32)
+    )
+
+
+def test_lazy_save_persists_categories_and_embeddings(tmp_path):
+    """Lazy save must persist categories + per-instance links + embeddings.
+
+    Category mirror of ``test_lazy_save_persists_identities_and_embeddings``:
+    ``load_slp(p, lazy=True).save(p2)`` must round-trip the /categories catalog,
+    the per-detection links, and the parallel category_* embedding datasets.
+    """
+    skel = Skeleton(["A", "B"])
+    video = Video(filename="test.mp4")
+    cat_a = sio.Category(name="female_fly", metadata={"cohort": "1"})
+    cat_b = sio.Category(name="male_fly")
+
+    i0 = Instance.from_numpy(
+        np.array([[0, 1], [2, 3]]),
+        skel,
+        category=cat_a,
+        category_score=0.95,
+        category_embedding=sio.Embedding(np.arange(64, dtype=np.float32)),
+    )
+    i1 = PredictedInstance.from_numpy(
+        np.array([[4, 5], [6, 7]]), skel, score=0.8, category=cat_b
+    )
+    i2 = Instance.from_numpy(np.array([[8, 9], [10, 11]]), skel)  # no category
+
+    labels = sio.Labels(
+        [LabeledFrame(video=video, frame_idx=0, instances=[i0, i1, i2])]
+    )
+    labels.update()
+
+    a = str(tmp_path / "a.slp")
+    sio.save_slp(labels, a, save_embedding_vectors=True)
+    lazy = sio.load_slp(a, lazy=True)
+    assert lazy.is_lazy
+
+    b = str(tmp_path / "b.slp")
+    sio.save_slp(lazy, b, save_embedding_vectors=True)
+    assert lazy.is_lazy  # fast path must not have materialized
+
+    with h5py.File(b, "r") as f:
+        assert f["metadata"].attrs["format_id"] == 2.7
+        assert "name" in f["categories"]
+        assert "links" in f["categories"]
+        assert "meta_owner" in f["categories"]  # cat_a carries metadata
+        emb = f["embeddings"]
+        for ds in ("category_vectors", "category_owner_type", "category_owner_id"):
+            assert emb[ds].compression == "gzip"
+
+    reb = sio.load_slp(b)
+    assert {c.name for c in reb.categories} == {"female_fly", "male_fly"}
+    rli = list(reb[0].instances)
+    assert rli[0].category.name == "female_fly"
+    assert rli[0].category.metadata == {"cohort": "1"}
+    assert rli[0].category_score == pytest.approx(0.95)
+    np.testing.assert_array_equal(
+        rli[0].category_embedding.vector, np.arange(64, dtype=np.float32)
+    )
+    assert rli[1].category.name == "male_fly"
+    assert rli[2].category is None
+
+
 def test_lazy_save_persists_identities_and_embeddings(tmp_path):
     """Lazy save must persist identities + per-instance links + embeddings.
 

--- a/tests/io/test_ultralytics.py
+++ b/tests/io/test_ultralytics.py
@@ -1344,12 +1344,12 @@ def test_ultralytics_detection_read_write_roundtrip(tmp_path):
 
     # Check first bbox (cat)
     bbox0 = labels.bboxes[0]
-    assert bbox0.category == "cat"
+    assert bbox0.category.name == "cat"
     assert isinstance(bbox0, UserBoundingBox)
 
     # Check second bbox (dog)
     bbox1 = labels.bboxes[1]
-    assert bbox1.category == "dog"
+    assert bbox1.category.name == "dog"
 
     # Verify both bboxes have valid areas
     for bbox in labels.bboxes:
@@ -1388,12 +1388,12 @@ def test_ultralytics_detection_with_confidence(tmp_path):
     # Check types and categories
     bbox0 = labels.bboxes[0]
     assert isinstance(bbox0, PredictedBoundingBox)
-    assert bbox0.category == "cat"
+    assert bbox0.category.name == "cat"
     assert bbox0.score == pytest.approx(0.95)
 
     bbox1 = labels.bboxes[1]
     assert isinstance(bbox1, PredictedBoundingBox)
-    assert bbox1.category == "dog"
+    assert bbox1.category.name == "dog"
     assert bbox1.score == pytest.approx(0.85)
 
 
@@ -1414,7 +1414,7 @@ def test_ultralytics_segmentation_read_write_roundtrip(tmp_path):
     assert len(bboxes) == 0
     roi = rois[0]
     assert not roi.is_bbox
-    assert roi.category == "animal"
+    assert roi.category.name == "animal"
     assert roi.area > 0
 
     # Verify polygon vertices
@@ -1536,12 +1536,12 @@ def test_write_bbox_label_file(tmp_path):
     assert len(bboxes_read) == 2
 
     assert isinstance(bboxes_read[0], UserBoundingBox)
-    assert bboxes_read[0].category == "cat"
+    assert bboxes_read[0].category.name == "cat"
     assert abs(bboxes_read[0].x_center - 100.0) < 1e-3
     assert abs(bboxes_read[0].y_center - 50.0) < 1e-3
 
     assert isinstance(bboxes_read[1], PredictedBoundingBox)
-    assert bboxes_read[1].category == "dog"
+    assert bboxes_read[1].category.name == "dog"
     assert bboxes_read[1].score == pytest.approx(0.9, abs=1e-4)
     assert abs(bboxes_read[1].x_center - 50.0) < 1e-3
     assert abs(bboxes_read[1].y_center - 25.0) < 1e-3
@@ -1676,7 +1676,7 @@ def test_write_bbox_label_file_predicted_score(tmp_path):
 
     assert isinstance(bboxes_read[0], PredictedBoundingBox)
     assert bboxes_read[0].score == pytest.approx(0.85, abs=1e-4)
-    assert bboxes_read[0].category == "cat"
+    assert bboxes_read[0].category.name == "cat"
 
     assert isinstance(bboxes_read[1], UserBoundingBox)
-    assert bboxes_read[1].category == "dog"
+    assert bboxes_read[1].category.name == "dog"

--- a/tests/model/test_bbox.py
+++ b/tests/model/test_bbox.py
@@ -44,7 +44,7 @@ def test_bbox_basic():
     assert bbox.angle == 0.0
     assert bbox.track is None
     assert bbox.instance is None
-    assert bbox.category == ""
+    assert bbox.category is None
     assert bbox.name == ""
     assert bbox.source == ""
 
@@ -74,7 +74,7 @@ def test_bbox_from_xyxy_swapped_raises():
 
 def test_bbox_from_xyxy_with_kwargs():
     bbox = UserBoundingBox.from_xyxy(10, 20, 110, 100, category="mouse")
-    assert bbox.category == "mouse"
+    assert bbox.category.name == "mouse"
 
 
 def test_bbox_from_xywh():
@@ -245,7 +245,7 @@ def test_bbox_to_roi():
     )
     roi = bbox.to_roi()
     assert roi.name == "box1"
-    assert roi.category == "mouse"
+    assert roi.category.name == "mouse"
     assert roi.source == "manual"
     assert roi.area == pytest.approx(200.0)
     assert roi.bounds == pytest.approx((40.0, 45.0, 60.0, 55.0))
@@ -269,7 +269,7 @@ def test_bbox_to_roi_preserves_metadata():
     )
     roi = bbox.to_roi()
     assert roi.name == "b1"
-    assert roi.category == "mouse"
+    assert roi.category.name == "mouse"
 
 
 def test_bbox_to_roi_preserves_tracking_score():
@@ -378,7 +378,7 @@ def test_bbox_to_centroid_propagates_metadata():
     assert centroid.identity is ident
     assert centroid.identity_score == pytest.approx(0.8)
     assert centroid.instance is inst
-    assert centroid.category == "mouse"
+    assert centroid.category.name == "mouse"
     assert centroid.name == "b1"
     assert centroid.source == "manual"
 
@@ -507,7 +507,7 @@ def test_bbox_pad_preserves_angle_and_metadata():
     assert padded.identity is ident
     assert padded.identity_score == pytest.approx(0.8)
     assert padded.instance is inst
-    assert padded.category == "mouse"
+    assert padded.category.name == "mouse"
     assert padded.name == "b1"
     assert padded.source == "manual"
 

--- a/tests/model/test_category.py
+++ b/tests/model/test_category.py
@@ -1,0 +1,96 @@
+"""Tests for the `Category` data structure and its converter."""
+
+import copy
+
+import pytest
+
+from sleap_io.model.category import Category, to_category
+
+
+def test_category_defaults():
+    cat = Category()
+    assert cat.name == ""
+    assert cat.metadata == {}
+
+
+def test_category_full():
+    cat = Category(name="female_fly", metadata={"color": "#e6194b", "sex": "F"})
+    assert cat.name == "female_fly"
+    assert cat.metadata == {"color": "#e6194b", "sex": "F"}
+
+
+def test_category_eq_false():
+    # Object-identity equality (like Track/Identity): distinct objects are not equal.
+    a = Category(name="female_fly")
+    b = Category(name="female_fly")
+    assert a is not b
+    assert a != b
+    assert a == a
+
+
+def test_category_hashable_by_object_identity():
+    a = Category(name="female_fly")
+    b = Category(name="female_fly")
+    assert len({a, b}) == 2
+
+
+def test_category_repr():
+    assert repr(Category(name="female_fly")) == 'Category(name="female_fly")'
+
+
+def test_category_matches_name_default():
+    a = Category(name="female_fly")
+    b = Category(name="female_fly")
+    c = Category(name="male_fly")
+    assert a.matches(b)  # default method is "name"
+    assert a.matches(b, method="name")
+    assert not a.matches(c)
+
+
+def test_category_matches_object_identity():
+    a = Category(name="female_fly")
+    b = Category(name="female_fly")
+    assert a.matches(a, method="identity")
+    assert not a.matches(b, method="identity")
+
+
+def test_category_matches_invalid_method():
+    a = Category(name="female_fly")
+    with pytest.raises(ValueError):
+        a.matches(a, method="uuid")
+
+
+def test_category_metadata_validation():
+    with pytest.raises(TypeError):
+        Category(name="x", metadata="notadict")
+
+
+def test_category_deepcopy():
+    a = Category(name="female_fly", metadata={"color": "#fff"})
+    b = copy.deepcopy(a)
+    assert b is not a
+    assert b.name == a.name
+    assert b.metadata == a.metadata
+    assert b.metadata is not a.metadata
+
+
+def test_to_category_none_and_empty_string():
+    # None and "" (the legacy "unset" sentinel) both map to None.
+    assert to_category(None) is None
+    assert to_category("") is None
+
+
+def test_to_category_from_string():
+    cat = to_category("mouse")
+    assert isinstance(cat, Category)
+    assert cat.name == "mouse"
+
+
+def test_to_category_passthrough():
+    cat = Category(name="mouse")
+    assert to_category(cat) is cat
+
+
+def test_to_category_invalid_type():
+    with pytest.raises(TypeError):
+        to_category(5)

--- a/tests/model/test_centroid.py
+++ b/tests/model/test_centroid.py
@@ -35,7 +35,7 @@ def test_user_centroid_basic():
     assert c.track is None
     assert c.tracking_score is None
     assert c.instance is None
-    assert c.category == ""
+    assert c.category is None
     assert c.name == ""
     assert c.source == ""
     assert not c.is_predicted
@@ -56,7 +56,7 @@ def test_user_centroid_all_fields():
     assert c.z == 3.0
     assert c.track is track
     assert c.tracking_score == 0.8
-    assert c.category == "cell"
+    assert c.category.name == "cell"
     assert c.name == "c1"
     assert c.source == "center_of_mass"
 
@@ -495,7 +495,7 @@ def test_from_pose_kwargs_passthrough():
     skel = Skeleton(["a"])
     inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skel)
     c = Centroid.from_pose(inst, category="cell", name="c7")
-    assert c.category == "cell"
+    assert c.category.name == "cell"
     assert c.name == "c7"
 
 
@@ -626,7 +626,7 @@ def test_to_roi_basic():
     cx, cy = roi.geometry.centroid.x, roi.geometry.centroid.y
     assert cx == pytest.approx(10.0, abs=1e-6)
     assert cy == pytest.approx(20.0, abs=1e-6)
-    assert roi.category == "cell"
+    assert roi.category.name == "cell"
 
 
 def test_to_roi_predicted():
@@ -705,7 +705,7 @@ def test_to_mask_metadata_propagated():
     c = UserCentroid(x=10.0, y=10.0, track=track, category="cell", name="c1")
     mask = c.to_mask(height=20, width=20, radius=3.0)
     assert mask.track is track
-    assert mask.category == "cell"
+    assert mask.category.name == "cell"
     assert mask.name == "c1"
 
 

--- a/tests/model/test_label_image.py
+++ b/tests/model/test_label_image.py
@@ -370,13 +370,13 @@ def test_to_masks():
     # First mask (label 1)
     np.testing.assert_array_equal(masks[0].data, [[True, False], [False, False]])
     assert masks[0].track is t1
-    assert masks[0].category == "neuron"
+    assert masks[0].category.name == "neuron"
     assert masks[0].name == "cell_1"
     assert masks[0].source == "test_source"
     # Second mask (label 2)
     np.testing.assert_array_equal(masks[1].data, [[False, False], [False, True]])
     assert masks[1].track is t2
-    assert masks[1].category == "glia"
+    assert masks[1].category.name == "glia"
 
 
 def test_to_masks_from_masks_roundtrip():
@@ -1473,7 +1473,7 @@ def test_to_bboxes_metadata():
     bboxes = li.to_bboxes()
     bb = bboxes[0]
     assert bb.track is track
-    assert bb.category == "cell"
+    assert bb.category.name == "cell"
     assert bb.name == "obj1"
     assert bb.source == "cellpose"
 

--- a/tests/model/test_labels.py
+++ b/tests/model/test_labels.py
@@ -6563,9 +6563,9 @@ def test_labels_copy_preserves_rois_and_masks(slp_minimal, tmp_path):
     labels_copy = lazy_labels.copy()
 
     assert len(labels_copy.rois) == 1
-    assert labels_copy.rois[0].category == "test"
+    assert labels_copy.rois[0].category.name == "test"
     assert len(labels_copy.masks) == 1
-    assert labels_copy.masks[0].category == "fg"
+    assert labels_copy.masks[0].category.name == "fg"
 
     # Verify independence (properties return new lists)
     assert len(lazy_labels.rois) == 1

--- a/tests/model/test_mask.py
+++ b/tests/model/test_mask.py
@@ -167,7 +167,7 @@ def test_segmentation_mask_to_polygon():
     roi = mask.to_polygon()
 
     assert roi.name == "test_mask"
-    assert roi.category == "cat"
+    assert roi.category.name == "cat"
     assert roi.geometry.area > 0
 
 
@@ -214,7 +214,7 @@ def test_user_segmentation_mask():
     data[2:5, 3:7] = True
     mask = UserSegmentationMask.from_numpy(data, name="cell", category="neuron")
     assert mask.name == "cell"
-    assert mask.category == "neuron"
+    assert mask.category.name == "neuron"
     assert mask.area == 12
     assert not mask.is_predicted
 
@@ -325,7 +325,7 @@ def test_segmentation_mask_resampled():
     assert resampled.scale == (1.0, 1.0)
     assert resampled.offset == (0.0, 0.0)
     assert resampled.name == "cell"
-    assert resampled.category == "neuron"
+    assert resampled.category.name == "neuron"
     assert resampled.has_spatial_transform is False
     assert resampled.data.any()
     assert isinstance(resampled, UserSegmentationMask)
@@ -494,7 +494,7 @@ def test_to_bbox_metadata():
     )
     bb = mask.to_bbox()
     assert bb.track is track
-    assert bb.category == "cell"
+    assert bb.category.name == "cell"
     assert bb.name == "obj1"
     assert bb.source == "manual"
 
@@ -564,7 +564,7 @@ def test_to_user_metadata():
     user = pred.to_user()
     assert user.track is track
     assert user.tracking_score == pytest.approx(0.7)
-    assert user.category == "cell"
+    assert user.category.name == "cell"
     assert user.name == "obj1"
     assert user.source == "model"
 
@@ -912,7 +912,7 @@ def test_to_centroid_propagates_metadata():
     assert c.tracking_score == pytest.approx(0.6)
     assert c.identity is ident
     assert c.identity_score == pytest.approx(0.8)
-    assert c.category == "cell"
+    assert c.category.name == "cell"
     assert c.name == "obj1"
     assert c.source == "manual"
 
@@ -1000,7 +1000,7 @@ def test_to_polygon_propagates_metadata():
     assert roi.tracking_score == pytest.approx(0.6)
     assert roi.identity is ident
     assert roi.identity_score == pytest.approx(0.8)
-    assert roi.category == "cell"
+    assert roi.category.name == "cell"
     assert roi.name == "obj1"
     assert roi.source == "manual"
 

--- a/tests/model/test_matching.py
+++ b/tests/model/test_matching.py
@@ -3,12 +3,16 @@
 import numpy as np
 
 import sleap_io as sio
+from sleap_io.model.category import Category
 from sleap_io.model.identity import Identity
 from sleap_io.model.instance import Instance, PredictedInstance, Track
 from sleap_io.model.labeled_frame import LabeledFrame
 from sleap_io.model.labels import Labels
 from sleap_io.model.matching import (
+    NAME_CATEGORY_MATCHER,
     NAME_IDENTITY_MATCHER,
+    CategoryMatcher,
+    CategoryMatchMethod,
     ConflictResolution,
     ErrorMode,
     FrameStrategy,
@@ -238,6 +242,39 @@ class TestIdentityMatcher:
     def test_prebuilt_matchers(self):
         """Test the module-level pre-built identity matchers."""
         assert NAME_IDENTITY_MATCHER.method == IdentityMatchMethod.NAME
+
+
+class TestCategoryMatcher:
+    """Test category matching functionality (mirror of identity matching)."""
+
+    def test_name_match_default(self):
+        """Test that the default method matches by name."""
+        cat1 = Category(name="female_fly")
+        cat2 = Category(name="female_fly")  # Same name, different object
+        cat3 = Category(name="male_fly")
+
+        matcher = CategoryMatcher()
+        assert matcher.method == CategoryMatchMethod.NAME
+        assert matcher.match(cat1, cat2)  # Same name
+        assert not matcher.match(cat1, cat3)  # Different names
+
+    def test_identity_match(self):
+        """Test category matching by Python object identity."""
+        cat1 = Category(name="female_fly")
+        cat2 = Category(name="female_fly")  # same name, diff object
+
+        matcher = CategoryMatcher(method=CategoryMatchMethod.IDENTITY)
+        assert not matcher.match(cat1, cat2)  # Different objects
+        assert matcher.match(cat1, cat1)  # Same object
+
+    def test_string_method_coercion(self):
+        """Test that a string method is coerced to the enum."""
+        matcher = CategoryMatcher(method="name")
+        assert matcher.method == CategoryMatchMethod.NAME
+
+    def test_prebuilt_matchers(self):
+        """Test the module-level pre-built category matchers."""
+        assert NAME_CATEGORY_MATCHER.method == CategoryMatchMethod.NAME
 
 
 class TestVideoMatcher:

--- a/tests/model/test_roi.py
+++ b/tests/model/test_roi.py
@@ -94,7 +94,7 @@ def test_roi_from_polygon_with_kwargs():
     coords = [(0, 0), (10, 0), (10, 10), (0, 10)]
     roi = UserROI.from_polygon(coords, name="test", category="cat1")
     assert roi.name == "test"
-    assert roi.category == "cat1"
+    assert roi.category.name == "cat1"
 
 
 def test_roi_video():
@@ -140,7 +140,7 @@ def test_roi_to_mask():
     assert mask.height == 20
     assert mask.width == 20
     assert mask.name == "test_roi"
-    assert mask.category == "cat"
+    assert mask.category.name == "cat"
     assert mask.area > 0
 
     # Check that the mask data has foreground pixels in the right region
@@ -158,7 +158,7 @@ def test_predicted_roi_to_mask_is_predicted():
 
     assert isinstance(mask, PredictedSegmentationMask)
     assert mask.score == pytest.approx(0.8)
-    assert mask.category == "cat"
+    assert mask.category.name == "cat"
     assert mask.area > 0
 
     # A user ROI still produces a user mask (no score field).
@@ -292,7 +292,7 @@ def test_roi_from_multi_polygon_with_kwargs():
     polygons = [[(0, 0), (5, 0), (5, 5), (0, 5)]]
     roi = UserROI.from_multi_polygon(polygons, name="multi", category="test")
     assert roi.name == "multi"
-    assert roi.category == "test"
+    assert roi.category.name == "test"
 
 
 def test_roi_explode_multi_polygon():
@@ -307,7 +307,7 @@ def test_roi_explode_multi_polygon():
     for part in parts:
         assert isinstance(part.geometry, Polygon)
         assert part.name == "test"
-        assert part.category == "cat"
+        assert part.category.name == "cat"
     assert parts[0].area == pytest.approx(100.0)
     assert parts[1].area == pytest.approx(100.0)
 
@@ -391,7 +391,7 @@ def test_predicted_roi():
     roi = PredictedROI(geometry=box(0, 0, 5, 5), score=0.75, category="arena")
     assert roi.score == 0.75
     assert roi.is_predicted
-    assert roi.category == "arena"
+    assert roi.category.name == "arena"
 
 
 def test_roi_from_bbox_deprecation():
@@ -499,7 +499,7 @@ def test_roi_to_centroid_predicted_carries_score_and_metadata():
     assert c.identity is ident
     assert c.identity_score == pytest.approx(0.4)
     assert c.instance is inst
-    assert c.category == "mouse"
+    assert c.category.name == "mouse"
     assert c.name == "m7"
     assert c.source == "manual"
 
@@ -586,7 +586,7 @@ def test_roi_to_bbox_predicted_carries_score_and_metadata():
     assert b.score == pytest.approx(0.6)
     assert b.track is track
     assert b.tracking_score == pytest.approx(0.9)
-    assert b.category == "fly"
+    assert b.category.name == "fly"
     assert b.name == "f1"
     assert b.source == "net"
 

--- a/tests/rendering/test_rendering.py
+++ b/tests/rendering/test_rendering.py
@@ -126,6 +126,37 @@ class TestColors:
         assert "node_colors" in colors
         assert len(colors["node_colors"]) == 5
 
+        # Identity scheme
+        colors = build_color_map(
+            scheme="identity",
+            n_instances=2,
+            n_nodes=5,
+            n_tracks=0,
+            identity_indices=[0, 1],
+            n_identities=2,
+        )
+        assert "instance_colors" in colors
+        assert len(colors["instance_colors"]) == 2
+
+        # Category scheme (mirrors identity)
+        colors = build_color_map(
+            scheme="category",
+            n_instances=2,
+            n_nodes=5,
+            n_tracks=0,
+            category_indices=[0, 1],
+            n_categories=2,
+        )
+        assert "instance_colors" in colors
+        assert len(colors["instance_colors"]) == 2
+
+        # Category scheme without indices falls back to instance ordering
+        colors = build_color_map(
+            scheme="category", n_instances=3, n_nodes=5, n_tracks=0
+        )
+        assert "instance_colors" in colors
+        assert len(colors["instance_colors"]) == 3
+
     def test_resolve_color_rgb_int_tuple(self):
         """Test resolve_color with RGB int tuple."""
         from sleap_io.rendering.colors import resolve_color
@@ -5526,3 +5557,118 @@ class TestRenderVideoTrails:
         )
         assert len(frames) == 4
         assert all(f.ndim == 3 for f in frames)
+
+
+# ============================================================================
+# Category coloring tests (mirror of the identity color scheme)
+# ============================================================================
+
+
+def _make_category_labels(n_frames: int = 2):
+    """Build a Labels with two categories assigned across two instances/frame."""
+    skeleton = sio.Skeleton(["a", "b"])
+    cat_a = sio.Category(name="female_fly")
+    cat_b = sio.Category(name="male_fly")
+    video = sio.Video(filename="cat.mp4", open_backend=False)
+    video.backend_metadata["shape"] = (n_frames, 100, 100, 3)
+    lfs = []
+    for fi in range(n_frames):
+        inst_a = sio.Instance.from_numpy(
+            np.array([[20.0, 20.0], [40.0, 40.0]]), skeleton=skeleton, category=cat_a
+        )
+        inst_b = sio.Instance.from_numpy(
+            np.array([[60.0, 60.0], [80.0, 80.0]]), skeleton=skeleton, category=cat_b
+        )
+        lfs.append(
+            sio.LabeledFrame(video=video, frame_idx=fi, instances=[inst_a, inst_b])
+        )
+    return sio.Labels(
+        labeled_frames=lfs,
+        videos=[video],
+        skeletons=[skeleton],
+        categories=[cat_a, cat_b],
+    )
+
+
+def test_compute_category_coloring():
+    """`_compute_category_coloring` maps instances to catalog indices."""
+    from sleap_io.rendering.core import _compute_category_coloring
+
+    cat_a = sio.Category(name="female_fly")
+    cat_b = sio.Category(name="male_fly")
+    skeleton = sio.Skeleton(["a"])
+    inst_a = sio.Instance.from_numpy(
+        np.array([[1.0, 2.0]]), skeleton=skeleton, category=cat_a
+    )
+    inst_b = sio.Instance.from_numpy(
+        np.array([[3.0, 4.0]]), skeleton=skeleton, category=cat_b
+    )
+    inst_none = sio.Instance.from_numpy(np.array([[5.0, 6.0]]), skeleton=skeleton)
+
+    indices, n = _compute_category_coloring([inst_a, inst_b, inst_none], [cat_a, cat_b])
+    assert indices == [0, 1, 0]  # category-less instance maps to index 0
+    assert n == 2
+
+
+def test_compute_category_coloring_discovers_uncataloged():
+    """Categories not in the catalog are discovered in encounter order."""
+    from sleap_io.rendering.core import _compute_category_coloring
+
+    cat_a = sio.Category(name="female_fly")
+    skeleton = sio.Skeleton(["a"])
+    inst_a = sio.Instance.from_numpy(
+        np.array([[1.0, 2.0]]), skeleton=skeleton, category=cat_a
+    )
+    # Empty starting catalog -> discovered at index 0, catalog grows to 1.
+    indices, n = _compute_category_coloring([inst_a], None)
+    assert indices == [0]
+    assert n == 1
+
+
+def test_render_image_color_by_category():
+    """`render_image(color_by="category")` renders on a Labels source."""
+    labels = _make_category_labels(n_frames=1)
+    rendered = render_image(labels[0], background="black", color_by="category")
+    assert rendered.ndim == 3
+
+
+def test_render_video_color_by_category():
+    """`render_video(color_by="category")` colors instances by category."""
+    labels = _make_category_labels(n_frames=2)
+    frames = render_video(
+        labels,
+        background="black",
+        color_by="category",
+        show_progress=False,
+    )
+    assert len(frames) == 2
+    assert all(f.ndim == 3 for f in frames)
+
+
+def test_render_video_color_by_category_includes_unlabeled():
+    """color_by="category" with an empty frame exercises the no-instances branch."""
+    skeleton = sio.Skeleton(["a", "b"])
+    cat_a = sio.Category(name="female_fly")
+    video = sio.Video(filename="cat.mp4", open_backend=False)
+    video.backend_metadata["shape"] = (3, 100, 100, 3)
+    inst = sio.Instance.from_numpy(
+        np.array([[20.0, 20.0], [40.0, 40.0]]), skeleton=skeleton, category=cat_a
+    )
+    # Frame 0 has an instance; frames 1-2 are empty (no-instances render branch).
+    lfs = [sio.LabeledFrame(video=video, frame_idx=0, instances=[inst])]
+    labels = sio.Labels(
+        labeled_frames=lfs,
+        videos=[video],
+        skeletons=[skeleton],
+        categories=[cat_a],
+    )
+    frames = render_video(
+        labels,
+        background="black",
+        color_by="category",
+        include_unlabeled=True,
+        start=0,
+        end=3,
+        show_progress=False,
+    )
+    assert len(frames) == 3


### PR DESCRIPTION
## Summary

Adds **`Category`** as a first-class concept — a third grouping axis alongside `Track` and `Identity`:

| Concept | Scope | Example |
|---------|-------|---------|
| `Track` | same individual **within** a video (tracking) | `track_0` |
| `Identity` | same individual **across** videos (unique ID) | `C57BL6.cohort2.12` |
| **`Category`** | individuals of the **same class** (classified / re-ID'd) | `female_fly`, `fur_shaved` |

`Category` is a direct mirror of `Identity`: a named catalog entry (`name` + string `metadata` + `matches()`), attached per-detection via a `category` / `category_score` / `category_embedding` slot trio, collected into `Labels.categories`, and persisted in `.slp`.

Motivated by moving toward object detection, where the object **class** is a first-class citizen (COCO "category" ↔ this `Category`).

## Key Changes

- **`Category` model class** (`sleap_io/model/category.py`) mirroring `Identity`, plus a `to_category` converter.
- **Promotes the pre-existing free-form `category: str`** on `BoundingBox`/`Centroid`/`ROI`/`SegmentationMask` to `category: Category | None`. A `str → Category` converter keeps existing construction working (`category="mouse"` → `Category(name="mouse")`, `category=""` → `None`). Adds sibling `category_score` / `category_embedding` slots on all six detection modalities (`Instance`, `PredictedInstance`, `BoundingBox`, `Centroid`, `ROI`, `SegmentationMask`); a bare `category` slot on `InstanceGroup`.
- **`Labels.categories`** catalog (auto-collected like `identities`, kw-only) + **`CategoryMatcher`** / `CategoryMatchMethod`. `Labels.merge(category=...)` dedups the catalog by name.
- **SLP persistence (format 2.6 → 2.7)**: new self-contained `/categories` group mirroring `/identity` (name catalog + EAV metadata + a `links` dataset with `category_idx`/`category_score`), and category embeddings as **parallel `category_*` datasets** in `/embeddings` (so identity and category embeddings are independent and need not share dimensionality). Fully additive and read-on-presence — **pre-2.7 files load unchanged**; identity-only files stay byte-identical.
- **Reader migration**: every reader of the class label as a string (COCO / Ultralytics / JABS / GeoJSON writers, `roi.__geo_interface__`, `get_*(category=...)` filters) now uses `.category.name`.
- **CLI / rendering**: `sio merge --category`, `sio render --color-by category`, and `sio show` / `--json` category reporting (`n_categories`, `categories[]`, `n_instances_with_category_embedding`).
- **Docs**: new `docs/model/category.md`; SLP format 2.7 and CLI docs updated.

## Example Usage

```python
import numpy as np
import sleap_io as sio

# Promotion: a bare class-label string still works, and is now a Category
bbox = sio.UserBoundingBox(x1=0, y1=0, x2=10, y2=10, category="mouse")
bbox.category            # Category(name="mouse")

# Full first-class use: catalog entry + per-detection score + embedding
fly = sio.Category(name="female_fly", metadata={"sex": "F"})
inst = sio.Instance.from_numpy(
    pts, skeleton=skel,
    category=fly, category_score=0.94,
    category_embedding=sio.Embedding(np.random.rand(128).astype("float32")),
)
labels = sio.Labels(labeled_frames=[sio.LabeledFrame(video=v, frame_idx=0, instances=[inst])])
labels.categories        # [Category(name="female_fly")]

sio.save_slp(labels, "out.slp", save_embedding_vectors=True)   # format 2.7
```

```bash
sio render preds.slp -o out.mp4 --color-by category
sio merge a.slp b.slp -o merged.slp --category name
sio show preds.slp --json          # includes n_categories, categories[], ...
```

## API Changes

- **New:** `sio.Category`; `category` / `category_score` / `category_embedding` kwargs+attrs on all six detection modalities; `InstanceGroup.category`; `Labels.categories`; `Labels.merge(category=...)`; `CategoryMatcher` / `CategoryMatchMethod` / `NAME_CATEGORY_MATCHER` (in `sleap_io.model.matching`).
- **Breaking:** `.category` on `BoundingBox`/`Centroid`/`ROI`/`SegmentationMask` is now a `Category | None` instead of a `str`. **Construction is unchanged** (converter), but code that *reads* `.category` as a string must use `.category.name` (and treat `None` as unset). SLP `roi_categories`/`mask_categories`/bbox/centroid category datasets still store the name string, so the on-disk string format is unchanged. `LabelImage.Info.category` remains a plain `str` (separate panoptic-mask subsystem, no change).
- **SLP format 2.6 → 2.7** (additive; older files load unchanged).

## Testing

- New `tests/model/test_category.py` (class + converter, 100% coverage of `category.py`) and `TestCategoryMatcher` in `tests/model/test_matching.py`.
- SLP round-trip tests (catalog, per-detection category+score, category embeddings, `save_embedding_vectors` gate, identity+category embeddings with **different dims**, pre-2.7 fixture loads with empty `categories`), lazy-store parity, CLI `--json`/merge/`--color-by`, and rendering coloring tests.
- Full suite: **4356 passed, 3 skipped**; docs pycon guard **109 passed**; `ruff` clean.

## Design Decisions

- **Promote the existing `category: str` rather than introduce a parallel name.** The pre-existing free-form field *is* the object-detection class label — promoting it to a first-class `Category` unifies the concept and matches the "toward object detection" direction, at the cost of a small, mechanical breaking change (reads of `.category` → `.category.name`).
- **Mirror `Identity` exactly** (name + metadata + object-identity equality + name-based matching), including a per-detection embedding slot, since identity has one.
- **Parallel `category_*` embedding datasets** (not a shared `role`-discriminator column) so the identity storage path is byte-identical and the two embedding kinds can have independent dimensionality.
- **`Category` is a catalog entry, not a `User*`/`Predicted*` type** (like `Track`/`Identity`); the User/Predicted semantics live on the detection's `category_score`/`category_embedding` (meaningful on predicted, `None` on user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DiaqkmRcp1L9yD8dx4jLj