### PR TITLE
chore(release): Bump version to 0.9.1

### DIFF
--- a/sleap_io/version.py
+++ b/sleap_io/version.py
@@ -3,4 +3,4 @@
 # Define package version.
 # This is read dynamically by setuptools in pyproject.toml to determine the release
 # version.
-__version__ = "0.9.0"
+__version__ = "0.9.1"


### PR DESCRIPTION
Patch release bumping `sleap_io` version `0.9.0` → `0.9.1`.

## Included since v0.9.0
- **#542** — feat(model,io,cli): first-class `Category` (class membership) mirroring `Identity`
- **#543** — perf(io): fix slow/silent embed write; `ImageVideo` byte-copy; write-phase progress

## Changes
- `sleap_io/version.py`: `__version__ = "0.9.1"`

Merging this does not publish; PyPI publish is triggered separately by creating a GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DiaqkmRcp1L9yD8dx4jLj