### PR TITLE
Read h5wasm flat-2D identity/category links (coordinated sleap-io.js port)

### DIFF
--- a/sleap_io/io/slp.py
+++ b/sleap_io/io/slp.py
@@ -2467,7 +2467,12 @@ def read_identity_links(
     with cm as f:
         if "identity" not in f or "links" not in f["identity"]:
             return {}
-        data = f["identity"]["links"][:]
+        # Route through the conversion-aware helper so a links table written by the
+        # coordinated sleap-io.js port (h5wasm cannot create compound datasets, so
+        # it writes a flat 2D f8 array + a ``field_names`` attribute) is rebuilt as
+        # a structured array, matching /session_data and points/instances/frames.
+        # A genuine compound dataset (Python-written) passes through unchanged.
+        data = _read_dataset_from_open_file(f, "identity/links")
     result: dict[int, dict[int, tuple[int, float | None]]] = {}
     for row in data:
         owner_type = int(row["owner_type"])
@@ -2674,7 +2679,9 @@ def read_category_links(
     with cm as f:
         if "categories" not in f or "links" not in f["categories"]:
             return {}
-        data = f["categories"]["links"][:]
+        # See read_identity_links: accept the sleap-io.js flat-2D + ``field_names``
+        # form and the Python-native compound form via the shared helper.
+        data = _read_dataset_from_open_file(f, "categories/links")
     result: dict[int, dict[int, tuple[int, float | None]]] = {}
     for row in data:
         owner_type = int(row["owner_type"])

--- a/tests/io/test_slp.py
+++ b/tests/io/test_slp.py
@@ -1199,6 +1199,53 @@ def test_read_identity_links_owner_type_keyed(tmp_path):
     assert links[OWNER_INSTANCE] == {0: (0, pytest.approx(0.5))}
 
 
+def _write_flat_2d_links(path, group, cols, rows):
+    """Write a links table in the h5wasm form: flat 2D f8 + field_names attr.
+
+    Mirrors how sleap-io.js (via h5wasm, which cannot create compound datasets)
+    stores a structured table -- see `utils._read_dataset_from_open_file`.
+    """
+    with h5py.File(path, "w") as f:
+        grp = f.require_group(group)
+        ds = grp.create_dataset("links", data=np.array(rows, dtype="<f8"))
+        ds.attrs["field_names"] = json.dumps(cols)
+
+
+def test_read_identity_links_h5wasm_flat_2d(tmp_path):
+    """read_identity_links accepts a sleap-io.js flat-2D + field_names links table."""
+    path = str(tmp_path / "js_identity_links.slp")
+    _write_flat_2d_links(
+        path,
+        "identity",
+        ["owner_type", "owner_id", "identity_idx", "identity_score"],
+        [
+            [OWNER_INSTANCE, 0, 2, 0.75],
+            [OWNER_INSTANCE, 1, 1, np.nan],  # unrecorded score -> None
+            [OWNER_MASK, 5, 3, 0.5],
+        ],
+    )
+    links = read_identity_links(path)
+    assert links[OWNER_INSTANCE] == {0: (2, pytest.approx(0.75)), 1: (1, None)}
+    assert links[OWNER_MASK] == {5: (3, pytest.approx(0.5))}
+
+
+def test_read_category_links_h5wasm_flat_2d(tmp_path):
+    """read_category_links accepts a sleap-io.js flat-2D + field_names links table."""
+    path = str(tmp_path / "js_category_links.slp")
+    _write_flat_2d_links(
+        path,
+        "categories",
+        ["owner_type", "owner_id", "category_idx", "category_score"],
+        [
+            [OWNER_INSTANCE, 0, 1, np.nan],  # unrecorded score -> None
+            [OWNER_BBOX, 9, 0, 0.9],
+        ],
+    )
+    links = read_category_links(path)
+    assert links[OWNER_INSTANCE] == {0: (1, None)}
+    assert links[OWNER_BBOX] == {9: (0, pytest.approx(0.9))}
+
+
 def test_read_embeddings_skips_unknown_owner_type(tmp_path):
     """Unknown owner_type embeddings are skipped (not mis-routed) with a warning."""
     skel = Skeleton(["A", "B"])


### PR DESCRIPTION
## Summary

`read_identity_links` and `read_category_links` read `/identity/links` /
`/categories/links` via structured field access (`f["identity"]["links"][:]` →
`row["owner_type"]`) with **no `field_names` fallback**, so a links table written by
[sleap-io.js](https://github.com/talmolab/sleap-io.js) is unreadable by Python.

h5wasm (which sleap-io.js writes SLP files through) **cannot create HDF5 compound
datasets**, so it stores every structured table as a **flat 2-D `f8` array + a
`field_names` attribute** — exactly as for `points` / `pred_points` / `instances` /
`frames`, and as #546 established for the `/session_data` struct tables. The
per-detection identity/category link readers were the one place not wired through
the shared conversion helper.

Closes #547. Companion to talmolab/sleap-io.js#220.

## Change

Route both reads through `utils._read_dataset_from_open_file(f, "identity/links")` /
`("categories/links")` (the same helper `_read_session_data` uses in #546). It
rebuilds a structured array when a `field_names` attribute is present and returns a
genuine compound dataset unchanged. Presence guards unchanged.

```python
# read_identity_links / read_category_links (inside the existing `with cm as f:`)
data = _read_dataset_from_open_file(f, "identity/links")     # was f["identity"]["links"][:]
data = _read_dataset_from_open_file(f, "categories/links")   # was f["categories"]["links"][:]
```

## Why it's lossless both ways

- **JS-written** (flat-2D `<f8` + `field_names=["owner_type","owner_id","identity_idx","identity_score"]`):
  the helper rebuilds an all-`f8` structured array; the existing
  `int(row["owner_type"])` / `int(row["owner_id"])` / `int(row["identity_idx"])` /
  `float(row["identity_score"])` / `np.isnan(...)` casts already tolerate `f8`-backed
  fields (`int(1.0) == 1`) — the same reason the `/session_data` reader works on the JS form.
- **Python-written** (genuine compound, no `field_names` attr): the helper's guard is
  `if data.ndim == 2 and data.dtype.names is None` — a compound dataset is 1-D with named
  fields, so it's returned unchanged. Existing files are unaffected.

Out of scope (sleap-io.js writes these Python-native, no reader change needed):
`/identity/name` (vlen-utf8 + EAV) and `/embeddings` (plain `(N,D)` float + plain join columns).

## Testing

- New `test_read_identity_links_h5wasm_flat_2d` / `test_read_category_links_h5wasm_flat_2d`:
  write a flat-2D `f8` + `field_names` links table (simulating h5wasm) and assert both
  readers reconstruct the `owner_type → {owner_id: (idx, score)}` mapping, including
  `NaN` score → `None` and multiple owner types.
- Existing compound round-trip tests (`test_read_identity_links_owner_type_keyed`, etc.)
  cover the Python-written path unchanged.
- Full `test_slp.py`: **407 passed**. `ruff format` / `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzZNM1mhjJw82JqTrWfiux