### PR TITLE
perf(io): fix slow/silent embed write; ImageVideo byte-copy; write-phase progress

### DIFF
--- a/docs/formats/slp.md
+++ b/docs/formats/slp.md
@@ -166,9 +166,22 @@ file.slp
 
 !!! note "Source video metadata over 64 KB"
     Source video metadata is normally stored in the `source_video/@json`
-    attribute. If it would exceed HDF5's 64 KB attribute limit (e.g. a very large
-    `backend_metadata`), it is written to a `source_video/json` *dataset* instead
-    and a warning is emitted; readers prefer the dataset when present.
+    attribute. If it would exceed HDF5's 64 KB attribute limit (e.g. an image
+    sequence with many thousands of filenames), it is written to a
+    `source_video/json` *dataset* instead and a warning is emitted; readers prefer
+    the dataset when present.
+
+!!! note "Embedded image storage and format"
+    For encoded formats (`png`/`jpg`), the `/video` dataset is stored
+    **uncompressed and contiguous**: the bytes are already entropy-coded, so gzip
+    gained almost nothing while its chunked storage made row-by-row writes
+    pathologically slow. Only the raw-array `hdf5` format is gzip-compressed.
+
+    When the source is an image sequence (`ImageVideo`) of PNG/JPEG files, the
+    original file bytes are **copied verbatim** — no decode/re-encode cycle — and
+    the stored `@format` follows the *source* (e.g. `jpg`) rather than the requested
+    default. This is faster, lossless (no added JPEG artifacts), and typically much
+    smaller than re-encoding to PNG.
 
 ### Core Datasets
 

--- a/sleap_io/io/main.py
+++ b/sleap_io/io/main.py
@@ -165,7 +165,7 @@ def save_slp(
     embed_inplace: bool = False,
     verbose: bool = True,
     plugin: str | None = None,
-    progress_callback: Callable[[int, int], bool] | None = None,
+    progress_callback: Callable[[int, int, str], bool] | None = None,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
     save_embedding_vectors: bool = False,
@@ -201,10 +201,12 @@ def save_slp(
             or "imageio". If None, uses the global default from
             `get_default_image_plugin()`. If no global default is set, auto-detects
             based on available packages (opencv preferred, then imageio).
-        progress_callback: Optional callback function called during frame embedding
-            with `(current, total)` arguments. If it returns `False`, the operation
-            is cancelled and `ExportCancelled` is raised. When provided, tqdm
-            progress bar is disabled in favor of the callback.
+        progress_callback: Optional callback function called during embedding with
+            `(current, total, phase)` arguments, where ``phase`` is ``"embed"`` or
+            ``"write"``. If it returns `False`, the operation is cancelled and
+            `ExportCancelled` is raised. When provided, tqdm progress bars are
+            disabled in favor of the callback. The ``phase`` argument is a breaking
+            change from the previous ``(current, total)`` signature.
         prefer_metadata: If `True` (the default), serialize each uncropped video's
             shape/grayscale/fps from its `backend_metadata` when recorded there
             instead of querying the live backend. For an open `MediaVideo` this
@@ -1640,7 +1642,7 @@ def save_file(
     filename: str | Path,
     format: str | None = None,
     verbose: bool = True,
-    progress_callback: Callable[[int, int], bool] | None = None,
+    progress_callback: Callable[[int, int, str], bool] | None = None,
     **kwargs,
 ):
     """Save a file based on the extension.
@@ -1654,8 +1656,11 @@ def save_file(
         verbose: If `True` (the default), display a progress bar when embedding frames
             (only applies to the SLP format).
         progress_callback: Optional callback function called during frame embedding
-            (SLP format only) with `(current, total)` arguments. If it returns `False`,
-            the operation is cancelled and `ExportCancelled` is raised.
+            (SLP format only) with `(current, total, phase)` arguments, where
+            ``phase`` is ``"embed"`` or ``"write"``. If it returns `False`, the
+            operation is cancelled and `ExportCancelled` is raised. The ``phase``
+            argument is a breaking change from the previous ``(current, total)``
+            signature.
         **kwargs: Additional arguments passed to the format-specific saving function:
             - For "slp" format: embed (bool | str | list[tuple[Video, int]] |
               None): Frames

--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -918,6 +918,41 @@ def can_use_fast_path(video: Video, frame_idx: int, target_format: str) -> bool:
     return True
 
 
+def _resolve_embed_format(video: Video, requested_format: str) -> str:
+    """Determine the on-disk image format to store a video's embedded frames in.
+
+    For an `ImageVideo` whose source files are already-compressed PNG/JPEG, the
+    frames are byte-copied verbatim into the package (see
+    `process_and_embed_frames`), so the stored format follows the *source* rather
+    than `requested_format` -- re-encoding an already-compressed image would only
+    inflate size (PNG) or add artifacts (JPEG) for no benefit. All other sources
+    use `requested_format` (their frames are decoded and re-encoded).
+
+    Args:
+        video: The source `Video` whose frames will be embedded.
+        requested_format: The format requested by the caller ("png", "jpg", or
+            "hdf5").
+
+    Returns:
+        The image format string to store for this video's frames. This is the
+        normalized source extension ("png" or "jpg") for a byte-copyable
+        `ImageVideo`, otherwise `requested_format`.
+    """
+    from sleap_io.io.video_reading import ImageVideo
+
+    if requested_format == "hdf5":
+        return "hdf5"
+    backend = video.backend
+    if isinstance(backend, ImageVideo):
+        fnames = backend.filename
+        first = fnames[0] if isinstance(fnames, list) and fnames else fnames
+        if isinstance(first, (str, Path)):
+            ext = Path(first).suffix.lower().lstrip(".")
+            if ext in ("png", "jpg", "jpeg"):
+                return "jpg" if ext == "jpeg" else ext
+    return requested_format
+
+
 def process_and_embed_frames(
     labels_path: str,
     frames_metadata: list[dict],
@@ -925,7 +960,7 @@ def process_and_embed_frames(
     fixed_length: bool = True,
     verbose: bool = True,
     plugin: str | None = None,
-    progress_callback: Callable[[int, int], bool] | None = None,
+    progress_callback: Callable[[int, int, str], bool] | None = None,
 ) -> dict[Video, Video]:
     """Process and embed frames into a SLEAP labels file.
 
@@ -946,11 +981,17 @@ def process_and_embed_frames(
         plugin: Image plugin to use for encoding. One of "opencv" or "imageio".
             If None, uses the global default from `get_default_image_plugin()`.
             If no global default is set, auto-detects based on available packages.
-        progress_callback: Optional callback function called during frame embedding
-            with `(current, total)` arguments (1-based current frame index and total
-            frame count). If it returns `False`, the operation is cancelled and
-            `ExportCancelled` is raised. When provided, tqdm progress bar is disabled
-            in favor of the callback.
+        progress_callback: Optional callback function called during embedding with
+            `(current, total, phase)` arguments (1-based current index and total
+            count for the phase). ``phase`` is ``"embed"`` while frames are loaded/
+            encoded/byte-copied into memory and ``"write"`` while the accumulated
+            bytes are written to the HDF5 file. If it returns `False`, the operation
+            is cancelled and `ExportCancelled` is raised. When provided, tqdm progress
+            bars are disabled in favor of the callback.
+
+            .. note::
+                The ``phase`` argument (and the separate ``"write"`` phase) is a
+                breaking change from the previous ``(current, total)`` signature.
 
     Returns:
         A dictionary mapping original Video objects to their embedded versions.
@@ -959,7 +1000,11 @@ def process_and_embed_frames(
         ExportCancelled: If the progress_callback returns `False`.
     """
     # Determine which plugin to use for encoding
-    from sleap_io.io.video_reading import CropVideoBackend, get_default_image_plugin
+    from sleap_io.io.video_reading import (
+        CropVideoBackend,
+        ImageVideo,
+        get_default_image_plugin,
+    )
 
     if plugin is None:
         plugin = get_default_image_plugin()
@@ -968,8 +1013,18 @@ def process_and_embed_frames(
         plugin = "opencv" if "cv2" in sys.modules else "imageio"
 
     # Initialize a dictionary to store data by group
-    data_by_group = {}
+    data_by_group: dict[str, dict] = {}
     total_frames = len(frames_metadata)
+
+    # Per-video (per-group) stored format: an ImageVideo of PNG/JPEG is byte-copied
+    # verbatim so its group stores the source format; everything else re-encodes to
+    # `image_format`. Decided once up front so a group's format is stable even when a
+    # stray frame falls back to the decode path.
+    group_format: dict[str, str] = {}
+    for frame_meta in frames_metadata:
+        grp = frame_meta["group"]
+        if grp not in group_format:
+            group_format[grp] = _resolve_embed_format(frame_meta["video"], image_format)
 
     # Use tqdm only if verbose AND no callback (CLI mode)
     use_tqdm = verbose and progress_callback is None
@@ -984,6 +1039,9 @@ def process_and_embed_frames(
         frame_idx = frame_meta["frame_idx"]
         group = frame_meta["group"]
 
+        # Format this group's frames are stored in (see `_resolve_embed_format`).
+        grp_format = group_format[group]
+
         # Initialize group data structure if this is the first frame for this group
         if group not in data_by_group:
             data_by_group[group] = {
@@ -991,6 +1049,7 @@ def process_and_embed_frames(
                 "frame_inds": [],
                 "imgs_data": [],
                 "channel_order": None,  # Track channel order: "RGB" or "BGR"
+                "image_format": grp_format,
             }
 
         # Fast path: Copy raw bytes directly if formats match (avoids decode/encode)
@@ -1006,9 +1065,38 @@ def process_and_embed_frames(
 
                 # Report progress via callback
                 if progress_callback is not None:
-                    if not progress_callback(i + 1, total_frames):
+                    if not progress_callback(i + 1, total_frames, "embed"):
                         raise ExportCancelled("Export cancelled by user")
                 continue
+
+        # Fast path 2: ImageVideo byte-copy. When embedding an image sequence whose
+        # files are already PNG/JPEG, copy the encoded bytes verbatim -- no decode/
+        # re-encode. This skips a lossy re-encode (JPEG) and stores the smaller
+        # source bytes. Guard that this frame's on-disk format matches the group's
+        # stored format (grp_format, decided from the first file); a stray frame with
+        # a different extension falls through to the decode path and is re-encoded.
+        if isinstance(video.backend, ImageVideo) and grp_format != "hdf5":
+            fname = video.backend.filename[frame_idx]
+            ext = (
+                Path(fname).suffix.lower().lstrip(".")
+                if isinstance(fname, (str, Path))
+                else ""
+            )
+            frame_format = "jpg" if ext == "jpeg" else ext
+            if frame_format == grp_format:
+                raw_bytes = video.backend.get_frame_raw_bytes(frame_idx)
+                if raw_bytes is not None:
+                    data_by_group[group]["imgs_data"].append(raw_bytes)
+                    data_by_group[group]["frame_inds"].append(frame_idx)
+                    # Bytes copied from an ImageVideo decode back to RGB (see
+                    # ImageVideo.get_frame_raw_bytes / _read_frame).
+                    if data_by_group[group]["channel_order"] is None:
+                        data_by_group[group]["channel_order"] = "RGB"
+
+                    if progress_callback is not None:
+                        if not progress_callback(i + 1, total_frames, "embed"):
+                            raise ExportCancelled("Export cancelled by user")
+                    continue
 
         # Slow path: Load and encode the frame. For a virtually-cropped video,
         # embed the UNCROPPED source frame; the crop is preserved separately in
@@ -1030,21 +1118,21 @@ def process_and_embed_frames(
                 f"{len(video)} frames."
             ) from e
 
-        # Encode the frame
-        if image_format == "hdf5":
+        # Encode the frame to this group's format.
+        if grp_format == "hdf5":
             img_data = frame
             channel_order = "RGB"  # HDF5 format stores as-is (RGB)
         else:
             if plugin == "opencv":
-                img_data = np.squeeze(
-                    cv2.imencode("." + image_format, frame)[1]
-                ).astype("int8")
+                img_data = np.squeeze(cv2.imencode("." + grp_format, frame)[1]).astype(
+                    "int8"
+                )
                 channel_order = "BGR"  # OpenCV encodes in BGR
             else:  # imageio
                 if frame.shape[-1] == 1:
                     frame = frame.squeeze(axis=-1)
                 img_data = np.frombuffer(
-                    iio.imwrite("<bytes>", frame, extension="." + image_format),
+                    iio.imwrite("<bytes>", frame, extension="." + grp_format),
                     dtype="int8",
                 )
                 channel_order = "RGB"  # imageio encodes in RGB
@@ -1059,23 +1147,53 @@ def process_and_embed_frames(
 
         # Report progress via callback
         if progress_callback is not None:
-            if not progress_callback(i + 1, total_frames):
+            if not progress_callback(i + 1, total_frames, "embed"):
                 raise ExportCancelled("Export cancelled by user")
 
-    # Write all frame data to the HDF5 file
+    # Write all frame data to the HDF5 file.
     replaced_videos = {}
+    total_to_write = sum(len(d["imgs_data"]) for d in data_by_group.values())
+    write_bar = (
+        tqdm(total=total_to_write, desc="Writing frames", disable=not use_tqdm)
+        if use_tqdm
+        else None
+    )
+    written = 0
+
+    def _report_write(n: int) -> None:
+        """Advance the write-phase progress bar / callback by ``n`` frames."""
+        nonlocal written
+        written += n
+        if write_bar is not None:
+            write_bar.update(n)
+        if progress_callback is not None:
+            if not progress_callback(written, total_to_write, "write"):
+                raise ExportCancelled("Export cancelled by user")
+
     with h5py.File(labels_path, "a") as f:
         for group, data in data_by_group.items():
             video = data["video"]
             frame_inds = data["frame_inds"]
             imgs_data = data["imgs_data"]
+            grp_format = data["image_format"]
 
-            if image_format == "hdf5":
+            if grp_format == "hdf5":
+                # Raw pixel arrays are genuinely compressible, so keep gzip; written
+                # in one shot (not row-by-row), so no read-modify-write amplification.
                 f.create_dataset(
                     f"{group}/video", data=imgs_data, compression="gzip", chunks=True
                 )
                 ds = f[f"{group}/video"]
+                _report_write(len(imgs_data))
             else:
+                # Encoded image bytes (PNG/JPEG) are already entropy-coded: gzip gains
+                # almost nothing on the bytes themselves (it only squeezes the
+                # fixed-length zero padding) while costing significant CPU. More
+                # importantly, gzip forces CHUNKED storage, and h5py auto-chunks a tall
+                # block (~100+ rows); the row-by-row writes below then trigger repeated
+                # read-modify-recompress of each chunk plus chunk-cache thrashing --
+                # the pathology that made large embeds take tens of minutes. Storing
+                # uncompressed (contiguous) makes each row a direct offset write.
                 if fixed_length:
                     img_bytes_len = 0
                     for img in imgs_data:
@@ -1084,10 +1202,10 @@ def process_and_embed_frames(
                         f"{group}/video",
                         shape=(len(imgs_data), img_bytes_len),
                         dtype="int8",
-                        compression="gzip",
                     )
                     for i, img in enumerate(imgs_data):
                         ds[i, : len(img)] = img
+                        _report_write(1)
                 else:
                     ds = f.create_dataset(
                         f"{group}/video",
@@ -1096,9 +1214,10 @@ def process_and_embed_frames(
                     )
                     for i, img in enumerate(imgs_data):
                         ds[i] = img
+                        _report_write(1)
 
             # Store metadata
-            ds.attrs["format"] = image_format
+            ds.attrs["format"] = grp_format
             ds.attrs["channel_order"] = data["channel_order"]
             # Embedded attrs describe the UNCROPPED frame for a cropped video
             # (the embedded pixels are the full source frame).
@@ -1169,6 +1288,9 @@ def process_and_embed_frames(
 
             # Store the embedded video for return
             replaced_videos[video] = embedded_video
+
+    if write_bar is not None:
+        write_bar.close()
 
     return replaced_videos
 
@@ -1248,7 +1370,7 @@ def embed_frames(
     verbose: bool = True,
     plugin: str | None = None,
     embed_all_videos: bool = True,
-    progress_callback: Callable[[int, int], bool] | None = None,
+    progress_callback: Callable[[int, int, str], bool] | None = None,
 ):
     """Embed frames in a SLEAP labels file.
 
@@ -1266,9 +1388,12 @@ def embed_frames(
             converted to embedded references, even if they have no frames to embed.
             This ensures package files are portable. If `False`, only videos with
             frames to embed are converted.
-        progress_callback: Optional callback function called during frame embedding
-            with `(current, total)` arguments. If it returns `False`, the operation
-            is cancelled and `ExportCancelled` is raised.
+        progress_callback: Optional callback function called during embedding with
+            `(current, total, phase)` arguments, where ``phase`` is ``"embed"``
+            (frames loaded/encoded/byte-copied) or ``"write"`` (bytes flushed to the
+            HDF5 file). If it returns `False`, the operation is cancelled and
+            `ExportCancelled` is raised. The ``phase`` argument is a breaking change
+            from the previous ``(current, total)`` signature.
 
     Notes:
         This function will embed the frames in the labels file and update the `Videos`
@@ -1305,7 +1430,7 @@ def embed_videos(
     verbose: bool = True,
     plugin: str | None = None,
     embed_all_videos: bool = True,
-    progress_callback: Callable[[int, int], bool] | None = None,
+    progress_callback: Callable[[int, int, str], bool] | None = None,
 ):
     """Embed videos in a SLEAP labels file.
 
@@ -1334,9 +1459,12 @@ def embed_videos(
             converted to embedded references, even if they have no frames to embed.
             This ensures package files are portable. If `False`, only videos with
             frames to embed are converted.
-        progress_callback: Optional callback function called during frame embedding
-            with `(current, total)` arguments. If it returns `False`, the operation
-            is cancelled and `ExportCancelled` is raised.
+        progress_callback: Optional callback function called during embedding with
+            `(current, total, phase)` arguments, where ``phase`` is ``"embed"``
+            (frames loaded/encoded/byte-copied) or ``"write"`` (bytes flushed to the
+            HDF5 file). If it returns `False`, the operation is cancelled and
+            `ExportCancelled` is raised. The ``phase`` argument is a breaking change
+            from the previous ``(current, total)`` signature.
     """
     if embed is True:
         embed = "all"
@@ -8439,7 +8567,7 @@ def write_labels(
     verbose: bool = True,
     plugin: str | None = None,
     embed_all_videos: bool = True,
-    progress_callback: Callable[[int, int], bool] | None = None,
+    progress_callback: Callable[[int, int, str], bool] | None = None,
     prefer_metadata: bool = True,
     preserve_unknown: bool = False,
     save_embedding_vectors: bool = False,
@@ -8479,9 +8607,12 @@ def write_labels(
             converted to embedded references, even if they have no frames to embed.
             This ensures package files are portable. If `False`, only videos with
             frames to embed are converted.
-        progress_callback: Optional callback function called during frame embedding
-            with `(current, total)` arguments. If it returns `False`, the operation
-            is cancelled and `ExportCancelled` is raised.
+        progress_callback: Optional callback function called during embedding with
+            `(current, total, phase)` arguments, where ``phase`` is ``"embed"``
+            (frames loaded/encoded/byte-copied) or ``"write"`` (bytes flushed to the
+            HDF5 file). If it returns `False`, the operation is cancelled and
+            `ExportCancelled` is raised. The ``phase`` argument is a breaking change
+            from the previous ``(current, total)`` signature.
         prefer_metadata: If `True` (the default), serialize each uncropped video's
             shape/grayscale/fps from its `backend_metadata` when recorded there
             instead of querying the live backend, avoiding frame decoding when the

--- a/sleap_io/io/video_reading.py
+++ b/sleap_io/io/video_reading.py
@@ -1367,9 +1367,22 @@ class HDF5Video(VideoBackend):
                     self.source_inds = frame_numbers
 
                 if "source_video" in ds.parent:
-                    self.source_filename = json.loads(
-                        ds.parent["source_video"].attrs["json"]
-                    )["backend"]["filename"]
+                    source_grp = ds.parent["source_video"]
+                    # Source metadata is normally in the "json" attribute, but
+                    # oversized metadata (e.g. an image-sequence source with many
+                    # thousands of filenames, exceeding HDF5's 64 KB attribute limit)
+                    # is stored in a "json" *dataset* instead (see
+                    # ``slp._write_source_video_json``). Read whichever is present so
+                    # such packages remain openable -- otherwise the backend fails to
+                    # open, ``Video.backend`` is left ``None``, and embedded frames
+                    # cannot be read.
+                    if "json" in source_grp:
+                        source_json = source_grp["json"][()]
+                    else:
+                        source_json = source_grp.attrs["json"]
+                    self.source_filename = json.loads(source_json)["backend"][
+                        "filename"
+                    ]
 
                 # Read FPS from attributes if present
                 if "fps" in ds.attrs:
@@ -1919,6 +1932,42 @@ class ImageVideo(VideoBackend):
     def num_frames(self) -> int:
         """Number of frames in the video."""
         return len(self.filename)
+
+    def get_frame_raw_bytes(self, frame_idx: int) -> np.ndarray | None:
+        """Return the raw encoded bytes of the source image file for a frame.
+
+        Reads the on-disk image file verbatim (no decode/re-encode), enabling a
+        direct byte-for-byte embed of already-compressed sources. This avoids both
+        the cost of a decode/re-encode cycle and any additional compression
+        artifacts (important for lossy JPEG sources).
+
+        Only PNG/JPEG sources are supported here -- these are already entropy-coded
+        and are decodable by the embedded-image reader (`HDF5Video.decode_embedded`).
+        Other extensions (e.g. TIFF/BMP) return `None` so the caller falls back to
+        decoding and re-encoding to the requested format.
+
+        Args:
+            frame_idx: Index of the frame to read.
+
+        Returns:
+            The raw file bytes as an `int8` numpy vector, or `None` if the source
+            file is not a directly-storable compressed image (PNG/JPEG) or cannot
+            be read.
+
+        Notes:
+            Bytes copied this way decode back to RGB (matching `_read_frame`), so
+            the embedded dataset should record `channel_order="RGB"`.
+        """
+        filename = self.filename[frame_idx]
+        ext = Path(filename).suffix.lower().lstrip(".")
+        if ext not in ("png", "jpg", "jpeg"):
+            return None
+        try:
+            with open(filename, "rb") as f:
+                data = f.read()
+        except OSError:
+            return None
+        return np.frombuffer(data, dtype="int8")
 
     def _read_frame(self, frame_idx: int) -> np.ndarray:
         """Read a single frame from the video.

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -2491,12 +2491,161 @@ def test_fast_path_progress_callback_cancellation(tmpdir, slp_minimal_pkg):
     save_path = str(tmpdir / "cancelled.pkg.slp")
 
     # Cancel immediately
-    def cancel_immediately(current, total):
+    def cancel_immediately(current, total, phase):
         return False
 
     with pytest.raises(ExportCancelled, match="Export cancelled by user"):
         write_labels(
             save_path, labels, embed="user", progress_callback=cancel_immediately
+        )
+
+
+def test_embed_imagevideo_byte_copy(tmp_path, centered_pair_frame_paths):
+    """Embedding an ImageVideo copies the source bytes verbatim (no re-encode).
+
+    The source files are JPEG, so the frames are byte-copied into the package with
+    the source format (jpg) rather than being decoded and re-encoded to the default
+    PNG. This is lossless (identical bytes) and avoids gzip on already-compressed
+    data.
+    """
+    video = Video.from_filename(centered_pair_frame_paths)
+    skel = Skeleton(["a"])
+    labels = Labels(
+        [
+            LabeledFrame(
+                video=video,
+                frame_idx=i,
+                instances=[Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skel)],
+            )
+            for i in range(len(centered_pair_frame_paths))
+        ]
+    )
+
+    out = tmp_path / "imgvid.pkg.slp"
+    labels.save(
+        str(out), embed=[(video, i) for i in range(len(centered_pair_frame_paths))]
+    )
+
+    with h5py.File(out, "r") as f:
+        ds = f["video0/video"]
+        # Stored as the source (jpg) format, not the default png.
+        assert ds.attrs["format"] == "jpg"
+        assert ds.attrs["channel_order"] == "RGB"
+        # Already-compressed bytes: no gzip, contiguous storage (no chunk thrash).
+        assert ds.compression is None
+        assert ds.chunks is None
+        # Row 0 (trailing zero padding stripped) is byte-identical to the source.
+        row = ds[0]
+        nz = np.where(row != 0)[0]
+        row = row[: nz[-1] + 1] if len(nz) else row
+        src = np.frombuffer(
+            Path(centered_pair_frame_paths[0]).read_bytes(), dtype="int8"
+        )
+        assert np.array_equal(row.astype("int8"), src)
+
+    # Round-trip is lossless: reloaded pixels match the original decode exactly.
+    reloaded = read_labels(str(out))
+    assert reloaded.videos[0].backend.image_format == "jpg"
+    assert np.array_equal(video[0], reloaded.videos[0][0])
+
+
+def test_embed_encoded_no_gzip(tmp_path, slp_real_data):
+    """Encoded (PNG) embedded frames are stored uncompressed, not gzip-chunked.
+
+    gzip only squeezed the fixed-length zero padding while forcing chunked storage
+    whose row-by-row writes thrashed the chunk cache (the historic slow embed). PNG
+    bytes are already compressed, so the dataset is now contiguous/uncompressed.
+    """
+    base_labels = read_labels(slp_real_data)
+    out = tmp_path / "encoded.pkg.slp"
+    base_labels.save(str(out), embed="user")
+
+    with h5py.File(out, "r") as f:
+        ds = f["video0/video"]
+        assert ds.attrs["format"] == "png"  # MediaVideo source -> decode + re-encode
+        assert ds.compression is None
+        assert ds.chunks is None
+
+
+def test_embed_source_metadata_dataset_backend_reads(
+    tmp_path, centered_pair_frame_paths
+):
+    """HDF5Video opens a package whose source_video metadata was spilled to a dataset.
+
+    Oversized source metadata (e.g. an image sequence with thousands of filenames)
+    is written to a ``source_video/json`` *dataset* instead of the 64 KB-limited
+    attribute. The backend must read whichever form is present; otherwise the backend
+    fails to open, ``Video.backend`` is ``None``, and frames cannot be read.
+    """
+    video = Video.from_filename(centered_pair_frame_paths)
+    skel = Skeleton(["a"])
+    labels = Labels(
+        [
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skel)],
+            )
+        ]
+    )
+    out = tmp_path / "spill.pkg.slp"
+    labels.save(str(out), embed=[(video, 0)])
+
+    # Simulate the oversized-metadata spill: move the source_video json from the
+    # attribute into a dataset (what _write_source_video_json does when >64 KB).
+    with h5py.File(out, "a") as f:
+        grp = f["video0/source_video"]
+        blob = grp.attrs["json"]
+        del grp.attrs["json"]
+        grp.create_dataset("json", data=np.bytes_(blob))
+
+    reloaded = read_labels(str(out))
+    # Reading a frame forces the HDF5Video backend to open (__attrs_post_init__),
+    # which previously raised KeyError on the missing attribute.
+    frame = reloaded.videos[0][0]
+    assert frame.shape == video[0].shape
+    assert reloaded.videos[0].source_video is not None
+
+
+def test_embed_imagevideo_progress_cancellation(tmp_path, centered_pair_frame_paths):
+    """Cancelling via the callback works on the ImageVideo byte-copy path."""
+    video = Video.from_filename(centered_pair_frame_paths)
+    skel = Skeleton(["a"])
+    labels = Labels(
+        [
+            LabeledFrame(
+                video=video,
+                frame_idx=i,
+                instances=[Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skel)],
+            )
+            for i in range(3)
+        ]
+    )
+
+    def cancel_after_first(current, total, phase):
+        return current < 1  # Cancel on the first embed callback.
+
+    with pytest.raises(ExportCancelled, match="Export cancelled by user"):
+        labels.save(
+            str(tmp_path / "cancel.pkg.slp"),
+            embed=[(video, i) for i in range(3)],
+            progress_callback=cancel_after_first,
+        )
+
+
+def test_progress_callback_cancellation_write_phase(tmp_path, slp_real_data):
+    """Returning False during the write phase cancels the export."""
+    base_labels = read_labels(slp_real_data)
+
+    def cancel_on_write(current, total, phase):
+        return phase != "write"  # Allow embed phase, cancel at first write.
+
+    with pytest.raises(ExportCancelled, match="Export cancelled by user"):
+        write_labels(
+            str(tmp_path / "cancel_write.pkg.slp"),
+            base_labels,
+            embed="user",
+            progress_callback=cancel_on_write,
         )
 
 
@@ -4740,26 +4889,32 @@ def test_load_slp_sparse_video_ids_with_fallback(tmp_path, small_robot_video):
 
 
 def test_progress_callback_receives_correct_values(tmp_path, slp_real_data):
-    """Test that progress_callback receives correct (current, total) values."""
+    """Test that progress_callback receives correct (current, total, phase) values."""
     base_labels = read_labels(slp_real_data)
     labels_path = str(tmp_path / "labels.pkg.slp")
 
     # Track all progress updates
     progress_updates = []
 
-    def track_progress(current, total):
-        progress_updates.append((current, total))
+    def track_progress(current, total, phase):
+        progress_updates.append((current, total, phase))
         return True  # Continue
 
     write_labels(
         labels_path, base_labels, embed="user", progress_callback=track_progress
     )
 
-    # Should have received updates for each frame
-    assert len(progress_updates) == 5  # user_labeled_frames count
+    # Embedding is reported in two phases: "embed" (encode/copy) then "write".
+    embed_updates = [(c, t) for c, t, p in progress_updates if p == "embed"]
+    write_updates = [(c, t) for c, t, p in progress_updates if p == "write"]
+    assert len(embed_updates) == 5  # user_labeled_frames count
+    assert len(write_updates) == 5
 
-    # Check that current values are 1-indexed and sequential
-    for i, (current, total) in enumerate(progress_updates):
+    # Each phase is 1-indexed and sequential, totaling the frame count.
+    for i, (current, total) in enumerate(embed_updates):
+        assert current == i + 1, f"Current should be {i + 1}, got {current}"
+        assert total == 5, f"Total should be 5, got {total}"
+    for i, (current, total) in enumerate(write_updates):
         assert current == i + 1, f"Current should be {i + 1}, got {current}"
         assert total == 5, f"Total should be 5, got {total}"
 
@@ -4770,7 +4925,7 @@ def test_progress_callback_cancellation(tmp_path, slp_real_data):
     labels_path = str(tmp_path / "labels.pkg.slp")
 
     # Cancel after the second frame
-    def cancel_after_two(current, total):
+    def cancel_after_two(current, total, phase):
         return current < 2  # Return False after 2nd frame
 
     with pytest.raises(ExportCancelled, match="Export cancelled by user"):
@@ -4784,7 +4939,7 @@ def test_progress_callback_disables_tqdm(tmp_path, slp_real_data, capsys):
     base_labels = read_labels(slp_real_data)
     labels_path = str(tmp_path / "labels.pkg.slp")
 
-    def noop_callback(current, total):
+    def noop_callback(current, total, phase):
         return True
 
     # With callback, even with verbose=True, no tqdm output should appear
@@ -4799,6 +4954,7 @@ def test_progress_callback_disables_tqdm(tmp_path, slp_real_data, capsys):
     # tqdm outputs to stderr by default
     captured = capsys.readouterr()
     assert "Embedding frames" not in captured.err
+    assert "Writing frames" not in captured.err
 
 
 def test_progress_callback_with_save_slp(tmp_path, slp_real_data):
@@ -4808,14 +4964,15 @@ def test_progress_callback_with_save_slp(tmp_path, slp_real_data):
 
     progress_updates = []
 
-    def track_progress(current, total):
-        progress_updates.append((current, total))
+    def track_progress(current, total, phase):
+        progress_updates.append((current, total, phase))
         return True
 
     save_slp(base_labels, labels_path, embed="user", progress_callback=track_progress)
 
-    assert len(progress_updates) == 5
-    assert progress_updates[-1] == (5, 5)
+    # 5 embed-phase + 5 write-phase updates; the last update ends the write phase.
+    assert len(progress_updates) == 10
+    assert progress_updates[-1] == (5, 5, "write")
 
 
 def test_progress_callback_with_save_file(tmp_path, slp_real_data):
@@ -4825,14 +4982,14 @@ def test_progress_callback_with_save_file(tmp_path, slp_real_data):
 
     progress_updates = []
 
-    def track_progress(current, total):
-        progress_updates.append((current, total))
+    def track_progress(current, total, phase):
+        progress_updates.append((current, total, phase))
         return True
 
     save_file(base_labels, labels_path, embed="user", progress_callback=track_progress)
 
-    assert len(progress_updates) == 5
-    assert progress_updates[-1] == (5, 5)
+    assert len(progress_updates) == 10
+    assert progress_updates[-1] == (5, 5, "write")
 
 
 def test_progress_callback_none_uses_tqdm(tmp_path, slp_real_data, capsys):
@@ -4842,9 +4999,10 @@ def test_progress_callback_none_uses_tqdm(tmp_path, slp_real_data, capsys):
 
     write_labels(labels_path, base_labels, embed="user", verbose=True)
 
-    # tqdm outputs to stderr
+    # tqdm outputs to stderr -- both the embed and write phases show a bar.
     captured = capsys.readouterr()
     assert "Embedding frames" in captured.err
+    assert "Writing frames" in captured.err
 
 
 def test_embed_inplace_false_preserves_original(tmp_path, slp_real_data):

--- a/tests/io/test_video_reading.py
+++ b/tests/io/test_video_reading.py
@@ -503,6 +503,30 @@ def test_imagevideo(centered_pair_frame_paths):
     assert backend.shape == (1, 384, 384, 1)
 
 
+def test_imagevideo_get_frame_raw_bytes(tmp_path, centered_pair_frame_paths):
+    """ImageVideo.get_frame_raw_bytes returns source bytes for JPEG/PNG, else None."""
+    import cv2
+
+    # JPEG source: returns the exact file bytes.
+    backend = ImageVideo(centered_pair_frame_paths)
+    raw = backend.get_frame_raw_bytes(0)
+    assert raw is not None
+    assert raw.dtype == np.dtype("int8")
+    assert raw.tobytes() == Path(centered_pair_frame_paths[0]).read_bytes()
+
+    # Unsupported (non-PNG/JPEG) format returns None -> caller re-encodes instead.
+    bmp = tmp_path / "frame.bmp"
+    cv2.imwrite(str(bmp), np.zeros((8, 8, 3), dtype=np.uint8))
+    assert ImageVideo([str(bmp)]).get_frame_raw_bytes(0) is None
+
+    # Unreadable file returns None (does not raise).
+    missing = tmp_path / "gone.jpg"
+    cv2.imwrite(str(missing), np.zeros((8, 8, 3), dtype=np.uint8))
+    backend_missing = ImageVideo([str(missing)])
+    missing.unlink()
+    assert backend_missing.get_frame_raw_bytes(0) is None
+
+
 def test_opencv_bgr_to_rgb_conversion(tmp_path):
     """Test that OpenCV backend correctly converts BGR to RGB."""
     try:


### PR DESCRIPTION
## Summary

Embedding video frames into a `.pkg.slp` could spend **tens of minutes silently writing to disk** after the `Embedding frames` progress bar finished. This PR fixes the write pathology, adds a byte-copy fast path for image-sequence sources, reports progress on the write phase, and fixes an incidental backend bug that made the resulting packages unreadable in some cases.

On a real 15,000-frame image-sequence project, end-to-end embed time went from **~32 minutes → ~4 seconds**, and the package shrank from ~3.9 GB (re-encoded PNG) to ~2.0 GB (byte-copied JPEG).

## 🚨 Breaking change (`progress_callback`)

The SLP embed `progress_callback` signature changed:

```
before:  progress_callback(current, total) -> bool
after:   progress_callback(current, total, phase) -> bool     # phase: "embed" | "write"
```

- The callback is now invoked in **two phases**: `"embed"` (frames loaded/encoded/byte-copied into memory) then `"write"` (bytes flushed to the HDF5 file).
- **Any caller passing a 2-arg callback will break** (e.g. the SLEAP GUI). The GUI is version-fenced to an older sleap-io, so this is safe for now, but GUI code that calls `write_labels`/`save_slp`/`save_file` with a `progress_callback` must be updated to accept the third `phase` argument before bumping.

## Key changes

### Performance — write is no longer slow or silent
- **Drop gzip on encoded frames.** PNG/JPEG bytes are already entropy-coded, so gzip only squeezed the fixed-length zero *padding* — while forcing chunked storage. `guess_chunk` picked a tall (~100–235 rows) chunk, and the row-by-row `ds[i, :len] = img` writes then forced repeated **read → decompress → modify → recompress → rewrite** of every chunk, compounded by the 1 MB default chunk cache thrashing. Encoded frames are now stored **uncompressed and contiguous**; only the raw-array `hdf5` format keeps gzip.

  Measured at 15,000 frames (0.56 GB), before → after strategies:

  | strategy | time | file |
  |---|---|---|
  | gzip + auto-chunk (old) | **>100 s** | 0.56 GB |
  | uncompressed contiguous (new) | **1.8 s** | 0.60 GB |

### `ImageVideo` byte-copy fast path (issue this PR was built around)
- When embedding an **image sequence of PNG/JPEG files**, the source bytes are now **copied verbatim** — no decode/re-encode. The embedded dataset's `@format` follows the *source* (e.g. `jpg`), `@channel_order` is `RGB`. This is:
  - **lossless** — no added JPEG artifacts (byte-identical to the source file),
  - **faster** — skips the decode+encode entirely (the "Embedding frames" phase also speeds up), and
  - **smaller** — stores the compact source bytes instead of a larger re-encoded PNG.
- New `ImageVideo.get_frame_raw_bytes`; per-video format decided by `_resolve_embed_format`. MediaVideo (mp4) still decodes + re-encodes to PNG.

### Progress on the write phase
- The HDF5 write loop now reports progress: a second **`Writing frames`** tqdm bar (CLI), shown in sequence after `Embedding frames`, and a `"write"` phase for `progress_callback`.

### Incidental fix — spilled `source_video` metadata was unreadable
Discovered while testing the above on a 15k-frame image sequence, whose `source_video` metadata (the filename list) is ~1 MB and gets spilled to a `source_video/json` **dataset** (since #516, which only fixed the *label loader*).

- `HDF5Video.__attrs_post_init__` still read the `source_video/@json` **attribute** directly (`video_reading.py`), so it raised `KeyError: can't locate attribute: 'json'`, left `Video.backend` as `None`, and made embedded frames unreadable — breaking `sio split` and frame access on any such package. Now reads the dataset-or-attribute, mirroring `_read_source_video_json`.

## Example

```bash
sio embed mars_top.slp -o mars_top.pkg.slp
# Embedding frames: 100%|██████████| 15000/15000 [00:01<00:00, 12071 it/s]
# Writing frames:   100%|██████████| 15000/15000 [00:02<00:00,  5578 it/s]
```

## Testing

- `test_embed_imagevideo_byte_copy` — stored format `jpg`, `compression None`/contiguous, byte-identical to source, lossless pixel round-trip.
- `test_embed_encoded_no_gzip` — MediaVideo → PNG stored uncompressed/contiguous.
- `test_embed_source_metadata_dataset_backend_reads` — regression: backend opens a package whose `source_video/json` is a dataset.
- `test_imagevideo_get_frame_raw_bytes` — bytes for PNG/JPEG, `None` for unsupported/unreadable.
- Two-phase progress values + cancellation in both `embed` and `write` phases.
- Existing `progress_callback` tests updated to the 3-arg signature.
- Full `tests/io/{test_slp,test_video_reading,test_main,test_cli}.py` pass.

## Design notes / decisions
- **Contiguous + uncompressed** (not `chunks=(1, maxlen)` + gzip): simplest, fastest, and most compatible with pickier HDF5 readers (jsfive/h5wasm). Tradeoff: fixed-length zero padding is no longer compressed away, so files can be modestly larger when per-frame sizes vary a lot. `fixed_length=False` (vlen) remains available for maximum compactness; switching the default to vlen is deferred pending jsfive/h5wasm verification.
- **Byte-copy stores the source format**, overriding the `png` default, since re-encoding an already-compressed image only inflates size (PNG) or adds artifacts (JPEG).
- The `source_video` spill format is unchanged (kept as a dataset; unembed preserved). A parallel reader issue was filed for sleap-io.js: talmolab/sleap-io.js#214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vvhj8XYZXttckr1fjZuHUe
